### PR TITLE
Fix Radar Relay ERC20 decimal error

### DIFF
--- a/wings/radar_relay_market.pyx
+++ b/wings/radar_relay_market.pyx
@@ -597,14 +597,14 @@ cdef class RadarRelayMarket(MarketBase):
     async def submit_market_order(self,
                                   symbol: str,
                                   side: TradeType,
-                                  amount: str) -> Tuple[float, str]:
+                                  amount: Decimal) -> Tuple[float, str]:
         response = await self.request_signed_market_orders(symbol=symbol,
                                                            side=side,
-                                                           amount=amount)
-        print(response)
+                                                           amount=str(amount))
         signed_market_orders = response["orders"]
         average_price = float(response["averagePrice"])
-        print(average_price)
+        base_asset_decimals = self.trading_rules.get(symbol).amount_decimals
+        amt_with_decimals = int(Decimal(amount) * Decimal(f"1e{base_asset_decimals}"))
 
         signatures = []
         orders = []
@@ -614,24 +614,23 @@ cdef class RadarRelayMarket(MarketBase):
             orders.append(jsdict_order_to_struct(order))
         tx_hash = ""
         if side is TradeType.BUY:
-            tx_hash = self._exchange.market_buy_orders(orders, amount, signatures)
+            tx_hash = self._exchange.market_buy_orders(orders, amt_with_decimals, signatures)
         elif side is TradeType.SELL:
-            tx_hash = self._exchange.market_sell_orders(orders, amount, signatures)
+            tx_hash = self._exchange.market_sell_orders(orders, amt_with_decimals, signatures)
         else:
             raise ValueError("Invalid side. Aborting.")
-        print(orders, tx_hash)
         return average_price, tx_hash
 
     async def submit_limit_order(self,
                                  symbol: str,
                                  side: TradeType,
-                                 amount: str,
+                                 amount: Decimal,
                                  price: str,
                                  expires: int) -> Tuple[str, Order]:
         url = f"{RADAR_RELAY_REST_ENDPOINT}/orders"
         unsigned_limit_order = await self.request_unsigned_limit_order(symbol=symbol,
                                                                        side=side,
-                                                                       amount=amount,
+                                                                       amount=str(amount),
                                                                        price=price,
                                                                        expires=expires)
         unsigned_limit_order["makerAddress"] = self._wallet.address.lower()
@@ -680,7 +679,7 @@ cdef class RadarRelayMarket(MarketBase):
                             expires: int) -> str:
         cdef:
             str q_price
-            str q_amt = str(self.c_quantize_order_amount(symbol, amount))
+            object q_amt = self.c_quantize_order_amount(symbol, amount)
             TradingRule trading_rule = self._trading_rules[symbol]
             bint is_buy = order_side is TradeType.BUY 
         try:
@@ -715,7 +714,6 @@ cdef class RadarRelayMarket(MarketBase):
                                                       expires=expires,
                                                       zero_ex_order=zero_ex_order)
             elif order_type is OrderType.MARKET:
-                print(q_amt)
                 avg_price, tx_hash = await self.submit_market_order(symbol=symbol,
                                                                     side=order_side,
                                                                     amount=q_amt)
@@ -750,7 +748,7 @@ cdef class RadarRelayMarket(MarketBase):
 
             return order_id
         except Exception:
-            self.logger().error(f"Error submitting trade order to Radar Relay for {q_amt} {symbol}.", exc_info=True)
+            self.logger().error(f"Error submitting trade order to Radar Relay for {str(q_amt)} {symbol}.", exc_info=True)
             self.c_trigger_event(
                 self.MARKET_TRANSACTION_FAILURE_EVENT_TAG,
                 MarketTransactionFailureEvent(self._current_timestamp, order_id)
@@ -949,12 +947,12 @@ cdef class RadarRelayMarket(MarketBase):
         cdef:
             TradingRule trading_rule = self._trading_rules[symbol]
         decimals_quantum = Decimal(f"1e-{trading_rule.amount_decimals}")
+
         if amount > 0:
             precision_quantum = Decimal(f"1e{math.ceil(math.log10(amount)) - trading_rule.price_precision}")
         else:
             precision_quantum = s_decimal_0
         return max(decimals_quantum, precision_quantum)
-
 
     cdef object c_quantize_order_amount(self, str symbol, double amount):
         cdef:

--- a/wings/zero_ex_exchange.py
+++ b/wings/zero_ex_exchange.py
@@ -39,21 +39,21 @@ class ZeroExExchange:
         order_epoch: int = self._contract.functions.orderEpoch(maker_address, sender_address).call()
         return order_epoch
 
-    def market_buy_orders(self, orders: List[Order], maker_asset_fill_amount: str, signatures: List[str]) -> str:
+    def market_buy_orders(self, orders: List[Order], maker_asset_fill_amount: Decimal, signatures: List[str]) -> str:
         order_tuples: List[tuple] = [convert_order_to_tuple(order) for order in orders]
         signatures: List[bytes] = [self._w3.toBytes(hexstr=signature) for signature in signatures]
         tx_hash: str = self._wallet.execute_transaction(
             self._contract.functions.marketBuyOrders(order_tuples,
-                                                     int(Decimal(maker_asset_fill_amount) * Decimal("1e18")),
+                                                     int(maker_asset_fill_amount),
                                                      signatures))
         return tx_hash
 
-    def market_sell_orders(self, orders: List[Order], taker_asset_fill_amount: str, signatures: List[str]) -> str:
+    def market_sell_orders(self, orders: List[Order], taker_asset_fill_amount: Decimal, signatures: List[str]) -> str:
         order_tuples: List[tuple] = [convert_order_to_tuple(order) for order in orders]
         signatures: List[bytes] = [self._w3.toBytes(hexstr=signature) for signature in signatures]
         tx_hash: str = self._wallet.execute_transaction(
             self._contract.functions.marketSellOrders(order_tuples,
-                                                      int(Decimal(taker_asset_fill_amount) * Decimal("1e18")),
+                                                      int(taker_asset_fill_amount),
                                                       signatures))
         return tx_hash
 


### PR DESCRIPTION
@chowryan 
Currently, we pass in `Decimal("1e18")` to 0x exchange contracts when placing market orders on Radar (the actual line is in `zero_ex_exchange.py`.
Since not all ERC20 tokens have 18 decimals, this causes transactions on those markets to fail (e.g. ZIL-WETH), and causes the ```gas required exceeds allowance or always failing transaction``` error in `w3.eth.estimateGas` and failed transactions on chain.