### PR TITLE
Delete describe and list orders CLI commands

### DIFF
--- a/hummingbot/cli/hummingbot_application.py
+++ b/hummingbot/cli/hummingbot_application.py
@@ -426,21 +426,10 @@ class HummingbotApplication:
                 self.app.log('\n'.join(EXCHANGES))
         elif obj == "configs":
             self.app.log('\n'.join(load_required_configs().keys()))
-        elif obj == "orders":
-            active_maker_orders: List[LimitOrder] = ([order for _, order in self.strategy.active_maker_orders]
-                                                     if self.strategy is not None
-                                                     else [])
-            if len(active_maker_orders) == 0:
-                self.app.log('No active orders available.')
-            else:
-                lines: List[str] = ["    " + line
-                                    for line
-                                    in f"{LimitOrder.to_pandas(active_maker_orders)}".split("\n")]
-                self.app.log("\n".join(lines))
         else:
             self.help("list")
 
-    def describe(self, wallet: bool = False, exchange: str = None, order: str = None):
+    def describe(self, wallet: bool = False, exchange: str = None):
         if wallet:
             if self.wallet is None:
                 self.app.log('None available. Your wallet may not have been initialized. Enter "start" to initialize '
@@ -453,16 +442,6 @@ class HummingbotApplication:
                 self.app.log(f"{self.get_exchange_balance(exchange)}")
             else:
                 raise InvalidCommandError("The exchange you specified has not been initialized")
-        elif order is not None:
-            limit_orders: List[LimitOrder] = []
-            for market in self.markets.values():
-                limit_orders += market.limit_orders
-            keys = list(map(lambda lo: lo.client_order_id, limit_orders))
-            order_dict = dict(zip(keys, limit_orders))
-            if order in order_dict:
-                self.app.log(str(order_dict.get(order)))
-            else:
-                self.app.log("Invalid order id")
         else:
             self.help("describe")
 

--- a/hummingbot/cli/ui/parser.py
+++ b/hummingbot/cli/ui/parser.py
@@ -54,14 +54,13 @@ def load_parser(hummingbot) -> ThrowingArgumentParser:
     status_parser.set_defaults(func=hummingbot.status)
 
     list_parser = subparsers.add_parser('list', help='List global objects')
-    list_parser.add_argument('obj', choices=["wallets", "exchanges", "configs", "orders"],
+    list_parser.add_argument('obj', choices=["wallets", "exchanges", "configs"],
                              help='Type of object to list', nargs='?')
     list_parser.set_defaults(func=hummingbot.list)
 
     describe_parser = subparsers.add_parser('describe', help='Print detailed description of objects ')
     describe_parser.add_argument('-w', '--wallet', action='store_true', help='Describe current wallet')
     describe_parser.add_argument('-e', '--exchange', help='Describe an exchange')
-    describe_parser.add_argument('-o', '--order', help='Describe an order')
     describe_parser.set_defaults(func=hummingbot.describe)
 
     get_balance_parser = subparsers.add_parser('get_balance', help='Print balance of a certain currency ')


### PR DESCRIPTION
I am deleting the `describe --order` and `list orders` CLI commands. Currently, `list orders` uses CrossExchangeMarketMaking.active_maker_orders, which does not exist in Arbitrage.  This causes an error on the CLI. 
Reading active orders from markets directly also does not work because even though the `limit_orders` property exists in MarketBase, not all markets have implemented them. 
So just deleting the command right now and users can see active orders by entering status.
In the future, we should implement StrategyBase to standardize.