### PR TITLE
Reduce radar relay api request frequency

### DIFF
--- a/test/test_radar_relay_market.py
+++ b/test/test_radar_relay_market.py
@@ -125,13 +125,13 @@ class RadarRelayMarketUnitTest(unittest.TestCase):
                                        amount=amount,
                                        order_type=OrderType.LIMIT,
                                        price=current_price - 0.2 * current_price,
-                                       expires=expires)
+                                       expiration_ts=expires)
         [buy_order_opened_event] = self.run_parallel(self.market_logger.wait_for(BuyOrderCreatedEvent))
         self.assertEqual("ZRX-WETH", buy_order_opened_event.symbol)
         self.assertEqual(OrderType.LIMIT, buy_order_opened_event.type)
         self.assertEqual(quantized_amount, Decimal(buy_order_opened_event.amount))
 
-        self.market.cancel_order(buy_order_id)
+        self.run_parallel(self.market.cancel_order(buy_order_id))
         [buy_order_cancelled_event] = self.run_parallel(self.market_logger.wait_for(OrderCancelledEvent))
         self.assertEqual(buy_order_opened_event.order_id, buy_order_cancelled_event.order_id)
 
@@ -148,7 +148,7 @@ class RadarRelayMarketUnitTest(unittest.TestCase):
                                        amount=amount,
                                        order_type=OrderType.LIMIT,
                                        price=current_price - 0.2 * current_price,
-                                       expires=expires)
+                                       expiration_ts=expires)
         [buy_order_opened_event] = self.run_parallel(self.market_logger.wait_for(BuyOrderCreatedEvent))
         self.assertEqual(buy_order_id, buy_order_opened_event.order_id)
         self.assertEqual(quantized_amount, Decimal(buy_order_opened_event.amount))
@@ -162,7 +162,7 @@ class RadarRelayMarketUnitTest(unittest.TestCase):
                                          amount=amount,
                                          order_type=OrderType.LIMIT,
                                          price=current_price + 0.2 * current_price,
-                                         expires=expires)
+                                         expiration_ts=expires)
         [sell_order_opened_event] = self.run_parallel(self.market_logger.wait_for(SellOrderCreatedEvent))
         self.assertEqual(sell_order_id, sell_order_opened_event.order_id)
         self.assertEqual(quantized_amount, Decimal(sell_order_opened_event.amount))
@@ -185,7 +185,7 @@ class RadarRelayMarketUnitTest(unittest.TestCase):
                                        amount=amount,
                                        order_type=OrderType.LIMIT,
                                        price=current_price - 0.2 * current_price,
-                                       expires=expires)
+                                       expiration_ts=expires)
         [buy_order_opened_event] = self.run_parallel(self.market_logger.wait_for(BuyOrderCreatedEvent))
 
         self.assertEqual("ZRX-WETH", buy_order_opened_event.symbol)

--- a/wings/data_source/radar_relay_api_order_book_data_source.py
+++ b/wings/data_source/radar_relay_api_order_book_data_source.py
@@ -175,8 +175,7 @@ class RadarRelayAPIOrderBookDataSource(OrderBookTrackerDataSource):
     async def listen_for_order_book_diffs(self, ev_loop: asyncio.BaseEventLoop, output: asyncio.Queue):
         while True:
             try:
-                active_markets: pd.DataFrame = await self.get_active_exchange_markets()
-                trading_pairs: List[str] = active_markets.index.tolist()
+                trading_pairs: List[str] = await self.get_trading_pairs()
                 async with websockets.connect(WS_URL) as ws:
                     ws: websockets.WebSocketClientProtocol = ws
                     for trading_pair in trading_pairs:
@@ -203,8 +202,7 @@ class RadarRelayAPIOrderBookDataSource(OrderBookTrackerDataSource):
     async def listen_for_order_book_snapshots(self, ev_loop: asyncio.BaseEventLoop, output: asyncio.Queue):
         while True:
             try:
-                active_markets: pd.DataFrame = await self.get_active_exchange_markets()
-                trading_pairs: List[str] = active_markets.index.tolist()
+                trading_pairs: List[str] = await self.get_trading_pairs()
                 client: aiohttp.ClientSession = self.http_client()
                 for trading_pair in trading_pairs:
                     try:

--- a/wings/radar_relay_market.pxd
+++ b/wings/radar_relay_market.pxd
@@ -14,7 +14,8 @@ cdef class RadarRelayMarket(MarketBase):
         object _ev_loop
         object _poll_notifier
         double _last_timestamp
-        double _last_update_order_timestamp
+        double _last_update_limit_order_timestamp
+        double _last_update_market_order_timestamp
         double _last_update_trading_rules_timestamp
         double _poll_interval
         dict _in_flight_limit_orders


### PR DESCRIPTION
We are keep tracking of expired orders for unnecessarily long (60min). This can cause Radar Relay to reject our api requests.  By reducing the tracking to 15min we will be well within Radar Relay's rest api limit.