### PR TITLE
Load global config in hummingbot.py. Also, fixed some oudated code in cross exchange market making strategy.

### DIFF
--- a/bin/hummingbot.py
+++ b/bin/hummingbot.py
@@ -26,13 +26,18 @@ from hummingbot import (
 )
 
 from hummingbot.cli.hummingbot_application import HummingbotApplication
-from hummingbot.cli.settings import global_config_map, create_yml_files
+from hummingbot.cli.settings import (
+    global_config_map,
+    create_yml_files,
+    read_configs_from_yml
+)
 from hummingbot.cli.ui.stdout_redirection import patch_stdout
 from hummingbot.management.console import start_management_console
 
 
 async def main():
     await create_yml_files()
+    read_configs_from_yml()
 
     init_logging("hummingbot_logs.yml")
 

--- a/hummingbot/strategy/cross_exchange_market_making.pyx
+++ b/hummingbot/strategy/cross_exchange_market_making.pyx
@@ -8,7 +8,10 @@ import pandas as pd
 from typing import (
     List,
     Tuple,
-    Optional)
+    Optional,
+    Dict,
+    Deque
+)
 
 from wings.clock cimport Clock
 from wings.events import (
@@ -193,12 +196,8 @@ cdef class CrossExchangeMarketMakingStrategy(Strategy):
         return [(market, limit_order) for market, limit_order in self.active_maker_orders if not limit_order.is_buy]
 
     @property
-    def suggested_bid_price_samples(self) -> List[Decimal]:
-        return self._suggested_bid_price_samples
-
-    @property
-    def suggested_ask_price_samples(self) -> List[Decimal]:
-        return self._suggested_ask_price_samples
+    def suggested_price_samples(self) -> Dict[CrossExchangeMarketPair, Tuple[Deque[Decimal], Deque[Decimal]]]:
+        return self._suggested_price_samples
 
     @property
     def logging_options(self) -> int:


### PR DESCRIPTION
As title.

The old code in cross exchange market making strategy was referencing some outdated attributes that have been replaced by `_suggested_price_samples`.