### PR TITLE
Improved active order cancellation config prompt.

### DIFF
--- a/hummingbot/cli/settings.py
+++ b/hummingbot/cli/settings.py
@@ -261,7 +261,7 @@ cross_exchange_market_making_config_map = {
                                                   type_str="float"),
     "top_depth_tolerance":              ConfigVar(key="top_depth_tolerance",
                                                   prompt="What is the maximum depth you would go into th"
-                                                         "e order book to make a trade? >>>",
+                                                         "e order book to make a trade? >>> ",
                                                   type_str="list",
                                                   required_if=lambda: False,
                                                   default=[
@@ -271,18 +271,18 @@ cross_exchange_market_making_config_map = {
                                                   ]),
     "active_order_canceling": ConfigVar(key="active_order_canceling",
                                         prompt="Do you want to actively adjust/cancel orders? "
-                                               "(Default True) >>>",
+                                               "(Default True, only set to False if maker market is Radar Relay) >>> ",
                                         type_str="bool",
                                         default=True),
     "cancel_order_threshold":   ConfigVar(key="cancel_order_threshold",
                                           prompt="What is the minimum profitability to actively cancel orders? "
                                                  "(Default to 0.0, only specify when active_order_canceling is "
-                                                 "disabled, value can be negative) >>>",
+                                                 "disabled, value can be negative) >>> ",
                                           default=0.0,
                                           type_str="float"),
     "limit_order_min_expiration":    ConfigVar(key="limit_order_min_expiration",
                                                prompt="What is the minimum limit order expiration in seconds? "
-                                                      "(Default to 130 seconds) >>>",
+                                                      "(Default to 130 seconds) >>> ",
                                                default=130.0,
                                                type_str="float")
 }


### PR DESCRIPTION
This patch adds a little bit of information on the active order cancellation config prompt, in which it should only be disabled for Radar Relay.