### PR TITLE
Shortened the cancelled order tracking duration in cross exchange market making strategy to 15 minutes.

### DIFF
--- a/hummingbot/strategy/cross_exchange_market_making.pyx
+++ b/hummingbot/strategy/cross_exchange_market_making.pyx
@@ -94,7 +94,7 @@ cdef class CrossExchangeMarketMakingStrategy(Strategy):
     ORDER_ADJUST_SAMPLE_INTERVAL = 5
     ORDER_ADJUST_SAMPLE_WINDOW = 12
 
-    SHADOW_MAKER_ORDER_KEEP_ALIVE_DURATION = 3600.0
+    SHADOW_MAKER_ORDER_KEEP_ALIVE_DURATION = 60.0 * 15
 
     @classmethod
     def logger(cls):


### PR DESCRIPTION
As title.

Tracking for longer than 15 minutes is not necessary because that's roughly the duration for 30 blocks already.