### PR TITLE
feat / Add error logging to status polling loop

### DIFF
--- a/hummingbot/client/liquidity_bounty/bounty_utils.py
+++ b/hummingbot/client/liquidity_bounty/bounty_utils.py
@@ -330,6 +330,7 @@ class LiquidityBounty(NetworkBase):
                 if "User not registered" in str(e):
                     self.logger().warning("User not registered. Aborting fetch_client_status_loop.")
                     break
+                self.logger().info(f"Error getting bounty status: {e}")
             await asyncio.sleep(self._update_interval)
 
     async def fetch_filled_volume_metrics(self, start_time: int) -> List[Dict[str, Any]]:

--- a/hummingbot/client/liquidity_bounty/bounty_utils.py
+++ b/hummingbot/client/liquidity_bounty/bounty_utils.py
@@ -330,7 +330,7 @@ class LiquidityBounty(NetworkBase):
                 if "User not registered" in str(e):
                     self.logger().warning("User not registered. Aborting fetch_client_status_loop.")
                     break
-                self.logger().info(f"Error getting bounty status: {e}")
+                self.logger().error(f"Error getting bounty status: {e}")
             await asyncio.sleep(self._update_interval)
 
     async def fetch_filled_volume_metrics(self, start_time: int) -> List[Dict[str, Any]]:


### PR DESCRIPTION
## Summary
- Organize pool templates by network instead of connector
- Standardize fetch-pools schema across Meteora and Orca connectors
- Remove `isVerified` field from pool responses (APIs don't reliably return this)
- Fix Orca getPools test to match new method signature

## Related PRs
- hummingbot: https://github.com/hummingbot/hummingbot/pull/8206
- hummingbot-api: https://github.com/hummingbot/hummingbot-api/pull/155
- hummingbot-api-client: https://github.com/hummingbot/hummingbot-api-client/pull/17
- condor: https://github.com/hummingbot/condor/pull/76

## Test plan
- [x] All Gateway tests pass (98 suites, 912 tests)
- [ ] Manual testing with Meteora and Orca pool listing

🤖 Generated with [Claude Code](https://claude.ai/code)