### PR TITLE
feat/enable derivatives in price source for external market in pmm

### DIFF
--- a/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
+++ b/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from hummingbot.client.config.config_var import ConfigVar
 from hummingbot.client.config.config_validators import (
     validate_exchange,
+    validate_connector,
     validate_market_trading_pair,
     validate_bool,
     validate_decimal,
@@ -58,7 +59,7 @@ def price_source_market_prompt() -> str:
 def validate_price_source_exchange(value: str) -> Optional[str]:
     if value == pure_market_making_config_map.get("exchange").value:
         return "Price source exchange cannot be the same as maker exchange."
-    return validate_exchange(value)
+    return validate_connector(value)
 
 
 def on_validated_price_source_exchange(value: str):

--- a/test/hummingbot/strategy/pure_market_making/test_pmm_config_map.py
+++ b/test/hummingbot/strategy/pure_market_making/test_pmm_config_map.py
@@ -112,5 +112,7 @@ class TestPMMConfigMap(unittest.TestCase):
 
     def test_validate_price_source_exchange(self):
         pmm_config_map["exchange"].value = self.exchange
-        self.assertIsNone(validate_price_source_exchange(value='binance'))
+        self.assertEqual(validate_price_source_exchange(value='binance'),
+                         'Price source exchange cannot be the same as maker exchange.')
+        self.assertIsNone(validate_price_source_exchange(value='kucoin'))
         self.assertIsNone(validate_price_source_exchange(value='binance_perpetual'))

--- a/test/hummingbot/strategy/pure_market_making/test_pmm_config_map.py
+++ b/test/hummingbot/strategy/pure_market_making/test_pmm_config_map.py
@@ -109,9 +109,8 @@ class TestPMMConfigMap(unittest.TestCase):
         expected = f"Enter the token trading pair you would like to trade on {self.exchange} (e.g. {example}) >>> "
 
         self.assertEqual(expected, prompt)
-    
+
     def test_validate_price_source_exchange(self):
         pmm_config_map["exchange"].value = self.exchange
-        self.assertIsNone(validate_price_source_exchange('binance'))
-        self.assertIsNone(validate_price_source_exchange('binance_perpetual'))
-
+        self.assertIsNone(validate_price_source_exchange(value='binance'))
+        self.assertIsNone(validate_price_source_exchange(value='binance_perpetual'))

--- a/test/hummingbot/strategy/pure_market_making/test_pmm_config_map.py
+++ b/test/hummingbot/strategy/pure_market_making/test_pmm_config_map.py
@@ -8,6 +8,7 @@ from hummingbot.strategy.pure_market_making.pure_market_making_config_map import
     validate_price_type,
     order_amount_prompt,
     maker_trading_pair_prompt,
+    validate_price_source_exchange
 )
 
 
@@ -108,3 +109,9 @@ class TestPMMConfigMap(unittest.TestCase):
         expected = f"Enter the token trading pair you would like to trade on {self.exchange} (e.g. {example}) >>> "
 
         self.assertEqual(expected, prompt)
+    
+    def test_validate_price_source_exchange(self):
+        pmm_config_map["exchange"].value = self.exchange
+        self.assertIsNone(validate_price_source_exchange('binance'))
+        self.assertIsNone(validate_price_source_exchange('binance_perpetual'))
+


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

* [x] Your code builds clean without any errors or warnings
* [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Enable derivates connectors to be used as price source for external markets

**Tests performed by the developer**:
Tested on binance perpetual with spread 2%
![image](https://user-images.githubusercontent.com/64965782/143350545-cfa5f482-9314-4208-8dcd-a9e0b8786592.png)
normal exchange work as normal
![image](https://user-images.githubusercontent.com/64965782/143351087-cf1e0b81-d6f7-4608-859e-d26b96c0e3cb.png)


**Tips for QA testing**:



┆Issue is synchronized with this [Clickup task](https://app.clickup.com/t/1pd0f9t) by [Unito](https://www.unito.io)
