### PR TITLE
Fix/min order size step on Coinbase Pro and Liquid

### DIFF
--- a/hummingbot/connector/exchange/coinbase_pro/coinbase_pro_exchange.pyx
+++ b/hummingbot/connector/exchange/coinbase_pro/coinbase_pro_exchange.pyx
@@ -409,9 +409,10 @@ cdef class CoinbaseProExchange(ExchangeBase):
             try:
                 trading_pair = rule.get("id")
                 retval.append(TradingRule(trading_pair,
-                                          min_price_increment=Decimal(rule.get("quote_increment")),
-                                          min_order_size=Decimal(rule.get("base_min_size")),
-                                          max_order_size=Decimal(rule.get("base_max_size")),
+                                          min_price_increment=Decimal(str(rule.get("quote_increment"))),
+                                          min_base_amount_increment=Decimal(str(rule.get("base_increment"))),
+                                          min_order_size=Decimal(str(rule.get("base_min_size"))),
+                                          max_order_size=Decimal(str(rule.get("base_max_size"))),
                                           supports_market_orders=(not rule.get("limit_only"))))
             except Exception:
                 self.logger().error(f"Error parsing the trading_pair rule {rule}. Skipping.", exc_info=True)
@@ -1051,10 +1052,7 @@ cdef class CoinbaseProExchange(ExchangeBase):
         """
         cdef:
             TradingRule trading_rule = self._trading_rules[trading_pair]
-
-        # Coinbase Pro is using the min_order_size as max_precision
-        # Order size must be a multiple of the min_order_size
-        return trading_rule.min_order_size
+        return trading_rule.min_base_amount_increment
 
     cdef object c_quantize_order_amount(self, str trading_pair, object amount, object price=s_decimal_0):
         """

--- a/hummingbot/connector/exchange/liquid/liquid_exchange.pyx
+++ b/hummingbot/connector/exchange/liquid/liquid_exchange.pyx
@@ -495,10 +495,11 @@ cdef class LiquidExchange(ExchangeBase):
                 # Find the corresponding rule based on currency
                 rule = trading_rules.get(currency)
 
+                min_base_increment = math.pow(10, -rule.get("assets_precision", Constants.DEFAULT_ASSETS_PRECISION))
+
                 min_order_size = rule.get("minimum_order_quantity")
                 if not min_order_size:
-                    min_order_size = math.pow(10, -rule.get(
-                        "assets_precision", Constants.DEFAULT_ASSETS_PRECISION))
+                    min_order_size = min_base_increment
 
                 min_price_increment = product.get("tick_size")
                 if not min_price_increment or min_price_increment == "0.0":
@@ -506,12 +507,13 @@ cdef class LiquidExchange(ExchangeBase):
                         "quoting_precision", Constants.DEFAULT_QUOTING_PRECISION))
 
                 retval.append(TradingRule(trading_pair,
-                                          min_price_increment=Decimal(min_price_increment),
-                                          min_order_size=Decimal(min_order_size),
-                                          max_order_size=Decimal(sys.maxsize),  # Liquid doesn't specify max order size
+                                          min_price_increment=Decimal(str(min_price_increment)),
+                                          min_base_amount_increment=Decimal(str(min_base_increment)),
+                                          min_order_size=Decimal(str(min_order_size)),
+                                          max_order_size=Decimal(str(sys.maxsize)),  # Liquid doesn't specify max order size
                                           supports_market_orders=None))  # Not sure if Liquid has equivalent info
             except Exception:
-                self.logger().error(f"Error parsing the trading_pair rule {rule}. Skipping.", exc_info=True)
+                self.logger().error(f"Error parsing the trading_pair rule {trading_pair}. Skipping.", exc_info=True)
         return retval
 
     async def _update_order_status(self):
@@ -1224,10 +1226,7 @@ cdef class LiquidExchange(ExchangeBase):
         """
         cdef:
             TradingRule trading_rule = self._trading_rules[trading_pair]
-
-        # Liquid is using the min_order_size as max_precision
-        # Order size must be a multiple of the min_order_size
-        return trading_rule.min_order_size
+        return Decimal(trading_rule.min_base_amount_increment)
 
     cdef object c_quantize_order_amount(self, str trading_pair, object amount, object price=s_decimal_0):
         """


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
- Corrected trading rule min_base_amount_increment (min order size step) 


**Tests performed by the developer**:
- Tested running PMM (ETH-USDC) on Coinbase Pro (but can't confirm on Coinbase Pro website, due to regional IP restriction)
- Tested running PMM (ETH-USDT) on Liquid


**Tips for QA testing**:
- The APIs can accept much smaller decimal value than what they show on their sites, for Liquid (ETH-USDT) it is up to 18 decimal precision, for Coinbase Pro (ETH-USDC) it is up to 8 decimal precision.
- The error is no longer present on Binance
