### PR TITLE
feat/ add `HBOT` broker id to Bybit Perpetual connector

### DIFF
--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_utils.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_utils.py
@@ -14,14 +14,16 @@ EXAMPLE_PAIR = "BTC-USD"
 # Fees have to be expressed as percent value
 DEFAULT_FEES = [-0.025, 0.075]
 
+HBOT_BROKER_ID = "HBOT"
 
 # USE_ETHEREUM_WALLET not required because default value is false
 # FEE_TYPE not required because default value is Percentage
 # FEE_TOKEN not required because the fee is not flat
 
+
 def get_new_client_order_id(is_buy: bool, trading_pair: str) -> str:
     side = "B" if is_buy else "S"
-    return f"{side}-{trading_pair}-{get_tracking_nonce()}"
+    return f"{HBOT_BROKER_ID}-{side}-{trading_pair}-{get_tracking_nonce()}"
 
 
 def convert_to_exchange_trading_pair(hb_trading_pair: str) -> str:

--- a/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_derivative.py
@@ -139,6 +139,7 @@ class BybitPerpetualDerivativeTests(TestCase):
     @aioresponses()
     @patch('hummingbot.connector.derivative.bybit_perpetual.bybit_perpetual_utils.get_tracking_nonce')
     def test_create_buy_order(self, post_mock, nonce_provider_mock):
+        nonce_provider_mock.return_value = 1000
         path_url = bybit_utils.rest_api_path_for_endpoint(CONSTANTS.PLACE_ACTIVE_ORDER_PATH_URL, self.trading_pair)
         url = bybit_utils.rest_api_url_for_endpoint(path_url, self.domain)
         regex_url = re.compile(f"^{url}")
@@ -165,7 +166,7 @@ class BybitPerpetualDerivativeTests(TestCase):
                 "cum_exec_value": 0,
                 "cum_exec_fee": 0,
                 "reject_reason": "",
-                "order_link_id": f"B-{self.trading_pair}-1000",
+                "order_link_id": bybit_utils.get_new_client_order_id(True, self.trading_pair),
                 "created_at": "2019-11-30T11:03:43.452Z",
                 "updated_at": "2019-11-30T11:03:43.455Z"
             },
@@ -176,7 +177,6 @@ class BybitPerpetualDerivativeTests(TestCase):
         }
         post_mock.post(regex_url, body=json.dumps(mock_response), callback=self._mock_responses_done_callback)
 
-        nonce_provider_mock.return_value = 1000
         self._simulate_trading_rules_initialized()
         self.connector._leverage[self.trading_pair] = 10
 
@@ -190,7 +190,7 @@ class BybitPerpetualDerivativeTests(TestCase):
 
         result = mock_response["result"]
 
-        self.assertEqual(f"B-{self.trading_pair}-1000", new_order_id)
+        self.assertEqual(f"HBOT-B-{self.trading_pair}-1000", new_order_id)
         self.assertEqual("Buy", result["side"])
         self.assertEqual(self.ex_trading_pair, result["symbol"])
         self.assertEqual("Limit", result["order_type"])
@@ -438,7 +438,7 @@ class BybitPerpetualDerivativeTests(TestCase):
                 "cum_exec_value": 0,
                 "cum_exec_fee": 0,
                 "reject_reason": "",
-                "order_link_id": f"B-{self.trading_pair}-1000",
+                "order_link_id": f"HBOT-B-{self.trading_pair}-1000",
                 "created_at": "2019-11-30T11:03:43.452Z",
                 "updated_at": "2019-11-30T11:03:43.455Z"
             },
@@ -524,7 +524,7 @@ class BybitPerpetualDerivativeTests(TestCase):
 
         result = mock_response["result"]
 
-        self.assertEqual(f"S-{self.trading_pair}-1000", new_order_id)
+        self.assertEqual(f"HBOT-S-{self.trading_pair}-1000", new_order_id)
         self.assertEqual("Sell", result["side"])
         self.assertEqual("BTCUSDT", result["symbol"])
         self.assertEqual("Market", result["order_type"])

--- a/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_utils.py
+++ b/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_utils.py
@@ -10,9 +10,9 @@ class BybitPerpetualUtilsTests(TestCase):
     @patch('hummingbot.connector.derivative.bybit_perpetual.bybit_perpetual_utils.get_tracking_nonce')
     def test_client_order_id_creation(self, nonce_provider_mock):
         nonce_provider_mock.return_value = int(1e15)
-        self.assertEqual("B-BTC-USDT-1000000000000000", utils.get_new_client_order_id(True, "BTC-USDT"))
+        self.assertEqual("HBOT-B-BTC-USDT-1000000000000000", utils.get_new_client_order_id(True, "BTC-USDT"))
         nonce_provider_mock.return_value = int(1e15) + 1
-        self.assertEqual("S-ETH-USDT-1000000000000001", utils.get_new_client_order_id(False, "ETH-USDT"))
+        self.assertEqual("HBOT-S-ETH-USDT-1000000000000001", utils.get_new_client_order_id(False, "ETH-USDT"))
 
     def test_trading_pair_convertion(self):
         trading_pair = "BTC-USDT"


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Include `HBOT-` prefix to all `client_order_id`


**Tests performed by the developer**:
Add `HBOT` prefix to `get_new_client_order_id()` in `bybit_perpetual_utils.py`
Update unit tests to reflect this changes.

**Tips for QA testing**:
None needed. Verification to be done by Bybit Team

