### PR TITLE
feat/ add HTTP `Referer` header into `_create_order` requests in Bybit Perpetual

### DIFF
--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_auth.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_auth.py
@@ -2,8 +2,11 @@ import hashlib
 import hmac
 import json
 import time
+
 from decimal import Decimal
-from typing import Dict, Any
+from typing import Dict, Any, Optional
+
+from hummingbot.connector.derivative.bybit_perpetual import bybit_perpetual_constants as CONSTANTS
 
 
 class BybitPerpetualAuth():
@@ -33,14 +36,19 @@ class BybitPerpetualAuth():
 
         return auth_info
 
-    def get_headers(self) -> Dict[str, Any]:
+    def get_headers(self, referer_header_required: Optional[bool] = False) -> Dict[str, Any]:
         """
         Generates authentication headers required by ProBit
         :return: a dictionary of auth headers
         """
-        return {
-            "Content-Type": 'application/json',
+        result = {
+            "Content-Type": "application/json"
         }
+        if referer_header_required:
+            result.update({
+                "Referer": CONSTANTS.HBOT_BROKER_ID
+            })
+        return result
 
     def extend_params_with_authentication_info(self, params: Dict[str, Any]):
         params["timestamp"] = self.get_timestamp()

--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_constants.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_constants.py
@@ -14,6 +14,8 @@ WSS_LINEAR_PRIVATE_URLS = {"bybit_perpetual_main": "wss://stream.bybit.com/realt
 
 REST_API_VERSION = "v2"
 
+HBOT_BROKER_ID = "HBOT"
+
 # REST API Public Endpoints
 LINEAR_MARKET = "linear"
 NON_LINEAR_MARKET = "non_linear"

--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_derivative.py
@@ -273,6 +273,7 @@ class BybitPerpetualDerivative(ExchangeBase, PerpetualTrading):
                            body: Optional[Dict[str, Any]] = None,
                            is_auth_required: bool = False,
                            limit_id: Optional[str] = None,
+                           referer_header_required: bool = False,
                            ):
         """
         Sends an aiohttp request and waits for a response.
@@ -301,7 +302,7 @@ class BybitPerpetualDerivative(ExchangeBase, PerpetualTrading):
                 params = self._auth.extend_params_with_authentication_info(params=params)
             async with self._throttler.execute_task(limit_id):
                 response = await client.get(url=url,
-                                            headers=self._auth.get_headers(),
+                                            headers=self._auth.get_headers(referer_header_required),
                                             params=params,
                                             )
         elif method == "POST":
@@ -309,7 +310,7 @@ class BybitPerpetualDerivative(ExchangeBase, PerpetualTrading):
                 params = self._auth.extend_params_with_authentication_info(params=body)
             async with self._throttler.execute_task(limit_id):
                 response = await client.post(url=url,
-                                             headers=self._auth.get_headers(),
+                                             headers=self._auth.get_headers(referer_header_required),
                                              data=ujson.dumps(params)
                                              )
         else:
@@ -459,6 +460,7 @@ class BybitPerpetualDerivative(ExchangeBase, PerpetualTrading):
                 trading_pair=trading_pair,
                 body=params,
                 is_auth_required=True,
+                referer_header_required=True,
             )
 
             if send_order_results["ret_code"] != 0:

--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_utils.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_utils.py
@@ -14,8 +14,6 @@ EXAMPLE_PAIR = "BTC-USD"
 # Fees have to be expressed as percent value
 DEFAULT_FEES = [-0.025, 0.075]
 
-HBOT_BROKER_ID = "HBOT"
-
 # USE_ETHEREUM_WALLET not required because default value is false
 # FEE_TYPE not required because default value is Percentage
 # FEE_TOKEN not required because the fee is not flat
@@ -23,7 +21,7 @@ HBOT_BROKER_ID = "HBOT"
 
 def get_new_client_order_id(is_buy: bool, trading_pair: str) -> str:
     side = "B" if is_buy else "S"
-    return f"{HBOT_BROKER_ID}-{side}-{trading_pair}-{get_tracking_nonce()}"
+    return f"{CONSTANTS.HBOT_BROKER_ID}-{side}-{trading_pair}-{get_tracking_nonce()}"
 
 
 def convert_to_exchange_trading_pair(hb_trading_pair: str) -> str:

--- a/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_auth.py
+++ b/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_auth.py
@@ -5,6 +5,7 @@ import time
 from unittest import TestCase
 from unittest.mock import patch
 
+from hummingbot.connector.derivative.bybit_perpetual import bybit_perpetual_constants as CONSTANTS
 from hummingbot.connector.derivative.bybit_perpetual.bybit_perpetual_auth import BybitPerpetualAuth
 
 
@@ -69,3 +70,22 @@ class BybitPerpetualAuthTests(TestCase):
         self.assertEqual(self.api_key, payload[0])
         self.assertEqual(expires, payload[1])
         self.assertEqual(expected_signature, payload[2])
+
+    def test_get_header_without_referer(self):
+        auth = BybitPerpetualAuth(api_key=self.api_key, secret_key=self.secret_key)
+        expected_header = {
+            "Content-Type": "application/json"
+        }
+
+        header = auth.get_headers()
+        self.assertTrue(header, expected_header)
+
+    def test_get_header_with_referer(self):
+        auth = BybitPerpetualAuth(api_key=self.api_key, secret_key=self.secret_key)
+        expected_header = {
+            "Content-Type": "application/json",
+            "Referer": CONSTANTS.HBOT_BROKER_ID
+        }
+
+        header = auth.get_headers(referer_header_required=True)
+        self.assertTrue(header, expected_header)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

* [x] Your code builds clean without any errors or warnings
* [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Add HTTP `Referer` header into create order requests.

Note: Referer tag is `HBOT`

**Tests performed by the developer**:
Include optional parameter to `_api_request()` function. It will be used to generate the relevant HTTP headers for the particular request.
Include unit tests.

**Tips for QA testing**:
None needed. Confirmation to be done by Bybit team.



┆Issue is synchronized with this [Clickup task](https://app.clickup.com/t/1pd0br1) by [Unito](https://www.unito.io)
