### PR TITLE
fix / TWAP accepting order_step_size greater than target_asset_amount

### DIFF
--- a/hummingbot/strategy/twap/twap_config_map.py
+++ b/hummingbot/strategy/twap/twap_config_map.py
@@ -52,7 +52,7 @@ def set_order_delay_default(value: str = None):
     twap_config_map.get("order_delay_time").default = default
 
 
-def validate_order_step_size(value: Decimal = None):
+def validate_order_step_size(value: str = None):
     """
     Validates if order_step_size is less than the target_asset_amount value
     :param value: User input for order_step_size parameter

--- a/test/hummingbot/strategy/twap/test_twap_config_map.py
+++ b/test/hummingbot/strategy/twap/test_twap_config_map.py
@@ -75,6 +75,6 @@ class TwapConfigMapTests(TestCase):
 
     def test_order_step_size(self):
         twap_config_map_module.twap_config_map.get("target_asset_amount").value = Decimal("1.0")
-        validate_order_step_size = twap_config_map_module.validate_order_step_size(Decimal("1.1"))
+        validate_order_step_size = twap_config_map_module.validate_order_step_size("1.1")
         self.assertEqual(validate_order_step_size,
                          "Order step size cannot be greater than the total trade amount.")


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

* [x] Your code builds clean without any errors or warnings
* [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Added a function to validate that the size of each order configured through `order_step_size` does not accept values greater than the total amount of assets to be traded in `target_asset_amount`.

Also added the corresponding unit test.

Fixes #3697 

**Tests performed by the developer**:

1. Ran `create` command to create a TWAP strategy configuration
1. For `order_step_size`, entered a value greater than `target_asset_amount`
1. Ran all unit tests in `test_twap_config_map.py`

**Tips for QA testing**:

* Create a TWAP strategy config file and enter a value for `order_step_size` > `target_asset_amount`
* Attempt to reconfigure order step size by running `config order_step_size` after the config file has been created
* Set a value `order_step_size` = `target_asset_amount` and should still be accepted
* The strategy should continue to create orders with order amount the same as the `target_asset_amount`



┆Issue is synchronized with this [Clickup task](https://app.clickup.com/t/1rnx5tm) by [Unito](https://www.unito.io)
