### PR TITLE
feat/add padding to panes

### DIFF
--- a/hummingbot/client/ui/layout.py
+++ b/hummingbot/client/ui/layout.py
@@ -1,14 +1,10 @@
-#!/usr/bin/env python
-
-from os.path import join, realpath, dirname
-import sys; sys.path.insert(0, realpath(join(__file__, "../../../")))
-
+from os.path import dirname, join, realpath
 from prompt_toolkit.layout.containers import (
-    VSplit,
-    HSplit,
-    Window,
-    FloatContainer,
     Float,
+    FloatContainer,
+    HSplit,
+    VSplit,
+    Window,
     WindowAlign,
 )
 from prompt_toolkit.layout.menus import CompletionsMenu
@@ -16,7 +12,7 @@ from prompt_toolkit.layout.layout import Layout
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from prompt_toolkit.completion import Completer
 from prompt_toolkit.layout.controls import FormattedTextControl
-from prompt_toolkit.widgets import SearchToolbar, Button
+from prompt_toolkit.widgets import Box, Button, SearchToolbar
 
 from hummingbot.client.ui.custom_widgets import CustomTextArea as TextArea
 from hummingbot.client.settings import (
@@ -236,10 +232,12 @@ def generate_layout(input_field: TextArea,
     components["pane_bottom"] = VSplit([trade_monitor,
                                         process_monitor,
                                         timer], height=1)
-    components["pane_left"] = HSplit([output_field,
-                                      input_field])
-    components["pane_right"] = HSplit([log_field,
-                                       search_field])
+    output_pane = Box(body=output_field, padding=0, padding_left=2, style="class:output-field")
+    input_pane = Box(body=input_field, padding=0, padding_left=2, padding_top=1, style="class:input-field")
+    components["pane_left"] = HSplit([output_pane,
+                                      input_pane])
+    right_pane = Box(body=HSplit([log_field, search_field]), padding=0, padding_left=2, style="class:log-field")
+    components["pane_right"] = HSplit([right_pane])
     components["hint_menus"] = [Float(xcursor=True,
                                       ycursor=True,
                                       transparent=True,
@@ -248,14 +246,9 @@ def generate_layout(input_field: TextArea,
 
     root_container = HSplit([
         components["pane_top"],
-        VSplit([
-            FloatContainer(
-                components["pane_left"],
-                components["hint_menus"]
-            ),
-            components["pane_right"],
-        ]),
+        VSplit(
+            [FloatContainer(components["pane_left"], components["hint_menus"]),
+             components["pane_right"]]),
         components["pane_bottom"],
-
     ])
     return Layout(root_container, focused_element=input_field), components


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

* [x] Your code builds clean without any errors or warnings
* [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
I have surrounded all the client panes with instances of the Box component, that allows to specify independent paddings for all the sides.

**Tests performed by the developer**:
Run the client and see the paddings are included:

* On the left for the output pane
* On the left and the top for the input pane
* on the left for the log pane

**Tips for QA testing**:
Check the padding is visible and the colors inside the margin areas are the same colors used in the rest of the pane.

Closes #4519



┆Issue is synchronized with this [Clickup task](https://app.clickup.com/t/1t1hm82) by [Unito](https://www.unito.io)
