### PR TITLE
Fix/huobi connector in binary for windows

### DIFF
--- a/hummingbot/connector/exchange/huobi/huobi_exchange.pyx
+++ b/hummingbot/connector/exchange/huobi/huobi_exchange.pyx
@@ -1,11 +1,9 @@
 import aiohttp
-from aiohttp.test_utils import TestClient
 import asyncio
 from decimal import Decimal
 from libc.stdint cimport int64_t
 import logging
 import time
-import pandas as pd
 from typing import (
     Any,
     AsyncIterable,


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

* [ ] Your code builds clean without any errors or warnings
* [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
I have removed two unnecessary dependencies from Huobi connector that were causing the issue at the moment of loading the module in the Windows binary image.

**Tests performed by the developer**:
After rebuilding the binary image I was able to connect to Huobi and check the balance.

**Tips for QA testing**:
Regenerate the Windows binary image. With the new image connect to Huobi exchange and check the balance.

Fixes #4604



┆Issue is synchronized with this [Clickup task](https://app.clickup.com/t/1tcy3xq) by [Unito](https://www.unito.io)
