### PR TITLE
fix/ClockUnitTest random failure

### DIFF
--- a/test/hummingbot/core/test_clock.py
+++ b/test/hummingbot/core/test_clock.py
@@ -23,7 +23,7 @@ class ClockUnitTest(unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        self.realtime_start_timestamp = time.time()
+        self.realtime_start_timestamp = int(time.time())
         self.realtime_end_timestamp = self.realtime_start_timestamp + 2.0  #
         self.clock_realtime = Clock(ClockMode.REALTIME, self.tick_size, self.realtime_start_timestamp, self.realtime_end_timestamp)
         self.clock_backtest = Clock(ClockMode.BACKTEST, self.tick_size, self.backtest_start_timestamp, self.backtest_end_timestamp)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

* [x] Your code builds clean without any errors or warnings
* [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
I made a change in the test class basic configuration to use the integer part of the current timestamp as the starting time for the clock.

**Tests performed by the developer**:
All unit tests running in green

**Tips for QA testing**:
Not required

Closes #4608



┆Issue is synchronized with this [Clickup task](https://app.clickup.com/t/1tjhju9) by [Unito](https://www.unito.io)
