### PR TITLE
feat/debug console host

### DIFF
--- a/bin/hummingbot.py
+++ b/bin/hummingbot.py
@@ -68,7 +68,8 @@ async def main():
 
             from hummingbot.core.management.console import start_management_console
             management_port: int = detect_available_port(8211)
-            tasks.append(start_management_console(locals(), host="localhost", port=management_port))
+            host: str = global_config_map.get("debug_console_host").value
+            tasks.append(start_management_console(locals(), host=host, port=management_port))
         await safe_gather(*tasks)
 
 

--- a/bin/hummingbot_quickstart.py
+++ b/bin/hummingbot_quickstart.py
@@ -117,7 +117,8 @@ async def quick_start(args):
         tasks: List[Coroutine] = [hb.run()]
         if global_config_map.get("debug_console").value:
             management_port: int = detect_available_port(8211)
-            tasks.append(start_management_console(locals(), host="localhost", port=management_port))
+            host: str = global_config_map.get("debug_console_host").value
+            tasks.append(start_management_console(locals(), host=host, port=management_port))
         await safe_gather(*tasks)
 
 

--- a/hummingbot/client/config/global_config_map.py
+++ b/hummingbot/client/config/global_config_map.py
@@ -80,6 +80,12 @@ main_config_map = {
                   type_str="bool",
                   required_if=lambda: False,
                   default=False),
+    "debug_console_host":
+        ConfigVar(key="debug_console_host",
+                  prompt=None,
+                  type_str="str",
+                  required_if=lambda: False,
+                  default="localhost"),
     "strategy_report_interval":
         ConfigVar(key="strategy_report_interval",
                   prompt=None,

--- a/hummingbot/templates/conf_global_TEMPLATE.yml
+++ b/hummingbot/templates/conf_global_TEMPLATE.yml
@@ -3,7 +3,7 @@
 #################################
 
 # For more detailed information: https://docs.hummingbot.io
-template_version: 31
+template_version: 32
 
 # Exchange configs
 

--- a/hummingbot/templates/conf_global_TEMPLATE.yml
+++ b/hummingbot/templates/conf_global_TEMPLATE.yml
@@ -172,6 +172,7 @@ send_error_logs: null
 instance_id: null
 log_level: INFO
 debug_console: false
+debug_console_host: localhost
 strategy_report_interval: 900.0
 logger_override_whitelist:
   - hummingbot.strategy.arbitrage


### PR DESCRIPTION
**A description of the changes proposed in the pull request**:

A variable called debug_console_host now appears in conf_global.yml, which is localhost by default but can be customized by the user. This only affects hummingbot when debug_console is enabled.

**Tests performed by the developer**:

Ran Hummingbot with and without the debug_console, and ensured that the debug console loaded correctly when this variable was changed to a different host.

**Tips for QA testing**:


