### PR TITLE
(feat) add ttyd and tmux  to dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,8 +103,11 @@ COPY --chown=hummingbot:hummingbot scripts/ scripts/
 
 # Install packages required in runtime
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y sudo libusb-1.0 && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y sudo libusb-1.0 curl tmux && \
     rm -rf /var/lib/apt/lists/*
+
+RUN curl -L https://github.com/tsl0922/ttyd/releases/download/1.6.3/ttyd.x86_64 -o /usr/local/bin/ttyd && chmod a+x /usr/local/bin/ttyd
+EXPOSE 7681
 
 # Switch to hummingbot user
 USER hummingbot:hummingbot

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -104,8 +104,11 @@ COPY --chown=hummingbot:hummingbot scripts/ scripts/
 
 # Install packages required in runtime
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y sudo libusb-1.0 libudev-dev libssl-dev && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y sudo libusb-1.0 libudev-dev libssl-dev curl tmux && \
     rm -rf /var/lib/apt/lists/*
+
+RUN curl -L https://github.com/tsl0922/ttyd/releases/download/1.6.3/ttyd.arm -o /usr/local/bin/ttyd && chmod a+x /usr/local/bin/ttyd
+EXPOSE 7681
 
 # Switch to hummingbot user
 USER hummingbot:hummingbot


### PR DESCRIPTION
Adds [ttyd](https://github.com/tsl0922/ttyd) to docker distribution. This doesn't change any existing functionality, but in future allows exposing TTY via browser to avoid `docker (kubectl) attach`.
```
CMD ttyd python bin/hummingbot_quickstart.py
```

UI could be exposed via usual HTTP(S) protocols, which makes it much easier to operate in orchestrators. 


![image](https://user-images.githubusercontent.com/779376/143576054-54f81acc-8d5c-4e74-98f4-6186b271df93.png)

P.S. I've prepared a Helm chart that relies on this potential functionality: https://github.com/DevopsCare/artifacts/tree/master/charts/hummingbot