### PR TITLE
fix/include str type in Prompt type

### DIFF
--- a/hummingbot/client/config/config_var.py
+++ b/hummingbot/client/config/config_var.py
@@ -6,14 +6,15 @@ by ConfigVar.
 
 from typing import (
     Optional,
-    Callable
+    Callable,
+    Union,
 )
 import inspect
 
 # function types passed into ConfigVar
 RequiredIf = Callable[[str], Optional[bool]]
 Validator = Callable[[str], Optional[str]]
-Prompt = Callable[[str], Optional[str]]
+Prompt = Union[Callable[[str], Optional[str]], str]
 OnValidated = Callable
 
 

--- a/hummingbot/client/config/config_var.py
+++ b/hummingbot/client/config/config_var.py
@@ -14,7 +14,7 @@ import inspect
 # function types passed into ConfigVar
 RequiredIf = Callable[[str], Optional[bool]]
 Validator = Callable[[str], Optional[str]]
-Prompt = Union[Callable[[str], Optional[str]], str]
+Prompt = Union[Callable[[str], Optional[str]], Optional[str]]
 OnValidated = Callable
 
 


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

There are examples that just use a normal `str` for `prompt`. However, built-in IDE type checkers get mad. This seems to be an inconsistency that can be resolved by including the `str` type as  a union.

**Tests performed by the developer**:



**Tips for QA testing**:


