### PR TITLE
docs/fix typo in developer strategy tutorial

### DIFF
--- a/documentation/docs/developers/strategies/tutorial.md
+++ b/documentation/docs/developers/strategies/tutorial.md
@@ -198,7 +198,7 @@ Both [StrategyPyBase](https://github.com/CoinAlpha/hummingbot/blob/master/hummin
 
 Lastly, we also need an additional file inside the templates folder, which acts as a placeholder for the strategy parameters. First, let’s navigate to the `templates` folder and create the file. Run the following commands.
 ```
-cd ~/hummingbot instance
+cd ~/hummingbot-instance
 cd hummingbot/templates
 touch conf_limit_order_strategy_TEMPLATE.yml  
 ```


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
I believe that `cd ~/hummingbot instance` should be `cd ~/hummingbot-instance` in this example.


**Tests performed by the developer**:



**Tips for QA testing**:
Please confirm that this change is consistent with other parts of this tutorial.


