### PR TITLE
Fix/trade monitor freezing

### DIFF
--- a/hummingbot/client/ui/interface_utils.py
+++ b/hummingbot/client/ui/interface_utils.py
@@ -60,15 +60,10 @@ async def start_trade_monitor(trade_monitor):
 
     while True:
         try:
-            hb.logger().debug(
-                f"Running start_trade_monitor loop: {hb.strategy_task}"
-                f" :: hb id = {id(hb)}, main app id = {id(HummingbotApplication.main_application())}"
-            )
             if hb.strategy_task is not None and not hb.strategy_task.done():
                 if all(market.ready for market in hb.markets.values()):
                     trades: List[TradeFill] = hb._get_trades_from_session(int(hb.init_time * 1e3),
                                                                           config_file_path=hb.strategy_file_name)
-                    hb.logger().debug(f"start_trade_monitor trades: {trades}")
                     if len(trades) > 0:
                         market_info: Set[Tuple[str, str]] = set((t.market, t.symbol) for t in trades)
                         for market, symbol in market_info:
@@ -89,4 +84,3 @@ async def start_trade_monitor(trade_monitor):
             await _sleep(2)  # sleeping for longer to manage resources
         except Exception:
             hb.logger().exception("start_trade_monitor failed.")
-            raise

--- a/hummingbot/client/ui/interface_utils.py
+++ b/hummingbot/client/ui/interface_utils.py
@@ -1,3 +1,4 @@
+import traceback
 from decimal import Decimal
 from typing import (
     Set,
@@ -59,25 +60,34 @@ async def start_trade_monitor(trade_monitor):
     pnls = []
 
     while True:
-        if hb.strategy_task is not None and not hb.strategy_task.done():
-            if all(market.ready for market in hb.markets.values()):
-                trades: List[TradeFill] = hb._get_trades_from_session(int(hb.init_time * 1e3),
-                                                                      config_file_path=hb.strategy_file_name)
-                if len(trades) > 0:
-                    market_info: Set[Tuple[str, str]] = set((t.market, t.symbol) for t in trades)
-                    for market, symbol in market_info:
-                        cur_trades = [t for t in trades if t.market == market and t.symbol == symbol]
-                        cur_balances = await hb.get_current_balances(market)
-                        perf = await PerformanceMetrics.create(market, symbol, cur_trades, cur_balances)
-                        return_pcts.append(perf.return_pct)
-                        pnls.append(perf.total_pnl)
-                    avg_return = sum(return_pcts) / len(return_pcts) if len(return_pcts) > 0 else s_decimal_0
-                    quote_assets = set(t.symbol.split("-")[1] for t in trades)
-                    if len(quote_assets) == 1:
-                        total_pnls = f"{PerformanceMetrics.smart_round(sum(pnls))} {list(quote_assets)[0]}"
-                    else:
-                        total_pnls = "N/A"
-                    trade_monitor.log(f"Trades: {len(trades)}, Total P&L: {total_pnls}, Return %: {avg_return:.2%}")
-                    return_pcts.clear()
-                    pnls.clear()
-        await _sleep(2)  # sleeping for longer to manage resources
+        try:
+            trade_monitor.log(
+                f"Running start_trade_monitor loop: {hb.strategy_task}, {hb.strategy_task.done()}"
+                f" :: hb id = {id(hb)}, main app id = {id(HummingbotApplication.main_application())}"
+            )
+            if hb.strategy_task is not None and not hb.strategy_task.done():
+                if all(market.ready for market in hb.markets.values()):
+                    trades: List[TradeFill] = hb._get_trades_from_session(int(hb.init_time * 1e3),
+                                                                          config_file_path=hb.strategy_file_name)
+                    trade_monitor.log(f"start_trade_monitor trades: {trades}")
+                    if len(trades) > 0:
+                        market_info: Set[Tuple[str, str]] = set((t.market, t.symbol) for t in trades)
+                        for market, symbol in market_info:
+                            cur_trades = [t for t in trades if t.market == market and t.symbol == symbol]
+                            cur_balances = await hb.get_current_balances(market)
+                            perf = await PerformanceMetrics.create(market, symbol, cur_trades, cur_balances)
+                            return_pcts.append(perf.return_pct)
+                            pnls.append(perf.total_pnl)
+                        avg_return = sum(return_pcts) / len(return_pcts) if len(return_pcts) > 0 else s_decimal_0
+                        quote_assets = set(t.symbol.split("-")[1] for t in trades)
+                        if len(quote_assets) == 1:
+                            total_pnls = f"{PerformanceMetrics.smart_round(sum(pnls))} {list(quote_assets)[0]}"
+                        else:
+                            total_pnls = "N/A"
+                        trade_monitor.log(f"Trades: {len(trades)}, Total P&L: {total_pnls}, Return %: {avg_return:.2%}")
+                        return_pcts.clear()
+                        pnls.clear()
+            await _sleep(2)  # sleeping for longer to manage resources
+        except Exception:
+            trade_monitor.log(f"start_trade_monitor failed.\n{traceback.format_exc()}")
+            raise

--- a/hummingbot/client/ui/interface_utils.py
+++ b/hummingbot/client/ui/interface_utils.py
@@ -1,4 +1,3 @@
-import traceback
 from decimal import Decimal
 from typing import (
     Set,
@@ -61,7 +60,7 @@ async def start_trade_monitor(trade_monitor):
 
     while True:
         try:
-            trade_monitor.log(
+            hb.logger().debug(
                 f"Running start_trade_monitor loop: {hb.strategy_task}, {hb.strategy_task.done()}"
                 f" :: hb id = {id(hb)}, main app id = {id(HummingbotApplication.main_application())}"
             )
@@ -69,7 +68,7 @@ async def start_trade_monitor(trade_monitor):
                 if all(market.ready for market in hb.markets.values()):
                     trades: List[TradeFill] = hb._get_trades_from_session(int(hb.init_time * 1e3),
                                                                           config_file_path=hb.strategy_file_name)
-                    trade_monitor.log(f"start_trade_monitor trades: {trades}")
+                    hb.logger().debug(f"start_trade_monitor trades: {trades}")
                     if len(trades) > 0:
                         market_info: Set[Tuple[str, str]] = set((t.market, t.symbol) for t in trades)
                         for market, symbol in market_info:
@@ -89,5 +88,5 @@ async def start_trade_monitor(trade_monitor):
                         pnls.clear()
             await _sleep(2)  # sleeping for longer to manage resources
         except Exception:
-            trade_monitor.log(f"start_trade_monitor failed.\n{traceback.format_exc()}")
+            hb.logger().exception("start_trade_monitor failed.")
             raise

--- a/hummingbot/client/ui/interface_utils.py
+++ b/hummingbot/client/ui/interface_utils.py
@@ -82,5 +82,7 @@ async def start_trade_monitor(trade_monitor):
                         return_pcts.clear()
                         pnls.clear()
             await _sleep(2)  # sleeping for longer to manage resources
+        except asyncio.CancelledError:
+            raise
         except Exception:
             hb.logger().exception("start_trade_monitor failed.")

--- a/hummingbot/client/ui/interface_utils.py
+++ b/hummingbot/client/ui/interface_utils.py
@@ -61,7 +61,7 @@ async def start_trade_monitor(trade_monitor):
     while True:
         try:
             hb.logger().debug(
-                f"Running start_trade_monitor loop: {hb.strategy_task}, {hb.strategy_task.done()}"
+                f"Running start_trade_monitor loop: {hb.strategy_task}"
                 f" :: hb id = {id(hb)}, main app id = {id(HummingbotApplication.main_application())}"
             )
             if hb.strategy_task is not None and not hb.strategy_task.done():

--- a/test/hummingbot/client/ui/test_interface_utils.py
+++ b/test/hummingbot/client/ui/test_interface_utils.py
@@ -1,6 +1,7 @@
 import unittest
 from decimal import Decimal
 import asyncio
+from typing import Awaitable
 from unittest.mock import patch, MagicMock, AsyncMock, PropertyMock
 from hummingbot.client.ui.interface_utils import start_trade_monitor, format_bytes, start_timer, start_process_monitor
 
@@ -10,6 +11,23 @@ class ExpectedException(Exception):
 
 
 class InterfaceUtilsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.ev_loop = asyncio.get_event_loop()
+        self.return_queue = asyncio.Queue()
+        self.done_event = asyncio.Event()
+
+    def async_run_with_timeout(self, coroutine: Awaitable, timeout: float = 1):
+        ret = self.ev_loop.run_until_complete(asyncio.wait_for(coroutine, timeout))
+        return ret
+
+    async def return_until_empty_then_signal_done_and_release_loop(self, *args, **kwargs):
+        if not self.return_queue.empty():
+            ret = self.return_queue.get_nowait()
+        else:
+            self.done_event.set()
+            await asyncio.sleep(0.3)  # simply to release loop — the 0.3 seconds are not actually awaited
+        return ret
 
     def test_format_bytes(self):
         size = 1024.
@@ -19,9 +37,11 @@ class InterfaceUtilsTest(unittest.TestCase):
     @patch("hummingbot.client.ui.interface_utils._sleep", new_callable=AsyncMock)
     def test_start_timer(self, mock_sleep):
         mock_timer = MagicMock()
-        mock_sleep.side_effect = [None, ExpectedException()]
-        with self.assertRaises(ExpectedException):
-            asyncio.get_event_loop().run_until_complete(start_timer(mock_timer))
+        self.return_queue.put_nowait(None)
+        mock_sleep.side_effect = self.return_until_empty_then_signal_done_and_release_loop
+        task = self.ev_loop.create_task(start_timer(mock_timer))
+        self.async_run_with_timeout(self.done_event.wait())
+        task.cancel()
         self.assertEqual('Duration: 0:00:02', mock_timer.log.call_args_list[0].args[0])
         self.assertEqual('Duration: 0:00:03', mock_timer.log.call_args_list[1].args[0])
 
@@ -37,9 +57,10 @@ class InterfaceUtilsTest(unittest.TestCase):
 
         mock_process.return_value.memory_info.return_value = memory_info
         mock_monitor = MagicMock()
-        mock_sleep.side_effect = ExpectedException()
-        with self.assertRaises(ExpectedException):
-            asyncio.get_event_loop().run_until_complete(start_process_monitor(mock_monitor))
+        mock_sleep.side_effect = self.return_until_empty_then_signal_done_and_release_loop
+        task = self.ev_loop.create_task(start_process_monitor(mock_monitor))
+        self.async_run_with_timeout(self.done_event.wait())
+        task.cancel()
         self.assertEqual(
             "CPU:    30%, Mem:   512.00 B (1.00 KB), Threads:   2, ",
             mock_monitor.log.call_args_list[0].args[0])
@@ -56,9 +77,11 @@ class InterfaceUtilsTest(unittest.TestCase):
         mock_app.get_current_balances = AsyncMock()
         mock_perf.side_effect = [MagicMock(return_pct=Decimal("0.01"), total_pnl=Decimal("2")),
                                  MagicMock(return_pct=Decimal("0.02"), total_pnl=Decimal("2"))]
-        mock_sleep.side_effect = [None, ExpectedException()]
-        with self.assertRaises(ExpectedException):
-            asyncio.get_event_loop().run_until_complete(start_trade_monitor(mock_result))
+        self.return_queue.put_nowait(None)
+        mock_sleep.side_effect = self.return_until_empty_then_signal_done_and_release_loop
+        task = self.ev_loop.create_task(start_trade_monitor(mock_result))
+        self.async_run_with_timeout(self.done_event.wait())
+        task.cancel()
         self.assertEqual(3, mock_result.log.call_count)
         self.assertEqual('Trades: 0, Total P&L: 0.00, Return %: 0.00%', mock_result.log.call_args_list[0].args[0])
         self.assertEqual('Trades: 1, Total P&L: 2.00 USDT, Return %: 1.00%', mock_result.log.call_args_list[1].args[0])
@@ -79,9 +102,10 @@ class InterfaceUtilsTest(unittest.TestCase):
         mock_app.get_current_balances = AsyncMock()
         mock_perf.side_effect = [MagicMock(return_pct=Decimal("0.01"), total_pnl=Decimal("2")),
                                  MagicMock(return_pct=Decimal("0.02"), total_pnl=Decimal("3"))]
-        mock_sleep.side_effect = ExpectedException()
-        with self.assertRaises(ExpectedException):
-            asyncio.get_event_loop().run_until_complete(start_trade_monitor(mock_result))
+        mock_sleep.side_effect = self.return_until_empty_then_signal_done_and_release_loop
+        task = self.ev_loop.create_task(start_trade_monitor(mock_result))
+        self.async_run_with_timeout(self.done_event.wait())
+        task.cancel()
         self.assertEqual(2, mock_result.log.call_count)
         self.assertEqual('Trades: 0, Total P&L: 0.00, Return %: 0.00%', mock_result.log.call_args_list[0].args[0])
         self.assertEqual('Trades: 2, Total P&L: N/A, Return %: 1.50%', mock_result.log.call_args_list[1].args[0])
@@ -101,9 +125,10 @@ class InterfaceUtilsTest(unittest.TestCase):
         mock_app.get_current_balances = AsyncMock()
         mock_perf.side_effect = [MagicMock(return_pct=Decimal("0.01"), total_pnl=Decimal("2")),
                                  MagicMock(return_pct=Decimal("0.02"), total_pnl=Decimal("3"))]
-        mock_sleep.side_effect = ExpectedException()
-        with self.assertRaises(ExpectedException):
-            asyncio.get_event_loop().run_until_complete(start_trade_monitor(mock_result))
+        mock_sleep.side_effect = self.return_until_empty_then_signal_done_and_release_loop
+        task = self.ev_loop.create_task(start_trade_monitor(mock_result))
+        self.async_run_with_timeout(self.done_event.wait())
+        task.cancel()
         self.assertEqual(2, mock_result.log.call_count)
         self.assertEqual('Trades: 0, Total P&L: 0.00, Return %: 0.00%', mock_result.log.call_args_list[0].args[0])
         self.assertEqual('Trades: 2, Total P&L: 5.00 USDT, Return %: 1.50%', mock_result.log.call_args_list[1].args[0])
@@ -115,9 +140,10 @@ class InterfaceUtilsTest(unittest.TestCase):
         mock_app = mock_hb_app.main_application()
         mock_app.strategy_task.done.return_value = False
         mock_app.markets.return_values = {"a": MagicMock(ready=False)}
-        mock_sleep.side_effect = ExpectedException()
-        with self.assertRaises(ExpectedException):
-            asyncio.get_event_loop().run_until_complete(start_trade_monitor(mock_result))
+        mock_sleep.side_effect = self.return_until_empty_then_signal_done_and_release_loop
+        task = self.ev_loop.create_task(start_trade_monitor(mock_result))
+        self.async_run_with_timeout(self.done_event.wait())
+        task.cancel()
         self.assertEqual(1, mock_result.log.call_count)
         self.assertEqual('Trades: 0, Total P&L: 0.00, Return %: 0.00%', mock_result.log.call_args_list[0].args[0])
 
@@ -129,8 +155,21 @@ class InterfaceUtilsTest(unittest.TestCase):
         mock_app.strategy_task.done.return_value = False
         mock_app.markets.return_values = {"a": MagicMock(ready=True)}
         mock_app._get_trades_from_session.return_value = []
-        mock_sleep.side_effect = ExpectedException()
-        with self.assertRaises(ExpectedException):
-            asyncio.get_event_loop().run_until_complete(start_trade_monitor(mock_result))
+        mock_sleep.side_effect = self.return_until_empty_then_signal_done_and_release_loop
+        task = self.ev_loop.create_task(start_trade_monitor(mock_result))
+        self.async_run_with_timeout(self.done_event.wait())
+        task.cancel()
         self.assertEqual(1, mock_result.log.call_count)
         self.assertEqual('Trades: 0, Total P&L: 0.00, Return %: 0.00%', mock_result.log.call_args_list[0].args[0])
+
+    @patch("hummingbot.client.ui.interface_utils._sleep", new_callable=AsyncMock)
+    @patch("hummingbot.client.hummingbot_application.HummingbotApplication")
+    def test_start_trade_monitor_loop_continues_on_failure(self, mock_hb_app, mock_sleep):
+        mock_result = MagicMock()
+        mock_app = mock_hb_app.main_application()
+        mock_app.strategy_task.done.side_effect = [RuntimeError(), True]
+        mock_sleep.side_effect = self.return_until_empty_then_signal_done_and_release_loop
+        task = self.ev_loop.create_task(start_trade_monitor(mock_result))
+        self.async_run_with_timeout(self.done_event.wait())
+        task.cancel()
+        self.assertEqual(2, mock_app.strategy_task.done.call_count)  # was called again after exception

--- a/test/hummingbot/client/ui/test_interface_utils.py
+++ b/test/hummingbot/client/ui/test_interface_utils.py
@@ -14,19 +14,9 @@ class InterfaceUtilsTest(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
         self.ev_loop = asyncio.get_event_loop()
-        self.return_queue = asyncio.Queue()
-        self.done_event = asyncio.Event()
 
     def async_run_with_timeout(self, coroutine: Awaitable, timeout: float = 1):
         ret = self.ev_loop.run_until_complete(asyncio.wait_for(coroutine, timeout))
-        return ret
-
-    async def return_until_empty_then_signal_done_and_release_loop(self, *args, **kwargs):
-        if not self.return_queue.empty():
-            ret = self.return_queue.get_nowait()
-        else:
-            self.done_event.set()
-            await asyncio.sleep(0.3)  # simply to release loop — the 0.3 seconds are not actually awaited
         return ret
 
     def test_format_bytes(self):
@@ -37,11 +27,9 @@ class InterfaceUtilsTest(unittest.TestCase):
     @patch("hummingbot.client.ui.interface_utils._sleep", new_callable=AsyncMock)
     def test_start_timer(self, mock_sleep):
         mock_timer = MagicMock()
-        self.return_queue.put_nowait(None)
-        mock_sleep.side_effect = self.return_until_empty_then_signal_done_and_release_loop
-        task = self.ev_loop.create_task(start_timer(mock_timer))
-        self.async_run_with_timeout(self.done_event.wait())
-        task.cancel()
+        mock_sleep.side_effect = [None, ExpectedException()]
+        with self.assertRaises(ExpectedException):
+            self.async_run_with_timeout(start_timer(mock_timer))
         self.assertEqual('Duration: 0:00:02', mock_timer.log.call_args_list[0].args[0])
         self.assertEqual('Duration: 0:00:03', mock_timer.log.call_args_list[1].args[0])
 
@@ -57,10 +45,9 @@ class InterfaceUtilsTest(unittest.TestCase):
 
         mock_process.return_value.memory_info.return_value = memory_info
         mock_monitor = MagicMock()
-        mock_sleep.side_effect = self.return_until_empty_then_signal_done_and_release_loop
-        task = self.ev_loop.create_task(start_process_monitor(mock_monitor))
-        self.async_run_with_timeout(self.done_event.wait())
-        task.cancel()
+        mock_sleep.side_effect = ExpectedException()
+        with self.assertRaises(ExpectedException):
+            self.async_run_with_timeout(start_process_monitor(mock_monitor))
         self.assertEqual(
             "CPU:    30%, Mem:   512.00 B (1.00 KB), Threads:   2, ",
             mock_monitor.log.call_args_list[0].args[0])
@@ -77,11 +64,9 @@ class InterfaceUtilsTest(unittest.TestCase):
         mock_app.get_current_balances = AsyncMock()
         mock_perf.side_effect = [MagicMock(return_pct=Decimal("0.01"), total_pnl=Decimal("2")),
                                  MagicMock(return_pct=Decimal("0.02"), total_pnl=Decimal("2"))]
-        self.return_queue.put_nowait(None)
-        mock_sleep.side_effect = self.return_until_empty_then_signal_done_and_release_loop
-        task = self.ev_loop.create_task(start_trade_monitor(mock_result))
-        self.async_run_with_timeout(self.done_event.wait())
-        task.cancel()
+        mock_sleep.side_effect = [None, asyncio.CancelledError()]
+        with self.assertRaises(asyncio.CancelledError):
+            self.async_run_with_timeout(start_trade_monitor(mock_result))
         self.assertEqual(3, mock_result.log.call_count)
         self.assertEqual('Trades: 0, Total P&L: 0.00, Return %: 0.00%', mock_result.log.call_args_list[0].args[0])
         self.assertEqual('Trades: 1, Total P&L: 2.00 USDT, Return %: 1.00%', mock_result.log.call_args_list[1].args[0])
@@ -102,10 +87,9 @@ class InterfaceUtilsTest(unittest.TestCase):
         mock_app.get_current_balances = AsyncMock()
         mock_perf.side_effect = [MagicMock(return_pct=Decimal("0.01"), total_pnl=Decimal("2")),
                                  MagicMock(return_pct=Decimal("0.02"), total_pnl=Decimal("3"))]
-        mock_sleep.side_effect = self.return_until_empty_then_signal_done_and_release_loop
-        task = self.ev_loop.create_task(start_trade_monitor(mock_result))
-        self.async_run_with_timeout(self.done_event.wait())
-        task.cancel()
+        mock_sleep.side_effect = asyncio.CancelledError()
+        with self.assertRaises(asyncio.CancelledError):
+            self.async_run_with_timeout(start_trade_monitor(mock_result))
         self.assertEqual(2, mock_result.log.call_count)
         self.assertEqual('Trades: 0, Total P&L: 0.00, Return %: 0.00%', mock_result.log.call_args_list[0].args[0])
         self.assertEqual('Trades: 2, Total P&L: N/A, Return %: 1.50%', mock_result.log.call_args_list[1].args[0])
@@ -125,10 +109,9 @@ class InterfaceUtilsTest(unittest.TestCase):
         mock_app.get_current_balances = AsyncMock()
         mock_perf.side_effect = [MagicMock(return_pct=Decimal("0.01"), total_pnl=Decimal("2")),
                                  MagicMock(return_pct=Decimal("0.02"), total_pnl=Decimal("3"))]
-        mock_sleep.side_effect = self.return_until_empty_then_signal_done_and_release_loop
-        task = self.ev_loop.create_task(start_trade_monitor(mock_result))
-        self.async_run_with_timeout(self.done_event.wait())
-        task.cancel()
+        mock_sleep.side_effect = asyncio.CancelledError()
+        with self.assertRaises(asyncio.CancelledError):
+            self.async_run_with_timeout(start_trade_monitor(mock_result))
         self.assertEqual(2, mock_result.log.call_count)
         self.assertEqual('Trades: 0, Total P&L: 0.00, Return %: 0.00%', mock_result.log.call_args_list[0].args[0])
         self.assertEqual('Trades: 2, Total P&L: 5.00 USDT, Return %: 1.50%', mock_result.log.call_args_list[1].args[0])
@@ -140,10 +123,9 @@ class InterfaceUtilsTest(unittest.TestCase):
         mock_app = mock_hb_app.main_application()
         mock_app.strategy_task.done.return_value = False
         mock_app.markets.return_values = {"a": MagicMock(ready=False)}
-        mock_sleep.side_effect = self.return_until_empty_then_signal_done_and_release_loop
-        task = self.ev_loop.create_task(start_trade_monitor(mock_result))
-        self.async_run_with_timeout(self.done_event.wait())
-        task.cancel()
+        mock_sleep.side_effect = asyncio.CancelledError()
+        with self.assertRaises(asyncio.CancelledError):
+            self.async_run_with_timeout(start_trade_monitor(mock_result))
         self.assertEqual(1, mock_result.log.call_count)
         self.assertEqual('Trades: 0, Total P&L: 0.00, Return %: 0.00%', mock_result.log.call_args_list[0].args[0])
 
@@ -155,10 +137,9 @@ class InterfaceUtilsTest(unittest.TestCase):
         mock_app.strategy_task.done.return_value = False
         mock_app.markets.return_values = {"a": MagicMock(ready=True)}
         mock_app._get_trades_from_session.return_value = []
-        mock_sleep.side_effect = self.return_until_empty_then_signal_done_and_release_loop
-        task = self.ev_loop.create_task(start_trade_monitor(mock_result))
-        self.async_run_with_timeout(self.done_event.wait())
-        task.cancel()
+        mock_sleep.side_effect = asyncio.CancelledError()
+        with self.assertRaises(asyncio.CancelledError):
+            self.async_run_with_timeout(start_trade_monitor(mock_result))
         self.assertEqual(1, mock_result.log.call_count)
         self.assertEqual('Trades: 0, Total P&L: 0.00, Return %: 0.00%', mock_result.log.call_args_list[0].args[0])
 
@@ -167,9 +148,7 @@ class InterfaceUtilsTest(unittest.TestCase):
     def test_start_trade_monitor_loop_continues_on_failure(self, mock_hb_app, mock_sleep):
         mock_result = MagicMock()
         mock_app = mock_hb_app.main_application()
-        mock_app.strategy_task.done.side_effect = [RuntimeError(), True]
-        mock_sleep.side_effect = self.return_until_empty_then_signal_done_and_release_loop
-        task = self.ev_loop.create_task(start_trade_monitor(mock_result))
-        self.async_run_with_timeout(self.done_event.wait())
-        task.cancel()
+        mock_app.strategy_task.done.side_effect = [RuntimeError(), asyncio.CancelledError()]
+        with self.assertRaises(asyncio.CancelledError):
+            self.async_run_with_timeout(start_trade_monitor(mock_result))
         self.assertEqual(2, mock_app.strategy_task.done.call_count)  # was called again after exception

--- a/test/hummingbot/client/ui/test_interface_utils.py
+++ b/test/hummingbot/client/ui/test_interface_utils.py
@@ -45,8 +45,8 @@ class InterfaceUtilsTest(unittest.TestCase):
 
         mock_process.return_value.memory_info.return_value = memory_info
         mock_monitor = MagicMock()
-        mock_sleep.side_effect = ExpectedException()
-        with self.assertRaises(ExpectedException):
+        mock_sleep.side_effect = asyncio.CancelledError
+        with self.assertRaises(asyncio.CancelledError):
             self.async_run_with_timeout(start_process_monitor(mock_monitor))
         self.assertEqual(
             "CPU:    30%, Mem:   512.00 B (1.00 KB), Threads:   2, ",


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [X] Your code builds clean without any errors or warnings
- [X] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
The issue is due to various exchanges sporadically failing to fetch the last traded prices which causes the loop to fail entirely. The solution is simply to log the exception and continue looping. Addressing the individual exchanges' sporadic issues should happen in separate tasks.


**Tests performed by the developer**:
- Adapts the existing test cases and adds new one for the fix.


**Tips for QA testing**:
Same testing procedure as performed so far.

