### PR TITLE
fix/hedge - maker market order book initialization error

### DIFF
--- a/hummingbot/strategy/hedge/hedge.pyx
+++ b/hummingbot/strategy/hedge/hedge.pyx
@@ -71,7 +71,7 @@ cdef class HedgeStrategy(StrategyBase):
         self._status_report_interval = status_report_interval
         self._position_mode = PositionMode.HEDGE if position_mode == "Hedge" else PositionMode.ONEWAY
         self._leverage = leverage
-        self.c_add_markets([exchanges.maker, exchanges.taker])
+        self.c_add_markets([exchanges.taker])
         self._last_trade_time = {}
         self._shadow_taker_balance = {}
         self._update_shadow_balance_interval = 600

--- a/hummingbot/strategy/hedge/start.py
+++ b/hummingbot/strategy/hedge/start.py
@@ -1,3 +1,4 @@
+from hummingbot.client.settings import AllConnectorSettings
 from hummingbot.strategy.market_trading_pair_tuple import MarketTradingPairTuple
 from hummingbot.strategy.hedge.hedge_config_map import hedge_config_map as c_map
 from hummingbot.strategy.hedge.hedge import HedgeStrategy
@@ -17,7 +18,8 @@ def start(self):
     max_order_age = c_map.get("max_order_age").value
     minimum_trade = c_map.get("minimum_trade").value
     hedge_interval = c_map.get("hedge_interval").value
-    self._initialize_markets([(maker_exchange, []), (taker_exchange, taker_markets)])
+    example_maker_pair = AllConnectorSettings.get_example_pairs().get(maker_exchange)
+    self._initialize_markets([(maker_exchange, [example_maker_pair]), (taker_exchange, taker_markets)])
     exchanges = ExchangePairTuple(maker=self.markets[maker_exchange], taker=self.markets[taker_exchange])
 
     market_infos = {}


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
remove unnecessary market initialization and add example maker pair to trading pair initialization
This is done to fix the order book error for some connectors.
This implementation feels hacky and I would love to have feedback if there is an alternative way to initialize the connector without the order book.

**Tests performed by the developer**:
Test working using taker: Binance Perpetual and Maker: Ascendex and Binance

**Tips for QA testing**:

```
Log File
2022-01-08 06:30:02,507 - 90708 - hummingbot.connector.exchange.binance.binance_api_order_book_data_source - ERROR - Unexpected error with WebSocket connection. Retrying after 30 seconds...
Traceback (most recent call last):
  File "/root/mm10/hummingbot/connector/exchange/binance/binance_api_order_book_data_source.py", line 195, in listen_for_trades
    trade_msg: OrderBookMessage = BinanceOrderBook.trade_message_from_exchange(json_msg)
  File "hummingbot/connector/exchange/binance/binance_order_book.pyx", line 130, in hummingbot.connector.exchange.binance.binance_order_book.BinanceOrderBook.trade_message_from_exchange
    ts = msg["E"]
KeyError: 'E'
2022-01-08 06:30:02,510 - 90708 - hummingbot.connector.exchange.binance.binance_api_order_book_data_source - ERROR - Unexpected error with WebSocket connection. Retrying after 30 seconds...
Traceback (most recent call last):
  File "/root/mm10/hummingbot/connector/exchange/binance/binance_api_order_book_data_source.py", line 225, in listen_for_order_book_diffs
    order_book_message: OrderBookMessage = BinanceOrderBook.diff_message_from_exchange(
  File "hummingbot/connector/exchange/binance/binance_order_book.pyx", line 54, in hummingbot.connector.exchange.binance.binance_order_book.BinanceOrderBook.diff_message_from_exchange
    "trading_pair": binance_utils.convert_from_exchange_trading_pair(msg["s"]),
```
