### PR TITLE
Fix/Avellaneda MM - Randomly appearing RunTimeWarning on the log pane

### DIFF
--- a/hummingbot/strategy/__utils__/trailing_indicators/trading_intensity.pyx
+++ b/hummingbot/strategy/__utils__/trailing_indicators/trading_intensity.pyx
@@ -120,7 +120,12 @@ cdef class TradingIntensityIndicator():
 
         # Fit the probability density function; reuse previously calculated parameters as initial values
         try:
-            params = curve_fit(lambda t, a, b: a*np.exp(-b*t), price_levels, lambdas_adj, p0=(self._alpha, self._kappa), method='dogbox')
+            params = curve_fit(lambda t, a, b: a*np.exp(-b*t),
+                               price_levels,
+                               lambdas_adj,
+                               p0=(self._alpha, self._kappa),
+                               method='dogbox',
+                               bounds=([0, 0], [np.inf, np.inf]))
 
             self._kappa = Decimal(str(params[0][1]))
             self._alpha = Decimal(str(params[0][0]))


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

- bounds specified for the scipy curve_fit parameters

Possible values of the curve parameters have to be restricted so that invalid values are not supplied to the equations. This also solves another issue where kappa and alpha become negative if the quality of collected order book data is low, either due to short buffer length settings, or other factors. The values need to be restricted to a range so that they make sense, and so that the probability density function is always approximated by an inverted logarithm.

This is a fix for the issue:
https://github.com/hummingbot/hummingbot/issues/4914

**Tests performed by the developer**:

- ran the strategy with binance paper and the AXS-USDT
- ran unit tests
