### PR TITLE
Fix/Avellaneda - Verify the eta parameter

### DIFF
--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
@@ -1085,7 +1085,17 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
         if (self._order_override is None) or (len(self._order_override) == 0):
             # eta parameter is described in the paper as the shape parameter for having exponentially decreasing order amount
             # for orders that go against inventory target (i.e. Want to buy when excess inventory or sell when deficit inventory)
-            q = market.get_balance(self.base_asset) - self.c_calculate_target_inventory()
+
+            # q cannot be in absolute values - cannot be dependent on the size of the inventory or amount of base asset
+            # because it's a scaling factor
+            inventory = Decimal(str(self.c_calculate_inventory()))
+
+            if inventory == 0:
+                return
+
+            q_target = Decimal(str(self.c_calculate_target_inventory()))
+            q = (market.get_balance(self.base_asset) - q_target) / (inventory)
+
             if len(proposal.buys) > 0:
                 if q > 0:
                     for i, proposed in enumerate(proposal.buys):


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

While reviewing the implementation and use of the eta parameter I came across this problem.

Currently the order sizes are calculated based on the eta parameter and the amount of base asset. The problem is that it depends on the absolute amount of the base asset. That means if the client trades with less assets, it will calculate a different order size given that the target and the current state of the portfolio allocation are the same. The sizing of orders should not depend on absolute value of assets but on their relative amount in comparison to the target.

**Tests performed by the developer**:

* Ran unit tests
* Ran the strategy with binance paper and setting the eta to 0.5
