### PR TITLE
 Feat/ PMM - Split and allow multiple order level spread 

### DIFF
--- a/hummingbot/strategy/pure_market_making/pure_market_making.pxd
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pxd
@@ -16,6 +16,9 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         int _order_levels
         int _buy_levels
         int _sell_levels
+        object _split_order_levels_enabled
+        object _bid_order_level_spreads
+        object _ask_order_level_spreads
         object _order_level_spread
         object _order_level_amount
         double _order_refresh_time

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pyx
@@ -971,7 +971,7 @@ cdef class PureMarketMakingStrategy(StrategyBase):
             lower_buy_price = min(proposal.buys[0].price, price_above_bid)
             for i, proposed in enumerate(proposal.buys):
                 if self._split_order_levels_enabled:
-                    proposal.buys[i].price = market.c_quantize_order_price(self.trading_pair, lower_buy_price) * (1 - self._bid_order_level_spreads[i])
+                    proposal.buys[i].price = market.c_quantize_order_price(self.trading_pair, lower_buy_price) * (1 - self._bid_order_level_spreads[i] / Decimal("100"))
                     continue
                 proposal.buys[i].price = market.c_quantize_order_price(self.trading_pair, lower_buy_price) * (1 - self.order_level_spread * i)
 
@@ -992,7 +992,7 @@ cdef class PureMarketMakingStrategy(StrategyBase):
             higher_sell_price = max(proposal.sells[0].price, price_below_ask)
             for i, proposed in enumerate(proposal.sells):
                 if self._split_order_levels_enabled:
-                    proposal.buys[i].price = market.c_quantize_order_price(self.trading_pair, lower_buy_price) * (1 - self._ask_order_level_spreads[i])
+                    proposal.sells[i].price = market.c_quantize_order_price(self.trading_pair, higher_sell_price) * (1 - self._ask_order_level_spreads[i] / Decimal("100"))
                     continue
                 proposal.sells[i].price = market.c_quantize_order_price(self.trading_pair, higher_sell_price) * (1 + self.order_level_spread * i)
 

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pyx
@@ -93,6 +93,9 @@ cdef class PureMarketMakingStrategy(StrategyBase):
                     minimum_spread: Decimal = Decimal(0),
                     hb_app_notification: bool = False,
                     order_override: Dict[str, List[str]] = None,
+                    split_order_levels_enabled: bool = False,
+                    bid_order_level_spreads: List[Decimal] = None,
+                    ask_order_level_spreads: List[Decimal] = None,
                     should_wait_order_cancel_confirmation = True,
                     ):
         if order_override is None:
@@ -133,7 +136,9 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         self._ping_pong_warning_lines = []
         self._hb_app_notification = hb_app_notification
         self._order_override = order_override
-
+        self._split_order_levels_enabled=split_order_levels_enabled
+        self._bid_order_level_spreads=bid_order_level_spreads
+        self._ask_order_level_spreads=ask_order_level_spreads
         self._cancel_timestamp = 0
         self._create_timestamp = 0
         self._limit_order_type = self._market_info.market.get_maker_order_type()
@@ -965,6 +970,9 @@ cdef class PureMarketMakingStrategy(StrategyBase):
             proposal.buys = sorted(proposal.buys, key = lambda p: p.price, reverse = True)
             lower_buy_price = min(proposal.buys[0].price, price_above_bid)
             for i, proposed in enumerate(proposal.buys):
+                if self._split_order_levels_enabled:
+                    proposal.buys[i].price = market.c_quantize_order_price(self.trading_pair, lower_buy_price) * (1 - self._bid_order_level_spreads[i])
+                    continue
                 proposal.buys[i].price = market.c_quantize_order_price(self.trading_pair, lower_buy_price) * (1 - self.order_level_spread * i)
 
         if len(proposal.sells) > 0:
@@ -983,6 +991,9 @@ cdef class PureMarketMakingStrategy(StrategyBase):
             proposal.sells = sorted(proposal.sells, key = lambda p: p.price)
             higher_sell_price = max(proposal.sells[0].price, price_below_ask)
             for i, proposed in enumerate(proposal.sells):
+                if self._split_order_levels_enabled:
+                    proposal.buys[i].price = market.c_quantize_order_price(self.trading_pair, lower_buy_price) * (1 - self._ask_order_level_spreads[i])
+                    continue
                 proposal.sells[i].price = market.c_quantize_order_price(self.trading_pair, higher_sell_price) * (1 + self.order_level_spread * i)
 
     cdef object c_apply_add_transaction_costs(self, object proposal):

--- a/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
+++ b/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
@@ -371,7 +371,7 @@ pure_market_making_config_map = {
     "split_order_levels_enabled":
         ConfigVar(key="split_order_levels_enabled",
                   prompt="Enable splitting and multiple different order levels spread and amount. "
-                         "This override order_overrides >>> ",
+                         "This acts as an order overrides which replaces order_amount, order_spreads, order_level_amount, order_level_spreads >>> ",
                   default=False,
                   type_str="bool",
                   validator=validate_bool),

--- a/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
+++ b/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
@@ -108,7 +108,7 @@ def exchange_on_validated(value: str):
     required_exchanges.append(value)
 
 
-def validate_decimal_list(value: str, config: str) -> Optional[str]:
+def validate_decimal_list(value: str) -> Optional[str]:
     decimal_list = list(value.split(","))
     for number in decimal_list:
         try:
@@ -385,7 +385,7 @@ pure_market_making_config_map = {
                   type_str="str",
                   required_if=lambda: pure_market_making_config_map.get(
                       "split_order_levels_enabled").value,
-                  validator=lambda v: validate_decimal_list(v, "bid_order_level_spreads")),
+                  validator=validate_decimal_list),
     "ask_order_level_spreads":
         ConfigVar(key="ask_order_level_spreads",
                   prompt="Enter the spreads (as percentage) for all ask spreads "
@@ -396,7 +396,7 @@ pure_market_making_config_map = {
                   type_str="str",
                   required_if=lambda: pure_market_making_config_map.get(
                       "split_order_levels_enabled").value,
-                  validator=lambda v: validate_decimal_list(v, "ask_order_level_spreads")),
+                  validator=validate_decimal_list),
     "bid_order_level_amounts":
         ConfigVar(key="bid_order_level_amounts",
                   prompt="Enter the amount for all bid amounts. "
@@ -407,7 +407,7 @@ pure_market_making_config_map = {
                   type_str="str",
                   required_if=lambda: pure_market_making_config_map.get(
                       "split_order_levels_enabled").value,
-                  validator=lambda v: validate_decimal_list(v, "bid_order_level_amounts")),
+                  validator=validate_decimal_list),
     "ask_order_level_amounts":
         ConfigVar(key="ask_order_level_amounts",
                   prompt="Enter the amount for all ask amounts. "
@@ -418,5 +418,5 @@ pure_market_making_config_map = {
                   required_if=lambda: pure_market_making_config_map.get(
                       "split_order_levels_enabled").value,
                   type_str="str",
-                  validator=lambda v: validate_decimal_list(v, "ask_order_level_amounts")),
+                  validator=validate_decimal_list),
 }

--- a/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
+++ b/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
@@ -370,8 +370,9 @@ pure_market_making_config_map = {
                   validator=validate_bool),
     "split_order_levels_enabled":
         ConfigVar(key="split_order_levels_enabled",
-                  prompt="Enable splitting and multiple different order levels spread and amount. "
-                         "This acts as an order overrides which replaces order_amount, order_spreads, order_level_amount, order_level_spreads >>> ",
+                  prompt="Do you want bid and ask orders to be placed at multiple defined spread and amount? "
+                         "(This acts as an overrides which replaces order_amount, order_spreads, "
+                         "order_level_amount, order_level_spreads) (Yes/No) >>> ",
                   default=False,
                   type_str="bool",
                   validator=validate_bool),

--- a/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
+++ b/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-
+import decimal
 from hummingbot.client.config.config_var import ConfigVar
 from hummingbot.client.config.config_validators import (
     validate_exchange,
@@ -106,6 +106,17 @@ def on_validated_price_type(value: str):
 
 def exchange_on_validated(value: str):
     required_exchanges.append(value)
+
+
+def validate_decimal_list(value: str, config: str) -> Optional[str]:
+    decimal_list = list(value.split(","))
+    for number in decimal_list:
+        try:
+            validate_result = validate_decimal(Decimal(number), 0, 100, inclusive=False)
+        except decimal.InvalidOperation:
+            return "Please enter valid decimal numbers"
+        if validate_result is not None:
+            return validate_result
 
 
 pure_market_making_config_map = {
@@ -357,4 +368,55 @@ pure_market_making_config_map = {
                   type_str="bool",
                   default=True,
                   validator=validate_bool),
+    "split_order_levels_enabled":
+        ConfigVar(key="split_order_levels_enabled",
+                  prompt="Enable splitting and multiple different order levels spread and amount. "
+                         "This override order_overrides >>> ",
+                  default=False,
+                  type_str="bool",
+                  validator=validate_bool),
+    "bid_order_level_spreads":
+        ConfigVar(key="bid_order_level_spreads",
+                  prompt="Enter the spreads (as percentage) for all bid spreads "
+                         "e.g 1,2,3,4 to represent 1%,2%,3%,4%. "
+                         "The number of levels set will be equal to the "
+                         "minimum length of bid_order_level_spreads and bid_order_level_amounts >>> ",
+                  default=None,
+                  type_str="str",
+                  required_if=lambda: pure_market_making_config_map.get(
+                      "split_order_levels_enabled").value,
+                  validator=lambda v: validate_decimal_list(v, "bid_order_level_spreads")),
+    "ask_order_level_spreads":
+        ConfigVar(key="ask_order_level_spreads",
+                  prompt="Enter the spreads (as percentage) for all ask spreads "
+                         "e.g 1,2,3,4 to represent 1%,2%,3%,4%. "
+                         "The number of levels set will be equal to the "
+                         "minimum length of bid_order_level_spreads and bid_order_level_amounts >>> ",
+                  default=None,
+                  type_str="str",
+                  required_if=lambda: pure_market_making_config_map.get(
+                      "split_order_levels_enabled").value,
+                  validator=lambda v: validate_decimal_list(v, "ask_order_level_spreads")),
+    "bid_order_level_amounts":
+        ConfigVar(key="bid_order_level_amounts",
+                  prompt="Enter the amount for all bid amounts. "
+                         "e.g 1,2,3,4. "
+                         "The number of levels set will be equal to the "
+                         "minimum length of bid_order_level_spreads and bid_order_level_amounts >>> ",
+                  default=None,
+                  type_str="str",
+                  required_if=lambda: pure_market_making_config_map.get(
+                      "split_order_levels_enabled").value,
+                  validator=lambda v: validate_decimal_list(v, "bid_order_level_amounts")),
+    "ask_order_level_amounts":
+        ConfigVar(key="ask_order_level_amounts",
+                  prompt="Enter the amount for all ask amounts. "
+                         "e.g 1,2,3,4. "
+                         "The number of levels set will be equal to the "
+                         "minimum length of bid_order_level_spreads and bid_order_level_amounts >>> ",
+                  default=None,
+                  required_if=lambda: pure_market_making_config_map.get(
+                      "split_order_levels_enabled").value,
+                  type_str="str",
+                  validator=lambda v: validate_decimal_list(v, "ask_order_level_amounts")),
 }

--- a/hummingbot/strategy/pure_market_making/start.py
+++ b/hummingbot/strategy/pure_market_making/start.py
@@ -74,7 +74,7 @@ def start(self):
             sell_list = [['sell', spread, amount] for spread, amount in zip(ask_order_level_spreads, ask_order_level_amounts)]
             both_list = buy_list + sell_list
             order_override = {
-                i: order for i, order in enumerate(both_list)
+                f'split_level_{i}': order for i, order in enumerate(both_list)
             }
         trading_pair: str = raw_trading_pair
         maker_assets: Tuple[str, str] = self._initialize_market_assets(exchange, [trading_pair])[0]
@@ -135,6 +135,9 @@ def start(self):
             minimum_spread=minimum_spread,
             hb_app_notification=True,
             order_override={} if order_override is None else order_override,
+            split_order_levels_enabled=split_order_levels_enabled,
+            bid_order_level_spreads=bid_order_level_spreads,
+            ask_order_level_spreads=ask_order_level_spreads,
             should_wait_order_cancel_confirmation=should_wait_order_cancel_confirmation,
         )
     except Exception as e:

--- a/hummingbot/strategy/pure_market_making/start.py
+++ b/hummingbot/strategy/pure_market_making/start.py
@@ -62,9 +62,9 @@ def start(self):
         order_override = c_map.get("order_override").value
         split_order_levels_enabled = c_map.get("split_order_levels_enabled").value
         bid_order_level_spreads = convert_decimal_string_to_list(
-            c_map.get("bid_order_level_spreads").value, Decimal("100"))
+            c_map.get("bid_order_level_spreads").value)
         ask_order_level_spreads = convert_decimal_string_to_list(
-            c_map.get("ask_order_level_spreads").value, Decimal("100"))
+            c_map.get("ask_order_level_spreads").value)
         bid_order_level_amounts = convert_decimal_string_to_list(
             c_map.get("bid_order_level_amounts").value)
         ask_order_level_amounts = convert_decimal_string_to_list(

--- a/hummingbot/strategy/pure_market_making/start.py
+++ b/hummingbot/strategy/pure_market_making/start.py
@@ -1,6 +1,7 @@
 from typing import (
     List,
     Tuple,
+    Optional
 )
 
 from hummingbot.client.hummingbot_application import HummingbotApplication
@@ -18,6 +19,13 @@ from decimal import Decimal
 
 
 def start(self):
+    def convert_decimal_string_to_list(string: Optional[str], divisor: Decimal = Decimal("1")) -> List[Decimal]:
+        '''convert order level spread string into a list of decimal divided by divisor '''
+        if string is None:
+            return []
+        string_list = list(string.split(","))
+        return [Decimal(v) / divisor for v in string_list]
+
     try:
         order_amount = c_map.get("order_amount").value
         order_refresh_time = c_map.get("order_refresh_time").value
@@ -52,7 +60,22 @@ def start(self):
         custom_api_update_interval = c_map.get("custom_api_update_interval").value
         order_refresh_tolerance_pct = c_map.get("order_refresh_tolerance_pct").value / Decimal('100')
         order_override = c_map.get("order_override").value
-
+        split_order_levels_enabled = c_map.get("split_order_levels_enabled").value
+        bid_order_level_spreads = convert_decimal_string_to_list(
+            c_map.get("bid_order_level_spreads").value, Decimal("100"))
+        ask_order_level_spreads = convert_decimal_string_to_list(
+            c_map.get("ask_order_level_spreads").value, Decimal("100"))
+        bid_order_level_amounts = convert_decimal_string_to_list(
+            c_map.get("bid_order_level_amounts").value)
+        ask_order_level_amounts = convert_decimal_string_to_list(
+            c_map.get("ask_order_level_amounts").value)
+        if split_order_levels_enabled:
+            buy_list = [['buy', spread, amount] for spread, amount in zip(bid_order_level_spreads, bid_order_level_amounts)]
+            sell_list = [['sell', spread, amount] for spread, amount in zip(ask_order_level_spreads, ask_order_level_amounts)]
+            both_list = buy_list + sell_list
+            order_override = {
+                i: order for i, order in enumerate(both_list)
+            }
         trading_pair: str = raw_trading_pair
         maker_assets: Tuple[str, str] = self._initialize_market_assets(exchange, [trading_pair])[0]
         market_names: List[Tuple[str, List[str]]] = [(exchange, [trading_pair])]

--- a/hummingbot/templates/conf_pure_market_making_strategy_TEMPLATE.yml
+++ b/hummingbot/templates/conf_pure_market_making_strategy_TEMPLATE.yml
@@ -2,7 +2,7 @@
 ###       Pure market making strategy config         ###
 ########################################################
 
-template_version: 22
+template_version: 23
 strategy: null
 
 # Exchange and token parameters.
@@ -125,6 +125,12 @@ take_if_crossed: null
 # Please make sure there is a space between : and [
 order_override: null
 
+# Simpler override config for seperate bid and order level spreads
+split_order_levels_enabled: null
+bid_order_level_spreads: null
+ask_order_level_spreads: null
+bid_order_level_amounts: null
+ask_order_level_amounts: null
 # If the strategy should wait to receive cancellations confirmation before creating new orders during refresh time
 should_wait_order_cancel_confirmation: True
 

--- a/test/hummingbot/strategy/pure_market_making/test_pmm.py
+++ b/test/hummingbot/strategy/pure_market_making/test_pmm.py
@@ -578,6 +578,21 @@ class PMMUnitTest(unittest.TestCase):
         self.assertEqual(Decimal("97.5001"), strategy.active_buys[0].price)
         self.assertEqual(Decimal("102.499"), strategy.active_sells[0].price)
 
+    def test_order_optimization_with_split_order_levels(self):
+        # Widening the order book, top bid is now 97.5 and top ask 102.5
+        simulate_order_book_widening(self.market.order_books[self.trading_pair], 98, 102)
+        strategy = self.one_level_strategy
+        strategy.order_optimization_enabled = True
+        strategy.split_order_levels_enabled = True
+        strategy.bid_order_levels_spread = [Decimal("0.01")]
+        strategy.ask_order_levels_spread = [Decimal("0.01")]
+        self.clock.add_iterator(strategy)
+        self.clock.backtest_til(self.start_timestamp + 1)
+        self.assertEqual(1, len(strategy.active_buys))
+        self.assertEqual(1, len(strategy.active_sells))
+        self.assertEqual(Decimal("99.0001"), strategy.active_buys[0].price)
+        self.assertEqual(Decimal("100.9999"), strategy.active_sells[0].price)
+
     def test_order_optimization_with_multiple_order_levels(self):
         # Widening the order book, top bid is now 97.5 and top ask 102.5
         simulate_order_book_widening(self.market.order_books[self.trading_pair], 98, 102)

--- a/test/hummingbot/strategy/pure_market_making/test_pmm.py
+++ b/test/hummingbot/strategy/pure_market_making/test_pmm.py
@@ -160,6 +160,26 @@ class PMMUnitTest(unittest.TestCase):
         )
         self.inventory_cost_price_del = InventoryCostPriceDelegate(trade_fill_sql, self.trading_pair)
 
+        self.split_order_level_strategy = PureMarketMakingStrategy()
+        self.split_order_level_strategy.init_params(
+            self.market_info,
+            bid_spread=Decimal("0.01"),
+            ask_spread=Decimal("0.01"),
+            order_amount=Decimal("1"),
+            order_refresh_time=5.0,
+            filled_order_delay=5.0,
+            order_refresh_tolerance_pct=-1,
+            minimum_spread=-1,
+            split_order_levels_enabled=True,
+            bid_order_level_spreads= [Decimal("1"), Decimal("2")],
+            ask_order_level_spreads= [Decimal("1"), Decimal("2")],
+            order_override={"split_level_0": ['buy', Decimal("1"), Decimal("1")],
+                            "split_level_1": ['buy', Decimal("2"), Decimal("2")],
+                            "split_level_2": ['sell', Decimal("1"), Decimal("1")]
+                            }
+        )
+        self.split_order_level_strategy.order_tracker._set_current_timestamp(1640001112.223)
+
     def simulate_maker_market_trade(
             self, is_buy: bool, quantity: Decimal, price: Decimal, market: Optional[MockPaperExchange] = None,
     ):
@@ -577,21 +597,6 @@ class PMMUnitTest(unittest.TestCase):
         self.assertEqual(1, len(strategy.active_sells))
         self.assertEqual(Decimal("97.5001"), strategy.active_buys[0].price)
         self.assertEqual(Decimal("102.499"), strategy.active_sells[0].price)
-
-    def test_order_optimization_with_split_order_levels(self):
-        # Widening the order book, top bid is now 97.5 and top ask 102.5
-        simulate_order_book_widening(self.market.order_books[self.trading_pair], 98, 102)
-        strategy = self.one_level_strategy
-        strategy.order_optimization_enabled = True
-        strategy.split_order_levels_enabled = True
-        strategy.bid_order_levels_spread = [Decimal("0.01")]
-        strategy.ask_order_levels_spread = [Decimal("0.01")]
-        self.clock.add_iterator(strategy)
-        self.clock.backtest_til(self.start_timestamp + 1)
-        self.assertEqual(1, len(strategy.active_buys))
-        self.assertEqual(1, len(strategy.active_sells))
-        self.assertEqual(Decimal("99.0001"), strategy.active_buys[0].price)
-        self.assertEqual(Decimal("100.9999"), strategy.active_sells[0].price)
 
     def test_order_optimization_with_multiple_order_levels(self):
         # Widening the order book, top bid is now 97.5 and top ask 102.5
@@ -1136,6 +1141,32 @@ class PMMUnitTest(unittest.TestCase):
 
         self.assertEqual(available_base_balance, base_balance + Decimal(2))
         self.assertEqual(available_quote_balance, quote_balance + (Decimal(1) * Decimal(1000)))
+
+    def test_split_order_levels(self):
+        # Widening the order book, top bid is now 97.5 and top ask 102.5
+        simulate_order_book_widening(self.market.order_books[self.trading_pair], 98, 102)
+        strategy = self.split_order_level_strategy
+        strategy.order_optimization_enabled = False
+        self.clock.add_iterator(strategy)
+        self.clock.backtest_til(self.start_timestamp + 1)
+        self.assertEqual(2, len(strategy.active_buys))
+        self.assertEqual(1, len(strategy.active_sells))
+        self.assertEqual(Decimal("99.000"), strategy.active_buys[0].price)
+        self.assertEqual(Decimal("101.000"), strategy.active_sells[0].price)
+        self.assertEqual(Decimal("98.000"), strategy.active_buys[1].price)
+
+    def test_order_optimization_with_split_order_levels(self):
+        # Widening the order book, top bid is now 97.5 and top ask 102.5
+        simulate_order_book_widening(self.market.order_books[self.trading_pair], 98, 102)
+        strategy = self.split_order_level_strategy
+        strategy.order_optimization_enabled = True
+        self.clock.add_iterator(strategy)
+        self.clock.backtest_til(self.start_timestamp + 1)
+        self.assertEqual(2, len(strategy.active_buys))
+        self.assertEqual(1, len(strategy.active_sells))
+        self.assertEqual(Decimal("97.5001"), strategy.active_buys[0].price)
+        self.assertEqual(Decimal("102.499"), strategy.active_sells[0].price)
+        self.assertEqual(strategy.active_buys[1].price / strategy.active_buys[0].price, Decimal("0.98") / Decimal("0.99"))
 
 
 class PureMarketMakingMinimumSpreadUnitTest(unittest.TestCase):

--- a/test/hummingbot/strategy/pure_market_making/test_pmm_config_map.py
+++ b/test/hummingbot/strategy/pure_market_making/test_pmm_config_map.py
@@ -119,8 +119,6 @@ class TestPMMConfigMap(unittest.TestCase):
         self.assertIsNone(validate_price_source_exchange(value='binance_perpetual'))
 
     def test_validate_decimal_list(self):
-        pmm_config_map["bid_order_level_spreads"].value = "1"
-
         error = validate_decimal_list(value="1")
         self.assertIsNone(error)
         error = validate_decimal_list(value="1,2")

--- a/test/hummingbot/strategy/pure_market_making/test_pmm_config_map.py
+++ b/test/hummingbot/strategy/pure_market_making/test_pmm_config_map.py
@@ -8,7 +8,8 @@ from hummingbot.strategy.pure_market_making.pure_market_making_config_map import
     validate_price_type,
     order_amount_prompt,
     maker_trading_pair_prompt,
-    validate_price_source_exchange
+    validate_price_source_exchange,
+    validate_decimal_list
 )
 
 
@@ -116,3 +117,14 @@ class TestPMMConfigMap(unittest.TestCase):
                          'Price source exchange cannot be the same as maker exchange.')
         self.assertIsNone(validate_price_source_exchange(value='kucoin'))
         self.assertIsNone(validate_price_source_exchange(value='binance_perpetual'))
+
+    def test_validate_decimal_list(self):
+        pmm_config_map["bid_order_level_spreads"].value = "1"
+
+        error = validate_decimal_list(value="1")
+        self.assertIsNone(error)
+        error = validate_decimal_list(value="1,2")
+        self.assertIsNone(error)
+        error = validate_decimal_list(value="asd")
+        expected = "Please enter valid decimal numbers"
+        self.assertEqual(expected, error)

--- a/test/hummingbot/strategy/pure_market_making/test_pure_market_making_start.py
+++ b/test/hummingbot/strategy/pure_market_making/test_pure_market_making_start.py
@@ -103,5 +103,4 @@ class PureMarketMakingStartTest(unittest.TestCase):
         self.assertEqual(self.strategy.ask_order_level_spreads, [Decimal("1"), Decimal("2")])
         self.assertEqual(self.strategy.order_override, {"split_level_0": ['buy', Decimal("1"), Decimal("1")],
                                                         "split_level_1": ['buy', Decimal("2"), Decimal("2")],
-                                                        "split_level_2": ['sell', Decimal("1"), Decimal("1")]
                                                         })

--- a/test/hummingbot/strategy/pure_market_making/test_pure_market_making_start.py
+++ b/test/hummingbot/strategy/pure_market_making/test_pure_market_making_start.py
@@ -55,7 +55,7 @@ class PureMarketMakingStartTest(unittest.TestCase):
         c_map.get("bid_order_level_spreads").value = "1,2"
         c_map.get("ask_order_level_spreads").value = "1,2"
         c_map.get("bid_order_level_amounts").value = "1,2"
-        c_map.get("ask_order_level_amounts").value = "1"
+        c_map.get("ask_order_level_amounts").value = None
 
     def _initialize_market_assets(self, market, trading_pairs):
         return [("ETH", "USDT")]

--- a/test/hummingbot/strategy/pure_market_making/test_pure_market_making_start.py
+++ b/test/hummingbot/strategy/pure_market_making/test_pure_market_making_start.py
@@ -99,9 +99,9 @@ class PureMarketMakingStartTest(unittest.TestCase):
         self.assertEqual(self.strategy.price_type, PriceType.BestBid)
         self.assertEqual(self.strategy.order_refresh_tolerance_pct, Decimal("0.02"))
         self.assertEqual(self.strategy.split_order_levels_enabled, True)
-        self.assertEqual(self.strategy.bid_order_level_spreads, [Decimal("0.01"), Decimal("0.02")])
-        self.assertEqual(self.strategy.ask_order_level_spreads, [Decimal("0.01"), Decimal("0.02")])
-        self.assertEqual(self.strategy.order_override, {"split_level_1": ['buy', 1, 1],
-                                                        "split_level_2": ['buy', 2, 2],
-                                                        "split_level_3": ['sell', 1, 1]
+        self.assertEqual(self.strategy.bid_order_level_spreads, [Decimal("1"), Decimal("2")])
+        self.assertEqual(self.strategy.ask_order_level_spreads, [Decimal("1"), Decimal("2")])
+        self.assertEqual(self.strategy.order_override, {"split_level_0": ['buy', Decimal("1"), Decimal("1")],
+                                                        "split_level_1": ['buy', Decimal("2"), Decimal("2")],
+                                                        "split_level_2": ['sell', Decimal("1"), Decimal("1")]
                                                         })

--- a/test/hummingbot/strategy/pure_market_making/test_pure_market_making_start.py
+++ b/test/hummingbot/strategy/pure_market_making/test_pure_market_making_start.py
@@ -51,6 +51,11 @@ class PureMarketMakingStartTest(unittest.TestCase):
         c_map.get("price_source_custom_api").value = "localhost.test"
         c_map.get("order_refresh_tolerance_pct").value = Decimal("2")
         c_map.get("order_override").value = None
+        c_map.get("split_order_levels_enabled").value = True
+        c_map.get("bid_order_level_spreads").value = "1,2"
+        c_map.get("ask_order_level_spreads").value = "1,2"
+        c_map.get("bid_order_level_amounts").value = "1,2"
+        c_map.get("ask_order_level_amounts").value = "1"
 
     def _initialize_market_assets(self, market, trading_pairs):
         return [("ETH", "USDT")]
@@ -93,3 +98,10 @@ class PureMarketMakingStartTest(unittest.TestCase):
         self.assertEqual(self.strategy.add_transaction_costs_to_orders, False)
         self.assertEqual(self.strategy.price_type, PriceType.BestBid)
         self.assertEqual(self.strategy.order_refresh_tolerance_pct, Decimal("0.02"))
+        self.assertEqual(self.strategy.split_order_levels_enabled, True)
+        self.assertEqual(self.strategy.bid_order_level_spreads, [Decimal("0.01"), Decimal("0.02")])
+        self.assertEqual(self.strategy.ask_order_level_spreads, [Decimal("0.01"), Decimal("0.02")])
+        self.assertEqual(self.strategy.order_override, {"split_level_1": ['buy', 1, 1],
+                                                        "split_level_2": ['buy', 2, 2],
+                                                        "split_level_3": ['sell', 1, 1]
+                                                        })


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
1. Split order_level_spread into bid_order_level_spread and ask_order_level_spread
2. Allow configuration of multiple order_level_spread
User can now set either a single number or a list of number to the order_level_spread.
The spread will be cumulative added.
e.g an order_level_spread 0.1, 0.2, 0.5, 0.1
Assume a bid spread of 1
The spread on top of the bid_spread/ask_spread of 2nd order will be 1 % + 0.1%, the 3rd will be 1% + 0.1% + 0.2%, the 4th will be 1%+ 0.1%+0.2%+0.5%, the 5th  1% + 0.1%+0.2%+0.5%+0.1% = 1.9%,
if there are more order levels then the listed, order spread, the system will take the last setting to continue, i.e 1.9% + 0.1% since 0.1% was the last spread applied.
This means if user does not need multiple different order level spread, he can set a single order level spread, 0.1 and the 1st to the 5th order level will just add +0.1% to the previous order level

**Tests performed by the developer**:
![image](https://user-images.githubusercontent.com/64965782/149939570-e4af050e-7e54-483a-9998-c71424249c2d.png)
![image](https://user-images.githubusercontent.com/64965782/149939588-ef676c9a-c951-4e7f-bae7-7082568549f0.png)



**Tips for QA testing**:


