### PR TITLE
docs/Remove outdated commands from documentation

### DIFF
--- a/installation/docker-commands/README.md
+++ b/installation/docker-commands/README.md
@@ -23,8 +23,6 @@ If you do not have `docker` permissions:
 wget https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/docker-commands/create.sh
 wget https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/docker-commands/start.sh
 wget https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/docker-commands/update.sh
-wget https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/docker-commands/create-web3.sh
-wget https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/docker-commands/update-web3.sh
 chmod a+x *.sh
 ```
 
@@ -33,8 +31,6 @@ chmod a+x *.sh
 curl https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/docker-commands/create.sh -o create.sh
 curl https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/docker-commands/start.sh -o start.sh
 curl https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/docker-commands/update.sh -o update.sh
-curl https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/docker-commands/create-web3.sh -o create-web3.sh
-curl https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/docker-commands/update-web3.sh -o update-web3.sh
 chmod a+x *.sh
 ```
 
@@ -44,8 +40,6 @@ cd ~
 curl https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/docker-commands/create.sh -o create.sh
 curl https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/docker-commands/start.sh -o start.sh
 curl https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/docker-commands/update.sh -o update.sh
-curl https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/docker-commands/create-web3.sh -o create-web3.sh
-curl https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/docker-commands/update-web3.sh -o update-web3.sh
 chmod a+x *.sh
 ```
 
@@ -71,24 +65,4 @@ The `update.sh` script will update your instance to the latest version of Hummin
 
 ```
 ./update.sh
-```
-
-## Create an instance of Hummingbot which connects to a local node at http://localhost:8545
-### Requires ethereum full node
-
-This `web3` version of scripts allows a user to connect to an Ethereum node running on the Docker host.
-
-The `create-web3.sh` is similar to the `create.sh` script; the difference is that it makes the `localhost` (127.0.0.1) available to the docker container by appending the `--network="host"` to the `docker run` command.
-
-```
-./create-web3.sh
-```
-
-## Updating Hummingbot version which connects to a local node at http:localhost:8545
-### Requires ethereum full node
-
-The `update-web3.sh` script will update your instance to the latest version of Hummingbot.
-
-```
-./update-web3.sh
 ```


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Removes commands to load and run web3 scripts (ref: https://github.com/hummingbot/hummingbot/commit/0f9d2aac41ac669cd9092780a56f6870d0698279#diff-692e25b83204c159774ede0d553329cc8f02555af89d7664787cc6ce9e77a9d8)
