### PR TITLE
fix/ `config` command accepting spaces in values

### DIFF
--- a/hummingbot/client/hummingbot_application.py
+++ b/hummingbot/client/hummingbot_application.py
@@ -136,7 +136,7 @@ class HummingbotApplication(*commands):
             self.app.to_stop_config = False
 
         raw_command = raw_command.lower().strip()
-        command_split = raw_command.split()
+        command_split = raw_command.split(maxsplit=2)
         try:
             if self.placeholder_mode:
                 pass

--- a/hummingbot/client/hummingbot_application.py
+++ b/hummingbot/client/hummingbot_application.py
@@ -136,7 +136,11 @@ class HummingbotApplication(*commands):
             self.app.to_stop_config = False
 
         raw_command = raw_command.lower().strip()
-        command_split = raw_command.split(maxsplit=2)
+        # NOTE: Only done for config command
+        if raw_command.startswith("config"):
+            command_split = raw_command.split(maxsplit=2)
+        else:
+            command_split = raw_command.split()
         try:
             if self.placeholder_mode:
                 pass


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Modify `_handle_command()` in `HummingbotApplication` to handle commands that accept values with spaces
Note:
All users inputs should strictly follow the following format:
`>>> <command> [argument] [value]`

**Tests performed by the developer**:
Made modifications to `_handle_command()` to specifically handle `config` command.


**Tips for QA testing**:
Ensure that Avellaneda's `config execution_timeframe`(specifically for `from_date_to_date` now works as intended
Verify that other commands and strategy configs that required spaces in its value works as intended.

