### PR TITLE
fix/Fix docker create script for CentOS/Fedora

### DIFF
--- a/installation/docker-commands/create.sh
+++ b/installation/docker-commands/create.sh
@@ -72,14 +72,14 @@ create_instance () {
  # 3) Set required permissions to save hummingbot password the first time
  sudo chmod a+rw $FOLDER/hummingbot_conf
  # 4) Launch a new instance of hummingbot
- docker run -it --log-opt max-size=10m --log-opt max-file=5 \
+ docker run -it \
  --name $INSTANCE_NAME \
  --network host \
- --mount "type=bind,source=$FOLDER/hummingbot_conf,destination=/conf/" \
- --mount "type=bind,source=$FOLDER/hummingbot_logs,destination=/logs/" \
- --mount "type=bind,source=$FOLDER/hummingbot_data,destination=/data/" \
- --mount "type=bind,source=$FOLDER/hummingbot_scripts,destination=/scripts/" \
- --mount "type=bind,source=$FOLDER/hummingbot_certs,destination=/certs/" \
+ -v "${FOLDER}"/hummingbot_conf:/conf:z \
+ -v "${FOLDER}"/hummingbot_logs:/logs:z \
+ -v "${FOLDER}"/hummingbot_data:/data:z \
+ -v "${FOLDER}"/hummingbot_scripts:/scripts:z \
+ -v "${FOLDER}"/hummingbot_certs:/certs:z \
  coinalpha/hummingbot:$TAG
 }
 


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
On Fedora/CentOS, the `:z` flag must be used to work with selinux. And the log driver don't support the `max-size` and max-file parameters.
