### PR TITLE
(fix) Removed unnecessary columns from the table

### DIFF
--- a/hummingbot/model/trade_fill.py
+++ b/hummingbot/model/trade_fill.py
@@ -114,10 +114,7 @@ class TradeFill(HummingbotBase):
                               "Amount",
                               "Leverage",
                               "Position",
-                              "Age",
-                              "Order ID",
-                              "Exchange Order ID",
-                              "Trade ID"]
+                              "Age"]
         data = []
         for trade in trades:
 
@@ -137,9 +134,6 @@ class TradeFill(HummingbotBase):
                 trade.leverage,
                 trade.position,
                 age,
-                trade.order_id,
-                trade.order.exchange_order_id,
-                trade.exchange_trade_id,
             ])
         df = pd.DataFrame(data=data, columns=columns)
         df.set_index('Id', inplace=True)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Removing extra columns added during the Binance spot update PR but are not required, since they make it difficult to the user to visualize the information in the table.


**Tests performed by the developer**:
Execute client with pure market making strategy and check the trades history table.


**Tips for QA testing**:
Wait until the client receives trade fills and display the column.


**Test Summary**:
- Start and run different strategies (Avellaneda, PMM, Cross Exchange, Arbitrage, and Spot-Perpetual Arbitrage)
- Check history in verbose mode whenever there is a trade fill and confirmed that only the necessary table columns are displayed.

Fixes #5018 

