### PR TITLE
Fix/Avellaneda orders not cancelled

### DIFF
--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
@@ -637,31 +637,27 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
         finally:
             self._last_timestamp = timestamp
 
-    def process_tick(self, timestamp: float, trading_allowed: bool):
+    def process_tick(self, timestamp: float):
         proposal = None
-        if trading_allowed:
-            # Trading is allowed
-            if self._create_timestamp <= self._current_timestamp:
-                # 1. Calculate reserved price and optimal spread from gamma, alpha, kappa and volatility
-                self.c_calculate_reserved_price_and_optimal_spread()
-                # 2. Check if calculated prices make sense
-                if self._optimal_bid > 0 and self._optimal_ask > 0:
-                    # 3. Create base order proposals
-                    proposal = self.c_create_base_proposal()
-                    # 4. Apply functions that modify orders amount
-                    self.c_apply_order_amount_eta_transformation(proposal)
-                    # 5. Apply functions that modify orders price
-                    self.c_apply_order_price_modifiers(proposal)
-                    # 6. Apply budget constraint, i.e. can't buy/sell more than what you have.
-                    self.c_apply_budget_constraint(proposal)
+        # Trading is allowed
+        if self._create_timestamp <= self._current_timestamp:
+            # 1. Calculate reserved price and optimal spread from gamma, alpha, kappa and volatility
+            self.c_calculate_reserved_price_and_optimal_spread()
+            # 2. Check if calculated prices make sense
+            if self._optimal_bid > 0 and self._optimal_ask > 0:
+                # 3. Create base order proposals
+                proposal = self.c_create_base_proposal()
+                # 4. Apply functions that modify orders amount
+                self.c_apply_order_amount_eta_transformation(proposal)
+                # 5. Apply functions that modify orders price
+                self.c_apply_order_price_modifiers(proposal)
+                # 6. Apply budget constraint, i.e. can't buy/sell more than what you have.
+                self.c_apply_budget_constraint(proposal)
 
-                    self.c_cancel_active_orders(proposal)
+                self.c_cancel_active_orders(proposal)
 
-            if self.c_to_create_orders(proposal):
-                self.c_execute_orders_proposal(proposal)
-        else:
-            # Trading is not allowed
-            self.c_cancel_active_orders(proposal)
+        if self.c_to_create_orders(proposal):
+            self.c_execute_orders_proposal(proposal)
 
         if self._is_debug:
             self.dump_debug_variables()
@@ -1256,7 +1252,7 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
         else:
             self.c_set_timers()
 
-    def cancel_active_orders(self, proposal: Proposal):
+    def cancel_active_orders(self, proposal: Proposal = None):
         return self.c_cancel_active_orders(proposal)
 
     cdef bint c_to_create_orders(self, object proposal):

--- a/hummingbot/strategy/conditional_execution_state.py
+++ b/hummingbot/strategy/conditional_execution_state.py
@@ -50,7 +50,7 @@ class RunAlwaysExecutionState(ConditionalExecutionState):
     def process_tick(self, timestamp: float, strategy: StrategyBase):
         self._closing_time = None
         self._time_left = None
-        strategy.process_tick(timestamp)
+        strategy.process_tick(timestamp, True)
 
 
 class RunInTimeConditionalExecutionState(ConditionalExecutionState):
@@ -87,9 +87,10 @@ class RunInTimeConditionalExecutionState(ConditionalExecutionState):
 
                 if self._start_timestamp.timestamp() <= timestamp < self._end_timestamp.timestamp():
                     self._time_left = max((self._end_timestamp.timestamp() - timestamp) * 1000, 0)
-                    strategy.process_tick(timestamp)
+                    strategy.process_tick(timestamp, True)
                 else:
                     self._time_left = 0
+                    strategy.process_tick(timestamp, False)
                     strategy.logger().debug("Time span execution: tick will not be processed "
                                             f"(executing between {self._start_timestamp.isoformat(sep=' ')} "
                                             f"and {self._end_timestamp.isoformat(sep=' ')})")
@@ -97,8 +98,9 @@ class RunInTimeConditionalExecutionState(ConditionalExecutionState):
                 self._closing_time = None
                 self._time_left = None
                 if self._start_timestamp.timestamp() <= timestamp:
-                    strategy.process_tick(timestamp)
+                    strategy.process_tick(timestamp, True)
                 else:
+                    strategy.process_tick(timestamp, False)
                     strategy.logger().debug("Delayed start execution: tick will not be processed "
                                             f"(executing from {self._start_timestamp.isoformat(sep=' ')})")
         if isinstance(self._start_timestamp, time):
@@ -110,9 +112,10 @@ class RunInTimeConditionalExecutionState(ConditionalExecutionState):
 
                 if self._start_timestamp <= current_time < self._end_timestamp:
                     self._time_left = max((datetime.combine(datetime.today(), self._end_timestamp) - datetime.combine(datetime.today(), current_time)).total_seconds() * 1000, 0)
-                    strategy.process_tick(timestamp)
+                    strategy.process_tick(timestamp, True)
                 else:
                     self._time_left = 0
+                    strategy.process_tick(timestamp, False)
                     strategy.logger().debug("Time span execution: tick will not be processed "
                                             f"(executing between {self._start_timestamp} "
                                             f"and {self._end_timestamp})")

--- a/hummingbot/strategy/conditional_execution_state.py
+++ b/hummingbot/strategy/conditional_execution_state.py
@@ -50,7 +50,7 @@ class RunAlwaysExecutionState(ConditionalExecutionState):
     def process_tick(self, timestamp: float, strategy: StrategyBase):
         self._closing_time = None
         self._time_left = None
-        strategy.process_tick(timestamp, True)
+        strategy.process_tick(timestamp)
 
 
 class RunInTimeConditionalExecutionState(ConditionalExecutionState):
@@ -87,10 +87,10 @@ class RunInTimeConditionalExecutionState(ConditionalExecutionState):
 
                 if self._start_timestamp.timestamp() <= timestamp < self._end_timestamp.timestamp():
                     self._time_left = max((self._end_timestamp.timestamp() - timestamp) * 1000, 0)
-                    strategy.process_tick(timestamp, True)
+                    strategy.process_tick(timestamp)
                 else:
                     self._time_left = 0
-                    strategy.process_tick(timestamp, False)
+                    strategy.cancel_active_orders()
                     strategy.logger().debug("Time span execution: tick will not be processed "
                                             f"(executing between {self._start_timestamp.isoformat(sep=' ')} "
                                             f"and {self._end_timestamp.isoformat(sep=' ')})")
@@ -98,9 +98,9 @@ class RunInTimeConditionalExecutionState(ConditionalExecutionState):
                 self._closing_time = None
                 self._time_left = None
                 if self._start_timestamp.timestamp() <= timestamp:
-                    strategy.process_tick(timestamp, True)
+                    strategy.process_tick(timestamp)
                 else:
-                    strategy.process_tick(timestamp, False)
+                    strategy.cancel_active_orders()
                     strategy.logger().debug("Delayed start execution: tick will not be processed "
                                             f"(executing from {self._start_timestamp.isoformat(sep=' ')})")
         if isinstance(self._start_timestamp, time):
@@ -112,10 +112,10 @@ class RunInTimeConditionalExecutionState(ConditionalExecutionState):
 
                 if self._start_timestamp <= current_time < self._end_timestamp:
                     self._time_left = max((datetime.combine(datetime.today(), self._end_timestamp) - datetime.combine(datetime.today(), current_time)).total_seconds() * 1000, 0)
-                    strategy.process_tick(timestamp, True)
+                    strategy.process_tick(timestamp)
                 else:
                     self._time_left = 0
-                    strategy.process_tick(timestamp, False)
+                    strategy.cancel_active_orders()
                     strategy.logger().debug("Time span execution: tick will not be processed "
                                             f"(executing between {self._start_timestamp} "
                                             f"and {self._end_timestamp})")

--- a/hummingbot/strategy/twap/twap.py
+++ b/hummingbot/strategy/twap/twap.py
@@ -311,31 +311,32 @@ class TwapTradeStrategy(StrategyPyBase):
         finally:
             self._last_timestamp = timestamp
 
-    def process_tick(self, timestamp: float):
+    def process_tick(self, timestamp: float, trading_allowed: bool):
         """
         Clock tick entry point.
         For the TWAP strategy, this function simply checks for the readiness and connection status of markets, and
         then delegates the processing of each market info to process_market().
         """
-        current_tick = timestamp // self._status_report_interval
-        last_tick = (self._last_timestamp // self._status_report_interval)
-        should_report_warnings = current_tick > last_tick
+        if trading_allowed:
+            current_tick = timestamp // self._status_report_interval
+            last_tick = (self._last_timestamp // self._status_report_interval)
+            should_report_warnings = current_tick > last_tick
 
-        if not self._all_markets_ready:
-            self._all_markets_ready = all([market.ready for market in self.active_markets])
             if not self._all_markets_ready:
-                # Markets not ready yet. Don't do anything.
-                if should_report_warnings:
-                    self.logger().warning("Markets are not ready. No market making trades are permitted.")
-                return
+                self._all_markets_ready = all([market.ready for market in self.active_markets])
+                if not self._all_markets_ready:
+                    # Markets not ready yet. Don't do anything.
+                    if should_report_warnings:
+                        self.logger().warning("Markets are not ready. No market making trades are permitted.")
+                    return
 
-        if (should_report_warnings
-                and not all([market.network_status is NetworkStatus.CONNECTED for market in self.active_markets])):
-            self.logger().warning("WARNING: Some markets are not connected or are down at the moment. Market "
-                                  "making may be dangerous when markets or networks are unstable.")
+            if (should_report_warnings
+                    and not all([market.network_status is NetworkStatus.CONNECTED for market in self.active_markets])):
+                self.logger().warning("WARNING: Some markets are not connected or are down at the moment. Market "
+                                      "making may be dangerous when markets or networks are unstable.")
 
-        for market_info in self._market_infos.values():
-            self.process_market(market_info)
+            for market_info in self._market_infos.values():
+                self.process_market(market_info)
 
     def place_orders_for_market(self, market_info):
         """

--- a/test/hummingbot/strategy/test_conditional_execution_state.py
+++ b/test/hummingbot/strategy/test_conditional_execution_state.py
@@ -10,9 +10,10 @@ class RunAlwaysExecutionStateTests(TestCase):
     def test_always_process_tick(self):
         strategy = MagicMock()
         state = RunAlwaysExecutionState()
-        state.process_tick(datetime.now, strategy)
+        timestamp = datetime.now
+        state.process_tick(timestamp, strategy)
 
-        strategy.process_tick.assert_called()
+        strategy.process_tick.assert_called_with(timestamp, True)
 
 
 class RunInTimeSpanExecutionStateTests(TestCase):
@@ -33,61 +34,73 @@ class RunInTimeSpanExecutionStateTests(TestCase):
         strategy = MagicMock()
         strategy.logger().debug.side_effect = self.debug
 
-        state.process_tick(datetime.fromisoformat("2021-06-22 08:59:59").timestamp(), strategy)
-        strategy.process_tick.assert_not_called()
+        timestamp = datetime.fromisoformat("2021-06-22 08:59:59").timestamp()
+        state.process_tick(timestamp, strategy)
+        strategy.process_tick.assert_called_with(timestamp, False)
         self.assertEqual(len(self.debug_logs), 1)
         self.assertEqual(self.debug_logs[0], "Time span execution: tick will not be processed "
                                              f"(executing between {start_timestamp} and {end_timestamp})")
 
-        state.process_tick(datetime.fromisoformat("2021-06-22 09:00:00").timestamp(), strategy)
-        strategy.process_tick.assert_called()
+        timestamp = datetime.fromisoformat("2021-06-22 09:00:00").timestamp()
+        state.process_tick(timestamp, strategy)
+        strategy.process_tick.assert_called_with(timestamp, True)
 
-        state.process_tick(datetime.fromisoformat("2021-06-22 09:00:00").timestamp(), strategy)
-        strategy.process_tick.assert_called()
+        timestamp = datetime.fromisoformat("2021-06-22 09:00:00").timestamp()
+        state.process_tick(timestamp, strategy)
+        strategy.process_tick.assert_called_with(timestamp, True)
 
         strategy.process_tick.reset_mock()
-        state.process_tick(datetime.fromisoformat("2021-06-22 10:00:01").timestamp(), strategy)
-        strategy.process_tick.assert_not_called()
+        timestamp = datetime.fromisoformat("2021-06-22 10:00:01").timestamp()
+        state.process_tick(timestamp, strategy)
+        strategy.process_tick.assert_called_with(timestamp, False)
         self.assertEqual(len(self.debug_logs), 2)
         self.assertEqual(self.debug_logs[1], "Time span execution: tick will not be processed "
                                              f"(executing between {start_timestamp} and {end_timestamp})")
 
         state = RunInTimeConditionalExecutionState(start_timestamp=start_timestamp.time(), end_timestamp=end_timestamp.time())
 
-        state.process_tick(datetime.fromisoformat("2021-06-22 08:59:59").timestamp(), strategy)
-        strategy.process_tick.assert_not_called()
+        timestamp = datetime.fromisoformat("2021-06-22 08:59:59").timestamp()
+        state.process_tick(timestamp, strategy)
+        strategy.process_tick.assert_called_with(timestamp, False)
         self.assertEqual(len(self.debug_logs), 3)
         self.assertEqual(self.debug_logs[0], "Time span execution: tick will not be processed "
                                              f"(executing between {start_timestamp} and {end_timestamp})")
 
-        state.process_tick(datetime.fromisoformat("2021-06-22 09:00:00").timestamp(), strategy)
-        strategy.process_tick.assert_called()
+        timestamp = datetime.fromisoformat("2021-06-22 09:00:00").timestamp()
+        state.process_tick(timestamp, strategy)
+        strategy.process_tick.assert_called_with(timestamp, True)
 
-        state.process_tick(datetime.fromisoformat("2021-06-22 09:00:00").timestamp(), strategy)
-        strategy.process_tick.assert_called()
+        timestamp = datetime.fromisoformat("2021-06-22 09:00:00").timestamp()
+        state.process_tick(timestamp, strategy)
+        strategy.process_tick.assert_called_with(timestamp, True)
 
         strategy.process_tick.reset_mock()
-        state.process_tick(datetime.fromisoformat("2021-06-22 10:00:01").timestamp(), strategy)
-        strategy.process_tick.assert_not_called()
+        timestamp = datetime.fromisoformat("2021-06-22 10:00:01").timestamp()
+        state.process_tick(timestamp, strategy)
+        strategy.process_tick.assert_called_with(timestamp, False)
         self.assertEqual(len(self.debug_logs), 4)
         self.assertEqual(self.debug_logs[1], "Time span execution: tick will not be processed "
                                              f"(executing between {start_timestamp} and {end_timestamp})")
 
-        state.process_tick(datetime.fromisoformat("2021-06-30 08:59:59").timestamp(), strategy)
-        strategy.process_tick.assert_not_called()
+        timestamp = datetime.fromisoformat("2021-06-30 08:59:59").timestamp()
+        state.process_tick(timestamp, strategy)
+        strategy.process_tick.assert_called_with(timestamp, False)
         self.assertEqual(len(self.debug_logs), 5)
         self.assertEqual(self.debug_logs[0], "Time span execution: tick will not be processed "
                                              f"(executing between {start_timestamp} and {end_timestamp})")
 
-        state.process_tick(datetime.fromisoformat("2021-06-30 09:00:00").timestamp(), strategy)
-        strategy.process_tick.assert_called()
+        timestamp = datetime.fromisoformat("2021-06-30 09:00:00").timestamp()
+        state.process_tick(timestamp, strategy)
+        strategy.process_tick.assert_called_with(timestamp, True)
 
-        state.process_tick(datetime.fromisoformat("2021-06-30 09:00:00").timestamp(), strategy)
-        strategy.process_tick.assert_called()
+        timestamp = datetime.fromisoformat("2021-06-30 09:00:00").timestamp()
+        state.process_tick(timestamp, strategy)
+        strategy.process_tick.assert_called_with(timestamp, True)
 
         strategy.process_tick.reset_mock()
-        state.process_tick(datetime.fromisoformat("2021-06-30 10:00:01").timestamp(), strategy)
-        strategy.process_tick.assert_not_called()
+        timestamp = datetime.fromisoformat("2021-06-30 10:00:01").timestamp()
+        state.process_tick(timestamp, strategy)
+        strategy.process_tick.assert_called_with(timestamp, False)
         self.assertEqual(len(self.debug_logs), 6)
         self.assertEqual(self.debug_logs[1], "Time span execution: tick will not be processed "
                                              f"(executing between {start_timestamp} and {end_timestamp})")

--- a/test/hummingbot/strategy/test_conditional_execution_state.py
+++ b/test/hummingbot/strategy/test_conditional_execution_state.py
@@ -10,10 +10,10 @@ class RunAlwaysExecutionStateTests(TestCase):
     def test_always_process_tick(self):
         strategy = MagicMock()
         state = RunAlwaysExecutionState()
-        timestamp = datetime.now
-        state.process_tick(timestamp, strategy)
+        state.process_tick(datetime.now, strategy)
 
-        strategy.process_tick.assert_called_with(timestamp, True)
+        strategy.process_tick.assert_called()
+        strategy.cancel_active_orders.assert_not_called()
 
 
 class RunInTimeSpanExecutionStateTests(TestCase):
@@ -34,73 +34,67 @@ class RunInTimeSpanExecutionStateTests(TestCase):
         strategy = MagicMock()
         strategy.logger().debug.side_effect = self.debug
 
-        timestamp = datetime.fromisoformat("2021-06-22 08:59:59").timestamp()
-        state.process_tick(timestamp, strategy)
-        strategy.process_tick.assert_called_with(timestamp, False)
+        state.process_tick(datetime.fromisoformat("2021-06-22 08:59:59").timestamp(), strategy)
+        strategy.process_tick.assert_not_called()
+        strategy.cancel_active_orders.assert_called()
         self.assertEqual(len(self.debug_logs), 1)
         self.assertEqual(self.debug_logs[0], "Time span execution: tick will not be processed "
                                              f"(executing between {start_timestamp} and {end_timestamp})")
 
-        timestamp = datetime.fromisoformat("2021-06-22 09:00:00").timestamp()
-        state.process_tick(timestamp, strategy)
-        strategy.process_tick.assert_called_with(timestamp, True)
+        state.process_tick(datetime.fromisoformat("2021-06-22 09:00:00").timestamp(), strategy)
+        strategy.process_tick.assert_called()
 
-        timestamp = datetime.fromisoformat("2021-06-22 09:00:00").timestamp()
-        state.process_tick(timestamp, strategy)
-        strategy.process_tick.assert_called_with(timestamp, True)
+        state.process_tick(datetime.fromisoformat("2021-06-22 09:00:00").timestamp(), strategy)
+        strategy.process_tick.assert_called()
 
         strategy.process_tick.reset_mock()
-        timestamp = datetime.fromisoformat("2021-06-22 10:00:01").timestamp()
-        state.process_tick(timestamp, strategy)
-        strategy.process_tick.assert_called_with(timestamp, False)
+        state.process_tick(datetime.fromisoformat("2021-06-22 10:00:01").timestamp(), strategy)
+        strategy.process_tick.assert_not_called()
+        strategy.cancel_active_orders.assert_called()
         self.assertEqual(len(self.debug_logs), 2)
         self.assertEqual(self.debug_logs[1], "Time span execution: tick will not be processed "
                                              f"(executing between {start_timestamp} and {end_timestamp})")
 
         state = RunInTimeConditionalExecutionState(start_timestamp=start_timestamp.time(), end_timestamp=end_timestamp.time())
 
-        timestamp = datetime.fromisoformat("2021-06-22 08:59:59").timestamp()
-        state.process_tick(timestamp, strategy)
-        strategy.process_tick.assert_called_with(timestamp, False)
+        state.process_tick(datetime.fromisoformat("2021-06-22 08:59:59").timestamp(), strategy)
+        strategy.process_tick.assert_not_called()
+        strategy.cancel_active_orders.assert_called()
         self.assertEqual(len(self.debug_logs), 3)
         self.assertEqual(self.debug_logs[0], "Time span execution: tick will not be processed "
                                              f"(executing between {start_timestamp} and {end_timestamp})")
 
-        timestamp = datetime.fromisoformat("2021-06-22 09:00:00").timestamp()
-        state.process_tick(timestamp, strategy)
-        strategy.process_tick.assert_called_with(timestamp, True)
+        state.process_tick(datetime.fromisoformat("2021-06-22 09:00:00").timestamp(), strategy)
+        strategy.process_tick.assert_called()
 
-        timestamp = datetime.fromisoformat("2021-06-22 09:00:00").timestamp()
-        state.process_tick(timestamp, strategy)
-        strategy.process_tick.assert_called_with(timestamp, True)
+        state.process_tick(datetime.fromisoformat("2021-06-22 09:00:00").timestamp(), strategy)
+        strategy.process_tick.assert_called()
 
         strategy.process_tick.reset_mock()
-        timestamp = datetime.fromisoformat("2021-06-22 10:00:01").timestamp()
-        state.process_tick(timestamp, strategy)
-        strategy.process_tick.assert_called_with(timestamp, False)
+        state.process_tick(datetime.fromisoformat("2021-06-22 10:00:01").timestamp(), strategy)
+        strategy.process_tick.assert_not_called()
+        strategy.cancel_active_orders.assert_called()
         self.assertEqual(len(self.debug_logs), 4)
         self.assertEqual(self.debug_logs[1], "Time span execution: tick will not be processed "
                                              f"(executing between {start_timestamp} and {end_timestamp})")
 
-        timestamp = datetime.fromisoformat("2021-06-30 08:59:59").timestamp()
-        state.process_tick(timestamp, strategy)
-        strategy.process_tick.assert_called_with(timestamp, False)
+        state.process_tick(datetime.fromisoformat("2021-06-30 08:59:59").timestamp(), strategy)
+        strategy.process_tick.assert_not_called()
+        strategy.cancel_active_orders.assert_called()
         self.assertEqual(len(self.debug_logs), 5)
         self.assertEqual(self.debug_logs[0], "Time span execution: tick will not be processed "
                                              f"(executing between {start_timestamp} and {end_timestamp})")
 
-        timestamp = datetime.fromisoformat("2021-06-30 09:00:00").timestamp()
-        state.process_tick(timestamp, strategy)
-        strategy.process_tick.assert_called_with(timestamp, True)
+        state.process_tick(datetime.fromisoformat("2021-06-30 09:00:00").timestamp(), strategy)
+        strategy.process_tick.assert_called()
 
-        timestamp = datetime.fromisoformat("2021-06-30 09:00:00").timestamp()
-        state.process_tick(timestamp, strategy)
-        strategy.process_tick.assert_called_with(timestamp, True)
+        state.process_tick(datetime.fromisoformat("2021-06-30 09:00:00").timestamp(), strategy)
+        strategy.process_tick.assert_called()
 
         strategy.process_tick.reset_mock()
-        timestamp = datetime.fromisoformat("2021-06-30 10:00:01").timestamp()
-        state.process_tick(timestamp, strategy)
-        strategy.process_tick.assert_called_with(timestamp, False)
+        state.process_tick(datetime.fromisoformat("2021-06-30 10:00:01").timestamp(), strategy)
+        strategy.process_tick.assert_not_called()
+        strategy.cancel_active_orders.assert_called()
         self.assertEqual(len(self.debug_logs), 6)
         self.assertEqual(self.debug_logs[1], "Time span execution: tick will not be processed "
                                              f"(executing between {start_timestamp} and {end_timestamp})")


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Currently orders are being cancelled on refresh time if the difference between them and the proposal is higher than `order_refresh_tolerance_pct` or if they're older than `max_order_age`. The first condition can't be satisfied if trading is not allowed because there's no proposal created and the `c_cancel_active_orders()` method is not even being called, because `process_tick()` is not being called. By default the `max_order_age` is set to a high value of 1800. Therefore when the trading period is over there's a possibility that active orders will remain in the market for a long time, creating a possibility of unpredictable / unwanted fills. All active orders therefore need to be cancelled right away after trading has ended. Conditional execution has to call a method to cancel all active orders immediately if if trading is not allowed.

**Tests performed by the developer**:

- Ran the unit tests
- Ran the Avellaneda strategy with binance paper and a constrained timeframe to verify if active orders are cancelled after the end of the trading period is reached

**Tests performed by QA**:

- Start an Avellaneda MM strategy with execution time set to from_date_to_date.
- Set the start_time and end_time for 10 minutes
- Configure a long refresh time (15 min)
- Start the strategy and monitor the order cancellation by running status --live and confirm that after the end_time is reached the order remains active until it reached the 15 min refresh duration and no new order is created after.
- Repeat the test but with low refresh duration and confirm that after reaching the end_time, all orders are canceled and no new order is created.
- Do the same test but using execution_time: daily_between_times