### PR TITLE
fix/ Docker build error libffi.so.6 not found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ USER hummingbot:hummingbot
 WORKDIR /home/hummingbot
 
 # Install miniconda
-RUN curl https://repo.anaconda.com/miniconda/Miniconda3-py38_4.8.2-Linux-x86_64.sh -o ~/miniconda.sh && \
+RUN curl https://repo.anaconda.com/miniconda/Miniconda3-py38_4.9.2-Linux-x86_64.sh -o ~/miniconda.sh && \
     /bin/bash ~/miniconda.sh -b && \
     rm ~/miniconda.sh && \
     ~/miniconda3/bin/conda update -n base conda -y && \


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
It appears that this error occurs specifically for Ubuntu 20.04 since `libffi.so.6` is no longer supported and instead has been upgraded to `libffi.so.7`. Online sources suggested that updating the miniconda version would resolve this issue. I've chosen to update it to `4.9.2` to maintain some consistency with `Dockerfile.arm`

Note:
This should resolve #5043

**Tests performed by the developer**:
None needed.


**Tips for QA testing**:
Ensure that `docker build` works on all OSes.
