### PR TITLE
Fix/XEMM-allow-auto-set-order-amount

### DIFF
--- a/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making_config_map.py
+++ b/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making_config_map.py
@@ -122,7 +122,7 @@ cross_exchange_market_making_config_map = {
         prompt=order_amount_prompt,
         prompt_on_new=True,
         type_str="decimal",
-        validator=lambda v: validate_decimal(v, min_value=Decimal("0"), inclusive=False),
+        validator=lambda v: validate_decimal(v, min_value=Decimal("0"), inclusive=True),
     ),
     "adjust_order_enabled": ConfigVar(
         key="adjust_order_enabled",


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
```
    cdef object c_get_adjusted_limit_order_size(self, object market_pair):
        """
        Given the proposed order size of a proposed limit order (regardless of bid or ask), adjust and refine the order
        sizing according to either the trade size override setting (if it exists), or the portfolio ratio limit (if
        no trade size override exists).

        Also, this function will convert the input order size proposal from floating point to Decimal by quantizing the
        order size.

        :param market_pair: cross exchange market pair
        :rtype: Decimal
        """
        cdef:
            ExchangeBase maker_market = market_pair.maker.market
            str trading_pair = market_pair.maker.trading_pair
        if self._order_amount and self._order_amount > 0:
            base_order_size = self._order_amount
            return maker_market.c_quantize_order_amount(trading_pair, Decimal(base_order_size))
        else:
            return self.c_get_order_size_after_portfolio_ratio_limit(market_pair)
```
code already allow for getting order size automated but order amount cannot be set to 0 due to config map validation.
**Tests performed by the developer**:



**Tips for QA testing**:


