### PR TITLE
fix/restore tracking state using client order tracker

### DIFF
--- a/hummingbot/connector/client_order_tracker.py
+++ b/hummingbot/connector/client_order_tracker.py
@@ -100,6 +100,16 @@ class ClientOrderTracker:
             self._cached_orders[client_order_id] = self._in_flight_orders[client_order_id]
             del self._in_flight_orders[client_order_id]
 
+    def restore_tracking_states(self, tracking_states: Dict[str, any]):
+        """
+        Restore in-flight orders from saved tracking states.
+        :param tracking_states: a dictionary associating order ids with the serialized order (JSON format).
+        """
+        for serialized_order in tracking_states.values():
+            order = InFlightOrder.from_json(serialized_order)
+            if order.is_open:
+                self.start_tracking_order(order)
+
     def fetch_tracked_order(self, client_order_id: str) -> Optional[InFlightOrder]:
         return self._in_flight_orders.get(client_order_id, None)
 

--- a/hummingbot/connector/derivative/binance_perpetual/binance_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/binance_perpetual/binance_perpetual_derivative.py
@@ -15,14 +15,14 @@ from hummingbot.connector.client_order_tracker import ClientOrderTracker
 from hummingbot.connector.derivative.binance_perpetual.binance_perpetual_api_order_book_data_source import (
     BinancePerpetualAPIOrderBookDataSource
 )
+from hummingbot.connector.derivative.binance_perpetual.binance_perpetual_auth import (
+    BinancePerpetualAuth
+)
 from hummingbot.connector.derivative.binance_perpetual.binance_perpetual_order_book_tracker import (
     BinancePerpetualOrderBookTracker
 )
 from hummingbot.connector.derivative.binance_perpetual.binance_perpetual_user_stream_tracker import (
     BinancePerpetualUserStreamTracker
-)
-from hummingbot.connector.derivative.binance_perpetual.binance_perpetual_auth import (
-    BinancePerpetualAuth
 )
 from hummingbot.connector.derivative.perpetual_budget_checker import PerpetualBudgetChecker
 from hummingbot.connector.derivative.position import Position
@@ -176,8 +176,7 @@ class BinancePerpetualDerivative(ExchangeBase, PerpetualTrading):
         Restore in-flight orders from saved tracking states; this is such that the connector can pick up
         on where it left off should it crash unexpectedly.
         """
-        for data in saved_states.values():
-            self._client_order_tracker.start_tracking_order(InFlightOrder.from_json(data))
+        self._client_order_tracker.restore_tracking_states(tracking_states=saved_states)
 
     def supported_order_types(self) -> List[OrderType]:
         """

--- a/hummingbot/connector/exchange/ascend_ex/ascend_ex_exchange.py
+++ b/hummingbot/connector/exchange/ascend_ex/ascend_ex_exchange.py
@@ -1,39 +1,36 @@
-import aiohttp
 import asyncio
 import json
 import logging
 import time
-
 from collections import namedtuple
 from decimal import Decimal
 from enum import Enum
 from typing import (
+    Any,
+    AsyncIterable,
     Dict,
     List,
     Optional,
-    Any,
-    AsyncIterable,
 )
 
+import aiohttp
+
 from hummingbot.connector.client_order_tracker import ClientOrderTracker
-from hummingbot.connector.exchange.ascend_ex import ascend_ex_constants as CONSTANTS
-from hummingbot.connector.exchange.ascend_ex import ascend_ex_utils
+from hummingbot.connector.exchange.ascend_ex import ascend_ex_constants as CONSTANTS, ascend_ex_utils
 from hummingbot.connector.exchange.ascend_ex.ascend_ex_auth import AscendExAuth
 from hummingbot.connector.exchange.ascend_ex.ascend_ex_order_book_tracker import AscendExOrderBookTracker
 from hummingbot.connector.exchange.ascend_ex.ascend_ex_user_stream_tracker import AscendExUserStreamTracker
 from hummingbot.connector.exchange_py_base import ExchangePyBase
 from hummingbot.connector.trading_rule import TradingRule
+from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.clock import Clock
 from hummingbot.core.data_type.cancellation_result import CancellationResult
+from hummingbot.core.data_type.common import OpenOrder
 from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState, OrderUpdate
 from hummingbot.core.data_type.limit_order import LimitOrder
 from hummingbot.core.data_type.order_book import OrderBook
-from hummingbot.core.event.events import (
-    OrderType, TradeType
-)
 from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee
-from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
-from hummingbot.core.data_type.common import OpenOrder
+from hummingbot.core.event.events import OrderType, TradeType
 from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.core.utils.async_utils import safe_ensure_future, safe_gather
 from hummingbot.logger import HummingbotLogger
@@ -204,8 +201,7 @@ class AscendExExchange(ExchangePyBase):
         when it disconnects.
         :param saved_states: The saved tracking_states.
         """
-        for data in saved_states.values():
-            self._in_flight_order_tracker.start_tracking_order(InFlightOrder.from_json(data))
+        self._in_flight_order_tracker.restore_tracking_states(tracking_states=saved_states)
 
     def supported_order_types(self) -> List[OrderType]:
         """

--- a/hummingbot/connector/exchange/binance/binance_exchange.py
+++ b/hummingbot/connector/exchange/binance/binance_exchange.py
@@ -241,8 +241,7 @@ class BinanceExchange(ExchangeBase):
         when it disconnects.
         :param saved_states: The saved tracking_states.
         """
-        for data in saved_states.values():
-            self._order_tracker.start_tracking_order(InFlightOrder.from_json(data))
+        self._order_tracker.restore_tracking_states(tracking_states=saved_states)
 
     def tick(self, timestamp: float):
         """

--- a/hummingbot/core/data_type/in_flight_order.py
+++ b/hummingbot/core/data_type/in_flight_order.py
@@ -146,7 +146,11 @@ class InFlightOrder:
 
     @property
     def is_open(self) -> bool:
-        return self.current_state in {OrderState.PENDING_CREATE, OrderState.OPEN, OrderState.PARTIALLY_FILLED}
+        return self.current_state in {
+            OrderState.PENDING_CREATE,
+            OrderState.OPEN,
+            OrderState.PARTIALLY_FILLED,
+            OrderState.PENDING_CANCEL}
 
     @property
     def is_done(self) -> bool:

--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
@@ -1,50 +1,46 @@
 import datetime
-from decimal import Decimal
 import logging
-from math import (
-    floor,
-    ceil,
-    isnan
-)
-import numpy as np
 import os
-import pandas as pd
 import time
+from decimal import Decimal
+from math import (
+    ceil,
+    floor,
+    isnan,
+)
 from typing import (
-    List,
     Dict,
+    List,
     Tuple,
 )
 
-from hummingbot.client.config.global_config_map import global_config_map
+import numpy as np
+import pandas as pd
+
 from hummingbot.connector.exchange_base import ExchangeBase
 from hummingbot.connector.exchange_base cimport ExchangeBase
 from hummingbot.core.clock cimport Clock
-from hummingbot.core.event.events import TradeType
 from hummingbot.core.data_type.limit_order cimport LimitOrder
 from hummingbot.core.data_type.limit_order import LimitOrder
-from hummingbot.core.data_type.order_book import OrderBook
-from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.core.event.events import OrderType
-
+from hummingbot.core.event.events import TradeType
+from hummingbot.core.network_iterator import NetworkStatus
+from hummingbot.core.utils import map_df_to_str
 from hummingbot.strategy.__utils__.trailing_indicators.instant_volatility import InstantVolatilityIndicator
 from hummingbot.strategy.__utils__.trailing_indicators.trading_intensity import TradingIntensityIndicator
-from hummingbot.strategy.conditional_execution_state import (
-    RunAlwaysExecutionState,
-    RunInTimeConditionalExecutionState
-)
+from hummingbot.strategy.conditional_execution_state import RunAlwaysExecutionState
 from hummingbot.strategy.data_types import (
+    PriceSize,
     Proposal,
-    PriceSize)
+)
 from hummingbot.strategy.hanging_orders_tracker import (
     CreatedPairOfOrders,
-    HangingOrdersTracker)
+    HangingOrdersTracker,
+)
 from hummingbot.strategy.market_trading_pair_tuple import MarketTradingPairTuple
 from hummingbot.strategy.order_tracker cimport OrderTracker
 from hummingbot.strategy.strategy_base import StrategyBase
 from hummingbot.strategy.utils import order_age
-from hummingbot.core.utils import map_df_to_str
-
 
 NaN = float("nan")
 s_decimal_zero = Decimal(0)
@@ -577,8 +573,7 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
             for order_id in restored_order_ids:
                 order = next(o for o in self.market_info.market.limit_orders if o.client_order_id == order_id)
                 if order:
-                    self._hanging_orders_tracker.add_order(order)
-                    self._hanging_orders_tracker.update_strategy_orders_with_equivalent_orders()
+                    self._hanging_orders_tracker.add_as_hanging_order(order)
 
         self._execution_state.time_left = self._execution_state.closing_time
 

--- a/hummingbot/strategy/hanging_orders_tracker.py
+++ b/hummingbot/strategy/hanging_orders_tracker.py
@@ -1,6 +1,6 @@
 import logging
 from decimal import Decimal
-from typing import Dict, List, Set, Tuple, Union, Optional
+from typing import Dict, List, Optional, Set, Tuple, Union
 
 from hummingbot.connector.connector_base import ConnectorBase
 from hummingbot.core.data_type.limit_order import LimitOrder
@@ -9,7 +9,8 @@ from hummingbot.core.event.events import (
     BuyOrderCompletedEvent,
     MarketEvent,
     OrderCancelledEvent,
-    SellOrderCompletedEvent)
+    SellOrderCompletedEvent,
+)
 from hummingbot.logger import HummingbotLogger
 from hummingbot.strategy.data_types import HangingOrder
 from hummingbot.strategy.strategy_base import StrategyBase
@@ -185,6 +186,10 @@ class HangingOrdersTracker:
 
     def add_order(self, order: LimitOrder):
         self.original_orders.add(order)
+
+    def add_as_hanging_order(self, order: LimitOrder):
+        self.strategy_current_hanging_orders.add(self._get_hanging_order_from_limit_order(order))
+        self.add_order(order)
 
     def remove_order(self, order: LimitOrder):
         if order in self.original_orders:

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pyx
@@ -1,48 +1,45 @@
-from decimal import Decimal
 import logging
-import pandas as pd
-import numpy as np
-from typing import (
-    List,
-    Dict,
-    Optional
-)
-from math import (
-    floor,
-    ceil
-)
 import time
-from hummingbot.core.clock cimport Clock
-from hummingbot.core.event.events import TradeType, PriceType
-from hummingbot.core.data_type.limit_order cimport LimitOrder
-from hummingbot.core.data_type.limit_order import LimitOrder
-from hummingbot.core.network_iterator import NetworkStatus
+from decimal import Decimal
+from math import (
+    ceil,
+    floor,
+)
+from typing import (
+    Dict,
+    List,
+    Optional,
+)
+
+import numpy as np
+import pandas as pd
+
 from hummingbot.connector.exchange_base import ExchangeBase
 from hummingbot.connector.exchange_base cimport ExchangeBase
-from hummingbot.core.event.events import OrderType
+from hummingbot.core.clock cimport Clock
+from hummingbot.core.data_type.limit_order cimport LimitOrder
+from hummingbot.core.data_type.limit_order import LimitOrder
+from hummingbot.core.event.events import OrderType, PriceType, TradeType
+from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.core.utils import map_df_to_str
-
-from hummingbot.strategy.market_trading_pair_tuple import MarketTradingPairTuple
-from hummingbot.strategy.strategy_base import StrategyBase
-from hummingbot.client.config.global_config_map import global_config_map
-from hummingbot.strategy.utils import order_age
-from .data_types import (
-    Proposal,
-    PriceSize
-)
-from .pure_market_making_order_tracker import PureMarketMakingOrderTracker
-
-from hummingbot.strategy.hanging_orders_tracker import (
-    CreatedPairOfOrders,
-    HangingOrdersTracker)
-
 from hummingbot.strategy.asset_price_delegate cimport AssetPriceDelegate
 from hummingbot.strategy.asset_price_delegate import AssetPriceDelegate
+from hummingbot.strategy.hanging_orders_tracker import (
+    CreatedPairOfOrders,
+    HangingOrdersTracker,
+)
+from hummingbot.strategy.market_trading_pair_tuple import MarketTradingPairTuple
+from hummingbot.strategy.order_book_asset_price_delegate cimport OrderBookAssetPriceDelegate
+from hummingbot.strategy.strategy_base import StrategyBase
+from hummingbot.strategy.utils import order_age
+from .data_types import (
+    PriceSize,
+    Proposal,
+)
+from .inventory_cost_price_delegate import InventoryCostPriceDelegate
 from .inventory_skew_calculator cimport c_calculate_bid_ask_ratios_from_base_asset_ratio
 from .inventory_skew_calculator import calculate_total_order_size
-from hummingbot.strategy.order_book_asset_price_delegate cimport OrderBookAssetPriceDelegate
-from .inventory_cost_price_delegate import InventoryCostPriceDelegate
-
+from .pure_market_making_order_tracker import PureMarketMakingOrderTracker
 
 NaN = float("nan")
 s_decimal_zero = Decimal(0)
@@ -673,8 +670,7 @@ cdef class PureMarketMakingStrategy(StrategyBase):
             for order_id in restored_order_ids:
                 order = next(o for o in self.market_info.market.limit_orders if o.client_order_id == order_id)
                 if order:
-                    self._hanging_orders_tracker.add_order(order)
-                    self._hanging_orders_tracker.update_strategy_orders_with_equivalent_orders()
+                    self._hanging_orders_tracker.add_as_hanging_order(order)
 
     cdef c_stop(self, Clock clock):
         self._hanging_orders_tracker.unregister_events(self.active_markets)

--- a/test/hummingbot/connector/exchange/ascend_ex/test_ascend_ex_exchange.py
+++ b/test/hummingbot/connector/exchange/ascend_ex/test_ascend_ex_exchange.py
@@ -4,20 +4,21 @@ import re
 import unittest
 
 from decimal import Decimal
-from typing import Awaitable, Optional, List
+from typing import Awaitable, List, Optional
 from unittest.mock import MagicMock
 
 from aioresponses import aioresponses
 
 from hummingbot.connector.exchange.ascend_ex import ascend_ex_constants as CONSTANTS, ascend_ex_utils
 from hummingbot.connector.exchange.ascend_ex.ascend_ex_exchange import (
+    AscendExCommissionType,
     AscendExExchange,
     AscendExTradingRule,
-    AscendExCommissionType,
 )
 from hummingbot.core.data_type.cancellation_result import CancellationResult
+from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState
 from hummingbot.core.event.event_logger import EventLogger
-from hummingbot.core.event.events import OrderType, TradeType, MarketEvent, MarketOrderFailureEvent
+from hummingbot.core.event.events import MarketEvent, MarketOrderFailureEvent, OrderType, TradeType
 from test.hummingbot.connector.network_mocking_assistant import NetworkMockingAssistant
 
 
@@ -244,3 +245,54 @@ class TestAscendExExchange(unittest.TestCase):
         self.assertEqual("INFO", self.log_records[3].levelname)
         self.assertTrue(
             self.log_records[3].getMessage().startswith(f"Order {order.client_order_id} has failed. Order Update:"))
+
+    def test_restore_tracking_states_only_registers_open_orders(self):
+        orders = []
+        orders.append(InFlightOrder(
+            client_order_id="OID1",
+            exchange_order_id="EOID1",
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            trade_type=TradeType.BUY,
+            amount=Decimal("1000.0"),
+            price=Decimal("1.0"),
+        ))
+        orders.append(InFlightOrder(
+            client_order_id="OID2",
+            exchange_order_id="EOID2",
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            trade_type=TradeType.BUY,
+            amount=Decimal("1000.0"),
+            price=Decimal("1.0"),
+            initial_state=OrderState.CANCELLED
+        ))
+        orders.append(InFlightOrder(
+            client_order_id="OID3",
+            exchange_order_id="EOID3",
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            trade_type=TradeType.BUY,
+            amount=Decimal("1000.0"),
+            price=Decimal("1.0"),
+            initial_state=OrderState.FILLED
+        ))
+        orders.append(InFlightOrder(
+            client_order_id="OID4",
+            exchange_order_id="EOID4",
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            trade_type=TradeType.BUY,
+            amount=Decimal("1000.0"),
+            price=Decimal("1.0"),
+            initial_state=OrderState.FAILED
+        ))
+
+        tracking_states = {order.client_order_id: order.to_json() for order in orders}
+
+        self.exchange.restore_tracking_states(tracking_states)
+
+        self.assertIn("OID1", self.exchange.in_flight_orders)
+        self.assertNotIn("OID2", self.exchange.in_flight_orders)
+        self.assertNotIn("OID3", self.exchange.in_flight_orders)
+        self.assertNotIn("OID4", self.exchange.in_flight_orders)

--- a/test/hummingbot/connector/exchange/binance/test_binance_exchange.py
+++ b/test/hummingbot/connector/exchange/binance/test_binance_exchange.py
@@ -9,8 +9,7 @@ from unittest.mock import AsyncMock, patch
 from aioresponses import aioresponses
 from bidict import bidict
 
-import hummingbot.connector.exchange.binance.binance_constants as CONSTANTS
-from hummingbot.connector.exchange.binance import binance_utils
+from hummingbot.connector.exchange.binance import binance_constants as CONSTANTS, binance_utils
 from hummingbot.connector.exchange.binance.binance_api_order_book_data_source import BinanceAPIOrderBookDataSource
 from hummingbot.connector.exchange.binance.binance_exchange import BinanceExchange
 from hummingbot.connector.trading_rule import TradingRule
@@ -1493,3 +1492,54 @@ class BinanceExchangeTests(TestCase):
 
         self.assertEqual(Decimal("10000"), self.exchange.available_balances["COINALPHA"])
         self.assertEqual(Decimal("10500"), self.exchange.get_balance("COINALPHA"))
+
+    def test_restore_tracking_states_only_registers_open_orders(self):
+        orders = []
+        orders.append(InFlightOrder(
+            client_order_id="OID1",
+            exchange_order_id="EOID1",
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            trade_type=TradeType.BUY,
+            amount=Decimal("1000.0"),
+            price=Decimal("1.0"),
+        ))
+        orders.append(InFlightOrder(
+            client_order_id="OID2",
+            exchange_order_id="EOID2",
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            trade_type=TradeType.BUY,
+            amount=Decimal("1000.0"),
+            price=Decimal("1.0"),
+            initial_state=OrderState.CANCELLED
+        ))
+        orders.append(InFlightOrder(
+            client_order_id="OID3",
+            exchange_order_id="EOID3",
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            trade_type=TradeType.BUY,
+            amount=Decimal("1000.0"),
+            price=Decimal("1.0"),
+            initial_state=OrderState.FILLED
+        ))
+        orders.append(InFlightOrder(
+            client_order_id="OID4",
+            exchange_order_id="EOID4",
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            trade_type=TradeType.BUY,
+            amount=Decimal("1000.0"),
+            price=Decimal("1.0"),
+            initial_state=OrderState.FAILED
+        ))
+
+        tracking_states = {order.client_order_id: order.to_json() for order in orders}
+
+        self.exchange.restore_tracking_states(tracking_states)
+
+        self.assertIn("OID1", self.exchange.in_flight_orders)
+        self.assertNotIn("OID2", self.exchange.in_flight_orders)
+        self.assertNotIn("OID3", self.exchange.in_flight_orders)
+        self.assertNotIn("OID4", self.exchange.in_flight_orders)

--- a/test/hummingbot/connector/test_client_order_tracker.py
+++ b/test/hummingbot/connector/test_client_order_tracker.py
@@ -767,3 +767,54 @@ class ClientOrderTrackerUnitTest(unittest.TestCase):
         self.tracker.process_order_not_found(order.client_order_id)
 
         self.assertNotIn(order.client_order_id, self.tracker.active_orders)
+
+    def test_restore_tracking_states_only_registers_open_orders(self):
+        orders = []
+        orders.append(InFlightOrder(
+            client_order_id="OID1",
+            exchange_order_id="EOID1",
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            trade_type=TradeType.BUY,
+            amount=Decimal("1000.0"),
+            price=Decimal("1.0"),
+        ))
+        orders.append(InFlightOrder(
+            client_order_id="OID2",
+            exchange_order_id="EOID2",
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            trade_type=TradeType.BUY,
+            amount=Decimal("1000.0"),
+            price=Decimal("1.0"),
+            initial_state=OrderState.CANCELLED
+        ))
+        orders.append(InFlightOrder(
+            client_order_id="OID3",
+            exchange_order_id="EOID3",
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            trade_type=TradeType.BUY,
+            amount=Decimal("1000.0"),
+            price=Decimal("1.0"),
+            initial_state=OrderState.FILLED
+        ))
+        orders.append(InFlightOrder(
+            client_order_id="OID4",
+            exchange_order_id="EOID4",
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            trade_type=TradeType.BUY,
+            amount=Decimal("1000.0"),
+            price=Decimal("1.0"),
+            initial_state=OrderState.FAILED
+        ))
+
+        tracking_states = {order.client_order_id: order.to_json() for order in orders}
+
+        self.tracker.restore_tracking_states(tracking_states)
+
+        self.assertIn("OID1", self.tracker.active_orders)
+        self.assertNotIn("OID2", self.tracker.all_orders)
+        self.assertNotIn("OID3", self.tracker.all_orders)
+        self.assertNotIn("OID4", self.tracker.all_orders)

--- a/test/hummingbot/core/data_type/test_in_flight_order.py
+++ b/test/hummingbot/core/data_type/test_in_flight_order.py
@@ -91,7 +91,10 @@ class InFlightOrderPyUnitTests(unittest.TestCase):
         # Simulate Order Cancellation request sent
         self._simulate_cancel_order_request_sent(order)
 
-        self.assertTrue(order.is_pending_cancel_confirmation and not order.is_open and not order.is_cancelled)
+        self.assertTrue(order.is_pending_cancel_confirmation
+                        and order.is_open
+                        and not order.is_cancelled
+                        and not order.is_done)
 
         # Simulate Order Cancelled
         self._simulate_order_cancelled(order)

--- a/test/hummingbot/strategy/test_hanging_orders_tracker.py
+++ b/test/hummingbot/strategy/test_hanging_orders_tracker.py
@@ -1,19 +1,19 @@
+import unittest
 from decimal import Decimal
 from datetime import datetime
 from mock import MagicMock, PropertyMock
-import unittest
 
+from hummingbot.core.data_type.limit_order import LimitOrder
 from hummingbot.core.event.events import (
     BuyOrderCompletedEvent,
     MarketEvent,
     OrderCancelledEvent,
 )
+from hummingbot.strategy.data_types import OrderType
 from hummingbot.strategy.hanging_orders_tracker import (
     CreatedPairOfOrders,
     HangingOrdersTracker,
 )
-from hummingbot.strategy.data_types import OrderType
-from hummingbot.core.data_type.limit_order import LimitOrder
 
 
 class TestHangingOrdersTracker(unittest.TestCase):
@@ -477,3 +477,14 @@ class TestHangingOrdersTracker(unittest.TestCase):
         self.assertNotIn(sell_order_1, self.tracker.original_orders)
         self.assertIn(sell_order_2, self.tracker.original_orders)
         self.assertNotIn(sell_order_3, self.tracker.original_orders)
+
+    def test_add_order_as_hanging_order(self):
+        order = LimitOrder("Order-number-1", "BTC-USDT", True, "BTC", "USDT", Decimal(100), Decimal(1))
+        self.tracker.add_as_hanging_order(order)
+
+        self.assertIn(order, self.tracker.original_orders)
+        self.assertEqual(1, len(self.tracker.strategy_current_hanging_orders))
+
+        hanging_order = next((hanging_order for hanging_order in self.tracker.strategy_current_hanging_orders))
+
+        self.assertEqual(order.client_order_id, hanging_order.order_id)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
This PR is a fix to the issue https://github.com/hummingbot/hummingbot/issues/5044
Change in the logic that registers recovered orders from previous sessions as hanging orders (in Pure Market Making strategy and Avellaneda strategy), to prevent the hanging order tracker from confusing this orders and trying to regenerate (recreate) them.
Fix in the code that recovers orders from previous sessions in the connectors that use the Client Order Tracker, to ignore orders that were marked as done in the previous session:
- Binance spot
- Binance perpetual
- AscendEx

Comes from https://github.com/CoinAlpha/hummingbot/pull/60

**Tests performed by the developer**:
Added new unit tests for the described scenarios.
I have also executed a bot configured to run PMM with hanging orders using Binance spot connector.


**Test summary**:
- Create and start a pure market-making strategy with hanging order enabled for both AscendEX and Binance connector.
- Wait for hanging order to be created and restart the strategy
- Check the status and confirmed that no hanging order was created after the restart.
- Configure the max order age to a low value to allow the hanging order to get refreshed
- Restart the strategy and run status live
- Confirm that no extra hanging orders are created when the existing hanging order is refreshed
- Create and started an Avellaneda market making strategy with hanging order enabled for bot AscendEX and Binance.
- Repeat the same steps performed on the PMM test and confirmed that hanging orders are canceled properly and no unwanted hanging orders were created.
- Create a perpetual market-making strategy using the Binance_perpetual connector and wait for an open order to be opened.
- Restart the strategy after opening a position and confirmed that the open position was picked up by the bot.



**Tips for QA testing**:
Please test the scenario described in the original issue, in the three connectors mentioned above using PMM and Avellaneda strategies.


Fixes #5044 