### PR TITLE
Fix/xemm order size taker volume factor

### DIFF
--- a/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pyx
+++ b/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pyx
@@ -65,7 +65,7 @@ cdef class CrossExchangeMarketMakingStrategy(StrategyBase):
                     market_pairs: List[CrossExchangeMarketPair],
                     min_profitability: Decimal,
                     order_amount: Optional[Decimal] = Decimal("0.0"),
-                    order_size_taker_volume_factor: Decimal = Decimal("0.25"),
+                    order_size_taker_volume_factor: Decimal = Decimal("1"),
                     order_size_taker_balance_factor: Decimal = Decimal("0.995"),
                     order_size_portfolio_ratio_limit: Decimal = Decimal("0.1667"),
                     limit_order_min_expiration: float = 130.0,

--- a/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pyx
+++ b/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pyx
@@ -715,7 +715,7 @@ cdef class CrossExchangeMarketMakingStrategy(StrategyBase):
                 sell_fill_quantity,
                 taker_market.c_get_available_balance(market_pair.taker.quote_asset) /
                 market_pair.taker.get_price_for_volume(True, sell_fill_quantity).result_price *
-                self._order_size_taker_balance_factor
+                self._order_size_taker_volume_factor
             )
             quantized_hedge_amount = taker_market.c_quantize_order_amount(taker_trading_pair, Decimal(hedged_order_quantity))
             taker_top = taker_market.c_get_price(taker_trading_pair, True)
@@ -837,7 +837,7 @@ cdef class CrossExchangeMarketMakingStrategy(StrategyBase):
             maker_balance = maker_market.c_get_available_balance(market_pair.maker.base_asset)
 
             taker_balance_in_quote = taker_market.c_get_available_balance(market_pair.taker.quote_asset) * \
-                self._order_size_taker_balance_factor
+                self._order_size_taker_volume_factor
 
             user_order = self.c_get_adjusted_limit_order_size(market_pair)
 

--- a/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making_config_map.py
+++ b/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making_config_map.py
@@ -178,10 +178,10 @@ cross_exchange_market_making_config_map = {
         key="order_size_taker_volume_factor",
         prompt="What percentage of hedge-able volume would you like to be traded on the taker market? "
                "(Enter 1 to indicate 1%) >>> ",
-        default=25,
+        default=100,
         type_str="decimal",
         required_if=lambda: False,
-        validator=lambda v: validate_decimal(v, Decimal(0), Decimal(100), inclusive=False)
+        validator=lambda v: validate_decimal(v, Decimal(0), Decimal(100), inclusive=True)
     ),
     "order_size_taker_balance_factor": ConfigVar(
         key="order_size_taker_balance_factor",


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Changed order_size_taker_balance to an unused parameter called order_size_taker_volume
There is no parameter that helps to limit the ratio of available quote asset on taker when calculating market size and this parameter is unused in the main code. I am not entirely sure of the purpose of this parameter. 
But to me, it seems that the intention of this parameter is to limit the taker quote volume that can be used in the strategy. Hence I am proposing this change to use this parameter instead to limit the taker quote volume so that there is a separation of quote asset allocation and base asset allocation.

Please reject this proposal if this is not the intent.


**Tests performed by the developer**:



**Tips for QA testing**:


