### PR TITLE
question on xemm check_if_sufficient_balance method

### DIFF
--- a/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pyx
+++ b/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pyx
@@ -1161,7 +1161,7 @@ cdef class CrossExchangeMarketMakingStrategy(StrategyBase):
             quote_asset_amount = taker_market.c_get_available_balance(market_pair.taker.quote_asset) * quote_rate
             taker_slippage_adjustment_factor = Decimal("1") + self._slippage_buffer
             taker_price = self.c_calculate_effective_hedging_price(
-                taker_trading_pair, True, active_order.quantity
+                market_pair, True, active_order.quantity
             )
             order_size_limit = taker_price * taker_slippage_adjustment_factor
 

--- a/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pyx
+++ b/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pyx
@@ -1158,12 +1158,13 @@ cdef class CrossExchangeMarketMakingStrategy(StrategyBase):
         if is_buy:
             order_size_limit = taker_market.c_get_available_balance(market_pair.taker.base_asset) * base_rate
         else:
-            quote_asset_amount = taker_market.c_get_available_balance(market_pair.taker.quote_asset) * quote_rate
+            quote_asset_amount = taker_market.c_get_available_balance(market_pair.taker.quote_asset)
             taker_slippage_adjustment_factor = Decimal("1") + self._slippage_buffer
             taker_price = self.c_calculate_effective_hedging_price(
                 market_pair, True, active_order.quantity
             )
-            order_size_limit = taker_price * taker_slippage_adjustment_factor
+            adjusted_taker_price =  taker_price * taker_slippage_adjustment_factor
+            order_size_limit = quote_asset_amount / adjusted_taker_price
 
         quantized_size_limit = maker_market.c_quantize_order_amount(active_order.trading_pair, order_size_limit)
 

--- a/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pyx
+++ b/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pyx
@@ -1161,7 +1161,7 @@ cdef class CrossExchangeMarketMakingStrategy(StrategyBase):
             quote_asset_amount = taker_market.c_get_available_balance(market_pair.taker.quote_asset) * quote_rate
             taker_slippage_adjustment_factor = Decimal("1") + self._slippage_buffer
             taker_price = self.c_calculate_effective_hedging_price(
-                taker_trading_pair, True, user_order
+                taker_trading_pair, True, active_order.quantity
             ).result_price
             order_size_limit = taker_price * taker_slippage_adjustment_factor
 

--- a/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pyx
+++ b/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pyx
@@ -1162,7 +1162,7 @@ cdef class CrossExchangeMarketMakingStrategy(StrategyBase):
             taker_slippage_adjustment_factor = Decimal("1") + self._slippage_buffer
             taker_price = self.c_calculate_effective_hedging_price(
                 taker_trading_pair, True, active_order.quantity
-            ).result_price
+            )
             order_size_limit = taker_price * taker_slippage_adjustment_factor
 
         quantized_size_limit = maker_market.c_quantize_order_amount(active_order.trading_pair, order_size_limit)

--- a/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pyx
+++ b/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pyx
@@ -1156,12 +1156,12 @@ cdef class CrossExchangeMarketMakingStrategy(StrategyBase):
             self.get_taker_to_maker_conversion_rate()
 
         if is_buy:
-            order_size_limit = taker_market.c_get_balance(market_pair.taker.base_asset) * base_rate
+            order_size_limit = taker_market.c_get_available_balance(market_pair.taker.base_asset) * base_rate
         else:
-            quote_asset_amount = taker_market.c_get_balance(market_pair.taker.quote_asset) * quote_rate
+            quote_asset_amount = taker_market.c_get_available_balance(market_pair.taker.quote_asset) * quote_rate
             taker_slippage_adjustment_factor = Decimal("1") + self._slippage_buffer
-            taker_price = taker_market.c_get_price_for_quote_volume(
-                taker_trading_pair, True, quote_asset_amount
+            taker_price = self.c_calculate_effective_hedging_price(
+                taker_trading_pair, True, user_order
             ).result_price
             order_size_limit = taker_price * taker_slippage_adjustment_factor
 

--- a/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pyx
+++ b/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.pyx
@@ -1156,18 +1156,14 @@ cdef class CrossExchangeMarketMakingStrategy(StrategyBase):
             self.get_taker_to_maker_conversion_rate()
 
         if is_buy:
-            quote_asset_amount = maker_market.c_get_balance(market_pair.maker.quote_asset)
-            base_asset_amount = taker_market.c_get_balance(market_pair.taker.base_asset) * base_rate
-            order_size_limit = min(base_asset_amount, quote_asset_amount / order_price)
+            order_size_limit = taker_market.c_get_balance(market_pair.taker.base_asset) * base_rate
         else:
-            base_asset_amount = maker_market.c_get_balance(market_pair.maker.base_asset)
             quote_asset_amount = taker_market.c_get_balance(market_pair.taker.quote_asset) * quote_rate
             taker_slippage_adjustment_factor = Decimal("1") + self._slippage_buffer
             taker_price = taker_market.c_get_price_for_quote_volume(
                 taker_trading_pair, True, quote_asset_amount
             ).result_price
-            adjusted_taker_price = taker_price * taker_slippage_adjustment_factor
-            order_size_limit = min(base_asset_amount, quote_asset_amount / adjusted_taker_price)
+            order_size_limit = taker_price * taker_slippage_adjustment_factor
 
         quantized_size_limit = maker_market.c_quantize_order_amount(active_order.trading_pair, order_size_limit)
 


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Putting this for discussion first before I commit the effort to update the test for upload in case there are disagreements.

I am wondering why do we need to check for maker balance in this part of the code. The order can only be made if there is sufficient balance on the maker exchange.  So there is no need to check.

I think it should be checking for available balance instead as taker balance does not mean there is available balance to be used.

The calculation of taker price should be using the active order quantity to calculate the hedging price it will occur instead of the initial order size.


**Tests performed by the developer**:



**Tips for QA testing**:


