### PR TITLE
(fix) Adds an initial ping to user stream ws connection to update last recv time.

### DIFF
--- a/hummingbot/connector/exchange/binance/binance_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/binance/binance_api_user_stream_data_source.py
@@ -65,7 +65,7 @@ class BinanceAPIUserStreamDataSource(UserStreamTrackerDataSource):
         """
         if self._ws_assistant:
             return self._ws_assistant.last_recv_time
-        return -1
+        return 0
 
     async def listen_for_user_stream(self, ev_loop: asyncio.AbstractEventLoop, output: asyncio.Queue):
         """
@@ -82,6 +82,7 @@ class BinanceAPIUserStreamDataSource(UserStreamTrackerDataSource):
                 ws: WSAssistant = await self._get_ws_assistant()
                 url = f"{CONSTANTS.WSS_URL.format(self._domain)}/{self._current_listen_key}"
                 await ws.connect(ws_url=url, ping_timeout=CONSTANTS.WS_HEARTBEAT_TIME_INTERVAL)
+                await ws.ping()  # to update last_recv_timestamp
 
                 async for ws_response in ws.iter_messages():
                     data = ws_response.data

--- a/hummingbot/connector/exchange/binance/binance_exchange.py
+++ b/hummingbot/connector/exchange/binance/binance_exchange.py
@@ -163,6 +163,7 @@ class BinanceExchange(ExchangeBase):
             "order_books_initialized": self._order_book_tracker.ready,
             "account_balance": len(self._account_balances) > 0 if self._trading_required else True,
             "trading_rule_initialized": len(self._trading_rules) > 0,
+            "user_stream_initialized": self._user_stream_tracker.data_source.last_recv_time > 0,
         }
 
     @property

--- a/test/hummingbot/connector/derivative/binance_perpetual/test_binance_perpetual_user_stream_data_source.py
+++ b/test/hummingbot/connector/derivative/binance_perpetual/test_binance_perpetual_user_stream_data_source.py
@@ -325,6 +325,7 @@ class BinancePerpetualUserStreamDataSourceUnitTests(unittest.TestCase):
 
         msg = self.async_run_with_timeout(msg_queue.get())
         self.assertTrue(msg, self._simulate_user_update_event)
+        mock_ws.return_value.ping.assert_called()
 
     @aioresponses()
     @patch("aiohttp.ClientSession.ws_connect", new_callable=AsyncMock)

--- a/test/hummingbot/connector/exchange/binance/test_binance_user_stream_data_source.py
+++ b/test/hummingbot/connector/exchange/binance/test_binance_user_stream_data_source.py
@@ -226,6 +226,7 @@ class BinanceUserStreamDataSourceUnitTests(unittest.TestCase):
 
         msg = self.async_run_with_timeout(msg_queue.get())
         self.assertTrue(msg, self._user_update_event)
+        mock_ws.return_value.ping.assert_called()
 
     @aioresponses()
     @patch("aiohttp.ClientSession.ws_connect", new_callable=AsyncMock)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [X] Your code builds clean without any errors or warnings
- [X] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Binance perpetual takes some time before it delivers the first ws message to the user stream. This keeps the last recevied timestamp zero for a while, which does not allow the strategy to start execution. In addition, Binance spot does not check if the user-stream is ready before marking itself as being ready.

This PR adds a check to Binance spot to determine if the user-stream is ready. It also adds an initial ping to both spot and perpetual to kick-start the readiness checks.


**Tests performed by the developer**:
Added a simple check to existing tests to determine if the ping was issued on user-stream startup.



**Tips for QA testing**:
Check that both binance spot and perpetual start trading with minimal delay (below 5 seconds).

