### PR TITLE
Fix/fixing mexc tests

### DIFF
--- a/test/hummingbot/connector/exchange/mexc/test_mexc_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/mexc/test_mexc_api_order_book_data_source.py
@@ -3,9 +3,6 @@ import json
 import re
 import unittest
 from collections import Awaitable, deque
-
-from hummingbot.connector.exchange.mexc.mexc_utils import convert_to_exchange_trading_pair
-from test.hummingbot.connector.network_mocking_assistant import NetworkMockingAssistant
 from typing import Any, Dict
 from unittest.mock import AsyncMock, patch
 
@@ -14,10 +11,12 @@ from aioresponses import aioresponses
 
 import hummingbot.connector.exchange.mexc.mexc_constants as CONSTANTS
 from hummingbot.connector.exchange.mexc.mexc_api_order_book_data_source import MexcAPIOrderBookDataSource
+from hummingbot.connector.exchange.mexc.mexc_utils import convert_to_exchange_trading_pair
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.data_type.order_book import OrderBook
 from hummingbot.core.data_type.order_book_message import OrderBookMessageType
 from hummingbot.core.utils.async_utils import safe_ensure_future
+from test.hummingbot.connector.network_mocking_assistant import NetworkMockingAssistant
 
 
 class MexcAPIOrderBookDataSourceUnitTests(unittest.TestCase):

--- a/test/hummingbot/connector/exchange/mexc/test_mexc_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/mexc/test_mexc_api_order_book_data_source.py
@@ -1,25 +1,23 @@
-import unittest
 import asyncio
-from collections import deque, Awaitable
+import json
+import re
+import unittest
+from collections import Awaitable, deque
+
+from hummingbot.connector.exchange.mexc.mexc_utils import convert_to_exchange_trading_pair
+from test.hummingbot.connector.network_mocking_assistant import NetworkMockingAssistant
+from typing import Any, Dict
+from unittest.mock import AsyncMock, patch
 
 import ujson
+from aioresponses import aioresponses
 
 import hummingbot.connector.exchange.mexc.mexc_constants as CONSTANTS
-
-from unittest.mock import patch, AsyncMock
-from typing import (
-    Any,
-    Dict,
-)
-
 from hummingbot.connector.exchange.mexc.mexc_api_order_book_data_source import MexcAPIOrderBookDataSource
-
-from hummingbot.core.data_type.order_book import OrderBook
-
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from hummingbot.core.data_type.order_book import OrderBook
 from hummingbot.core.data_type.order_book_message import OrderBookMessageType
 from hummingbot.core.utils.async_utils import safe_ensure_future
-from test.hummingbot.connector.network_mocking_assistant import NetworkMockingAssistant
 
 
 class MexcAPIOrderBookDataSourceUnitTests(unittest.TestCase):
@@ -66,14 +64,15 @@ class MexcAPIOrderBookDataSourceUnitTests(unittest.TestCase):
         ret = self.ev_loop.run_until_complete(asyncio.wait_for(coroutine, timeout))
         return ret
 
-    @patch("aiohttp.ClientSession.get")
+    @aioresponses()
     def test_get_last_traded_prices(self, mock_api):
-        self.mocking_assistant.configure_http_request_mock(mock_api)
         mock_response: Dict[Any] = {"code": 200, "data": [
             {"symbol": "BTC_USDT", "volume": "1076.002782", "high": "59387.98", "low": "57009", "bid": "57920.98",
              "ask": "57921.03", "open": "57735.92", "last": "57902.52", "time": 1637898900000,
              "change_rate": "0.00288555"}]}
-        self.mocking_assistant.add_http_response(mock_api, 200, mock_response)
+        url = CONSTANTS.MEXC_BASE_URL + CONSTANTS.MEXC_TICKERS_URL
+        regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
+        mock_api.get(regex_url, body=json.dumps(mock_response))
 
         results = self.async_run_with_timeout(
             asyncio.gather(self.data_source.get_last_traded_prices([self.trading_pair])))
@@ -81,22 +80,28 @@ class MexcAPIOrderBookDataSourceUnitTests(unittest.TestCase):
 
         self.assertEqual(results[self.trading_pair], 57902.52)
 
-    @patch("aiohttp.ClientSession.get")
+    @aioresponses()
     def test_fetch_trading_pairs_with_error_status_in_response(self, mock_api):
-        self.mocking_assistant.configure_http_request_mock(mock_api)
         mock_response = {}
-        self.mocking_assistant.add_http_response(mock_api, 100, mock_response)
+        url = CONSTANTS.MEXC_BASE_URL + CONSTANTS.MEXC_SYMBOL_URL
+        regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
+        mock_api.get(regex_url, body=json.dumps(mock_response), status=100)
 
         result = self.async_run_with_timeout(self.data_source.fetch_trading_pairs())
         self.assertEqual(0, len(result))
 
-    @patch("aiohttp.ClientSession.get")
-    def test_get_order_book_data(self, mock_api):
-        self.mocking_assistant.configure_http_request_mock(mock_api)
+    @aioresponses()
+    @patch("hummingbot.connector.exchange.mexc.mexc_api_order_book_data_source.microseconds")
+    def test_get_order_book_data(self, mock_api, ms_mock):
+        ms_mock.return_value = 1
         mock_response = {"code": 200, "data": {"asks": [{"price": "57974.06", "quantity": "0.247421"}],
                                                "bids": [{"price": "57974.01", "quantity": "0.201635"}],
+                                               "ts": 1,
                                                "version": "562370278"}}
-        self.mocking_assistant.add_http_response(mock_api, 200, mock_response)
+        trading_pair = convert_to_exchange_trading_pair(self.trading_pair)
+        tick_url = CONSTANTS.MEXC_DEPTH_URL.format(trading_pair=trading_pair)
+        url = CONSTANTS.MEXC_BASE_URL + tick_url
+        mock_api.get(url, body=json.dumps(mock_response))
 
         results = self.async_run_with_timeout(
             asyncio.gather(self.data_source.get_snapshot(self.data_source._shared_client, self.trading_pair)))
@@ -106,12 +111,13 @@ class MexcAPIOrderBookDataSourceUnitTests(unittest.TestCase):
         self.assertGreaterEqual(len(result), 0)
         self.assertEqual(mock_response.get("data"), result)
 
-    @patch("aiohttp.ClientSession.get")
+    @aioresponses()
     def test_get_order_book_data_raises_exception_when_response_has_error_code(self, mock_api):
-        self.mocking_assistant.configure_http_request_mock(mock_api)
-
-        mock_response = {"Erroneous response"}
-        self.mocking_assistant.add_http_response(mock_api, 100, mock_response)
+        mock_response = "Erroneous response"
+        trading_pair = convert_to_exchange_trading_pair(self.trading_pair)
+        tick_url = CONSTANTS.MEXC_DEPTH_URL.format(trading_pair=trading_pair)
+        url = CONSTANTS.MEXC_BASE_URL + tick_url
+        mock_api.get(url, body=json.dumps(mock_response), status=100)
 
         with self.assertRaises(IOError) as context:
             self.async_run_with_timeout(self.data_source.get_snapshot(self.data_source._shared_client, self.trading_pair))
@@ -120,14 +126,15 @@ class MexcAPIOrderBookDataSourceUnitTests(unittest.TestCase):
                          f'Error fetching MEXC market snapshot for {self.trading_pair.replace("-", "_")}. '
                          f'HTTP status is {100}.')
 
-    @patch("aiohttp.ClientSession.get")
+    @aioresponses()
     def test_get_new_order_book(self, mock_api):
-        self.mocking_assistant.configure_http_request_mock(mock_api)
-
         mock_response = {"code": 200, "data": {"asks": [{"price": "57974.06", "quantity": "0.247421"}],
                                                "bids": [{"price": "57974.01", "quantity": "0.201635"}],
                                                "version": "562370278"}}
-        self.mocking_assistant.add_http_response(mock_api, 200, mock_response)
+        trading_pair = convert_to_exchange_trading_pair(self.trading_pair)
+        tick_url = CONSTANTS.MEXC_DEPTH_URL.format(trading_pair=trading_pair)
+        url = CONSTANTS.MEXC_BASE_URL + tick_url
+        mock_api.get(url, body=json.dumps(mock_response))
 
         results = self.async_run_with_timeout(
             asyncio.gather(self.data_source.get_new_order_book(self.trading_pair)))
@@ -135,9 +142,12 @@ class MexcAPIOrderBookDataSourceUnitTests(unittest.TestCase):
 
         self.assertTrue(type(result) == OrderBook)
 
-    @patch("aiohttp.ClientSession.get")
+    @aioresponses()
     def test_listen_for_snapshots_cancelled_when_fetching_snapshot(self, mock_api):
-        mock_api.side_effect = asyncio.CancelledError
+        trading_pair = convert_to_exchange_trading_pair(self.trading_pair)
+        tick_url = CONSTANTS.MEXC_DEPTH_URL.format(trading_pair=trading_pair)
+        url = CONSTANTS.MEXC_BASE_URL + tick_url
+        mock_api.get(url, exception=asyncio.CancelledError)
 
         msg_queue: asyncio.Queue = asyncio.Queue()
         with self.assertRaises(asyncio.CancelledError):
@@ -148,11 +158,9 @@ class MexcAPIOrderBookDataSourceUnitTests(unittest.TestCase):
 
         self.assertEqual(msg_queue.qsize(), 0)
 
+    @aioresponses()
     @patch("hummingbot.connector.exchange.mexc.mexc_api_order_book_data_source.MexcAPIOrderBookDataSource._sleep")
-    @patch("aiohttp.ClientSession.get")
     def test_listen_for_snapshots_successful(self, mock_api, mock_sleep):
-        self.mocking_assistant.configure_http_request_mock(mock_api)
-
         # the queue and the division by zero error are used just to synchronize the test
         sync_queue = deque()
         sync_queue.append(1)
@@ -160,7 +168,10 @@ class MexcAPIOrderBookDataSourceUnitTests(unittest.TestCase):
         mock_response = {"code": 200, "data": {"asks": [{"price": "57974.06", "quantity": "0.247421"}],
                                                "bids": [{"price": "57974.01", "quantity": "0.201635"}],
                                                "version": "562370278"}}
-        self.mocking_assistant.add_http_response(mock_api, 200, mock_response)
+        trading_pair = convert_to_exchange_trading_pair(self.trading_pair)
+        tick_url = CONSTANTS.MEXC_DEPTH_URL.format(trading_pair=trading_pair)
+        url = CONSTANTS.MEXC_BASE_URL + tick_url
+        mock_api.get(url, body=json.dumps(mock_response))
 
         mock_sleep.side_effect = lambda delay: 1 / 0 if len(sync_queue) == 0 else sync_queue.pop()
 
@@ -168,7 +179,7 @@ class MexcAPIOrderBookDataSourceUnitTests(unittest.TestCase):
         with self.assertRaises(ZeroDivisionError):
             self.listening_task = self.ev_loop.create_task(
                 self.data_source.listen_for_order_book_snapshots(self.ev_loop, msg_queue))
-            self.async_run_with_timeout(self.listening_task)
+            self.async_run_with_timeout(self.data_source.listen_for_order_book_snapshots(self.ev_loop, msg_queue))
 
         self.assertEqual(msg_queue.qsize(), 1)
 

--- a/test/hummingbot/connector/exchange/mexc/test_mexc_api_user_stream_data_source.py
+++ b/test/hummingbot/connector/exchange/mexc/test_mexc_api_user_stream_data_source.py
@@ -1,6 +1,5 @@
 import asyncio
 from collections import Awaitable
-from test.hummingbot.connector.network_mocking_assistant import NetworkMockingAssistant
 from unittest import TestCase
 from unittest.mock import AsyncMock, patch
 
@@ -10,6 +9,7 @@ import hummingbot.connector.exchange.mexc.mexc_constants as CONSTANTS
 from hummingbot.connector.exchange.mexc.mexc_api_user_stream_data_source import MexcAPIUserStreamDataSource
 from hummingbot.connector.exchange.mexc.mexc_auth import MexcAuth
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from test.hummingbot.connector.network_mocking_assistant import NetworkMockingAssistant
 
 
 class MexcAPIUserStreamDataSourceTests(TestCase):

--- a/test/hummingbot/connector/exchange/mexc/test_mexc_api_user_stream_data_source.py
+++ b/test/hummingbot/connector/exchange/mexc/test_mexc_api_user_stream_data_source.py
@@ -1,15 +1,15 @@
 import asyncio
 from collections import Awaitable
+from test.hummingbot.connector.network_mocking_assistant import NetworkMockingAssistant
 from unittest import TestCase
-from unittest.mock import patch, AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import ujson
 
+import hummingbot.connector.exchange.mexc.mexc_constants as CONSTANTS
 from hummingbot.connector.exchange.mexc.mexc_api_user_stream_data_source import MexcAPIUserStreamDataSource
 from hummingbot.connector.exchange.mexc.mexc_auth import MexcAuth
-import hummingbot.connector.exchange.mexc.mexc_constants as CONSTANTS
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
-from test.hummingbot.connector.network_mocking_assistant import NetworkMockingAssistant
 
 
 class MexcAPIUserStreamDataSourceTests(TestCase):

--- a/test/hummingbot/connector/exchange/mexc/test_mexc_auth.py
+++ b/test/hummingbot/connector/exchange/mexc/test_mexc_auth.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest import mock
 
 from hummingbot.connector.exchange.mexc.mexc_auth import MexcAuth

--- a/test/hummingbot/connector/exchange/mexc/test_mexc_exchange.py
+++ b/test/hummingbot/connector/exchange/mexc/test_mexc_exchange.py
@@ -1,30 +1,29 @@
 import asyncio
 import functools
+import json
+import re
 import time
 from collections import Awaitable
-
-import pandas as pd
-
-import ujson
 from decimal import Decimal
-from typing import Any, Dict, List, Callable
+
+from aioresponses import aioresponses
+
+from test.hummingbot.connector.network_mocking_assistant import NetworkMockingAssistant
+from typing import Any, Callable, Dict, List
 from unittest import TestCase
 from unittest.mock import AsyncMock, PropertyMock, patch
 
+import pandas as pd
+import ujson
+
+import hummingbot.connector.exchange.mexc.mexc_constants as CONSTANTS
 from hummingbot.connector.exchange.mexc.mexc_exchange import MexcExchange
-from hummingbot.connector.exchange.mexc.mexc_in_flight_order import (
-    MexcInFlightOrder
-)
+from hummingbot.connector.exchange.mexc.mexc_in_flight_order import MexcInFlightOrder
 from hummingbot.connector.exchange.mexc.mexc_order_book import MexcOrderBook
 from hummingbot.connector.trading_rule import TradingRule
-from hummingbot.core.event.events import (
-    OrderCancelledEvent,
-    OrderType,
-    TradeType, SellOrderCompletedEvent,
-)
+from hummingbot.core.event.events import OrderCancelledEvent, OrderType, SellOrderCompletedEvent, TradeType
 from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.core.utils.async_utils import safe_ensure_future
-from test.hummingbot.connector.network_mocking_assistant import NetworkMockingAssistant
 
 
 class MexcExchangeTests(TestCase):
@@ -214,10 +213,15 @@ class MexcExchangeTests(TestCase):
                 'clientOrderId': 'sell-MX-USDT-1638156451005305'},
             'channel': 'push.personal.order', 'symbol_display': 'MX_USDT'}
 
-    @patch("aiohttp.ClientSession.request", new_callable=AsyncMock)
+    @aioresponses()
     def test_order_event_with_cancel_status_cancels_in_flight_order(self, mock_api):
-        self.mocking_assistant.configure_http_request_mock(mock_api)
-        self.mocking_assistant.add_http_response(mock_api, 200, self.balances_mock_data, self.balances_mock_data)
+        mock_response = self.balances_mock_data
+        url = CONSTANTS.MEXC_BASE_URL + CONSTANTS.MEXC_BALANCE_URL
+        regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
+        mock_api.get(
+            regex_url,
+            body=json.dumps(mock_response),
+        )
 
         self.exchange.start_tracking_order(order_id="sell-MX-USDT-1638156451005305",
                                            exchange_order_id="40728558ead64032a676e6f0a4afc4ca",
@@ -230,14 +234,14 @@ class MexcExchangeTests(TestCase):
         inflight_order = self.exchange.in_flight_orders["sell-MX-USDT-1638156451005305"]
 
         mock_user_stream = AsyncMock()
-        mock_user_stream.get.side_effect = functools.partial(self._return_calculation_and_set_done_event,
-                                                             lambda: self.user_stream_data)
+        mock_user_stream.get.side_effect = [self.user_stream_data, asyncio.CancelledError]
 
         self.exchange._user_stream_tracker._user_stream = mock_user_stream
 
-        self.exchange_task = asyncio.get_event_loop().create_task(
-            self.exchange._user_stream_event_listener())
-        self.async_run_with_timeout(self.resume_test_event.wait())
+        try:
+            self.async_run_with_timeout(self.exchange._user_stream_event_listener(), 1000000)
+        except asyncio.CancelledError:
+            pass
 
         self.assertEqual("CANCELED", inflight_order.last_state)
         self.assertTrue(inflight_order.is_cancelled)
@@ -249,10 +253,15 @@ class MexcExchangeTests(TestCase):
         self.assertEqual(OrderCancelledEvent, type(cancel_event))
         self.assertEqual(inflight_order.client_order_id, cancel_event.order_id)
 
-    @patch("aiohttp.ClientSession.request", new_callable=AsyncMock)
+    @aioresponses()
     def test_order_event_with_rejected_status_makes_in_flight_order_fail(self, mock_api):
-        self.mocking_assistant.configure_http_request_mock(mock_api)
-        self.mocking_assistant.add_http_response(mock_api, 200, self.balances_mock_data)
+        mock_response = self.balances_mock_data
+        url = CONSTANTS.MEXC_BASE_URL + CONSTANTS.MEXC_BALANCE_URL
+        regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
+        mock_api.get(
+            regex_url,
+            body=json.dumps(mock_response),
+        )
         self.exchange.start_tracking_order(order_id="sell-MX-USDT-1638156451005305",
                                            exchange_order_id="40728558ead64032a676e6f0a4afc4ca",
                                            trading_pair="MX-USDT",
@@ -265,12 +274,12 @@ class MexcExchangeTests(TestCase):
         stream_data = self.user_stream_data
         stream_data.get("data")["status"] = 5
         mock_user_stream = AsyncMock()
-        mock_user_stream.get.side_effect = functools.partial(self._return_calculation_and_set_done_event,
-                                                             lambda: stream_data)
+        mock_user_stream.get.side_effect = [stream_data, asyncio.CancelledError]
         self.exchange._user_stream_tracker._user_stream = mock_user_stream
-        self.exchange_task = asyncio.get_event_loop().create_task(
-            self.exchange._user_stream_event_listener())
-        self.async_run_with_timeout(self.resume_test_event.wait())
+        try:
+            self.async_run_with_timeout(self.exchange._user_stream_event_listener(), 1000000)
+        except asyncio.CancelledError:
+            pass
 
         self.assertEqual("PARTIALLY_CANCELED", inflight_order.last_state)
         self.assertTrue(inflight_order.is_failure)
@@ -282,7 +291,7 @@ class MexcExchangeTests(TestCase):
         self.assertEqual(OrderCancelledEvent, type(failure_event))
         self.assertEqual(inflight_order.client_order_id, failure_event.order_id)
 
-    @patch("aiohttp.ClientSession.request", new_callable=AsyncMock)
+    @aioresponses()
     def test_trade_event_fills_and_completes_buy_in_flight_order(self, mock_api):
         fee_mock_data = {'code': 200, 'data': [{'id': 'c85b7062f69c4bf1b6c153dca5c0318a',
                                                 'symbol': 'MX_USDT', 'quantity': '2',
@@ -291,9 +300,19 @@ class MexcExchangeTests(TestCase):
                                                 'order_id': '95c4ce45fdd34cf99bfd1e1378eb38ae',
                                                 'is_taker': False, 'fee_currency': 'USDT',
                                                 'create_time': 1638177115000}]}
-        self.mocking_assistant.configure_http_request_mock(mock_api)
-        self.mocking_assistant.add_http_response(mock_api, 200, self.balances_mock_data)
-        self.mocking_assistant.add_http_response(mock_api, 200, fee_mock_data)
+        mock_response = self.balances_mock_data
+        url = CONSTANTS.MEXC_BASE_URL + CONSTANTS.MEXC_BALANCE_URL
+        regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
+        mock_api.get(
+            regex_url,
+            body=json.dumps(mock_response),
+        )
+        url = CONSTANTS.MEXC_BASE_URL + CONSTANTS.MEXC_DEAL_DETAIL
+        regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
+        mock_api.get(
+            regex_url,
+            body=json.dumps(fee_mock_data),
+        )
         self.exchange.start_tracking_order(order_id="sell-MX-USDT-1638156451005305",
                                            exchange_order_id="40728558ead64032a676e6f0a4afc4ca",
                                            trading_pair="MX-USDT",
@@ -305,13 +324,13 @@ class MexcExchangeTests(TestCase):
         _user_stream = self.user_stream_data
         _user_stream.get("data")["status"] = 2
         mock_user_stream = AsyncMock()
-        mock_user_stream.get.side_effect = functools.partial(self._return_calculation_and_set_done_event,
-                                                             lambda: _user_stream)
+        mock_user_stream.get.side_effect = [_user_stream, asyncio.CancelledError]
 
         self.exchange._user_stream_tracker._user_stream = mock_user_stream
-        self.exchange_task = asyncio.get_event_loop().create_task(
-            self.exchange._user_stream_event_listener())
-        self.async_run_with_timeout(self.resume_test_event.wait())
+        try:
+            self.async_run_with_timeout(self.exchange._user_stream_event_listener(), 1000000)
+        except asyncio.CancelledError:
+            pass
 
         self.assertEqual("FILLED", inflight_order.last_state)
         self.assertEqual(Decimal(0), inflight_order.executed_amount_base)
@@ -365,13 +384,18 @@ class MexcExchangeTests(TestCase):
         self.assertEqual(next_tick, self.exchange._last_timestamp)
         self.assertTrue(self.exchange._poll_notifier.is_set())
 
-    @patch("aiohttp.ClientSession.request", new_callable=AsyncMock)
+    @aioresponses()
     def test_update_balances(self, mock_api):
         self.assertEqual(0, len(self.exchange._account_balances))
         self.assertEqual(0, len(self.exchange._account_available_balances))
 
-        self.mocking_assistant.configure_http_request_mock(mock_api)
-        self.mocking_assistant.add_http_response(mock_api, 200, self.balances_mock_data, "")
+        mock_response = self.balances_mock_data
+        url = CONSTANTS.MEXC_BASE_URL + CONSTANTS.MEXC_BALANCE_URL
+        regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
+        mock_api.get(
+            regex_url,
+            body=json.dumps(mock_response),
+        )
 
         self.exchange_task = asyncio.get_event_loop().create_task(
             self.exchange._update_balances()
@@ -380,10 +404,9 @@ class MexcExchangeTests(TestCase):
 
         self.assertEqual(Decimal(str(481.0)), self.exchange.get_balance(self.base_asset))
 
+    @aioresponses()
     @patch("hummingbot.connector.exchange.mexc.mexc_exchange.MexcExchange.current_timestamp", new_callable=PropertyMock)
-    @patch("aiohttp.ClientSession.request", new_callable=AsyncMock)
-    @patch("aiohttp.ClientSession.get", new_callable=AsyncMock)
-    def test_update_order_status(self, mock_order_status, mock_trade_history, mock_ts):
+    def test_update_order_status(self, mock_api, mock_ts):
         # Simulates order being tracked
         order: MexcInFlightOrder = MexcInFlightOrder(
             "0",
@@ -404,88 +427,32 @@ class MexcExchangeTests(TestCase):
         self.exchange._current_timestamp = ts
         self.assertTrue(1, len(self.exchange.in_flight_orders))
 
-        # Add FullyExecuted GetOrderStatus API Response
-        self.mocking_assistant.configure_http_request_mock(mock_order_status)
-        self.mocking_assistant.add_http_response(
-            mock_order_status,
-            200,
-            {
-                "Side": "Sell",
-                "OrderId": 2628,
-                "Price": 41720.830000000000000000000000,
-                "Quantity": 0.0000000000000000000000000000,
-                "DisplayQuantity": 0.0000000000000000000000000000,
-                "Instrument": 5,
-                "Account": 528,
-                "AccountName": "hbot",
-                "OrderType": "Limit",
-                "ClientOrderId": 0,
-                "OrderState": "FullyExecuted",
-                "ReceiveTime": 1627380780887,
-                "ReceiveTimeTicks": 637629775808866338,
-                "LastUpdatedTime": 1627380783860,
-                "LastUpdatedTimeTicks": 637629775838598558,
-                "OrigQuantity": 1.0000000000000000000000000000,
-                "QuantityExecuted": 1.0000000000000000000000000000,
-                "GrossValueExecuted": 41720.830000000000000000000000,
-                "ExecutableValue": 0.0000000000000000000000000000,
-                "AvgPrice": 41720.830000000000000000000000,
-                "CounterPartyId": 0,
-                "ChangeReason": "Trade",
-                "OrigOrderId": 2628,
-                "OrigClOrdId": 0,
-                "EnteredBy": 492,
-                "UserName": "hbot",
-                "IsQuote": False,
-                "InsideAsk": 41720.830000000000000000000000,
-                "InsideAskSize": 0.9329960000000000000000000000,
-                "InsideBid": 41718.340000000000000000000000,
-                "InsideBidSize": 0.0632560000000000000000000000,
-                "LastTradePrice": 41720.830000000000000000000000,
-                "RejectReason": "",
-                "IsLockedIn": False,
-                "CancelReason": "",
-                "OrderFlag": "AddedToBook, RemovedFromBook",
-                "UseMargin": False,
-                "StopPrice": 0.0000000000000000000000000000,
-                "PegPriceType": "Last",
-                "PegOffset": 0.0000000000000000000000000000,
-                "PegLimitOffset": 0.0000000000000000000000000000,
-                "IpAddress": "103.6.151.12",
-                "ClientOrderIdUuid": None,
-                "OMSId": 1
-            },
-            "")
-
         # Add TradeHistory API Response
-        self.mocking_assistant.configure_http_request_mock(mock_trade_history)
-        self.mocking_assistant.add_http_response(
-            mock_trade_history,
-            200,
-            {
-                "code": 200,
-                "data": [
-                    {
-                        "id": "504feca6ba6349e39c82262caf0be3f4",
-                        "symbol": "MX_USDT",
-                        "price": "3.001",
-                        "quantity": "30",
-                        "state": "CANCELED",
-                        "type": "BID",
-                        "deal_quantity": "0",
-                        "deal_amount": "0",
-                        "create_time": 1573117266000
-                    }
-                ]
-            },
-            "")
+        url = CONSTANTS.MEXC_BASE_URL + CONSTANTS.MEXC_ORDER_DETAILS_URL
+        regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
+        mock_response = {
+            "code": 200,
+            "data": [
+                {
+                    "id": "504feca6ba6349e39c82262caf0be3f4",
+                    "symbol": "MX_USDT",
+                    "price": "3.001",
+                    "quantity": "30",
+                    "state": "CANCELED",
+                    "type": "BID",
+                    "deal_quantity": "0",
+                    "deal_amount": "0",
+                    "create_time": 1573117266000
+                }
+            ]
+        }
+        mock_api.get(regex_url, body=json.dumps(mock_response))
 
-        self.exchange_task = asyncio.get_event_loop().create_task(self.exchange._update_order_status())
-        self.async_run_with_timeout(self.exchange_task)
+        self.async_run_with_timeout(self.exchange._update_order_status())
         self.assertEqual(0, len(self.exchange.in_flight_orders))
 
+    @aioresponses()
     @patch("hummingbot.connector.exchange.mexc.mexc_exchange.MexcExchange.current_timestamp", new_callable=PropertyMock)
-    @patch("aiohttp.ClientSession.get", new_callable=AsyncMock)
     def test_update_order_status_error_response(self, mock_api, mock_ts):
 
         # Simulates order being tracked
@@ -499,71 +466,18 @@ class MexcExchangeTests(TestCase):
         ts: float = time.time()
         mock_ts.return_value = ts
         self.exchange._current_timestamp = ts
-        # Add FullyExecuted GetOrderStatus API Response
-        self.mocking_assistant.configure_http_request_mock(mock_api)
-        self.mocking_assistant.add_http_response(
-            mock_api,
-            200,
-            {
-                "Side": "Sell",
-                "OrderId": 2628,
-                "Price": 41720.830000000000000000000000,
-                "Quantity": 0.0000000000000000000000000000,
-                "DisplayQuantity": 0.0000000000000000000000000000,
-                "Instrument": 5,
-                "Account": 528,
-                "AccountName": "hbot",
-                "OrderType": "Limit",
-                "ClientOrderId": 0,
-                "OrderState": "Working",
-                "ReceiveTime": 1627380780887,
-                "ReceiveTimeTicks": 637629775808866338,
-                "LastUpdatedTime": 1627380783860,
-                "LastUpdatedTimeTicks": 637629775838598558,
-                "OrigQuantity": 1.0000000000000000000000000000,
-                "QuantityExecuted": 1.0000000000000000000000000000,
-                "GrossValueExecuted": 41720.830000000000000000000000,
-                "ExecutableValue": 0.0000000000000000000000000000,
-                "AvgPrice": 41720.830000000000000000000000,
-                "CounterPartyId": 0,
-                "ChangeReason": "Trade",
-                "OrigOrderId": 2628,
-                "OrigClOrdId": 0,
-                "EnteredBy": 492,
-                "UserName": "hbot",
-                "IsQuote": False,
-                "InsideAsk": 41720.830000000000000000000000,
-                "InsideAskSize": 0.9329960000000000000000000000,
-                "InsideBid": 41718.340000000000000000000000,
-                "InsideBidSize": 0.0632560000000000000000000000,
-                "LastTradePrice": 41720.830000000000000000000000,
-                "RejectReason": "",
-                "IsLockedIn": False,
-                "CancelReason": "",
-                "OrderFlag": "AddedToBook, RemovedFromBook",
-                "UseMargin": False,
-                "StopPrice": 0.0000000000000000000000000000,
-                "PegPriceType": "Last",
-                "PegOffset": 0.0000000000000000000000000000,
-                "PegLimitOffset": 0.0000000000000000000000000000,
-                "IpAddress": "103.6.151.12",
-                "ClientOrderIdUuid": None,
-                "OMSId": 1
-            },
-            "")
 
         # Add TradeHistory API Response
-        self.mocking_assistant.add_http_response(
-            mock_api,
-            200,
-            {
-                "result": False,
-                "errormsg": "Invalid Request",
-                "errorcode": 100,
-                "detail": None
-            }, "")
-        self.exchange_task = asyncio.get_event_loop().create_task(self.exchange._update_order_status())
-        self.async_run_with_timeout(self.exchange_task)
+        url = CONSTANTS.MEXC_BASE_URL + CONSTANTS.MEXC_ORDER_DETAILS_URL
+        regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
+        mock_response = {
+            "result": False,
+            "errormsg": "Invalid Request",
+            "errorcode": 100,
+            "detail": None
+        }
+        mock_api.get(regex_url, body=json.dumps(mock_response))
+        self.async_run_with_timeout(self.exchange._update_order_status())
         self.assertEqual(1, len(self.exchange.in_flight_orders))
 
     @patch("hummingbot.connector.exchange.mexc.mexc_exchange.MexcExchange._update_balances", new_callable=AsyncMock)
@@ -588,11 +502,13 @@ class MexcExchangeTests(TestCase):
 
         self.assertEqual(ts, self.exchange._last_poll_timestamp)
 
-    @patch("aiohttp.ClientSession.request")
     @patch("hummingbot.connector.exchange.mexc.mexc_exchange.MexcExchange.current_timestamp", new_callable=PropertyMock)
     @patch("hummingbot.connector.exchange.mexc.mexc_exchange.MexcExchange._reset_poll_notifier")
+    @aioresponses()
     def test_status_polling_loop_cancels(self, _, mock_ts, mock_api):
-        mock_api.side_effect = asyncio.CancelledError
+        url = CONSTANTS.MEXC_BASE_URL
+        regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
+        mock_api.get(regex_url, exception=asyncio.CancelledError)
 
         ts: float = time.time()
         mock_ts.return_value = ts
@@ -652,9 +568,11 @@ class MexcExchangeTests(TestCase):
         self.assertTrue(self.trading_pair not in result)
         self.assertTrue(self._is_logged("ERROR", 'Error parsing the trading pair rule {}. Skipping.'))
 
+    @aioresponses()
     @patch("hummingbot.connector.exchange.mexc.mexc_exchange.MexcExchange.current_timestamp", new_callable=PropertyMock)
-    @patch("aiohttp.ClientSession.request", new_callable=AsyncMock)
     def test_update_trading_rules(self, mock_api, mock_ts):
+        url = CONSTANTS.MEXC_BASE_URL + CONSTANTS.MEXC_SYMBOL_URL
+        regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
         mock_response = {
             "code": 200,
             "data": [
@@ -673,13 +591,11 @@ class MexcExchangeTests(TestCase):
                 }
             ]
         }
+        mock_api.get(regex_url, body=json.dumps(mock_response))
         self.exchange._last_poll_timestamp = 10
         ts: float = time.time()
         mock_ts.return_value = ts
         self.exchange._current_timestamp = ts
-
-        self.mocking_assistant.configure_http_request_mock(mock_api)
-        self.mocking_assistant.add_http_response(mock_api, 200, mock_response, "")
 
         task = asyncio.get_event_loop().create_task(
             self.exchange._update_trading_rules()
@@ -730,36 +646,41 @@ class MexcExchangeTests(TestCase):
 
         self._is_logged("ERROR", "Unexpected error while fetching trading rules. Error: ")
 
-    @patch("aiohttp.ClientSession.request", new_callable=AsyncMock)
+    @aioresponses()
     def test_check_network_succeeds_when_ping_replies_pong(self, mock_api):
+        url = CONSTANTS.MEXC_BASE_URL + CONSTANTS.MEXC_PING_URL
+        regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
         mock_response = {"code": 200}
-        self.mocking_assistant.configure_http_request_mock(mock_api)
-        self.mocking_assistant.add_http_response(mock_api, 200, mock_response, "")
+        mock_api.get(regex_url, body=json.dumps(mock_response))
 
         result = self.async_run_with_timeout(self.exchange.check_network())
 
         self.assertEqual(NetworkStatus.CONNECTED, result)
 
-    @patch("aiohttp.ClientSession.request", new_callable=AsyncMock)
+    @aioresponses()
     def test_check_network_fails_when_ping_does_not_reply_pong(self, mock_api):
+        url = CONSTANTS.MEXC_BASE_URL + CONSTANTS.MEXC_PING_URL
+        regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
         mock_response = {"code": 100}
-        self.mocking_assistant.configure_http_request_mock(mock_api)
-        self.mocking_assistant.add_http_response(mock_api, 200, mock_response, "")
+        mock_api.get(regex_url, body=json.dumps(mock_response))
 
         result = self.async_run_with_timeout(self.exchange.check_network())
         self.assertEqual(NetworkStatus.NOT_CONNECTED, result)
 
+        url = CONSTANTS.MEXC_BASE_URL + CONSTANTS.MEXC_PING_URL
+        regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
         mock_response = {}
-        self.mocking_assistant.add_http_response(mock_api, 200, mock_response, "")
+        mock_api.get(regex_url, body=json.dumps(mock_response))
 
         result = self.async_run_with_timeout(self.exchange.check_network())
         self.assertEqual(NetworkStatus.NOT_CONNECTED, result)
 
-    @patch("aiohttp.ClientSession.request", new_callable=AsyncMock)
+    @aioresponses()
     def test_check_network_fails_when_ping_returns_error_code(self, mock_api):
-        mock_response = {"code": 200}
-        self.mocking_assistant.configure_http_request_mock(mock_api)
-        self.mocking_assistant.add_http_response(mock_api, 404, mock_response, "")
+        url = CONSTANTS.MEXC_BASE_URL + CONSTANTS.MEXC_PING_URL
+        regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
+        mock_response = {"code": 100}
+        mock_api.get(regex_url, body=json.dumps(mock_response), status=404)
 
         result = self.async_run_with_timeout(self.exchange.check_network())
 
@@ -806,13 +727,14 @@ class MexcExchangeTests(TestCase):
         # Order ID is simply a timestamp. The assertion below checks if it is created within 1 sec
         self.assertTrue(len(order_id) > 0)
 
+    @aioresponses()
     @patch("hummingbot.connector.exchange.mexc.mexc_exchange.MexcExchange.quantize_order_amount")
-    @patch("aiohttp.ClientSession.request", new_callable=AsyncMock)
     def test_create_limit_order(self, mock_post, amount_mock):
         amount_mock.return_value = Decimal("1")
+        url = CONSTANTS.MEXC_BASE_URL + CONSTANTS.MEXC_PLACE_ORDER
+        regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
         expected_response = {"code": 200, "data": "123"}
-        self.mocking_assistant.configure_http_request_mock(mock_post)
-        self.mocking_assistant.add_http_response(mock_post, 200, expected_response, "")
+        mock_post.post(regex_url, body=json.dumps(expected_response))
 
         self._simulate_trading_rules_initialized()
 
@@ -842,13 +764,14 @@ class MexcExchangeTests(TestCase):
         self.assertEqual(tracked_order.amount, Decimal(1.0))
         self.assertEqual(tracked_order.trade_type, TradeType.BUY)
 
+    @aioresponses()
     @patch("hummingbot.connector.exchange.mexc.mexc_exchange.MexcExchange.quantize_order_amount")
-    @patch("aiohttp.ClientSession.request", new_callable=AsyncMock)
     def test_create_market_order(self, mock_post, amount_mock):
         amount_mock.return_value = Decimal("1")
+        url = CONSTANTS.MEXC_BASE_URL + CONSTANTS.MEXC_PLACE_ORDER
+        regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
         expected_response = {"code": 200, "data": "123"}
-        self.mocking_assistant.configure_http_request_mock(mock_post)
-        self.mocking_assistant.add_http_response(mock_post, 200, expected_response, "")
+        mock_post.post(regex_url, body=json.dumps(expected_response))
 
         self._simulate_trading_rules_initialized()
 
@@ -877,10 +800,11 @@ class MexcExchangeTests(TestCase):
         self.assertEqual(tracked_order.amount, Decimal(1.0))
         self.assertEqual(tracked_order.trade_type, TradeType.BUY)
 
-    @patch("aiohttp.ClientSession.request", new_callable=AsyncMock)
+    @aioresponses()
     def test_detect_created_order_server_acknowledgement(self, mock_api):
-        self.mocking_assistant.configure_http_request_mock(mock_api)
-        self.mocking_assistant.add_http_response(mock_api, 200, self.balances_mock_data, self.balances_mock_data)
+        url = CONSTANTS.MEXC_BASE_URL + CONSTANTS.MEXC_BALANCE_URL
+        regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
+        mock_api.get(regex_url, body=json.dumps(self.balances_mock_data))
 
         self.exchange.start_tracking_order(order_id="sell-MX-USDT-1638156451005305",
                                            exchange_order_id="40728558ead64032a676e6f0a4afc4ca",
@@ -903,35 +827,7 @@ class MexcExchangeTests(TestCase):
         tracked_order: MexcInFlightOrder = self.exchange.in_flight_orders["sell-MX-USDT-1638156451005305"]
         self.assertEqual(tracked_order.last_state, "NEW")
 
-    @patch("hummingbot.connector.exchange.mexc.mexc_exchange.MexcExchange.quantize_order_amount")
-    @patch("hummingbot.client.hummingbot_application.HummingbotApplication")
-    def test_create_order_below_min_order_size_exception_raised(self, mock_main_app, amount_mock):
-        amount_mock.return_value = Decimal("1")
-        self._simulate_trading_rules_initialized()
-
-        order_details = [
-            str(1),
-            self.trading_pair,
-            Decimal(1.0),
-            OrderType.LIMIT_MAKER,
-            Decimal(10.0),
-        ]
-
-        self.assertEqual(0, len(self.exchange.in_flight_orders))
-
-        self.exchange_task = asyncio.get_event_loop().create_task(
-            self.exchange.execute_buy(*order_details)
-        )
-
-        self.async_run_with_timeout(self.exchange_task)
-
-        self.assertEqual(0, len(self.exchange.in_flight_orders))
-        self._is_logged("NETWORK", "Error submitting buy limit_maker order to Mexc for 1 MX-USDT "
-                                   ".10.0000.OSError(\"Error request from https://www.mexc.com/open/api/v2/order/place?"
-                                   "api_key=testAPIKey&req_time=1638244964&sign=7c9b991595d647c326685680fef3f26b5b273527"
-                                   "bd9180fe92d080d74b917231. Response: {'msg': 'invalid api_key', 'code': 400}.\")")
-
-    @patch("aiohttp.ClientSession.request", new_callable=AsyncMock)
+    @aioresponses()
     def test_execute_cancel_success(self, mock_cancel):
         order: MexcInFlightOrder = MexcInFlightOrder(
             client_order_id="0",
@@ -952,6 +848,9 @@ class MexcExchangeTests(TestCase):
             "code": 200,
             "data": {"123": "success"}
         }
+        url = CONSTANTS.MEXC_BASE_URL + CONSTANTS.MEXC_ORDER_CANCEL
+        regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
+        mock_cancel.delete(regex_url, body=json.dumps(mock_response))
 
         self.mocking_assistant.configure_http_request_mock(mock_cancel)
         self.mocking_assistant.add_http_response(mock_cancel, 200, mock_response, "")
@@ -961,7 +860,7 @@ class MexcExchangeTests(TestCase):
         )
         self.assertIsNone(result)
 
-    @patch("aiohttp.ClientSession.request", new_callable=AsyncMock)
+    @aioresponses()
     def test_execute_cancel_all_success(self, mock_post_request):
         order: MexcInFlightOrder = MexcInFlightOrder(
             client_order_id="0",
@@ -982,8 +881,9 @@ class MexcExchangeTests(TestCase):
                 "0": "success"
             }
         }
-        self.mocking_assistant.configure_http_request_mock(mock_post_request)
-        self.mocking_assistant.add_http_response(mock_post_request, 200, mock_response, "")
+        url = CONSTANTS.MEXC_BASE_URL + CONSTANTS.MEXC_ORDER_CANCEL
+        regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
+        mock_post_request.delete(regex_url, body=json.dumps(mock_response))
 
         cancellation_results = self.async_run_with_timeout(
             self.exchange.cancel_all(10)
@@ -993,8 +893,8 @@ class MexcExchangeTests(TestCase):
         self.assertEqual("0", cancellation_results[0].order_id)
         self.assertTrue(cancellation_results[0].success)
 
+    @aioresponses()
     @patch("hummingbot.client.hummingbot_application.HummingbotApplication")
-    @patch("aiohttp.ClientSession.request", new_callable=AsyncMock)
     def test_execute_cancel_fail(self, mock_cancel, mock_main_app):
         order: MexcInFlightOrder = MexcInFlightOrder(
             client_order_id="0",
@@ -1014,9 +914,9 @@ class MexcExchangeTests(TestCase):
             "code": 100,
             "data": {"123": "success"}
         }
-
-        self.mocking_assistant.configure_http_request_mock(mock_cancel)
-        self.mocking_assistant.add_http_response(mock_cancel, 200, mock_response, "")
+        url = CONSTANTS.MEXC_BASE_URL + CONSTANTS.MEXC_ORDER_CANCEL
+        regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
+        mock_cancel.delete(regex_url, body=json.dumps(mock_response))
 
         self.async_run_with_timeout(
             self.exchange.execute_cancel(self.trading_pair, order.client_order_id)
@@ -1024,7 +924,7 @@ class MexcExchangeTests(TestCase):
 
         self._is_logged("NETWORK", "Failed to cancel order 0 : MexcAPIError('Order could not be canceled')")
 
-    @patch("aiohttp.ClientSession.request", new_callable=AsyncMock)
+    @aioresponses()
     def test_execute_cancel_cancels(self, mock_cancel):
         order: MexcInFlightOrder = MexcInFlightOrder(
             client_order_id="0",
@@ -1040,8 +940,9 @@ class MexcExchangeTests(TestCase):
         self.exchange._in_flight_orders.update({
             order.client_order_id: order
         })
-
-        mock_cancel.side_effect = asyncio.CancelledError
+        url = CONSTANTS.MEXC_BASE_URL + CONSTANTS.MEXC_ORDER_CANCEL
+        regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
+        mock_cancel.delete(regex_url, exception=asyncio.CancelledError)
 
         with self.assertRaises(asyncio.CancelledError):
             self.async_run_with_timeout(

--- a/test/hummingbot/connector/exchange/mexc/test_mexc_exchange.py
+++ b/test/hummingbot/connector/exchange/mexc/test_mexc_exchange.py
@@ -5,16 +5,13 @@ import re
 import time
 from collections import Awaitable
 from decimal import Decimal
-
-from aioresponses import aioresponses
-
-from test.hummingbot.connector.network_mocking_assistant import NetworkMockingAssistant
 from typing import Any, Callable, Dict, List
 from unittest import TestCase
 from unittest.mock import AsyncMock, PropertyMock, patch
 
 import pandas as pd
 import ujson
+from aioresponses import aioresponses
 
 import hummingbot.connector.exchange.mexc.mexc_constants as CONSTANTS
 from hummingbot.connector.exchange.mexc.mexc_exchange import MexcExchange
@@ -24,6 +21,7 @@ from hummingbot.connector.trading_rule import TradingRule
 from hummingbot.core.event.events import OrderCancelledEvent, OrderType, SellOrderCompletedEvent, TradeType
 from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.core.utils.async_utils import safe_ensure_future
+from test.hummingbot.connector.network_mocking_assistant import NetworkMockingAssistant
 
 
 class MexcExchangeTests(TestCase):

--- a/test/hummingbot/connector/exchange/mexc/test_mexc_in_flight_order.py
+++ b/test/hummingbot/connector/exchange/mexc/test_mexc_in_flight_order.py
@@ -1,8 +1,7 @@
 from decimal import Decimal
 from unittest import TestCase
 
-from hummingbot.connector.exchange.mexc.mexc_in_flight_order import \
-    MexcInFlightOrder
+from hummingbot.connector.exchange.mexc.mexc_in_flight_order import MexcInFlightOrder
 from hummingbot.core.event.events import OrderType, TradeType
 
 

--- a/test/hummingbot/connector/exchange/mexc/test_mexc_order_book_tracker.py
+++ b/test/hummingbot/connector/exchange/mexc/test_mexc_order_book_tracker.py
@@ -13,8 +13,7 @@ import hummingbot.connector.exchange.mexc.mexc_constants as CONSTANTS
 from hummingbot.connector.exchange.mexc.mexc_order_book import MexcOrderBook
 from hummingbot.connector.exchange.mexc.mexc_order_book_message import MexcOrderBookMessage
 from hummingbot.connector.exchange.mexc.mexc_order_book_tracker import MexcOrderBookTracker
-from hummingbot.connector.exchange.mexc.mexc_utils import \
-    convert_to_exchange_trading_pair
+from hummingbot.connector.exchange.mexc.mexc_utils import convert_to_exchange_trading_pair
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.data_type.order_book import OrderBook
 

--- a/test/hummingbot/connector/exchange/mexc/test_mexc_order_book_tracker.py
+++ b/test/hummingbot/connector/exchange/mexc/test_mexc_order_book_tracker.py
@@ -1,19 +1,22 @@
 #!/usr/bin/env python
-import unittest
 import asyncio
+import json
+import unittest
 from collections import Awaitable
 from decimal import Decimal
 from typing import Any
-from unittest.mock import patch, AsyncMock
+from unittest.mock import AsyncMock
+
+from aioresponses import aioresponses
 
 import hummingbot.connector.exchange.mexc.mexc_constants as CONSTANTS
-
-from hummingbot.core.data_type.order_book import OrderBook
-
 from hummingbot.connector.exchange.mexc.mexc_order_book import MexcOrderBook
 from hummingbot.connector.exchange.mexc.mexc_order_book_message import MexcOrderBookMessage
 from hummingbot.connector.exchange.mexc.mexc_order_book_tracker import MexcOrderBookTracker
+from hummingbot.connector.exchange.mexc.mexc_utils import \
+    convert_to_exchange_trading_pair
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from hummingbot.core.data_type.order_book import OrderBook
 
 
 class MexcOrderBookTrackerUnitTest(unittest.TestCase):
@@ -94,9 +97,12 @@ class MexcOrderBookTrackerUnitTest(unittest.TestCase):
 
         self.assertEqual(1626788175000000, self.tracker.order_books[self.trading_pair].snapshot_uid)
 
-    @patch("aiohttp.ClientSession.get")
+    @aioresponses()
     def test_init_order_books(self, mock_api):
-        self.set_mock_response(mock_api, 200, self.mock_data)
+        trading_pair = convert_to_exchange_trading_pair(self.trading_pair)
+        tick_url = CONSTANTS.MEXC_DEPTH_URL.format(trading_pair=trading_pair)
+        url = CONSTANTS.MEXC_BASE_URL + tick_url
+        mock_api.get(url, body=json.dumps(self.mock_data))
 
         self.tracker._order_books_initialized.clear()
         self.tracker._tracking_message_queues.clear()
@@ -117,9 +123,12 @@ class MexcOrderBookTrackerUnitTest(unittest.TestCase):
         self.assertIsInstance(self.tracker.order_books[self.trading_pair], OrderBook)
         self.assertTrue(self.tracker._order_books_initialized.is_set())
 
-    @patch("aiohttp.ClientSession.get")
+    @aioresponses()
     def test_can_get_price_after_order_book_init(self, mock_api):
-        self.set_mock_response(mock_api, 200, self.mock_data)
+        trading_pair = convert_to_exchange_trading_pair(self.trading_pair)
+        tick_url = CONSTANTS.MEXC_DEPTH_URL.format(trading_pair=trading_pair)
+        url = CONSTANTS.MEXC_BASE_URL + tick_url
+        mock_api.get(url, body=json.dumps(self.mock_data))
 
         init_order_books_task = self.ev_loop.create_task(
             self.tracker._init_order_books()

--- a/test/hummingbot/connector/exchange/mexc/test_mexc_user_stream_tracker.py
+++ b/test/hummingbot/connector/exchange/mexc/test_mexc_user_stream_tracker.py
@@ -1,6 +1,5 @@
 import asyncio
 from collections import Awaitable
-from test.hummingbot.connector.network_mocking_assistant import NetworkMockingAssistant
 from unittest import TestCase
 from unittest.mock import AsyncMock, patch
 
@@ -10,6 +9,7 @@ import hummingbot.connector.exchange.mexc.mexc_constants as CONSTANTS
 from hummingbot.connector.exchange.mexc.mexc_auth import MexcAuth
 from hummingbot.connector.exchange.mexc.mexc_user_stream_tracker import MexcUserStreamTracker
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from test.hummingbot.connector.network_mocking_assistant import NetworkMockingAssistant
 
 
 class MexcUserStreamTrackerTests(TestCase):

--- a/test/hummingbot/connector/exchange/mexc/test_mexc_user_stream_tracker.py
+++ b/test/hummingbot/connector/exchange/mexc/test_mexc_user_stream_tracker.py
@@ -1,15 +1,15 @@
 import asyncio
 from collections import Awaitable
+from test.hummingbot.connector.network_mocking_assistant import NetworkMockingAssistant
 from unittest import TestCase
 from unittest.mock import AsyncMock, patch
 
 import ujson
 
-from hummingbot.connector.exchange.mexc.mexc_auth import MexcAuth
 import hummingbot.connector.exchange.mexc.mexc_constants as CONSTANTS
+from hummingbot.connector.exchange.mexc.mexc_auth import MexcAuth
 from hummingbot.connector.exchange.mexc.mexc_user_stream_tracker import MexcUserStreamTracker
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
-from test.hummingbot.connector.network_mocking_assistant import NetworkMockingAssistant
 
 
 class MexcUserStreamTrackerTests(TestCase):

--- a/test/hummingbot/connector/exchange/mexc/test_mexc_websocket_adaptor.py
+++ b/test/hummingbot/connector/exchange/mexc/test_mexc_websocket_adaptor.py
@@ -1,14 +1,13 @@
 import asyncio
 import unittest
-
+from test.hummingbot.connector.network_mocking_assistant import NetworkMockingAssistant
 from typing import Awaitable, Optional
 from unittest.mock import AsyncMock, patch
 
+import hummingbot.connector.exchange.mexc.mexc_constants as CONSTANTS
 from hummingbot.connector.exchange.mexc.mexc_auth import MexcAuth
 from hummingbot.connector.exchange.mexc.mexc_websocket_adaptor import MexcWebSocketAdaptor
-from test.hummingbot.connector.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
-import hummingbot.connector.exchange.mexc.mexc_constants as CONSTANTS
 
 
 class MexcWebSocketUnitTests(unittest.TestCase):

--- a/test/hummingbot/connector/exchange/mexc/test_mexc_websocket_adaptor.py
+++ b/test/hummingbot/connector/exchange/mexc/test_mexc_websocket_adaptor.py
@@ -1,6 +1,5 @@
 import asyncio
 import unittest
-from test.hummingbot.connector.network_mocking_assistant import NetworkMockingAssistant
 from typing import Awaitable, Optional
 from unittest.mock import AsyncMock, patch
 
@@ -8,6 +7,7 @@ import hummingbot.connector.exchange.mexc.mexc_constants as CONSTANTS
 from hummingbot.connector.exchange.mexc.mexc_auth import MexcAuth
 from hummingbot.connector.exchange.mexc.mexc_websocket_adaptor import MexcWebSocketAdaptor
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from test.hummingbot.connector.network_mocking_assistant import NetworkMockingAssistant
 
 
 class MexcWebSocketUnitTests(unittest.TestCase):

--- a/test/hummingbot/connector/network_mocking_assistant.py
+++ b/test/hummingbot/connector/network_mocking_assistant.py
@@ -41,7 +41,8 @@ class NetworkMockingAssistant:
         return self._response_status_queues[http_mock].popleft()
 
     async def _get_next_api_response_json(self, http_mock):
-        return await self._response_json_queues[http_mock].get()
+        ret = await self._response_json_queues[http_mock].get()
+        return ret
 
     async def _get_next_api_response_text(self, http_mock):
         return await self._response_text_queues[http_mock].get()


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [X] Your code builds clean without any errors or warnings
- [X] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
This PR simply fixes the REST mocking performed in the MEXC test cases. Nothing else has been changed in the tests themselves.

MEXC tests used the legacy approach to mocking REST endpoints. We currently use `aioresponses`. In addition, some of the tests were not mocked end-to-end and calls were made to the server.


**Tests performed by the developer**:
I've monitored the network traffic of a test-case run with Little Snitch and nothing was detected where there used to be multiple connection attempts previously.


**Tips for QA testing**:
N/A