### PR TITLE
(fix) Fixes PNL issue on `history` command.

### DIFF
--- a/hummingbot/client/performance.py
+++ b/hummingbot/client/performance.py
@@ -1,15 +1,17 @@
 from decimal import Decimal
 from dataclasses import dataclass
 from typing import (
-    Dict,
-    Optional,
-    List,
     Any,
-    Tuple
+    Dict,
+    List,
+    Optional,
+    Tuple,
 )
-from hummingbot.model.trade_fill import TradeFill
+
+from hummingbot.connector.utils import split_hb_trading_pair
 from hummingbot.core.utils.market_price import get_last_price
-from hummingbot.core.event.events import TradeType
+from hummingbot.core.event.events import TradeType, PositionAction
+from hummingbot.model.trade_fill import TradeFill
 
 s_decimal_0 = Decimal("0")
 s_decimal_nan = Decimal("NaN")
@@ -167,7 +169,11 @@ class PerformanceMetrics:
         return type(trade) == TradeFill
 
     def _are_derivatives(self, trades: List[Any]) -> bool:
-        return trades and self._is_trade_fill(trades[0]) and "NILL" not in [t.position for t in trades]
+        return (
+            trades
+            and self._is_trade_fill(trades[0])
+            and PositionAction.NIL.value not in [t.position for t in trades]
+        )
 
     def _preprocess_trades_and_group_by_type(self, trades: List[Any]) -> Tuple[List[Any], List[Any]]:
         buys = []
@@ -260,7 +266,7 @@ class PerformanceMetrics:
         :param current_balances: current user account balance
         """
 
-        base, quote = trading_pair.split("-")
+        base, quote = split_hb_trading_pair(trading_pair)
         buys, sells = self._preprocess_trades_and_group_by_type(trades)
 
         self.num_buys = len(buys)
@@ -273,7 +279,7 @@ class PerformanceMetrics:
         self.start_quote_bal = self.cur_quote_bal - self.tot_vol_quote
 
         self.start_price = Decimal(str(trades[0].price))
-        self.cur_price = await get_last_price(exchange.replace("_PaperTrade", ""), trading_pair)
+        self.cur_price = await get_last_price(exchange.replace("_paper_trade", ""), trading_pair)
         if self.cur_price is None:
             self.cur_price = Decimal(str(trades[-1].price))
         self.start_base_ratio_pct = self.divide(self.start_base_bal * self.start_price,

--- a/hummingbot/connector/markets_recorder.py
+++ b/hummingbot/connector/markets_recorder.py
@@ -4,13 +4,7 @@ import threading
 import time
 from decimal import Decimal
 from shutil import move
-from typing import (
-    Dict,
-    List,
-    Optional,
-    Tuple,
-    Union,
-)
+from typing import Dict, List, Optional, Tuple, Union
 
 import pandas as pd
 from sqlalchemy.orm import Query, Session
@@ -28,10 +22,11 @@ from hummingbot.core.event.events import (
     OrderCancelledEvent,
     OrderExpiredEvent,
     OrderFilledEvent,
+    PositionAction,
     RangePositionInitiatedEvent,
     RangePositionUpdatedEvent,
     SellOrderCompletedEvent,
-    SellOrderCreatedEvent,
+    SellOrderCreatedEvent
 )
 from hummingbot.model.funding_payment import FundingPayment
 from hummingbot.model.market_state import MarketState
@@ -211,7 +206,7 @@ class MarketsRecorder:
                                             amount=Decimal(evt.amount),
                                             leverage=evt.leverage if evt.leverage else 1,
                                             price=Decimal(evt.price) if evt.price == evt.price else Decimal(0),
-                                            position=evt.position if evt.position else "NILL",
+                                            position=evt.position if evt.position else PositionAction.NIL.value,
                                             last_status=event_type.name,
                                             last_update_timestamp=timestamp,
                                             exchange_order_id=evt.exchange_order_id)
@@ -250,22 +245,25 @@ class MarketsRecorder:
                                                         timestamp=timestamp,
                                                         status=event_type.name)
 
-                trade_fill_record: TradeFill = TradeFill(config_file_path=self.config_file_path,
-                                                         strategy=self.strategy_name,
-                                                         market=market.display_name,
-                                                         symbol=evt.trading_pair,
-                                                         base_asset=base_asset,
-                                                         quote_asset=quote_asset,
-                                                         timestamp=timestamp,
-                                                         order_id=order_id,
-                                                         trade_type=evt.trade_type.name,
-                                                         order_type=evt.order_type.name,
-                                                         price=Decimal(evt.price) if evt.price == evt.price else Decimal(0),
-                                                         amount=Decimal(evt.amount),
-                                                         leverage=evt.leverage if evt.leverage else 1,
-                                                         trade_fee=evt.trade_fee.to_json(),
-                                                         exchange_trade_id=evt.exchange_trade_id,
-                                                         position=evt.position if evt.position else "NILL", )
+                trade_fill_record: TradeFill = TradeFill(
+                    config_file_path=self.config_file_path,
+                    strategy=self.strategy_name,
+                    market=market.display_name,
+                    symbol=evt.trading_pair,
+                    base_asset=base_asset,
+                    quote_asset=quote_asset,
+                    timestamp=timestamp,
+                    order_id=order_id,
+                    trade_type=evt.trade_type.name,
+                    order_type=evt.order_type.name,
+                    price=Decimal(
+                        evt.price) if evt.price == evt.price else Decimal(0),
+                    amount=Decimal(evt.amount),
+                    leverage=evt.leverage if evt.leverage else 1,
+                    trade_fee=evt.trade_fee.to_json(),
+                    exchange_trade_id=evt.exchange_trade_id,
+                    position=evt.position if evt.position else PositionAction.NIL.value,
+                )
                 session.add(order_status)
                 session.add(trade_fill_record)
                 self.save_market_states(self._config_file_path, market, session=session)

--- a/hummingbot/core/event/events.py
+++ b/hummingbot/core/event/events.py
@@ -164,7 +164,7 @@ class OrderFilledEvent(NamedTuple):
     trade_fee: TradeFeeBase
     exchange_trade_id: str = ""
     leverage: Optional[int] = 1
-    position: Optional[str] = "NIL"
+    position: Optional[str] = PositionAction.NIL.value
 
     @classmethod
     def order_filled_events_from_order_book_rows(cls,
@@ -210,7 +210,7 @@ class BuyOrderCreatedEvent:
     order_id: str
     exchange_order_id: Optional[str] = None
     leverage: Optional[int] = 1
-    position: Optional[str] = "NILL"
+    position: Optional[str] = PositionAction.NIL.value
 
 
 @dataclass
@@ -223,7 +223,7 @@ class SellOrderCreatedEvent:
     order_id: str
     exchange_order_id: Optional[str] = None
     leverage: Optional[int] = 1
-    position: Optional[str] = "NILL"
+    position: Optional[str] = PositionAction.NIL.value
 
 
 @dataclass

--- a/hummingbot/model/trade_fill.py
+++ b/hummingbot/model/trade_fill.py
@@ -22,6 +22,7 @@ from sqlalchemy.orm import (
     Session
 )
 
+from hummingbot.core.event.events import PositionAction
 from hummingbot.model import HummingbotBase
 from hummingbot.model.decimal_type_decorator import SqliteDecimal
 
@@ -53,7 +54,7 @@ class TradeFill(HummingbotBase):
     leverage = Column(Integer, nullable=False, default=1)
     trade_fee = Column(JSON, nullable=False)
     exchange_trade_id = Column(Text, primary_key=True, nullable=False)
-    position = Column(Text, nullable=True)
+    position = Column(Text, nullable=True, default=PositionAction.NIL.value)
     order = relationship("Order", back_populates="trade_fills")
 
     def __repr__(self) -> str:

--- a/test/hummingbot/client/test_performance.py
+++ b/test/hummingbot/client/test_performance.py
@@ -1,19 +1,20 @@
-from decimal import Decimal
-from typing import List
-import unittest
 import asyncio
+import time
+import unittest
+from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
 from hummingbot.client.performance import PerformanceMetrics
-from hummingbot.core.data_type.trade import Trade, TradeType
 from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee, TokenAmount
+from hummingbot.core.event.events import PositionAction
+from hummingbot.model.trade_fill import TradeFill
+from hummingbot.model.order import Order  # noqa — Order needs to be defined for TradeFill
 
 trading_pair = "HBOT-USDT"
 base, quote = trading_pair.split("-")
 
 
 class PerformanceMetricsUnitTest(unittest.TestCase):
-
     def mock_trade(self, id, amount, price, position="OPEN", type="BUY", fee=None):
         trade = MagicMock()
         trade.order_id = id
@@ -110,26 +111,41 @@ class PerformanceMetricsUnitTest(unittest.TestCase):
         self.assertEqual(aggregated_sells[1], trades[1])
 
     def test_performance_metrics(self):
-        trades: List[Trade] = [
-            Trade(
-                trading_pair,
-                TradeType.BUY,
-                100,
-                10,
-                None,
-                trading_pair,
-                1,
-                AddedToCostTradeFee(flat_fees=[TokenAmount(quote, 0)])
+        trade_fee = AddedToCostTradeFee(flat_fees=[TokenAmount(quote, Decimal("0"))])
+        trades = [
+            TradeFill(
+                config_file_path="some-strategy.yml",
+                strategy="pure_market_making",
+                market="binance",
+                symbol=trading_pair,
+                base_asset=base,
+                quote_asset=quote,
+                timestamp=int(time.time()),
+                order_id="someId0",
+                trade_type="BUY",
+                order_type="LIMIT",
+                price=100,
+                amount=10,
+                trade_fee=trade_fee.to_json(),
+                exchange_trade_id="someExchangeId0",
+                position=PositionAction.NIL.value,
             ),
-            Trade(
-                trading_pair,
-                TradeType.SELL,
-                120,
-                15,
-                None,
-                trading_pair,
-                1,
-                AddedToCostTradeFee(flat_fees=[TokenAmount(quote, 0)])
+            TradeFill(
+                config_file_path="some-strategy.yml",
+                strategy="pure_market_making",
+                market="binance",
+                symbol=trading_pair,
+                base_asset=base,
+                quote_asset=quote,
+                timestamp=int(time.time()),
+                order_id="someId1",
+                trade_type="SELL",
+                order_type="LIMIT",
+                price=120,
+                amount=15,
+                trade_fee=trade_fee.to_json(),
+                exchange_trade_id="someExchangeId1",
+                position=PositionAction.NIL.value,
             )
         ]
         cur_bals = {base: 100, quote: 10000}

--- a/test/hummingbot/connector/test_markets_recorder.py
+++ b/test/hummingbot/connector/test_markets_recorder.py
@@ -13,7 +13,8 @@ from hummingbot.core.event.events import (
     MarketEvent,
     OrderFilledEvent,
     OrderType,
-    TradeType,
+    PositionAction,
+    TradeType
 )
 from hummingbot.model.order import Order
 from hummingbot.model.sql_connection_manager import SQLConnectionManager, SQLConnectionType
@@ -83,7 +84,7 @@ class MarketsRecorderTests(TestCase):
                     leverage=1,
                     trade_fee=AddedToCostTradeFee().to_json(),
                     exchange_trade_id="EOID1",
-                    position="NILL")
+                    position=PositionAction.NIL.value)
                 session.add(trade_fill_record)
 
             fill_id = trade_fill_record.exchange_trade_id

--- a/test/hummingbot/core/data_type/test_in_flight_order.py
+++ b/test/hummingbot/core/data_type/test_in_flight_order.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 from hummingbot.core.data_type.limit_order import LimitOrder
 from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState, OrderUpdate, TradeUpdate
-from hummingbot.core.event.events import OrderType, TradeType
+from hummingbot.core.event.events import OrderType, PositionAction, TradeType
 
 
 class InFlightOrderPyUnitTests(unittest.TestCase):
@@ -247,7 +247,7 @@ class InFlightOrderPyUnitTests(unittest.TestCase):
             "fee_paid": "0",
             "last_state": "0",
             "leverage": "1",
-            "position": "NIL",
+            "position": PositionAction.NIL.value,
         }
 
         expected_order: InFlightOrder = InFlightOrder(


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [X] Your code builds clean without any errors or warnings
- [X] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Fixes the PNL issue on the `history` command where the trade pnl always showed zero. I've also addressed several other instances where I think we're in danger of a related error happening in the future.


**Tests performed by the developer**:
- Edited an existing test to represent the reality more accurately.



**Tips for QA testing**:
Test summary:
- Run different strategies (Arbitrage, Avellaneda MM, Cross-exchange MM, Pure MM, Perpetual MM, Spot-Perpetual Arbitrage, and TWAP strategy)
- Run history when a fill event takes place and confirmed that PnL is no longer showing 0 value
- Run history --precision [value] if history shows that PnL is 0 and confirmed that the right value is calculated.
- Check PnL displayed on paper trade connectors and confirm that they are showing a calculated value

