### PR TITLE
Fix/error on install source

### DIFF
--- a/hummingbot/connector/exchange/bitfinex/bitfinex_exchange.pyx
+++ b/hummingbot/connector/exchange/bitfinex/bitfinex_exchange.pyx
@@ -10,7 +10,7 @@ from typing import Any, AsyncIterable, Dict, List, Optional
 import aiohttp
 from libc.stdint cimport int64_t
 from libcpp cimport bool
-
+from libcpp import bool as cppbool
 from hummingbot.connector.exchange.bitfinex import (
     AFF_CODE,
     BITFINEX_REST_AUTH_URL,
@@ -1358,7 +1358,7 @@ cdef class BitfinexExchange(ExchangeBase):
                 order_side: TradeType,
                 amount: Decimal,
                 price: Decimal = s_decimal_nan,
-                is_maker: Optional[bool] = None) -> AddedToCostTradeFee:
+                is_maker: Optional[cppbool] = None) -> AddedToCostTradeFee:
         return self.c_get_fee(base_currency, quote_currency, order_type, order_side, amount, price, is_maker)
 
     def get_order_book(self, trading_pair: str) -> OrderBook:

--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
@@ -40,6 +40,7 @@ from hummingbot.strategy.market_trading_pair_tuple import MarketTradingPairTuple
 from hummingbot.strategy.order_tracker cimport OrderTracker
 from hummingbot.strategy.strategy_base import StrategyBase
 from hummingbot.strategy.utils import order_age
+from hummingbot.stragety.conditional_execution_stat import ConditionalExecutionState
 
 NaN = float("nan")
 s_decimal_zero = Decimal(0)

--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
@@ -40,7 +40,7 @@ from hummingbot.strategy.market_trading_pair_tuple import MarketTradingPairTuple
 from hummingbot.strategy.order_tracker cimport OrderTracker
 from hummingbot.strategy.strategy_base import StrategyBase
 from hummingbot.strategy.utils import order_age
-from hummingbot.stragety.conditional_execution_stat import ConditionalExecutionState
+from hummingbot.stragety.conditional_execution_state import ConditionalExecutionState
 
 NaN = float("nan")
 s_decimal_zero = Decimal(0)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

[Yes] Your code builds clean without any errors or warnings
[Yes] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
When following the  [installation documentation](https://hummingbot.org/installation/source/) for source installation (AWS Ubuntu Server 20.04 LTS (HVM), SSD Volume Type 64bit x86), two errors are encountered. One is a lack of necessary imports, and one is a C++ type error, although it can work with my Mac. so I fixed it. This commit is related to [issue 5107](https://github.com/hummingbot/hummingbot/issues/5107)

**Tests performed by the developer**:
I try it work both ubunta and mac


**Tips for QA testing**:
You can try create an Ubuntu Server 20.04 LTS  instace on AWS, then follow [installation documentation](https://hummingbot.org/installation/source/)  try source install. you will got follow error on compile step:

`(hummingbot) ubuntu@ip-172-31-2-54:~/hummingbot$ ./compile
Warning: passing language='c++' to cythonize() is deprecated. Instead, put "# distutils: language=c++" in your .pyx or .pxd file(s)
Compiling hummingbot/connector/exchange/bitfinex/bitfinex_exchange.pyx because it changed.
Compiling hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx because it changed.
[1/2] Cythonizing hummingbot/connector/exchange/bitfinex/bitfinex_exchange.pyx

Error compiling Cython file:
------------------------------------------------------------
...
                quote_currency: str,
                order_type: OrderType,
                order_side: TradeType,
                amount: Decimal,
                price: Decimal = s_decimal_nan,
                is_maker: Optional[bool] = None) -> AddedToCostTradeFee:
                                  ^
------------------------------------------------------------

hummingbot/connector/exchange/bitfinex/bitfinex_exchange.pyx:1360:35: 'bool' is not a constant, variable or function identifier
Traceback (most recent call last):
  File "/home/ubuntu/anaconda3/envs/hummingbot/lib/python3.10/site-packages/Cython/Build/Dependencies.py", line 1274, in cythonize_one_helper
    return cythonize_one(*m)
  File "/home/ubuntu/anaconda3/envs/hummingbot/lib/python3.10/site-packages/Cython/Build/Dependencies.py", line 1250, in cythonize_one
    raise CompileError(None, pyx_file)
Cython.Compiler.Errors.CompileError: hummingbot/connector/exchange/bitfinex/bitfinex_exchange.pyx
[2/2] Cythonizing hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx

Error compiling Cython file:
------------------------------------------------------------
...
                    status_report_interval: float = 900,
                    hb_app_notification: bool = False,
                    risk_factor: Decimal = Decimal("0.5"),
                    order_amount_shape_factor: Decimal = Decimal("0.0"),
                    execution_timeframe: str = "infinite",
                    execution_state: ConditionalExecutionState = RunAlwaysExecutionState(),
                                    ^
------------------------------------------------------------

hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx:86:37: undeclared name not builtin: ConditionalExecutionState
Traceback (most recent call last):
  File "/home/ubuntu/anaconda3/envs/hummingbot/lib/python3.10/site-packages/Cython/Build/Dependencies.py", line 1274, in cythonize_one_helper
    return cythonize_one(*m)
  File "/home/ubuntu/anaconda3/envs/hummingbot/lib/python3.10/site-packages/Cython/Build/Dependencies.py", line 1250, in cythonize_one
    raise CompileError(None, pyx_file)
Cython.Compiler.Errors.CompileError: hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
multiprocessing.pool.RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/home/ubuntu/anaconda3/envs/hummingbot/lib/python3.10/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/home/ubuntu/anaconda3/envs/hummingbot/lib/python3.10/multiprocessing/pool.py", line 48, in mapstar
    return list(map(*args))
  File "/home/ubuntu/anaconda3/envs/hummingbot/lib/python3.10/site-packages/Cython/Build/Dependencies.py", line 1274, in cythonize_one_helper
    return cythonize_one(*m)
  File "/home/ubuntu/anaconda3/envs/hummingbot/lib/python3.10/site-packages/Cython/Build/Dependencies.py", line 1250, in cythonize_one
    raise CompileError(None, pyx_file)
Cython.Compiler.Errors.CompileError: hummingbot/connector/exchange/bitfinex/bitfinex_exchange.pyx
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/ubuntu/hummingbot/setup.py", line 153, in <module>
    main()
  File "/home/ubuntu/hummingbot/setup.py", line 140, in main
    ext_modules=cythonize(cython_sources, compiler_directives=compiler_directives, **cython_kwargs),
  File "/home/ubuntu/anaconda3/envs/hummingbot/lib/python3.10/site-packages/Cython/Build/Dependencies.py", line 1118, in cythonize
    result.get(99999)  # seconds
  File "/home/ubuntu/anaconda3/envs/hummingbot/lib/python3.10/multiprocessing/pool.py", line 771, in get
    raise self._value
Cython.Compiler.Errors.CompileError: hummingbot/connector/exchange/bitfinex/bitfinex_exchange.pyx
`

