### PR TITLE
fix/order tracker not match orders with undefined ids

### DIFF
--- a/hummingbot/connector/client_order_tracker.py
+++ b/hummingbot/connector/client_order_tracker.py
@@ -1,6 +1,5 @@
-import logging
 import asyncio
-
+import logging
 from collections import defaultdict
 from decimal import Decimal
 from typing import Callable, Dict, Optional
@@ -120,13 +119,16 @@ class ClientOrderTracker:
     def fetch_order(
         self, client_order_id: Optional[str] = None, exchange_order_id: Optional[str] = None
     ) -> Optional[InFlightOrder]:
-        if client_order_id in self.all_orders:
-            return self.all_orders[client_order_id]
+        found_order = None
 
-        for order in self.all_orders.values():
-            if order.exchange_order_id == exchange_order_id:
-                return order
-        return None
+        if client_order_id in self.all_orders:
+            found_order = self.all_orders[client_order_id]
+        elif exchange_order_id is not None:
+            found_order = next(
+                (order for order in self.all_orders.values() if order.exchange_order_id == exchange_order_id),
+                None)
+
+        return found_order
 
     def _trigger_created_event(self, order: InFlightOrder):
         event_tag = MarketEvent.BuyOrderCreated if order.trade_type is TradeType.BUY else MarketEvent.SellOrderCreated

--- a/hummingbot/core/data_type/in_flight_order.py
+++ b/hummingbot/core/data_type/in_flight_order.py
@@ -348,10 +348,10 @@ class InFlightOrder:
         return: True if the order gets updated otherwise False
         """
         trade_id: str = trade_update.trade_id
-        if self.exchange_order_id is None and trade_update.exchange_order_id:
-            self.update_exchange_order_id(trade_update.exchange_order_id)
 
-        if trade_id in self.order_fills or trade_update.exchange_order_id != self.exchange_order_id:
+        if (trade_id in self.order_fills
+                or (self.client_order_id != trade_update.client_order_id
+                    and self.exchange_order_id != trade_update.exchange_order_id)):
             return False
 
         self.executed_amount_base += trade_update.fill_base_amount

--- a/test/hummingbot/connector/exchange/altmarkets/test_altmarkets_websocket.py
+++ b/test/hummingbot/connector/exchange/altmarkets/test_altmarkets_websocket.py
@@ -35,9 +35,9 @@ class AltmarketsWebsocketTests(TestCase):
         self.async_run_with_timeout(websocket.unsubscribe(message))
 
         sent_requests = self.mocking_assistant.text_messages_sent_through_websocket(ws_connect_mock.return_value)
-        sent_subscribe_message = json.loads(sent_requests[0])
         expected_subscribe_message = {"event": "subscribe", "id": 1234567899, "streams": ['btcusdt.trades']}
-        self.assertEquals(expected_subscribe_message, sent_subscribe_message)
-        sent_unsubscribe_message = json.loads(sent_requests[1])
+        self.assertTrue(any(
+            (expected_subscribe_message == json.loads(sent_request) for sent_request in sent_requests)))
         expected_unsubscribe_message = {"event": "unsubscribe", "id": 1234567899, "streams": ['btcusdt.trades']}
-        self.assertEquals(expected_unsubscribe_message, sent_unsubscribe_message)
+        self.assertTrue(any(
+            (expected_unsubscribe_message == json.loads(sent_request) for sent_request in sent_requests)))

--- a/test/hummingbot/connector/test_client_order_tracker.py
+++ b/test/hummingbot/connector/test_client_order_tracker.py
@@ -213,6 +213,23 @@ class ClientOrderTrackerUnitTest(unittest.TestCase):
 
         self.assertTrue(fetched_order == order)
 
+    def test_fetch_order_does_not_match_orders_with_undefined_exchange_id(self):
+        order: InFlightOrder = InFlightOrder(
+            client_order_id="someClientOrderId",
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            trade_type=TradeType.BUY,
+            amount=Decimal("1000.0"),
+            creation_timestamp=1640001112.0,
+            price=Decimal("1.0"),
+        )
+        self.tracker.start_tracking_order(order)
+        self.assertEqual(1, len(self.tracker.active_orders))
+
+        fetched_order = self.tracker.fetch_order("invalid_order_id")
+
+        self.assertIsNone(fetched_order)
+
     def test_process_order_update_invalid_order_update(self):
 
         order_creation_update: OrderUpdate = OrderUpdate(

--- a/test/hummingbot/core/data_type/test_in_flight_order.py
+++ b/test/hummingbot/core/data_type/test_in_flight_order.py
@@ -522,8 +522,6 @@ class InFlightOrderPyUnitTests(unittest.TestCase):
         )
 
         self.assertTrue(order.update_with_trade_update(trade_update))
-        self.assertIsNotNone(order.exchange_order_id)
-        self.assertTrue(order.exchange_order_id_update_event.is_set())
         self.assertEqual(order.executed_amount_base, trade_update.fill_base_amount)
         self.assertEqual(order.executed_amount_quote, trade_update.fill_quote_amount)
         self.assertEqual(order.fee_asset, trade_update.fee_asset)
@@ -559,8 +557,6 @@ class InFlightOrderPyUnitTests(unittest.TestCase):
         )
 
         self.assertTrue(order.update_with_trade_update(trade_update))
-        self.assertIsNotNone(order.exchange_order_id)
-        self.assertTrue(order.exchange_order_id_update_event.is_set())
         self.assertEqual(order.executed_amount_base, trade_update.fill_base_amount)
         self.assertEqual(order.executed_amount_quote, trade_update.fill_quote_amount)
         self.assertEqual(order.fee_asset, trade_update.fee_asset)
@@ -617,8 +613,6 @@ class InFlightOrderPyUnitTests(unittest.TestCase):
 
         self.assertTrue(order.update_with_trade_update(trade_update_1))
         self.assertIn(trade_update_1.trade_id, order.order_fills)
-        self.assertIsNotNone(order.exchange_order_id)
-        self.assertTrue(order.exchange_order_id_update_event.is_set())
         self.assertEqual(order.executed_amount_base, trade_update_1.fill_base_amount)
         self.assertEqual(order.executed_amount_quote, trade_update_1.fill_quote_amount)
         self.assertEqual(order.fee_asset, trade_update_1.fee_asset)
@@ -649,3 +643,31 @@ class InFlightOrderPyUnitTests(unittest.TestCase):
 
         self.assertTrue(order.is_filled)
         self.assertEqual(order.current_state, OrderState.FILLED)
+
+    def test_trade_update_does_not_change_exchange_order_id(self):
+        order: InFlightOrder = InFlightOrder(
+            client_order_id=self.client_order_id,
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            trade_type=TradeType.BUY,
+            amount=Decimal("1000.0"),
+            creation_timestamp=1640001112.0,
+            price=Decimal("1.0"),
+        )
+
+        trade_update: TradeUpdate = TradeUpdate(
+            trade_id="someTradeId",
+            client_order_id=self.client_order_id,
+            exchange_order_id=self.exchange_order_id,
+            trading_pair=self.trading_pair,
+            fill_price=Decimal("1.0"),
+            fill_base_amount=Decimal("500.0"),
+            fill_quote_amount=Decimal("500.0"),
+            fee_asset=self.base_asset,
+            fee_paid=self.trade_fee_percent * Decimal("500.0"),
+            fill_timestamp=1,
+        )
+
+        self.assertTrue(order.update_with_trade_update(trade_update))
+        self.assertIsNone(order.exchange_order_id)
+        self.assertFalse(order.exchange_order_id_update_event.is_set())


### PR DESCRIPTION
I am creating this PR to replace #5079, that was incorrectly merged into master branch

**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
PR created to solve the issue https://github.com/hummingbot/hummingbot/issues/5056
Change the fetch order logic in the client order tracker to not look for orders using the exchange order id if it has not been provided as a parameter. Without this change if the exchange order id is not specified it will be None, and the fetch method will match orders in the tracker without exchange order id.
Also in this PR the update logic from a trade update has been changed to never update the exchange order id. That id should be only updated by the order update.


**Tests performed by the developer**:
Added unit tests for the described scenarios.


**Test Summary**:
- Setup multiple test bots using a single Binance account (same API key)
- 3 bots running using PMM strategy and the rest are running Avellaneda MM and Liquidity mining strategy
- Let the test bots run for almost 24 hours
- Regularly check the filled records by running history --verbose and by browsing the TradeFill table 
- Verify amounts seen in the table that differ from the specified order amount in the strategy and confirmed that these are partial fills


**Tips for QA testing**:
It is not easy to replicate the scenario running the client. The best approach is to have several client instances running using the a Binance connector with the same user account (it could be for different trading pairs in each instance).


Fixes #5056 

This PR comes from https://github.com/CoinAlpha/hummingbot/pull/70