### PR TITLE
Refactor/preventing duplicate client order ids 2

### DIFF
--- a/hummingbot/connector/derivative/binance_perpetual/binance_perpetual_utils.py
+++ b/hummingbot/connector/derivative/binance_perpetual/binance_perpetual_utils.py
@@ -1,12 +1,9 @@
-import os
-import socket
 from typing import Any, Dict, Optional
 
 import hummingbot.connector.derivative.binance_perpetual.constants as CONSTANTS
 
 from hummingbot.client.config.config_var import ConfigVar
 from hummingbot.client.config.config_methods import using_exchange
-from hummingbot.core.utils.tracking_nonce import get_tracking_nonce
 from hummingbot.core.web_assistant.auth import AuthBase
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, RESTRequest
 from hummingbot.core.web_assistant.rest_pre_processors import RESTPreProcessorBase
@@ -22,9 +19,6 @@ EXAMPLE_PAIR = "BTC-USDT"
 DEFAULT_FEES = [0.02, 0.04]
 
 
-BROKER_ID = "x-3QreWesy"
-
-
 class BinancePerpetualRESTPreProcessor(RESTPreProcessorBase):
 
     async def pre_process(self, request: RESTRequest) -> RESTRequest:
@@ -34,17 +28,6 @@ class BinancePerpetualRESTPreProcessor(RESTPreProcessorBase):
             "application/json" if request.method == RESTMethod.POST else "application/x-www-form-urlencoded"
         )
         return request
-
-
-def get_client_order_id(order_side: str, trading_pair: object):
-    nonce = get_tracking_nonce()
-    symbols: str = trading_pair.split("-")
-    base: str = symbols[0].upper()
-    quote: str = symbols[1].upper()
-    base_str = f"{base[0]}{base[-1]}"
-    quote_str = f"{quote[0]}{quote[-1]}"
-    client_instance_id = hex(abs(hash(f"{socket.gethostname()}{os.getpid()}")))[2:6]
-    return f"{BROKER_ID}-{order_side.upper()[0]}{base_str}{quote_str}{client_instance_id}{nonce}"
 
 
 def rest_url(path_url: str, domain: str = "binance_perpetual", api_version: str = CONSTANTS.API_VERSION):

--- a/hummingbot/connector/derivative/binance_perpetual/constants.py
+++ b/hummingbot/connector/derivative/binance_perpetual/constants.py
@@ -2,6 +2,8 @@ from hummingbot.core.api_throttler.data_types import LinkedLimitWeightPair, Rate
 from hummingbot.core.data_type.in_flight_order import OrderState
 
 EXCHANGE_NAME = "binance_perpetual"
+BROKER_ID = "x-3QreWesy"
+MAX_ORDER_ID_LEN = 36
 
 DOMAIN = EXCHANGE_NAME
 TESTNET_DOMAIN = "binance_perpetual_testnet"

--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_derivative.py
@@ -32,7 +32,7 @@ from hummingbot.connector.derivative.position import Position
 from hummingbot.connector.exchange_base import ExchangeBase
 from hummingbot.connector.perpetual_trading import PerpetualTrading
 from hummingbot.connector.trading_rule import TradingRule
-from hummingbot.connector.utils import combine_to_hb_trading_pair
+from hummingbot.connector.utils import combine_to_hb_trading_pair, get_new_client_order_id
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.data_type.cancellation_result import CancellationResult
 from hummingbot.core.data_type.common import (
@@ -510,7 +510,7 @@ class BybitPerpetualDerivative(ExchangeBase, PerpetualTrading):
         :param price: The price in which the order is to be placed at
         :returns: A new client order id
         """
-        order_id: str = bybit_utils.get_new_client_order_id(True, trading_pair)
+        order_id = get_new_client_order_id(is_buy=True, trading_pair=trading_pair)
         safe_ensure_future(self._create_order(trade_type=TradeType.BUY,
                                               trading_pair=trading_pair,
                                               order_id=order_id,
@@ -532,7 +532,7 @@ class BybitPerpetualDerivative(ExchangeBase, PerpetualTrading):
         :param price: The price in which the order is to be placed at
         :returns: A new client order id
         """
-        order_id: str = bybit_utils.get_new_client_order_id(False, trading_pair)
+        order_id = get_new_client_order_id(is_buy=False, trading_pair=trading_pair)
         safe_ensure_future(self._create_order(trade_type=TradeType.SELL,
                                               trading_pair=trading_pair,
                                               order_id=order_id,

--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_utils.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_utils.py
@@ -5,7 +5,6 @@ from hummingbot.client.config.config_var import ConfigVar
 from hummingbot.connector.derivative.bybit_perpetual import bybit_perpetual_constants as CONSTANTS
 from hummingbot.connector.utils import split_hb_trading_pair
 from hummingbot.core.api_throttler.data_types import LinkedLimitWeightPair, RateLimit
-from hummingbot.core.utils.tracking_nonce import get_tracking_nonce
 
 CENTRALIZED = True
 
@@ -18,11 +17,6 @@ DEFAULT_FEES = [-0.025, 0.075]
 # USE_ETHEREUM_WALLET not required because default value is false
 # FEE_TYPE not required because default value is Percentage
 # FEE_TOKEN not required because the fee is not flat
-
-
-def get_new_client_order_id(is_buy: bool, trading_pair: str) -> str:
-    side = "B" if is_buy else "S"
-    return f"{CONSTANTS.HBOT_BROKER_ID}-{side}-{trading_pair}-{get_tracking_nonce()}"
 
 
 def convert_to_exchange_trading_pair(hb_trading_pair: str) -> str:

--- a/hummingbot/connector/exchange/ascend_ex/ascend_ex_exchange.py
+++ b/hummingbot/connector/exchange/ascend_ex/ascend_ex_exchange.py
@@ -22,6 +22,7 @@ from hummingbot.connector.exchange.ascend_ex.ascend_ex_order_book_tracker import
 from hummingbot.connector.exchange.ascend_ex.ascend_ex_user_stream_tracker import AscendExUserStreamTracker
 from hummingbot.connector.exchange_py_base import ExchangePyBase
 from hummingbot.connector.trading_rule import TradingRule
+from hummingbot.connector.utils import get_new_client_order_id
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.clock import Clock
 from hummingbot.core.data_type.cancellation_result import CancellationResult
@@ -459,7 +460,9 @@ class AscendExExchange(ExchangePyBase):
         :param price: The price (note: this is no longer optional)
         :returns A new internal order id
         """
-        client_order_id = ascend_ex_utils.gen_client_order_id(True, trading_pair)
+        client_order_id = get_new_client_order_id(
+            is_buy=True, trading_pair=trading_pair, hbot_order_id_prefix=ascend_ex_utils.HBOT_BROKER_ID
+        )
         safe_ensure_future(self._create_order(TradeType.BUY, client_order_id, trading_pair, amount, order_type, price))
         return client_order_id
 
@@ -476,7 +479,9 @@ class AscendExExchange(ExchangePyBase):
         :param price: The price (note: this is no longer optional)
         :returns A new internal order id
         """
-        client_order_id = ascend_ex_utils.gen_client_order_id(False, trading_pair)
+        client_order_id = get_new_client_order_id(
+            is_buy=False, trading_pair=trading_pair, hbot_order_id_prefix=ascend_ex_utils.HBOT_BROKER_ID
+        )
         safe_ensure_future(self._create_order(TradeType.SELL, client_order_id, trading_pair, amount, order_type, price))
         return client_order_id
 

--- a/hummingbot/connector/exchange/ascend_ex/ascend_ex_utils.py
+++ b/hummingbot/connector/exchange/ascend_ex/ascend_ex_utils.py
@@ -2,10 +2,9 @@ import random
 import string
 import time
 from typing import Optional, Tuple
-from hummingbot.core.utils.tracking_nonce import get_tracking_nonce
 
-from hummingbot.client.config.config_var import ConfigVar
 from hummingbot.client.config.config_methods import using_exchange
+from hummingbot.client.config.config_var import ConfigVar
 
 
 CENTRALIZED = True
@@ -81,16 +80,6 @@ def gen_exchange_order_id(userUid: str, client_order_id: str, timestamp: Optiona
         ),
         time
     ]
-
-
-def gen_client_order_id(is_buy: bool, trading_pair: str) -> str:
-    """
-    Generates the client order id.
-    Note: All AscendEx API interactions, after order creation, utilizes the exchange_order_id instead.
-    """
-    side = "B" if is_buy else "S"
-    base, quote = trading_pair.split("-")
-    return f"{HBOT_BROKER_ID}-{side}{base[:3]}{quote[:3]}{get_tracking_nonce()}"
 
 
 KEYS = {

--- a/hummingbot/connector/exchange/binance/binance_constants.py
+++ b/hummingbot/connector/exchange/binance/binance_constants.py
@@ -2,6 +2,7 @@ from hummingbot.core.api_throttler.data_types import LinkedLimitWeightPair, Rate
 from hummingbot.core.data_type.in_flight_order import OrderState
 
 HBOT_ORDER_ID_PREFIX = "x-XEKWYICX"
+MAX_ORDER_ID_LEN = 36
 
 # Base URL
 REST_URL = "https://api.binance.{}/api/"

--- a/hummingbot/connector/exchange/binance/binance_exchange.py
+++ b/hummingbot/connector/exchange/binance/binance_exchange.py
@@ -23,7 +23,7 @@ from hummingbot.connector.exchange.binance.binance_order_book_tracker import Bin
 from hummingbot.connector.exchange.binance.binance_user_stream_tracker import BinanceUserStreamTracker
 from hummingbot.connector.time_synchronizer import TimeSynchronizer
 from hummingbot.connector.trading_rule import TradingRule
-from hummingbot.connector.utils import TradeFillOrderDetails
+from hummingbot.connector.utils import TradeFillOrderDetails, get_new_client_order_id
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.data_type.cancellation_result import CancellationResult
 from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderUpdate, OrderState, TradeUpdate
@@ -391,9 +391,14 @@ class BinanceExchange(ExchangeBase):
         :param price: the order price
         :return: the id assigned by the connector to the order (the client id)
         """
-        new_order_id = binance_utils.get_new_client_order_id(is_buy=True, trading_pair=trading_pair)
-        safe_ensure_future(self._create_order(TradeType.BUY, new_order_id, trading_pair, amount, order_type, price))
-        return new_order_id
+        client_order_id = get_new_client_order_id(
+            is_buy=True,
+            trading_pair=trading_pair,
+            hbot_order_id_prefix=CONSTANTS.HBOT_ORDER_ID_PREFIX,
+            max_id_len=CONSTANTS.MAX_ORDER_ID_LEN,
+        )
+        safe_ensure_future(self._create_order(TradeType.BUY, client_order_id, trading_pair, amount, order_type, price))
+        return client_order_id
 
     def sell(self, trading_pair: str, amount: Decimal, order_type: OrderType = OrderType.MARKET,
              price: Decimal = s_decimal_NaN, **kwargs) -> str:
@@ -405,9 +410,14 @@ class BinanceExchange(ExchangeBase):
         :param price: the order price
         :return: the id assigned by the connector to the order (the client id)
         """
-        order_id = binance_utils.get_new_client_order_id(is_buy=False, trading_pair=trading_pair)
-        safe_ensure_future(self._create_order(TradeType.SELL, order_id, trading_pair, amount, order_type, price))
-        return order_id
+        client_order_id = get_new_client_order_id(
+            is_buy=False,
+            trading_pair=trading_pair,
+            hbot_order_id_prefix=CONSTANTS.HBOT_ORDER_ID_PREFIX,
+            max_id_len=CONSTANTS.MAX_ORDER_ID_LEN,
+        )
+        safe_ensure_future(self._create_order(TradeType.SELL, client_order_id, trading_pair, amount, order_type, price))
+        return client_order_id
 
     def cancel(self, trading_pair: str, order_id: str):
         """

--- a/hummingbot/connector/exchange/binance/binance_utils.py
+++ b/hummingbot/connector/exchange/binance/binance_utils.py
@@ -1,34 +1,13 @@
-import os
-import socket
 from typing import Any, Dict
 
 import hummingbot.connector.exchange.binance.binance_constants as CONSTANTS
-
 from hummingbot.client.config.config_methods import using_exchange
 from hummingbot.client.config.config_var import ConfigVar
-from hummingbot.core.utils.tracking_nonce import get_tracking_nonce
 
 
 CENTRALIZED = True
 EXAMPLE_PAIR = "ZRX-ETH"
 DEFAULT_FEES = [0.1, 0.1]
-
-
-def get_new_client_order_id(is_buy: bool, trading_pair: str) -> str:
-    """
-    Creates a client order id for a new order
-    :param is_buy: True if the order is a buy order, False otherwise
-    :param trading_pair: the trading pair the order will be operating with
-    :return: an identifier for the new order to be used in the client
-    """
-    side = "B" if is_buy else "S"
-    symbols = trading_pair.split("-")
-    base = symbols[0].upper()
-    quote = symbols[1].upper()
-    base_str = f"{base[0]}{base[-1]}"
-    quote_str = f"{quote[0]}{quote[-1]}"
-    client_instance_id = hex(abs(hash(f"{socket.gethostname()}{os.getpid()}")))[2:6]
-    return f"{CONSTANTS.HBOT_ORDER_ID_PREFIX}-{side}{base_str}{quote_str}{client_instance_id}{get_tracking_nonce()}"
 
 
 def is_exchange_information_valid(exchange_info: Dict[str, Any]) -> bool:

--- a/hummingbot/connector/exchange/gate_io/gate_io_constants.py
+++ b/hummingbot/connector/exchange/gate_io/gate_io_constants.py
@@ -8,6 +8,7 @@ WS_URL = "wss://api.gateio.ws/ws/v4/"
 
 HBOT_BROKER_ID = "hummingbot"
 HBOT_ORDER_ID = "t-HBOT"
+MAX_ID_LEN = 30
 
 NETWORK_CHECK_PATH_URL = "spot/currencies/BTC"
 SYMBOL_PATH_URL = "spot/currency_pairs"

--- a/hummingbot/connector/exchange/gate_io/gate_io_exchange.py
+++ b/hummingbot/connector/exchange/gate_io/gate_io_exchange.py
@@ -20,10 +20,10 @@ from hummingbot.connector.exchange.gate_io.gate_io_utils import (
     convert_to_exchange_trading_pair,
     GateIoAPIError,
     GateIORESTRequest,
-    get_new_client_order_id
 )
 from hummingbot.connector.exchange_base import ExchangeBase
 from hummingbot.connector.trading_rule import TradingRule
+from hummingbot.connector.utils import get_new_client_order_id
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.clock import Clock
 from hummingbot.core.data_type.cancellation_result import CancellationResult
@@ -365,7 +365,12 @@ class GateIoExchange(ExchangeBase):
         :param price: The price (note: this is no longer optional)
         :returns A new internal order id
         """
-        order_id: str = get_new_client_order_id(True, trading_pair)
+        order_id = get_new_client_order_id(
+            is_buy=True,
+            trading_pair=trading_pair,
+            hbot_order_id_prefix=CONSTANTS.HBOT_ORDER_ID,
+            max_id_len=CONSTANTS.MAX_ID_LEN,
+        )
         safe_ensure_future(self._create_order(TradeType.BUY, order_id, trading_pair, amount, order_type, price))
         return order_id
 
@@ -380,7 +385,12 @@ class GateIoExchange(ExchangeBase):
         :param price: The price (note: this is no longer optional)
         :returns A new internal order id
         """
-        order_id: str = get_new_client_order_id(False, trading_pair)
+        order_id = get_new_client_order_id(
+            is_buy=False,
+            trading_pair=trading_pair,
+            hbot_order_id_prefix=CONSTANTS.HBOT_ORDER_ID,
+            max_id_len=CONSTANTS.MAX_ID_LEN,
+        )
         safe_ensure_future(self._create_order(TradeType.SELL, order_id, trading_pair, amount, order_type, price))
         return order_id
 

--- a/hummingbot/connector/exchange/gate_io/gate_io_utils.py
+++ b/hummingbot/connector/exchange/gate_io/gate_io_utils.py
@@ -14,7 +14,6 @@ from hummingbot.core.web_assistant.connections.data_types import (
 )
 from hummingbot.core.web_assistant.rest_assistant import RESTAssistant
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
-from hummingbot.core.utils.tracking_nonce import get_tracking_nonce
 
 CENTRALIZED = True
 
@@ -76,17 +75,6 @@ def convert_from_exchange_trading_pair(ex_trading_pair: str) -> Optional[str]:
 def convert_to_exchange_trading_pair(hb_trading_pair: str) -> str:
     # Gate.io uses uppercase with underscore split (BTC_USDT)
     return hb_trading_pair.replace("-", "_").upper()
-
-
-def get_new_client_order_id(is_buy: bool, trading_pair: str) -> str:
-    side = "B" if is_buy else "S"
-    symbols = trading_pair.split("-")
-    base = symbols[0].upper()
-    quote = symbols[1].upper()
-    base_str = f"{base[0]}{base[-1]}"
-    quote_str = f"{quote[0]}{quote[-1]}"
-    # Max length 30 chars including `t-`
-    return f"{CONSTANTS.HBOT_ORDER_ID}-{side}-{base_str}{quote_str}{get_tracking_nonce()}"
 
 
 def retry_sleep_time(try_count: int) -> float:

--- a/hummingbot/connector/exchange/huobi/huobi_exchange.pyx
+++ b/hummingbot/connector/exchange/huobi/huobi_exchange.pyx
@@ -21,8 +21,9 @@ from hummingbot.connector.exchange.huobi.huobi_user_stream_tracker import HuobiU
 from hummingbot.connector.exchange.huobi.huobi_utils import (
     build_api_factory,
     convert_to_exchange_trading_pair,
-    get_new_client_order_id,
+    BROKER_ID,
 )
+from hummingbot.connector.utils import get_new_client_order_id
 from hummingbot.connector.exchange_base import ExchangeBase
 from hummingbot.connector.trading_rule cimport TradingRule
 from hummingbot.core.clock cimport Clock
@@ -50,7 +51,6 @@ from hummingbot.core.utils.async_utils import (
     safe_gather,
 )
 from hummingbot.core.utils.estimate_fee import estimate_fee
-from hummingbot.core.utils.tracking_nonce import get_tracking_nonce
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, RESTRequest
 from hummingbot.core.web_assistant.rest_assistant import RESTAssistant
 from hummingbot.logger import HummingbotLogger
@@ -800,7 +800,9 @@ cdef class HuobiExchange(ExchangeBase):
                    object price=s_decimal_0,
                    dict kwargs={}):
         cdef:
-            str order_id = get_new_client_order_id(TradeType.BUY, trading_pair)
+            str order_id = get_new_client_order_id(
+                is_buy=True, trading_pair=trading_pair, hbot_order_id_prefix=BROKER_ID
+            )
 
         safe_ensure_future(self.execute_buy(order_id, trading_pair, amount, order_type, price))
         return order_id
@@ -870,8 +872,10 @@ cdef class HuobiExchange(ExchangeBase):
                     object order_type=OrderType.LIMIT, object price=s_decimal_0,
                     dict kwargs={}):
         cdef:
-            int64_t tracking_nonce = <int64_t> get_tracking_nonce()
-            str order_id = get_new_client_order_id(TradeType.SELL, trading_pair)
+            str order_id = get_new_client_order_id(
+                is_buy=False, trading_pair=trading_pair, hbot_order_id_prefix=BROKER_ID
+            )
+
         safe_ensure_future(self.execute_sell(order_id, trading_pair, amount, order_type, price))
         return order_id
 

--- a/hummingbot/connector/exchange/huobi/huobi_utils.py
+++ b/hummingbot/connector/exchange/huobi/huobi_utils.py
@@ -1,15 +1,9 @@
 import re
-from typing import (
-    Optional,
-    Tuple)
-from hummingbot.client.config.config_var import ConfigVar
-from hummingbot.client.config.config_methods import using_exchange
-from hummingbot.connector.exchange.huobi.huobi_ws_post_processor import HuobiWSPostProcessor
-from hummingbot.core.utils.tracking_nonce import get_tracking_nonce
+from typing import Optional, Tuple
 
-from hummingbot.core.event.events import (
-    TradeType
-)
+from hummingbot.client.config.config_methods import using_exchange
+from hummingbot.client.config.config_var import ConfigVar
+from hummingbot.connector.exchange.huobi.huobi_ws_post_processor import HuobiWSPostProcessor
 from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
 
 
@@ -50,16 +44,6 @@ def convert_from_exchange_trading_pair(exchange_trading_pair: str) -> Optional[s
 def convert_to_exchange_trading_pair(hb_trading_pair: str) -> str:
     # Huobi uses lowercase (btcusdt)
     return hb_trading_pair.replace("-", "").lower()
-
-
-def get_new_client_order_id(trade_type: TradeType, trading_pair: str) -> str:
-    side = ""
-    if trade_type is TradeType.BUY:
-        side = "buy"
-    if trade_type is TradeType.SELL:
-        side = "sell"
-    tracking_nonce = get_tracking_nonce()
-    return f"{BROKER_ID}-{side}-{trading_pair}-{tracking_nonce}"
 
 
 def build_api_factory() -> WebAssistantsFactory:

--- a/hummingbot/connector/exchange/kucoin/kucoin_constants.py
+++ b/hummingbot/connector/exchange/kucoin/kucoin_constants.py
@@ -2,6 +2,8 @@ import sys
 
 from hummingbot.core.api_throttler.data_types import RateLimit
 
+MAX_ORDER_ID_LEN = 40
+
 # REST endpoints
 BASE_PATH_URL = "https://api.kucoin.com"
 PUBLIC_WS_DATA_PATH_URL = "/api/v1/bullet-public"

--- a/hummingbot/connector/exchange/kucoin/kucoin_exchange.pyx
+++ b/hummingbot/connector/exchange/kucoin/kucoin_exchange.pyx
@@ -30,6 +30,7 @@ from hummingbot.connector.exchange.kucoin.kucoin_utils import (
 )
 from hummingbot.connector.exchange_base import ExchangeBase
 from hummingbot.connector.trading_rule cimport TradingRule
+from hummingbot.connector.utils import get_new_client_order_id
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.clock cimport Clock
 from hummingbot.core.data_type.cancellation_result import CancellationResult
@@ -56,7 +57,6 @@ from hummingbot.core.utils.async_utils import (
     safe_gather,
 )
 from hummingbot.core.utils.estimate_fee import estimate_fee
-from hummingbot.core.utils.tracking_nonce import get_tracking_nonce
 from hummingbot.logger import HummingbotLogger
 
 km_logger = None
@@ -784,8 +784,9 @@ cdef class KucoinExchange(ExchangeBase):
                    object price = s_decimal_0,
                    dict kwargs = {}):
         cdef:
-            int64_t tracking_nonce = <int64_t> get_tracking_nonce()
-            str order_id = f"buy-{trading_pair}-{tracking_nonce}"
+            str order_id = get_new_client_order_id(
+                is_buy=True, trading_pair=trading_pair, max_id_len=CONSTANTS.MAX_ORDER_ID_LEN
+            )
 
         safe_ensure_future(self.execute_buy(order_id, trading_pair, amount, order_type, price))
         return order_id
@@ -859,8 +860,10 @@ cdef class KucoinExchange(ExchangeBase):
                     object price = s_decimal_0,
                     dict kwargs = {}):
         cdef:
-            int64_t tracking_nonce = <int64_t> get_tracking_nonce()
-            str order_id = f"sell-{trading_pair}-{tracking_nonce}"
+            str order_id = get_new_client_order_id(
+                is_buy=False, trading_pair=trading_pair, max_id_len=CONSTANTS.MAX_ORDER_ID_LEN
+            )
+
         safe_ensure_future(self.execute_sell(order_id, trading_pair, amount, order_type, price))
         return order_id
 

--- a/hummingbot/connector/exchange/okex/constants.py
+++ b/hummingbot/connector/exchange/okex/constants.py
@@ -1,5 +1,7 @@
 from urllib.parse import urljoin
 
+CLIENT_ID_PREFIX = "93027a12dac34fBC"
+MAX_ID_LEN = 32
 
 # URLs
 

--- a/hummingbot/connector/exchange/okex/okex_exchange.pyx
+++ b/hummingbot/connector/exchange/okex/okex_exchange.pyx
@@ -23,6 +23,7 @@ from hummingbot.connector.exchange_base import (
     ExchangeBase,
     s_decimal_NaN)
 from hummingbot.connector.trading_rule cimport TradingRule
+from hummingbot.connector.utils import get_new_client_order_id
 from hummingbot.core.clock cimport Clock
 from hummingbot.core.data_type.cancellation_result import CancellationResult
 from hummingbot.core.data_type.common import OrderType, TradeType
@@ -55,7 +56,6 @@ from hummingbot.logger import HummingbotLogger
 hm_logger = None
 s_decimal_0 = Decimal(0)
 TRADING_PAIR_SPLITTER = "-"
-CLIENT_ID_PREFIX = "93027a12dac34fBC"
 
 
 class OKExAPIError(IOError):
@@ -668,7 +668,10 @@ cdef class OkexExchange(ExchangeBase):
             data=data,
             is_auth_required=True
         )
-        return str(exchange_order_id['data'][0]['ordId'])
+        data = exchange_order_id["data"][0]
+        if data["sCode"] != "0":
+            raise IOError(f"Error submitting order {order_id}: {data['sMsg']}")
+        return str(data['ordId'])
 
     async def execute_buy(self,
                           order_id: str,
@@ -739,8 +742,12 @@ cdef class OkexExchange(ExchangeBase):
                    object price=s_decimal_0,
                    dict kwargs={}):
         cdef:
-            int64_t tracking_nonce = <int64_t> get_tracking_nonce()
-            str order_id = f"{CLIENT_ID_PREFIX}{tracking_nonce}"  # OKEx doesn't permits special characters
+            str order_id = get_new_client_order_id(
+                is_buy=True,
+                trading_pair=trading_pair,
+                hbot_order_id_prefix=CLIENT_ID_PREFIX,
+                max_id_len=MAX_ID_LEN,
+            )
 
         safe_ensure_future(self.execute_buy(order_id, trading_pair, amount, order_type, price))
         return order_id
@@ -798,7 +805,6 @@ cdef class OkexExchange(ExchangeBase):
                 f"Error submitting sell {order_type_str} order to OKEx for "
                 f"{decimal_amount} {trading_pair} "
                 f"{decimal_price if order_type is OrderType.LIMIT else ''}.",
-                f"{decimal_price}.",
                 exc_info=True,
                 app_warning_msg=f"Failed to submit sell order to OKEx. Check API key and network connection."
             )
@@ -811,8 +817,12 @@ cdef class OkexExchange(ExchangeBase):
                     object order_type=OrderType.LIMIT, object price=s_decimal_0,
                     dict kwargs={}):
         cdef:
-            int64_t tracking_nonce = <int64_t> get_tracking_nonce()
-            str order_id = f"{CLIENT_ID_PREFIX}{tracking_nonce}"  # OKEx doesn't permits special characters
+            str order_id = get_new_client_order_id(
+                is_buy=False,
+                trading_pair=trading_pair,
+                hbot_order_id_prefix=CLIENT_ID_PREFIX,
+                max_id_len=MAX_ID_LEN,
+            )
 
         safe_ensure_future(self.execute_sell(order_id, trading_pair, amount, order_type, price))
         return order_id

--- a/hummingbot/connector/exchange/okex/okex_utils.py
+++ b/hummingbot/connector/exchange/okex/okex_utils.py
@@ -2,7 +2,6 @@ from hummingbot.client.config.config_var import ConfigVar
 from hummingbot.client.config.config_methods import using_exchange
 import zlib
 
-
 CENTRALIZED = True
 
 

--- a/hummingbot/connector/exchange/probit/probit_constants.py
+++ b/hummingbot/connector/exchange/probit/probit_constants.py
@@ -2,6 +2,8 @@
 
 EXCHANGE_NAME = "probit"
 
+MAX_ORDER_ID_LEN = 36
+
 REST_URL = "https://api.probit.{}/api/exchange/"
 WSS_URL = "wss://api.probit.{}/api/exchange/v1/ws"
 

--- a/hummingbot/connector/exchange/probit/probit_exchange.py
+++ b/hummingbot/connector/exchange/probit/probit_exchange.py
@@ -21,6 +21,7 @@ from hummingbot.connector.exchange.probit.probit_order_book_tracker import Probi
 from hummingbot.connector.exchange.probit.probit_user_stream_tracker import ProbitUserStreamTracker
 from hummingbot.connector.exchange_base import ExchangeBase
 from hummingbot.connector.trading_rule import TradingRule
+from hummingbot.connector.utils import get_new_client_order_id
 from hummingbot.core.clock import Clock
 from hummingbot.core.data_type.cancellation_result import CancellationResult
 from hummingbot.core.data_type.common import OpenOrder
@@ -389,7 +390,9 @@ class ProbitExchange(ExchangeBase):
         :param price: The price (note: this is no longer optional)
         :returns A new internal order id
         """
-        order_id: str = probit_utils.get_new_client_order_id(True, trading_pair)
+        order_id = get_new_client_order_id(
+            is_buy=True, trading_pair=trading_pair, max_id_len=CONSTANTS.MAX_ORDER_ID_LEN
+        )
         safe_ensure_future(self._create_order(TradeType.BUY, order_id, trading_pair, amount, order_type, price))
         return order_id
 
@@ -404,7 +407,9 @@ class ProbitExchange(ExchangeBase):
         :param price: The price (note: this is no longer optional)
         :returns A new internal order id
         """
-        order_id: str = probit_utils.get_new_client_order_id(False, trading_pair)
+        order_id = get_new_client_order_id(
+            is_buy=False, trading_pair=trading_pair, max_id_len=CONSTANTS.MAX_ORDER_ID_LEN
+        )
         safe_ensure_future(self._create_order(TradeType.SELL, order_id, trading_pair, amount, order_type, price))
         return order_id
 

--- a/hummingbot/connector/exchange/probit/probit_utils.py
+++ b/hummingbot/connector/exchange/probit/probit_utils.py
@@ -1,32 +1,20 @@
 #!/usr/bin/env python
 
+from datetime import datetime
+from typing import Any, Dict, List, Tuple
+
 import dateutil.parser as dp
 
-from datetime import datetime
-from typing import (
-    Any,
-    Dict,
-    List,
-    Tuple
-)
-
-from hummingbot.core.utils.tracking_nonce import get_tracking_nonce
-from hummingbot.core.data_type.order_book_row import OrderBookRow
-from hummingbot.core.data_type.order_book_message import OrderBookMessage
-
-from hummingbot.client.config.config_var import ConfigVar
 from hummingbot.client.config.config_methods import using_exchange
+from hummingbot.client.config.config_var import ConfigVar
+from hummingbot.core.data_type.order_book_message import OrderBookMessage
+from hummingbot.core.data_type.order_book_row import OrderBookRow
 
 CENTRALIZED = True
 
 EXAMPLE_PAIR = "ETH-USDT"
 
 DEFAULT_FEES = [0.2, 0.2]
-
-
-def get_new_client_order_id(is_buy: bool, trading_pair: str) -> str:
-    side = "B" if is_buy else "S"
-    return f"{side}-{trading_pair}-{get_tracking_nonce()}"
 
 
 def convert_iso_to_epoch(ts: str) -> float:

--- a/hummingbot/core/utils/tracking_nonce.py
+++ b/hummingbot/core/utils/tracking_nonce.py
@@ -1,12 +1,9 @@
 import time
 
 _last_tracking_nonce: int = 0
-
 _last_tracking_nonce_low_res: int = 0
 
 
-# This tracking nonce is needed bc resolution for time.time() on Windows is very low (16ms),
-# not good enough to create unique order_id.
 def get_tracking_nonce() -> int:
     global _last_tracking_nonce
     nonce = int(time.time() * 1e6)

--- a/test/hummingbot/connector/derivative/binance_perpetual/test_binance_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/binance_perpetual/test_binance_perpetual_derivative.py
@@ -17,6 +17,7 @@ from hummingbot.connector.derivative.binance_perpetual.binance_perpetual_api_ord
     BinancePerpetualAPIOrderBookDataSource
 from hummingbot.connector.derivative.binance_perpetual.binance_perpetual_derivative import \
     BinancePerpetualDerivative
+from hummingbot.connector.utils import get_new_client_order_id
 from hummingbot.core.data_type.common import OrderType, PositionAction, PositionMode, TradeType
 from hummingbot.core.data_type.in_flight_order import OrderState, InFlightOrder
 from hummingbot.core.data_type.trade_fee import TokenAmount
@@ -1578,3 +1579,39 @@ class BinancePerpetualDerivativeUnitTest(unittest.TestCase):
         self.assertNotIn("OID2", self.exchange.in_flight_orders)
         self.assertNotIn("OID3", self.exchange.in_flight_orders)
         self.assertNotIn("OID4", self.exchange.in_flight_orders)
+
+    @patch("hummingbot.connector.utils.get_tracking_nonce_low_res")
+    def test_client_order_id_on_order(self, mocked_nonce):
+        mocked_nonce.return_value = 4
+
+        result = self.exchange.buy(
+            trading_pair=self.trading_pair,
+            amount=Decimal("1"),
+            order_type=OrderType.LIMIT,
+            price=Decimal("2"),
+            position_action="OPEN",
+        )
+        expected_client_order_id = get_new_client_order_id(
+            is_buy=True,
+            trading_pair=self.trading_pair,
+            hbot_order_id_prefix=CONSTANTS.BROKER_ID,
+            max_id_len=CONSTANTS.MAX_ORDER_ID_LEN,
+        )
+
+        self.assertEqual(result, expected_client_order_id)
+
+        result = self.exchange.sell(
+            trading_pair=self.trading_pair,
+            amount=Decimal("1"),
+            order_type=OrderType.LIMIT,
+            price=Decimal("2"),
+            position_action="OPEN",
+        )
+        expected_client_order_id = get_new_client_order_id(
+            is_buy=False,
+            trading_pair=self.trading_pair,
+            hbot_order_id_prefix=CONSTANTS.BROKER_ID,
+            max_id_len=CONSTANTS.MAX_ORDER_ID_LEN,
+        )
+
+        self.assertEqual(result, expected_client_order_id)

--- a/test/hummingbot/connector/derivative/binance_perpetual/test_binance_perpetual_utils.py
+++ b/test/hummingbot/connector/derivative/binance_perpetual/test_binance_perpetual_utils.py
@@ -1,18 +1,10 @@
 import asyncio
-import os
-import socket
 import unittest
-
-import hummingbot.connector.derivative.binance_perpetual.constants as CONSTANTS
-import hummingbot.connector.derivative.binance_perpetual.binance_perpetual_utils as utils
-
-from mock import patch
 from typing import Awaitable
 
-from hummingbot.connector.derivative.binance_perpetual.binance_perpetual_utils import (
-    BROKER_ID,
-    BinancePerpetualRESTPreProcessor,
-)
+import hummingbot.connector.derivative.binance_perpetual.binance_perpetual_utils as utils
+import hummingbot.connector.derivative.binance_perpetual.constants as CONSTANTS
+from hummingbot.connector.derivative.binance_perpetual.binance_perpetual_utils import BinancePerpetualRESTPreProcessor
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, RESTRequest
 from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
 
@@ -55,21 +47,8 @@ class BinancePerpetualUtilsUnitTests(unittest.TestCase):
         self.assertIn("Content-Type", result_request.headers)
         self.assertEqual(result_request.headers["Content-Type"], "application/json")
 
-    @patch("hummingbot.connector.derivative.binance_perpetual.binance_perpetual_utils.get_tracking_nonce")
-    def test_get_client_order_id(self, mock_nonce):
-        mock_nonce.return_value = int("1" * 16)
-        client_instance_id = hex(abs(hash(f"{socket.gethostname()}{os.getpid()}")))[2:6]
-
-        result = utils.get_client_order_id("buy", self.trading_pair)
-
-        expected_client_order_id = f"{BROKER_ID}-BCAHT{client_instance_id}{int('1'*16)}"
-
-        self.assertEqual(result, expected_client_order_id)
-
     def test_rest_url_main_domain(self):
         path_url = "/TEST_PATH_URL"
-
-        expected_url = path_url = "/TEST_PATH_URL"
 
         expected_url = f"{CONSTANTS.PERPETUAL_BASE_URL}{CONSTANTS.API_VERSION_V2}{path_url}"
         self.assertEqual(expected_url, utils.rest_url(path_url, api_version=CONSTANTS.API_VERSION_V2))

--- a/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_derivative.py
@@ -18,6 +18,7 @@ from hummingbot.connector.derivative.bybit_perpetual.bybit_perpetual_derivative 
 from hummingbot.connector.derivative.bybit_perpetual.bybit_perpetual_in_flight_order import BybitPerpetualInFlightOrder
 from hummingbot.connector.derivative.bybit_perpetual.bybit_perpetual_order_book import BybitPerpetualOrderBook
 from hummingbot.connector.trading_rule import TradingRule
+from hummingbot.connector.utils import get_new_client_order_id
 from hummingbot.core.data_type.common import OrderType, PositionAction, PositionMode, PositionSide, TradeType
 from hummingbot.core.event.event_logger import EventLogger
 from hummingbot.core.event.events import FundingInfo, MarketEvent
@@ -176,9 +177,9 @@ class BybitPerpetualDerivativeTests(TestCase):
         self.mock_done_event.set()
 
     @aioresponses()
-    @patch('hummingbot.connector.derivative.bybit_perpetual.bybit_perpetual_utils.get_tracking_nonce')
-    def test_create_buy_order(self, post_mock, nonce_provider_mock):
-        nonce_provider_mock.return_value = 1000
+    @patch("hummingbot.connector.utils.get_tracking_nonce_low_res")
+    def test_create_buy_order(self, post_mock, mocked_nonce):
+        mocked_nonce.return_value = 5
         path_url = bybit_utils.rest_api_path_for_endpoint(CONSTANTS.PLACE_ACTIVE_ORDER_PATH_URL, self.trading_pair)
         url = bybit_utils.rest_api_url_for_endpoint(path_url, self.domain)
         regex_url = re.compile(f"^{url}")
@@ -205,7 +206,7 @@ class BybitPerpetualDerivativeTests(TestCase):
                 "cum_exec_value": 0,
                 "cum_exec_fee": 0,
                 "reject_reason": "",
-                "order_link_id": bybit_utils.get_new_client_order_id(True, self.trading_pair),
+                "order_link_id": get_new_client_order_id(True, self.trading_pair),
                 "created_at": "2019-11-30T11:03:43.452Z",
                 "updated_at": "2019-11-30T11:03:43.455Z"
             },
@@ -229,7 +230,7 @@ class BybitPerpetualDerivativeTests(TestCase):
 
         result = mock_response["result"]
 
-        self.assertEqual(f"HBOT-B-{self.trading_pair}-1000", new_order_id)
+        self.assertEqual(get_new_client_order_id(True, self.trading_pair), new_order_id)
         self.assertEqual("Buy", result["side"])
         self.assertEqual(self.ex_trading_pair, result["symbol"])
         self.assertEqual("Limit", result["order_type"])
@@ -511,9 +512,9 @@ class BybitPerpetualDerivativeTests(TestCase):
         self.assertTrue(self._is_logged("INFO", "Created LIMIT BUY order C1 for BTC-USDT. Amount: 1 Price: 46000."))
 
     @aioresponses()
-    @patch('hummingbot.connector.derivative.bybit_perpetual.bybit_perpetual_utils.get_tracking_nonce')
-    def test_create_sell_order(self, post_mock, nonce_provider_mock):
-        nonce_provider_mock.return_value = 1000
+    @patch("hummingbot.connector.utils.get_tracking_nonce_low_res")
+    def test_create_sell_order(self, post_mock, mocked_nonce):
+        mocked_nonce.return_value = 6
         path_url = bybit_utils.rest_api_path_for_endpoint(CONSTANTS.PLACE_ACTIVE_ORDER_PATH_URL, self.trading_pair)
         url = bybit_utils.rest_api_url_for_endpoint(path_url, self.domain)
         regex_url = re.compile(f"^{url}")
@@ -539,7 +540,7 @@ class BybitPerpetualDerivativeTests(TestCase):
                 "cum_exec_value": 0,
                 "cum_exec_fee": 0,
                 "reject_reason": "",
-                "order_link_id": bybit_utils.get_new_client_order_id(False, self.trading_pair),
+                "order_link_id": get_new_client_order_id(False, self.trading_pair),
                 "created_at": "2019-11-30T11:03:43.452Z",
                 "updated_at": "2019-11-30T11:03:43.455Z"
             },
@@ -563,7 +564,7 @@ class BybitPerpetualDerivativeTests(TestCase):
 
         result = mock_response["result"]
 
-        self.assertEqual(f"HBOT-S-{self.trading_pair}-1000", new_order_id)
+        self.assertEqual(get_new_client_order_id(False, self.trading_pair), new_order_id)
         self.assertEqual("Sell", result["side"])
         self.assertEqual("BTCUSDT", result["symbol"])
         self.assertEqual("Market", result["order_type"])
@@ -2688,3 +2689,33 @@ class BybitPerpetualDerivativeTests(TestCase):
 
         self.assertEqual(self.non_linear_base, non_linear_buy_collateral_token)
         self.assertEqual(self.non_linear_base, non_linear_sell_collateral_token)
+
+    @patch("hummingbot.connector.utils.get_tracking_nonce_low_res")
+    def test_client_order_id_on_order(self, mocked_nonce):
+        mocked_nonce.return_value = 5
+
+        result = self.connector.buy(
+            trading_pair=self.trading_pair,
+            amount=Decimal("1"),
+            order_type=OrderType.LIMIT,
+            price=Decimal("2"),
+            position_action="OPEN",
+        )
+        expected_client_order_id = get_new_client_order_id(
+            is_buy=True, trading_pair=self.trading_pair
+        )
+
+        self.assertEqual(result, expected_client_order_id)
+
+        result = self.connector.sell(
+            trading_pair=self.trading_pair,
+            amount=Decimal("1"),
+            order_type=OrderType.LIMIT,
+            price=Decimal("2"),
+            position_action="OPEN",
+        )
+        expected_client_order_id = get_new_client_order_id(
+            is_buy=False, trading_pair=self.trading_pair
+        )
+
+        self.assertEqual(result, expected_client_order_id)

--- a/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_utils.py
+++ b/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_utils.py
@@ -1,19 +1,11 @@
-import pandas as pd
 from unittest import TestCase
-from unittest.mock import patch
+
+import pandas as pd
 
 from hummingbot.connector.derivative.bybit_perpetual import bybit_perpetual_constants as CONSTANTS, bybit_perpetual_utils as utils
 
 
 class BybitPerpetualUtilsTests(TestCase):
-
-    @patch('hummingbot.connector.derivative.bybit_perpetual.bybit_perpetual_utils.get_tracking_nonce')
-    def test_client_order_id_creation(self, nonce_provider_mock):
-        nonce_provider_mock.return_value = int(1e15)
-        self.assertEqual("HBOT-B-BTC-USDT-1000000000000000", utils.get_new_client_order_id(True, "BTC-USDT"))
-        nonce_provider_mock.return_value = int(1e15) + 1
-        self.assertEqual("HBOT-S-ETH-USDT-1000000000000001", utils.get_new_client_order_id(False, "ETH-USDT"))
-
     def test_trading_pair_convertion(self):
         trading_pair = "BTC-USDT"
         self.assertEqual("BTCUSDT", utils.convert_to_exchange_trading_pair(trading_pair))

--- a/test/hummingbot/connector/exchange/ascend_ex/test_ascend_ex_utils.py
+++ b/test/hummingbot/connector/exchange/ascend_ex/test_ascend_ex_utils.py
@@ -10,13 +10,6 @@ class AscendExUtilsTests(TestCase):
     def _get_ms_timestamp(self):
         return 1633084102569
 
-    @patch('hummingbot.connector.exchange.ascend_ex.ascend_ex_utils.get_tracking_nonce')
-    def test_gen_client_order_id(self, nonce_provider_mock):
-        nonce_provider_mock.return_value = int(1e15)
-        self.assertEqual("HMBot-BBTCUSD1000000000000000", utils.gen_client_order_id(True, "BTC-USDT"))
-        nonce_provider_mock.return_value = int(1e15) + 1
-        self.assertEqual("HMBot-SETHUSD1000000000000001", utils.gen_client_order_id(False, "ETH-USDT"))
-
     def test_gen_exchange_order_id(self):
         with mock.patch('hummingbot.connector.exchange.ascend_ex.ascend_ex_utils.get_ms_timestamp') as get_ms_timestamp_mock:
             timestamp = self._get_ms_timestamp()

--- a/test/hummingbot/connector/exchange/binance/test_binance_exchange.py
+++ b/test/hummingbot/connector/exchange/binance/test_binance_exchange.py
@@ -13,6 +13,7 @@ from hummingbot.connector.exchange.binance import binance_constants as CONSTANTS
 from hummingbot.connector.exchange.binance.binance_api_order_book_data_source import BinanceAPIOrderBookDataSource
 from hummingbot.connector.exchange.binance.binance_exchange import BinanceExchange
 from hummingbot.connector.trading_rule import TradingRule
+from hummingbot.connector.utils import get_new_client_order_id
 from hummingbot.core.data_type.cancellation_result import CancellationResult
 from hummingbot.core.data_type.common import OrderType, TradeType
 from hummingbot.core.data_type.in_flight_order import OrderState, InFlightOrder
@@ -1540,3 +1541,37 @@ class BinanceExchangeTests(TestCase):
         self.assertNotIn("OID2", self.exchange.in_flight_orders)
         self.assertNotIn("OID3", self.exchange.in_flight_orders)
         self.assertNotIn("OID4", self.exchange.in_flight_orders)
+
+    @patch("hummingbot.connector.utils.get_tracking_nonce_low_res")
+    def test_client_order_id_on_order(self, mocked_nonce):
+        mocked_nonce.return_value = 7
+
+        result = self.exchange.buy(
+            trading_pair=self.trading_pair,
+            amount=Decimal("1"),
+            order_type=OrderType.LIMIT,
+            price=Decimal("2"),
+        )
+        expected_client_order_id = get_new_client_order_id(
+            is_buy=True,
+            trading_pair=self.trading_pair,
+            hbot_order_id_prefix=CONSTANTS.HBOT_ORDER_ID_PREFIX,
+            max_id_len=CONSTANTS.MAX_ORDER_ID_LEN,
+        )
+
+        self.assertEqual(result, expected_client_order_id)
+
+        result = self.exchange.sell(
+            trading_pair=self.trading_pair,
+            amount=Decimal("1"),
+            order_type=OrderType.LIMIT,
+            price=Decimal("2"),
+        )
+        expected_client_order_id = get_new_client_order_id(
+            is_buy=False,
+            trading_pair=self.trading_pair,
+            hbot_order_id_prefix=CONSTANTS.HBOT_ORDER_ID_PREFIX,
+            max_id_len=CONSTANTS.MAX_ORDER_ID_LEN,
+        )
+
+        self.assertEqual(result, expected_client_order_id)

--- a/test/hummingbot/connector/exchange/binance/test_binance_utils.py
+++ b/test/hummingbot/connector/exchange/binance/test_binance_utils.py
@@ -1,8 +1,4 @@
-import os
-import socket
-import time
 import unittest
-from unittest.mock import patch
 
 import hummingbot.connector.exchange.binance.binance_constants as CONSTANTS
 from hummingbot.connector.exchange.binance import binance_utils as utils
@@ -15,6 +11,7 @@ class BinanceUtilTestCases(unittest.TestCase):
         super().setUpClass()
         cls.base_asset = "COINALPHA"
         cls.quote_asset = "HBOT"
+        cls.trading_pair = f"{cls.base_asset}-{cls.quote_asset}"
         cls.hb_trading_pair = f"{cls.base_asset}-{cls.quote_asset}"
         cls.ex_trading_pair = f"{cls.base_asset}{cls.quote_asset}"
 
@@ -58,21 +55,3 @@ class BinanceUtilTestCases(unittest.TestCase):
         }
 
         self.assertTrue(utils.is_exchange_information_valid(invalid_info_4))
-
-    @patch("hummingbot.connector.exchange.binance.binance_utils.get_tracking_nonce")
-    def test_client_order_id_generation(self, nonce_mock):
-        nonce = int(time.time() * 1e6)
-        nonce_mock.return_value = nonce
-        client_instance_id = hex(abs(hash(f"{socket.gethostname()}{os.getpid()}")))[2:6]
-
-        client_order_id = utils.get_new_client_order_id(is_buy=True, trading_pair=self.hb_trading_pair)
-        expected_id = (f"{CONSTANTS.HBOT_ORDER_ID_PREFIX}-{'B'}"
-                       f"{self.base_asset[0]}{self.base_asset[-1]}{self.quote_asset[0]}{self.quote_asset[-1]}"
-                       f"{client_instance_id}{nonce}")
-        self.assertEqual(expected_id, client_order_id)
-
-        client_order_id = utils.get_new_client_order_id(is_buy=False, trading_pair=self.hb_trading_pair)
-        expected_id = (f"{CONSTANTS.HBOT_ORDER_ID_PREFIX}-{'S'}"
-                       f"{self.base_asset[0]}{self.base_asset[-1]}{self.quote_asset[0]}{self.quote_asset[-1]}"
-                       f"{client_instance_id}{nonce}")
-        self.assertEqual(expected_id, client_order_id)

--- a/test/hummingbot/connector/exchange/huobi/test_huobi_exchange.py
+++ b/test/hummingbot/connector/exchange/huobi/test_huobi_exchange.py
@@ -2,11 +2,12 @@ import asyncio
 from decimal import Decimal
 from typing import Awaitable, Optional
 from unittest import TestCase
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
-import hummingbot.connector.exchange.huobi.huobi_constants as CONSTANTS
+from hummingbot.connector.exchange.huobi import huobi_constants as CONSTANTS, huobi_utils
 from hummingbot.connector.exchange.huobi.huobi_exchange import HuobiExchange
 from hummingbot.core.data_type.common import OrderType, TradeType
+from hummingbot.connector.utils import get_new_client_order_id
 from hummingbot.core.data_type.trade_fee import TokenAmount
 from hummingbot.core.event.event_logger import EventLogger
 from hummingbot.core.event.events import (
@@ -293,3 +294,31 @@ class HuobiExchangeTests(TestCase):
         buy_event: BuyOrderCompletedEvent = self.buy_order_completed_logger.event_log[0]
         self.assertEqual(complete_fill["feeCurrency"].upper(), buy_event.fee_asset)
         self.assertEqual(Decimal(complete_fill["transactFee"]), buy_event.fee_amount)
+
+    @patch("hummingbot.connector.utils.get_tracking_nonce_low_res")
+    def test_client_order_id_on_order(self, mocked_nonce):
+        mocked_nonce.return_value = 8
+
+        result = self.exchange.buy(
+            trading_pair=self.trading_pair,
+            amount=Decimal("1"),
+            order_type=OrderType.LIMIT,
+            price=Decimal("2"),
+        )
+        expected_client_order_id = get_new_client_order_id(
+            is_buy=True, trading_pair=self.trading_pair, hbot_order_id_prefix=huobi_utils.BROKER_ID
+        )
+
+        self.assertEqual(result, expected_client_order_id)
+
+        result = self.exchange.sell(
+            trading_pair=self.trading_pair,
+            amount=Decimal("1"),
+            order_type=OrderType.LIMIT,
+            price=Decimal("2"),
+        )
+        expected_client_order_id = get_new_client_order_id(
+            is_buy=False, trading_pair=self.trading_pair, hbot_order_id_prefix=huobi_utils.BROKER_ID
+        )
+
+        self.assertEqual(result, expected_client_order_id)

--- a/test/hummingbot/connector/exchange/okex/test_okex_exchange.py
+++ b/test/hummingbot/connector/exchange/okex/test_okex_exchange.py
@@ -1,0 +1,62 @@
+import asyncio
+import unittest
+from decimal import Decimal
+from unittest.mock import patch
+
+from hummingbot.connector.exchange.okex.constants import CLIENT_ID_PREFIX, MAX_ID_LEN
+from hummingbot.connector.exchange.okex.okex_exchange import OkexExchange
+from hummingbot.connector.utils import get_new_client_order_id
+from hummingbot.core.event.events import OrderType
+
+
+class TestOKExExchange(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls.ev_loop = asyncio.get_event_loop()
+        cls.base_asset = "COINALPHA"
+        cls.quote_asset = "HBOT"
+        cls.trading_pair = f"{cls.base_asset}-{cls.quote_asset}"
+        cls.api_key = "someKey"
+        cls.api_passphrase = "somePassPhrase"
+        cls.api_secret_key = "someSecretKey"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.exchange = OkexExchange(
+            self.api_key, self.api_secret_key, self.api_passphrase, trading_pairs=[self.trading_pair]
+        )
+
+    @patch("hummingbot.connector.utils.get_tracking_nonce_low_res")
+    def test_client_order_id_on_order(self, mocked_nonce):
+        mocked_nonce.return_value = 9
+
+        result = self.exchange.buy(
+            trading_pair=self.trading_pair,
+            amount=Decimal("1"),
+            order_type=OrderType.LIMIT,
+            price=Decimal("2"),
+        )
+        expected_client_order_id = get_new_client_order_id(
+            is_buy=True,
+            trading_pair=self.trading_pair,
+            hbot_order_id_prefix=CLIENT_ID_PREFIX,
+            max_id_len=MAX_ID_LEN,
+        )
+
+        self.assertEqual(result, expected_client_order_id)
+
+        result = self.exchange.sell(
+            trading_pair=self.trading_pair,
+            amount=Decimal("1"),
+            order_type=OrderType.LIMIT,
+            price=Decimal("2"),
+        )
+        expected_client_order_id = get_new_client_order_id(
+            is_buy=False,
+            trading_pair=self.trading_pair,
+            hbot_order_id_prefix=CLIENT_ID_PREFIX,
+            max_id_len=MAX_ID_LEN,
+        )
+
+        self.assertEqual(result, expected_client_order_id)

--- a/test/hummingbot/connector/exchange/probit/test_probit_exchange.py
+++ b/test/hummingbot/connector/exchange/probit/test_probit_exchange.py
@@ -3,12 +3,14 @@ import unittest
 from decimal import Decimal
 from unittest.mock import patch
 
+from hummingbot.connector.exchange.probit.probit_constants import \
+    MAX_ORDER_ID_LEN
 from hummingbot.connector.exchange.probit.probit_exchange import ProbitExchange
 from hummingbot.connector.utils import get_new_client_order_id
 from hummingbot.core.event.events import OrderType
 
 
-class TestOKExExchange(unittest.TestCase):
+class TestProbitExchange(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         super().setUpClass()
@@ -36,7 +38,7 @@ class TestOKExExchange(unittest.TestCase):
             price=Decimal("2"),
         )
         expected_client_order_id = get_new_client_order_id(
-            is_buy=True, trading_pair=self.trading_pair
+            is_buy=True, trading_pair=self.trading_pair, max_id_len=MAX_ORDER_ID_LEN
         )
 
         self.assertEqual(result, expected_client_order_id)
@@ -48,7 +50,7 @@ class TestOKExExchange(unittest.TestCase):
             price=Decimal("2"),
         )
         expected_client_order_id = get_new_client_order_id(
-            is_buy=False, trading_pair=self.trading_pair
+            is_buy=False, trading_pair=self.trading_pair, max_id_len=MAX_ORDER_ID_LEN
         )
 
         self.assertEqual(result, expected_client_order_id)

--- a/test/hummingbot/connector/exchange/probit/test_probit_exchange.py
+++ b/test/hummingbot/connector/exchange/probit/test_probit_exchange.py
@@ -1,0 +1,54 @@
+import asyncio
+import unittest
+from decimal import Decimal
+from unittest.mock import patch
+
+from hummingbot.connector.exchange.probit.probit_exchange import ProbitExchange
+from hummingbot.connector.utils import get_new_client_order_id
+from hummingbot.core.event.events import OrderType
+
+
+class TestOKExExchange(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls.ev_loop = asyncio.get_event_loop()
+        cls.base_asset = "COINALPHA"
+        cls.quote_asset = "HBOT"
+        cls.trading_pair = f"{cls.base_asset}-{cls.quote_asset}"
+        cls.api_key = "someKey"
+        cls.api_secret_key = "someSecretKey"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.exchange = ProbitExchange(
+            self.api_key, self.api_secret_key, trading_pairs=[self.trading_pair]
+        )
+
+    @patch("hummingbot.connector.utils.get_tracking_nonce_low_res")
+    def test_client_order_id_on_order(self, mocked_nonce):
+        mocked_nonce.return_value = 9
+
+        result = self.exchange.buy(
+            trading_pair=self.trading_pair,
+            amount=Decimal("1"),
+            order_type=OrderType.LIMIT,
+            price=Decimal("2"),
+        )
+        expected_client_order_id = get_new_client_order_id(
+            is_buy=True, trading_pair=self.trading_pair
+        )
+
+        self.assertEqual(result, expected_client_order_id)
+
+        result = self.exchange.sell(
+            trading_pair=self.trading_pair,
+            amount=Decimal("1"),
+            order_type=OrderType.LIMIT,
+            price=Decimal("2"),
+        )
+        expected_client_order_id = get_new_client_order_id(
+            is_buy=False, trading_pair=self.trading_pair
+        )
+
+        self.assertEqual(result, expected_client_order_id)

--- a/test/hummingbot/connector/test_utils.py
+++ b/test/hummingbot/connector/test_utils.py
@@ -1,6 +1,4 @@
-import time
 import unittest
-from unittest.mock import patch
 
 from hummingbot.connector.utils import get_new_client_order_id
 
@@ -12,10 +10,7 @@ class UtilsTest(unittest.TestCase):
         cls.quote = "COINALPHA"
         cls.trading_pair = f"{cls.base}-{cls.quote}"
 
-    @patch("hummingbot.core.utils.tracking_nonce._time")
-    def test_get_new_client_order_id(self, mocked_time):
-        t = int(time.time() * 1e3)
-        mocked_time.return_value = t
+    def test_get_new_client_order_id(self):
         host_prefix = "hbot"
 
         id0 = get_new_client_order_id(is_buy=True, trading_pair=self.trading_pair)

--- a/test/hummingbot/connector/test_utils.py
+++ b/test/hummingbot/connector/test_utils.py
@@ -1,0 +1,29 @@
+import time
+import unittest
+from unittest.mock import patch
+
+from hummingbot.connector.utils import get_new_client_order_id
+
+
+class UtilsTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.base = "HBOT"
+        cls.quote = "COINALPHA"
+        cls.trading_pair = f"{cls.base}-{cls.quote}"
+
+    @patch("hummingbot.core.utils.tracking_nonce._time")
+    def test_get_new_client_order_id(self, mocked_time):
+        t = int(time.time() * 1e3)
+        mocked_time.return_value = t
+        host_prefix = "hbot"
+
+        id0 = get_new_client_order_id(is_buy=True, trading_pair=self.trading_pair)
+        id1 = get_new_client_order_id(is_buy=True, trading_pair=self.trading_pair, hbot_order_id_prefix=host_prefix)
+
+        self.assertFalse(id0.startswith(host_prefix))
+        self.assertTrue(id1.startswith(host_prefix))
+
+        id2 = get_new_client_order_id(is_buy=True, trading_pair=self.trading_pair, max_id_len=len(id0) - 2)
+
+        self.assertEqual(len(id0) - 2, len(id2))

--- a/test/hummingbot/core/utils/test_tracking_nonce.py
+++ b/test/hummingbot/core/utils/test_tracking_nonce.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 import asyncio
+
 import hummingbot.core.utils.tracking_nonce as tracking_nonce
 
 
@@ -30,18 +31,3 @@ class TrackingNonceTest(TestCase):
         tasks = [task(), task()]
         ret = asyncio.get_event_loop().run_until_complete(asyncio.gather(*tasks))
         self.assertGreaterEqual(ret[1], ret[0])
-
-    def test_resolution_difference_between_high_and_low_res(self):
-        async def task():
-            return tracking_nonce.get_tracking_nonce()
-        tasks = [task(), task()]
-        ret = asyncio.get_event_loop().run_until_complete(asyncio.gather(*tasks))
-        high_res_diff = ret[1] - ret[0]
-
-        async def task():
-            return tracking_nonce.get_tracking_nonce_low_res()
-        tasks = [task(), task()]
-        ret = asyncio.get_event_loop().run_until_complete(asyncio.gather(*tasks))
-        low_res_diff = ret[1] - ret[0]
-
-        self.assertGreater(high_res_diff, low_res_diff)


### PR DESCRIPTION
NOTE: The original PR can be found [here](https://github.com/hummingbot/hummingbot/pull/5138). This PR was created as a means of solving the issues that arose from the fact that the original PR branched off of another feature branch. This caused many issues with resolving conflicts with development.

**Before submitting this PR, please make sure**:

- [X] Your code builds clean without any errors or warnings
- [X] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Duplicated client order IDs can cause orders to be rejected by the exchange and can cause issues with historical analysis of strategy performance. Currently, the client uses a nonce derived from the current timestamp to generate "unique" client order IDs. The issue is that those IDs can be duplicated across multiple instances of `hummingbot` running in parallel. To prevent this from happening, this PR introduces a new method of generating the IDs that will be unique across instances as well.

The two main changes are:
- Propagates the Binance approach of ensuring unique client order Ids into the rest of the CoinAlpha-maintained exchanges with slight modifications.
- Adds a default function to use for that purpose with options for adding an exchange-specific prefix and limiting the length of the ID string.

### The new order ID schema
- Optional exchange-specific `hbot_order_id_prefix`
- Order `side` ["B", "S"]
- The `base_str`, which is the first and last letter of the base token
- The `quote_str`, which is the first and last letter of the quote token
- Tracking nonce (low-res version, with milliseconds)
- The `client_instance_id`, which are generated so that they differ between instances on the same machine, but also between instances on different machines (eng: see concerns below)


**Tests performed by the developer**:
- Tests for the new function
- Tests for all of the exchanges affected:
    - AscendEx
    - Binance spot
    - Binance perp
    - Bybit perp
    - Gate.io
    - Huobi
    - KuCoin
    - OKEX
    - ProBit
- Successfully placed orders on the following exchanges (expired creds for ByBit perp; invalid ones for Huobi and OkEx):
    - AscendEx
    - Binance spot
    - Binance perp (testnet)
    - Gate.io
    - KuCoin
    - ProBit

**Tested and confirmed working QA.**

Tests performed:
- Created a strategy using the affected connectors and went through initial prompts successfully
- Started the strategy without issues, confirmed orders are created and cancelled based on config
- Confirmed that the orders created now uses the new order ID schema
- Confirmed that no duplicate client order IDs were created when running between instances on the same and different machine
- Trade information are correct (price, size and order ID) based on history command output, sqlite and csv file
- Confirmed all issues reported are now fixed