### PR TITLE
Feat/Adapt Trade Intensity Indicator to Use Trade Events

### DIFF
--- a/hummingbot/core/data_type/order_book.pxd
+++ b/hummingbot/core/data_type/order_book.pxd
@@ -20,6 +20,7 @@ cdef class OrderBook(PubSub):
     cdef double _last_applied_trade
     cdef double _last_trade_price_rest_updated
     cdef bint _dex
+    cdef object _trades
 
     cdef c_apply_diffs(self, vector[OrderBookEntry] bids, vector[OrderBookEntry] asks, int64_t update_id)
     cdef c_apply_snapshot(self, vector[OrderBookEntry] bids, vector[OrderBookEntry] asks, int64_t update_id)

--- a/hummingbot/strategy/__utils__/trailing_indicators/trading_intensity.pxd
+++ b/hummingbot/strategy/__utils__/trailing_indicators/trading_intensity.pxd
@@ -10,6 +10,8 @@ cdef class TradingIntensityIndicator():
         object _asks_df
         int _sampling_length
         int _samples_length
+        object _last_trade
+        float _last_timestamp
 
-    cdef c_simulate_execution(self, bids_df, asks_df)
+    cdef c_process_sample(self, new_bids_df, new_asks_df, trades)
     cdef c_estimate_intensity(self)

--- a/hummingbot/strategy/__utils__/trailing_indicators/trading_intensity.pyx
+++ b/hummingbot/strategy/__utils__/trailing_indicators/trading_intensity.pyx
@@ -75,6 +75,8 @@ cdef class TradingIntensityIndicator():
         if len(self._trades) > _sampling_length:
             self._trades = self._trades[-_sampling_length:]
 
+        return len(new_trades) > 0
+
     def _estimate_intensity(self):
         self.c_estimate_intensity()
 
@@ -133,9 +135,9 @@ cdef class TradingIntensityIndicator():
 
         # Do not process until a previous order book is not available
         if self._bids_df is not None and self._asks_df is not None:
-            self.c_process_sample(bids_df, asks_df, trades)
+            is_new_trades = self.c_process_sample(bids_df, asks_df, trades)
 
-            if self.is_sampling_buffer_full:
+            if is_new_trades and self.is_sampling_buffer_full:
                 # Estimate alpha and kappa
                 self.c_estimate_intensity()
 

--- a/hummingbot/strategy/__utils__/trailing_indicators/trading_intensity.pyx
+++ b/hummingbot/strategy/__utils__/trailing_indicators/trading_intensity.pyx
@@ -70,8 +70,6 @@ cdef class TradingIntensityIndicator():
         # Store the last processed trade
         self._last_trade = trades.iloc[-1]
 
-        print(new_trades)
-
         # Add trades
         self._trades += [new_trades]
         if len(self._trades) > _sampling_length:

--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pxd
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pxd
@@ -59,6 +59,7 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
 
     cdef object c_get_mid_price(self)
     cdef object c_get_order_book_snapshot(self)
+    cdef object c_get_recent_trades(self)
     cdef _create_proposal_based_on_order_levels(self)
     cdef _create_proposal_based_on_order_override(self)
     cdef _create_basic_proposal(self)

--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pyx
@@ -374,6 +374,12 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
     cdef object c_get_order_book_snapshot(self):
         return self._market_info.order_book.snapshot
 
+    def get_recent_trades(self) -> float:
+        return self.c_get_recent_trades()
+
+    cdef object c_get_recent_trades(self):
+        return self._market_info.order_book.trades
+
     @property
     def market_info_to_active_orders(self) -> Dict[MarketTradingPairTuple, List[LimitOrder]]:
         return self._sb_order_tracker.market_pair_to_active_orders
@@ -642,8 +648,9 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
 
         price = self.get_price()
         snapshot = self.get_order_book_snapshot()
+        trades = self.get_recent_trades()
         self._avg_vol.add_sample(price)
-        self._trading_intensity.add_sample(snapshot)
+        self._trading_intensity.add_sample(timestamp, snapshot, trades)
         # Calculate adjustment factor to have 0.01% of inventory resolution
         base_balance = market.get_balance(base_asset)
         quote_balance = market.get_balance(quote_asset)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Stores the most recent trades in the order book class and makes them available to strategies.
Replaces simulation in trading intensity with real trades from the exchange.
Update of the Avellaneda-Stoikov strategy to use the new sampling.

**Tests performed by the developer**:

Ran the Avellaneda-Stoikov strategy in this branch side by side with the version in the development branch and compared their behavior as well as calculated trading intensity variables.
Ran unit tests.

**Tips for QA testing**:

The version in this branch should give roughly the same results as the version in the development branch, but not necessarily exactly the same. Namely the orders placed in the market should be roughly the same, and the variables `order_book_intensity_factor` and `order_book_depth_factor` should be roughly the same.


