### PR TITLE
fix/set codec to utf-8 when opening config files

### DIFF
--- a/hummingbot/client/config/config_helpers.py
+++ b/hummingbot/client/config/config_helpers.py
@@ -1,39 +1,28 @@
-import logging
-from decimal import Decimal
-import ruamel.yaml
-from os import (
-    unlink
-)
-from os.path import (
-    join,
-    isfile
-)
-from collections import OrderedDict, defaultdict
 import json
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-)
-from os import listdir
+import logging
 import shutil
+from collections import OrderedDict, defaultdict
+from decimal import Decimal
+from os import listdir, unlink
+from os.path import isfile, join
+from typing import Any, Callable, Dict, List, Optional
 
+import ruamel.yaml
+
+from hummingbot import get_strategy_list
 from hummingbot.client.config.config_var import ConfigVar
-from hummingbot.client.config.global_config_map import global_config_map
 from hummingbot.client.config.fee_overrides_config_map import fee_overrides_config_map, init_fee_overrides_config
+from hummingbot.client.config.global_config_map import global_config_map
+from hummingbot.client.config.security import Security
 from hummingbot.client.settings import (
-    GLOBAL_CONFIG_PATH,
-    TRADE_FEES_CONFIG_PATH,
-    TEMPLATE_PATH,
     CONF_FILE_PATH,
     CONF_POSTFIX,
     CONF_PREFIX,
+    GLOBAL_CONFIG_PATH,
+    TEMPLATE_PATH,
+    TRADE_FEES_CONFIG_PATH,
     AllConnectorSettings,
 )
-from hummingbot.client.config.security import Security
-from hummingbot import get_strategy_list
 
 # Use ruamel.yaml to preserve order and comments in .yml file
 yaml_parser = ruamel.yaml.YAML()
@@ -204,7 +193,7 @@ def load_required_configs(strategy_name) -> OrderedDict:
 
 
 def strategy_name_from_file(file_path: str) -> str:
-    with open(file_path) as stream:
+    with open(file_path, encoding='utf-8') as stream:
         data = yaml_parser.load(stream) or {}
         strategy = data.get("strategy")
     return strategy
@@ -255,11 +244,11 @@ async def load_yml_into_cm(yml_path: str, template_file_path: str, cm: Dict[str,
         data = {}
         conf_version = -1
         if isfile(yml_path):
-            with open(yml_path) as stream:
+            with open(yml_path, encoding='utf-8') as stream:
                 data = yaml_parser.load(stream) or {}
                 conf_version = data.get("template_version", 0)
 
-        with open(template_file_path, "r") as template_fd:
+        with open(template_file_path, "r", encoding='utf-8') as template_fd:
             template_data = yaml_parser.load(template_fd)
             template_version = template_data.get("template_version", 0)
 
@@ -337,7 +326,7 @@ def save_to_yml(yml_path: str, cm: Dict[str, ConfigVar]):
     Write current config saved a single config map into each a single yml file
     """
     try:
-        with open(yml_path) as stream:
+        with open(yml_path, encoding='utf-8') as stream:
             data = yaml_parser.load(stream) or {}
             for key in cm:
                 cvar = cm.get(key)
@@ -349,7 +338,7 @@ def save_to_yml(yml_path: str, cm: Dict[str, ConfigVar]):
                     data[key] = float(cvar.value)
                 else:
                     data[key] = cvar.value
-            with open(yml_path, "w+") as outfile:
+            with open(yml_path, "w+", encoding='utf-8') as outfile:
                 yaml_parser.dump(data, outfile)
     except Exception as e:
         logging.getLogger().error("Error writing configs: %s" % (str(e),), exc_info=True)
@@ -376,10 +365,10 @@ async def create_yml_files():
 
             # Only overwrite log config. Updating `conf_global.yml` is handled by `read_configs_from_yml`
             if conf_path.endswith("hummingbot_logs.yml"):
-                with open(template_path, "r") as template_fd:
+                with open(template_path, "r", encoding='utf-8') as template_fd:
                     template_data = yaml_parser.load(template_fd)
                     template_version = template_data.get("template_version", 0)
-                with open(conf_path, "r") as conf_fd:
+                with open(conf_path, "r", encoding='utf-8') as conf_fd:
                     conf_version = 0
                     try:
                         conf_data = yaml_parser.load(conf_fd)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
When running from source on Windows and the default encoding is not `utf-8`, the  error (similar to https://github.com/hummingbot/hummingbot/issues/5112) will happen:

> 2022-04-17 15:17:50,323 - 3564 - root - ERROR - Error loading configs. Your config file may be corrupt. 'gbk' codec can't decode byte 0xac in position 2829: illegal multibyte sequence
Traceback (most recent call last):
  File "\hummingbot\hummingbot\client\config\config_helpers.py", line 248, in load_yml_into_cm
    data = yaml_parser.load(stream) or {}
...
UnicodeDecodeError: 'gbk' codec can't decode byte 0xac in position 2829: illegal multibyte sequence

Set the encoding to always `utf-8` will solve this issue.

**Tests performed by the developer**:

**Tips for QA testing**:


