### PR TITLE
fix/binance_market_order_no_price

### DIFF
--- a/hummingbot/connector/exchange/binance/binance_exchange.py
+++ b/hummingbot/connector/exchange/binance/binance_exchange.py
@@ -463,7 +463,8 @@ class BinanceExchange(ExchangeBase):
         trading_rule: TradingRule = self._trading_rules[trading_pair]
         price = self.quantize_order_price(trading_pair, price)
         quantize_amount_price = Decimal("0") if price.is_nan() else price
-        amount = self.quantize_order_amount(trading_pair=trading_pair, amount=amount, price=quantize_amount_price)
+        if order_type in (OrderType.LIMIT, OrderType.LIMIT_MAKER):
+            amount = self.quantize_order_amount(trading_pair=trading_pair, amount=amount, price=quantize_amount_price)
 
         self.start_tracking_order(
             order_id=order_id,
@@ -501,10 +502,10 @@ class BinanceExchange(ExchangeBase):
                       "side": side_str,
                       "quantity": amount_str,
                       "type": type_str,
-                      "newClientOrderId": order_id,
-                      "price": price_str}
+                      "newClientOrderId": order_id}
         if order_type == OrderType.LIMIT:
             api_params["timeInForce"] = CONSTANTS.TIME_IN_FORCE_GTC
+            api_params["price"] = price_str
 
         try:
             order_result = await self._api_request(


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Fixes Binance market order without price fails with illegal characters #5251

**Tests performed by the developer**:

Added new unit test for market orders

**Tips for QA testing**:

Create custom strategy with market orders for binance to test. 


