### PR TITLE
Separate parameters for buy and sell spreads

### DIFF
--- a/hummingbot/strategy/liquidity_mining/liquidity_mining_config_map.py
+++ b/hummingbot/strategy/liquidity_mining/liquidity_mining_config_map.py
@@ -5,16 +5,10 @@ The configuration parameters for a user made liquidity_mining strategy.
 import re
 from decimal import Decimal
 from typing import Optional
+
+from hummingbot.client.config.config_validators import validate_bool, validate_decimal, validate_exchange, validate_int
 from hummingbot.client.config.config_var import ConfigVar
-from hummingbot.client.config.config_validators import (
-    validate_exchange,
-    validate_decimal,
-    validate_int,
-    validate_bool
-)
-from hummingbot.client.settings import (
-    required_exchanges,
-)
+from hummingbot.client.settings import required_exchanges
 
 
 def exchange_on_validated(value: str) -> None:
@@ -92,9 +86,16 @@ liquidity_mining_config_map = {
                   type_str="decimal",
                   validator=lambda v: validate_decimal(v, 0, inclusive=False),
                   prompt_on_new=True),
-    "spread":
-        ConfigVar(key="spread",
-                  prompt="How far away from the mid price do you want to place bid and ask orders? "
+    "buy_spread":
+        ConfigVar(key="buy_spread",
+                  prompt="How far away from the mid price do you want to place bid orders? "
+                         "(Enter 1 to indicate 1%) >>> ",
+                  type_str="decimal",
+                  validator=lambda v: validate_decimal(v, 0, 100, inclusive=False),
+                  prompt_on_new=True),
+    "sell_spread":
+        ConfigVar(key="sell_spread",
+                  prompt="How far away from the mid price do you want to place ask orders? "
                          "(Enter 1 to indicate 1%) >>> ",
                   type_str="decimal",
                   validator=lambda v: validate_decimal(v, 0, 100, inclusive=False),

--- a/hummingbot/strategy/liquidity_mining/start.py
+++ b/hummingbot/strategy/liquidity_mining/start.py
@@ -1,7 +1,8 @@
 from decimal import Decimal
-from hummingbot.strategy.market_trading_pair_tuple import MarketTradingPairTuple
+
 from hummingbot.strategy.liquidity_mining.liquidity_mining import LiquidityMiningStrategy
 from hummingbot.strategy.liquidity_mining.liquidity_mining_config_map import liquidity_mining_config_map as c_map
+from hummingbot.strategy.market_trading_pair_tuple import MarketTradingPairTuple
 
 
 def start(self):
@@ -13,7 +14,8 @@ def start(self):
     base_markets = [m for m in el_markets if m.split("-")[0] == token]
     markets = quote_markets if quote_markets else base_markets
     order_amount = c_map.get("order_amount").value
-    spread = c_map.get("spread").value / Decimal("100")
+    buy_spread = c_map.get("buy_spread").value / Decimal("100")
+    sell_spread = c_map.get("sell_spread").value / Decimal("100")
     inventory_skew_enabled = c_map.get("inventory_skew_enabled").value
     target_base_pct = c_map.get("target_base_pct").value / Decimal("100")
     order_refresh_time = c_map.get("order_refresh_time").value
@@ -37,7 +39,8 @@ def start(self):
         market_infos=market_infos,
         token=token,
         order_amount=order_amount,
-        spread=spread,
+        buy_spread=buy_spread,
+        sell_spread=sell_spread,
         inventory_skew_enabled=inventory_skew_enabled,
         target_base_pct=target_base_pct,
         order_refresh_time=order_refresh_time,

--- a/hummingbot/templates/conf_liquidity_mining_strategy_TEMPLATE.yml
+++ b/hummingbot/templates/conf_liquidity_mining_strategy_TEMPLATE.yml
@@ -18,8 +18,11 @@ token: null
 # The size of each order in specified token amount
 order_amount: null
 
-# The spread from mid price to place bid and ask orders, enter 1 to indicate 1%
-spread: null
+# The spread from mid price to place bid orders, enter 1 to indicate 1%
+buy_spread: null
+  #
+# The spread from mid price to place ask orders, enter 1 to indicate 1%
+sell_spread: null
 
 # Whether to enable Inventory skew feature (true/false).
 inventory_skew_enabled: null


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

This PR targets minor changes for the `Liquidity Mining` strategy.

Split `spread` parameter into the introduced `buy_spread` and `sell_spread` parameters.

New parameters, `buy_spread` and `sell_spread` have `prompt` enabled, so as to as for the default values on strategy creation.

**Tests performed by the developer**:

Tested on `paper-trade` and real exhanges (kucoin and ascentex).

**Tips for QA testing**:

Just create a new `liquidity_mining` and set the `buy_spread` and `sell_spread` parameters with different values.