### PR TITLE
ignore runtime error in case of concurrent call to receive()

### DIFF
--- a/hummingbot/core/web_assistant/connections/ws_connection.py
+++ b/hummingbot/core/web_assistant/connections/ws_connection.py
@@ -1,11 +1,9 @@
 import asyncio
 import time
-from typing import (
-    Dict,
-    Optional,
-)
+from typing import Dict, Optional
 
 import aiohttp
+
 from hummingbot.core.web_assistant.connections.data_types import WSRequest, WSResponse
 
 
@@ -34,10 +32,7 @@ class WSConnection:
     ):
         self._ensure_not_connected()
         self._connection = await self._client_session.ws_connect(
-            ws_url,
-            headers=ws_headers,
-            autoping=False,
-            heartbeat=ping_timeout,
+            ws_url, headers=ws_headers, autoping=False, heartbeat=ping_timeout,
         )
         self._message_timeout = message_timeout
         self._connected = True
@@ -77,6 +72,11 @@ class WSConnection:
     async def _read_message(self) -> aiohttp.WSMessage:
         try:
             msg = await self._connection.receive(self._message_timeout)
+        except RuntimeError as e:
+            if str(e) == "Concurrent call to receive() is not allowed":
+                pass
+            else:
+                raise
         except asyncio.TimeoutError:
             raise asyncio.TimeoutError("Message receive timed out.")
         return msg


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ x] Your code builds clean without any errors or warnings
- [ x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Related to [issue 5276](https://github.com/hummingbot/hummingbot/issues/5276) and after quite extensive investigation (I am just starting on this project...) this error message comes from concurrent call to `receive()` in the `aiohttp.ClientWebSocketResponse` instance (see [line raising error](https://github.com/aio-libs/aiohttp/blob/e485c4d5f8e02ab0c68059236608fc13ba194daa/aiohttp/client_ws.py#L238)). If its class variable `_waiting` is not None, means if it's busy, it can't take call.
Since:
- there are many calls to this `receive()` from independent data sources within the dydx connector
- refactoring those calls to prevent those concurrent calls is quite inextricable and that every (of the many...) attempts lead to quite massive side effect
- this error is not blocking at all and completely harmless
I thought, just passing it is enough.

(There are also minor linting changes introduced by [black](https://pypi.org/project/black/))

**Tests performed by the developer**:
Re-running the Docker container with the `create.sh` script, use the same `dydx_perpetual_connector` and the same `perpetual_making_strategy`, observe that this message does not pop up anymore


**Tips for QA testing**:


