### PR TITLE
(fix) fix arithmetic typo calculating price_floor

### DIFF
--- a/hummingbot/strategy/pure_market_making/moving_price_band.py
+++ b/hummingbot/strategy/pure_market_making/moving_price_band.py
@@ -47,7 +47,7 @@ class MovingPriceBand:
         :param timestamp: current timestamp of the strategy/connector
         :param price: reference price to set price band
         """
-        self._price_floor = (Decimal("100") + self.price_floor_pct) / Decimal("100") * price
+        self._price_floor = (Decimal("100") - self.price_floor_pct) / Decimal("100") * price
         self._price_ceiling = (Decimal("100") + self.price_ceiling_pct) / Decimal("100") * price
         self._set_time = timestamp
         self.logger().info(


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Both for price_ceiling and price_floor percentage was added to 100. Now it is subtracted for price_floor calculation.


**Tests performed by the developer**:
**Tips for QA testing**:

Before:

2022-05-10 22:37:32,002 - 3899248 - hummingbot.strategy.pure_market_making.moving_price_band - INFO - moving price band updated: price_floor: 0.3022425 price_ceiling: 0.3022425


After:

022-05-10 22:39:04,001 - 3903150 - hummingbot.strategy.pure_market_making.moving_price_band - INFO - moving price band updated: price_floor: 0.2962575 price_ceiling: 0.3022425


