### PR TITLE
fix/remove redundant `GET /connectors` route

### DIFF
--- a/gateway/src/app.ts
+++ b/gateway/src/app.ts
@@ -18,9 +18,6 @@ import { NetworkRoutes } from './network/network.routes';
 import { ConnectorsRoutes } from './connectors/connectors.routes';
 import { EVMRoutes } from './evm/evm.routes';
 import { AmmRoutes } from './amm/amm.routes';
-import { PangolinConfig } from './connectors/pangolin/pangolin.config';
-import { UniswapConfig } from './connectors/uniswap/uniswap.config';
-import { AvailableNetworks } from './services/config-manager-types';
 import morgan from 'morgan';
 
 const swaggerUi = require('swagger-ui-express');
@@ -59,21 +56,6 @@ gatewayApp.use('/solana', SolanaRoutes.router);
 gatewayApp.get('/', (_req: Request, res: Response) => {
   res.status(200).json({ status: 'ok' });
 });
-
-interface ConnectorsResponse {
-  uniswap: Array<AvailableNetworks>;
-  pangolin: Array<AvailableNetworks>;
-}
-
-gatewayApp.get(
-  '/connectors',
-  asyncHandler(async (_req, res: Response<ConnectorsResponse, {}>) => {
-    res.status(200).json({
-      uniswap: UniswapConfig.config.availableNetworks,
-      pangolin: PangolinConfig.config.availableNetworks,
-    });
-  })
-);
 
 // watch the exit even, spawn an independent process with the same args and
 // pass the stdio from this process to it.


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

`gatewayApp.get('/connectors')` is redundant with `gatewayApp.use('/connectors', ConnectorsRoutes.router);`. Remove
the former.

**Tests performed by the developer**:

```
$ curl http://localhost:5000/connectors
{"connectors":[{"name":"uniswap","trading_type":["EVM_AMM"],"available_networks":[{"chain":"ethereum","networks":["mainnet","kovan","ropsten"]}]},{"name":"pangolin","trading_type":["EVM_AMM"],"available_networks":[{"chain":"avalanche","networks":["avalanche","fuji"]}]}]}
```

**Tips for QA testing**:

Easy
