### PR TITLE
Fix/kucoin trading fee issue

### DIFF
--- a/hummingbot/connector/exchange/kucoin/kucoin_exchange.py
+++ b/hummingbot/connector/exchange/kucoin/kucoin_exchange.py
@@ -812,14 +812,18 @@ class KucoinExchange(ExchangePyBase):
             throttler=self._throttler,
             time_synchronizer=self._time_synchronizer) for trading_pair in self._trading_pairs]
 
-        params = {"symbols": ",".join(trading_symbols)}
-
-        resp = await self._api_request(
-            path_url=CONSTANTS.FEE_PATH_URL,
-            params=params,
-            method=RESTMethod.GET,
-            is_auth_required=True,
-        )
+        # It appears that the SIGN is incorrect when more than 1 pais is passed
+        # This is likely not the correct fix due to the multiplicity of PAI calls
+        resp = {'data': []}
+        for pair in trading_symbols:
+            params = {"symbols": pair}
+            r = await self._api_request(
+                path_url=CONSTANTS.FEE_PATH_URL,
+                params=params,
+                method=RESTMethod.GET,
+                is_auth_required=True,
+            )
+            resp['data'] += r['data']
 
         fees_json = resp["data"]
         for fee_json in fees_json:


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Proposing a workaround of an apparent disconnect in KuCoin API trade-fees method/doc
The documentation states that up to 10 pairs can be in the symbols parameter, however the call SIGN is recognized only when one trading pair is passed as symbols. This could be an issue with the signing method that was not investigated

The hummingbot logs document the failure as:
OSError: The request to Kucoin failed. Error: {"code":"400005","msg":"Invalid KC-API-SIGN"}. Request: RESTRequest(method=GET, url='https://api.kucoin.com/api/v1/trade-fees', endpoint_url=None, params={'symbols': 'ALGO-USDT,AVAX-USDT,DAO-USDT,FEAR-USDT'}

**Tests performed by the developer**:
The liquidity mining strategy was tested with the fix and the error message was no longer reported. The fix was monitored with the debugger and showed live expected behavior of the update_trading_fee() module
A test method was added to the test_kucoin_exchange.py as part of this pull request

**Tips for QA testing**:


