### PR TITLE
(fix) Workaround to KuCoin SIGN exception on trade-fees API call

### DIFF
--- a/gateway/setup/generate_conf.sh
+++ b/gateway/setup/generate_conf.sh
@@ -9,7 +9,7 @@ echo
 
 
 HOST_CONF_PATH="${1:=(pwd -P)/conf}"
-INFURA_API_KEY="${2:=null}"
+INFURA_API_KEY="${2-}"
 
 echo "HOST_CONF_PATH=$HOST_CONF_PATH"
 echo "INFURA_API_KEY=$INFURA_API_KEY"
@@ -18,7 +18,12 @@ mkdir -p $HOST_CONF_PATH
 
 # generate ethereum file
 cp "$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )/../src/templates/ethereum.yml" "$HOST_CONF_PATH/ethereum.yml"
-sed -i'.bak' -e "/nodeAPIKey:/ s/[^ ][^ ]*$/$INFURA_API_KEY/" "$HOST_CONF_PATH/ethereum.yml"
+
+if [[ -z "$INFURA_API_KEY" ]];
+then
+else
+    sed -i'.bak' -e "/nodeAPIKey:/ s/[^ ][^ ]*$/$INFURA_API_KEY/" "$HOST_CONF_PATH/ethereum.yml"
+fi
 echo "created $HOST_CONF_PATH/ethereum.yml"
 
 # generate ssl file

--- a/gateway/src/chains/avalanche/avalanche.ts
+++ b/gateway/src/chains/avalanche/avalanche.ts
@@ -6,6 +6,7 @@ import { getEthereumConfig as getAvalancheConfig } from '../ethereum/ethereum.co
 import { Provider } from '@ethersproject/abstract-provider';
 import { PangolinConfig } from '../../connectors/pangolin/pangolin.config';
 import { Ethereumish } from '../../services/common-interfaces';
+import { replaceOrAppend } from '../../services/base';
 
 export class Avalanche extends EthereumBase implements Ethereumish {
   private static _instances: { [name: string]: Avalanche };
@@ -18,7 +19,7 @@ export class Avalanche extends EthereumBase implements Ethereumish {
     super(
       'avalanche',
       config.network.chainID,
-      config.network.nodeURL,
+      replaceOrAppend(config.network.nodeURL, config.nodeAPIKey),
       config.network.tokenListSource,
       config.network.tokenListType,
       config.manualGasPrice,

--- a/gateway/src/services/base.ts
+++ b/gateway/src/services/base.ts
@@ -82,6 +82,17 @@ export const latency = (startTime: number, endTime: number): number => {
 
 export const walletPath = './conf/wallets';
 
+// API URLs may require the key in the middle or the end of the route.
+// If the src string contains '{}', replace it with the value, otherwise
+// append the value at the end
+export const replaceOrAppend = (src: string, value: string): string => {
+  if (src.includes('{}')) {
+    return src.replace('{}', value);
+  } else {
+    return src + value;
+  }
+};
+
 // convert a fraction string to a number
 export const fromFractionString = (value: string): number | null => {
   if (isFractionString(value)) {

--- a/gateway/src/templates/avalanche.yml
+++ b/gateway/src/templates/avalanche.yml
@@ -2,17 +2,17 @@
 networks:
   fuji: 
     chainID: 43113
-    nodeURL: 'https://api.avax-test.network/ext/bc/C/rpc'
+    nodeURL: 'https://speedy-nodes-nyc.moralis.io/{}/avalanche/testnet'
     tokenListType: 'FILE'
     tokenListSource: 'src/chains/avalanche/avalanche_tokens_fuji.json'
     nativeCurrencySymbol: 'AVAX'    
   avalanche: 
     chainID: 43114
-    nodeURL: 'https://api.avax.network/ext/bc/C/rpc'
+    nodeURL: 'https://speedy-nodes-nyc.moralis.io/{}/avalanche/mainnet'
     tokenListType: 'URL'
     tokenListSource: 'https://raw.githubusercontent.com/pangolindex/tokenlists/main/pangolin.tokenlist.json'
     nativeCurrencySymbol: 'AVAX'
-    
-nodeAPIKey: '3712b320394b413fb4c42fdadcebdf54'
+
+nodeAPIKey: ''
 manualGasPrice: 100
 gasLimit: 3000000

--- a/gateway/test/services/base.test.ts
+++ b/gateway/test/services/base.test.ts
@@ -3,6 +3,7 @@ import {
   bigNumberWithDecimalToStr,
   gasCostInEthString,
   countDecimals,
+  replaceOrAppend,
   fromFractionString,
   toFractionString,
 } from '../../src/services/base';
@@ -45,6 +46,19 @@ test('bigNumberWithDecimalToStr', () => {
 
 test('gasCostInEthString', () => {
   expect(gasCostInEthString(200, 21000)).toEqual('0.004200000000000000');
+});
+
+test('replaceOrAppend', () => {
+  expect(
+    replaceOrAppend(
+      'https://speedy-nodes-nyc.moralis.io/{}/avalanche/testnet',
+      'xyz'
+    )
+  ).toEqual('https://speedy-nodes-nyc.moralis.io/xyz/avalanche/testnet');
+
+  expect(
+    replaceOrAppend('https://speedy-nodes-nyc.moralis.io/', '123')
+  ).toEqual('https://speedy-nodes-nyc.moralis.io/123');
 });
 
 test('fromFractionString', () => {

--- a/hummingbot/client/command/__init__.py
+++ b/hummingbot/client/command/__init__.py
@@ -10,6 +10,7 @@ from .history_command import HistoryCommand
 from .import_command import ImportCommand
 from .order_book_command import OrderBookCommand
 from .pmm_script_command import PMMScriptCommand
+from .previous_strategy_command import PreviousCommand
 from .rate_command import RateCommand
 from .silly_commands import SillyCommands
 from .start_command import StartCommand
@@ -36,4 +37,5 @@ __all__ = [
     GatewayCommand,
     PMMScriptCommand,
     RateCommand,
+    PreviousCommand
 ]

--- a/hummingbot/client/command/create_command.py
+++ b/hummingbot/client/command/create_command.py
@@ -2,24 +2,25 @@ import asyncio
 import copy
 import os
 import shutil
+from typing import TYPE_CHECKING, Dict, Optional
 
-from hummingbot.client.config.config_var import ConfigVar
-from hummingbot.core.utils.async_utils import safe_ensure_future
 from hummingbot.client.config.config_helpers import (
-    get_strategy_config_map,
-    parse_cvar_value,
     default_strategy_file_path,
-    save_to_yml,
-    get_strategy_template_path,
     format_config_file_name,
-    parse_config_default_to_text
+    get_strategy_config_map,
+    get_strategy_template_path,
+    parse_config_default_to_text,
+    parse_cvar_value,
+    save_previous_strategy_value,
+    save_to_yml,
 )
-from hummingbot.client.settings import CONF_FILE_PATH, required_exchanges
+from hummingbot.client.config.config_validators import validate_strategy
+from hummingbot.client.config.config_var import ConfigVar
 from hummingbot.client.config.global_config_map import global_config_map
 from hummingbot.client.config.security import Security
-from hummingbot.client.config.config_validators import validate_strategy
+from hummingbot.client.settings import CONF_FILE_PATH, required_exchanges
 from hummingbot.client.ui.completer import load_completer
-from typing import TYPE_CHECKING, Dict, Optional
+from hummingbot.core.utils.async_utils import safe_ensure_future
 
 if TYPE_CHECKING:
     from hummingbot.client.hummingbot_application import HummingbotApplication
@@ -76,6 +77,7 @@ class CreateCommand:
 
         if file_name is None:
             file_name = await self.prompt_new_file_name(strategy)
+            save_previous_strategy_value(file_name)
             if self.app.to_stop_config:
                 self.stop_config(config_map, config_map_backup)
                 self.app.set_text("")

--- a/hummingbot/client/command/gateway_api_manager.py
+++ b/hummingbot/client/command/gateway_api_manager.py
@@ -1,0 +1,145 @@
+import json
+from contextlib import contextmanager
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Dict, Generator, Optional
+
+import aiohttp
+
+from hummingbot.core.gateway.gateway_http_client import GatewayHttpClient
+
+if TYPE_CHECKING:
+    from hummingbot.client.hummingbot_application import HummingbotApplication
+
+
+class Chain(Enum):
+    ETHEREUM = 0
+    AVALANCHE = 1
+
+    @staticmethod
+    def from_str(label: str) -> "Chain":
+        label = label.lower()
+        if label == "ethereum":
+            return Chain.ETHEREUM
+        elif label == "avalanche":
+            return Chain.AVALANCHE
+        else:
+            raise NotImplementedError
+
+    @staticmethod
+    def to_str(chain: "Chain") -> str:
+        if chain == Chain.ETHEREUM:
+            return "ethereum"
+        else:
+            return "avalanche"
+
+
+@contextmanager
+def begin_placeholder_mode(hb: "HummingbotApplication") -> Generator["HummingbotApplication", None, None]:
+    hb.app.clear_input()
+    hb.placeholder_mode = True
+    hb.app.hide_input = True
+    try:
+        yield hb
+    finally:
+        hb.app.to_stop_config = False
+        hb.placeholder_mode = False
+        hb.app.hide_input = False
+        hb.app.change_prompt(prompt=">>> ")
+
+
+class GatewayChainApiManager:
+    """
+    Manage and test connections from gateway to chain APIs like Infura and
+    Moralis.
+    """
+
+    async def _test_evm_node(self, url_with_api_key: str) -> bool:
+        """
+        Verify that the Infura API Key is valid. If it is an empty string,
+        ignore it, but let the user know they cannot connect to ethereum.
+        """
+        async with aiohttp.ClientSession() as tmp_client:
+            headers = {"Content-Type": "application/json"}
+            data = {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "eth_blockNumber",
+                "params": []
+            }
+
+            resp = await tmp_client.post(url=url_with_api_key,
+                                         data=json.dumps(data),
+                                         headers=headers)
+
+            success = resp.status == 200
+            if success:
+                self.notify("The API Key works.")
+            else:
+                self.notify("Error occurred verifying the API Key. Please check your API Key and try again.")
+            return success
+
+    async def _get_api_key(self, chain: Chain, required=False) -> Optional[str]:
+        """
+        Get the API key from user input, then check that it is valid
+        """
+        with begin_placeholder_mode(self):
+            while True:
+                if chain == Chain.ETHEREUM:
+                    service = 'Infura'
+                    chain_name = 'Ethereum'
+                    service_url = 'infura.io'
+                elif chain == Chain.AVALANCHE:
+                    service = 'Moralis'
+                    chain_name = 'Avalanche'
+                    service_url = 'moralis.io'
+
+                api_key: str = await self.app.prompt(prompt=f"Enter {service} API Key (required for {chain_name} node, "
+                                                            f"if you do not have one, make an account at {service_url})"
+                                                            f", otherwise configure gateway after creation:  >>> ")
+
+                self.app.clear_input()
+
+                if self.app.to_stop_config:
+                    self.app.to_stop_config = False
+                    return None
+                try:
+                    api_key = api_key.strip()  # help check for an empty string which is valid input
+                    if not required and (api_key is None or api_key == "" or api_key == "''" or api_key == "\"\""):
+                        self.notify(f"Setting up gateway without an {chain_name} node.")
+                        return None
+                    else:
+                        if chain == Chain.ETHEREUM:
+                            api_url = f"https://mainnet.infura.io/v3/{api_key}"
+                        elif chain == Chain.AVALANCHE:
+                            api_url = f"https://speedy-nodes-nyc.moralis.io/{api_key}/avalanche/mainnet"
+                        success: bool = await self._test_evm_node(api_url)
+                        if not success:
+                            # the API key test was unsuccessful, try again
+                            continue
+                        return api_key
+                except Exception:
+                    self.notify(f"Error occur calling the API route: {api_url}.")
+                    raise
+
+    @staticmethod
+    async def _update_gateway_api_key(chain: Chain, api_key: str):
+        """
+        Update a chain's API key in gateway
+        """
+        await GatewayHttpClient.get_instance().update_config(f"{Chain.to_str(chain)}.nodeAPIKey", api_key)
+
+    @staticmethod
+    async def _get_api_key_from_gateway_config(chain: Chain) -> Optional[str]:
+        """
+        Check if gateway has an API key for gateway
+        """
+        config_dict: Dict[str, Any] = await GatewayHttpClient.get_instance().get_configuration()
+        chain_config: Optional[Dict[str, Any]] = config_dict.get(Chain.to_str(chain))
+        if chain_config is not None:
+            api_key: Optional[str] = chain_config.get("nodeAPIKey")
+            if api_key is None or api_key == "" or api_key == "''" or api_key == "\"\"":
+                return None
+            else:
+                return api_key
+        else:
+            return None

--- a/hummingbot/client/command/gateway_command.py
+++ b/hummingbot/client/command/gateway_command.py
@@ -1,75 +1,51 @@
 #!/usr/bin/env python
-import aiohttp
 import asyncio
-from contextlib import contextmanager
-import docker
 import itertools
-import json
-import pandas as pd
-from typing import (
-    Dict,
-    Any,
-    TYPE_CHECKING,
-    List,
-    Generator,
-)
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+import pandas as pd
+
+import docker
+from hummingbot.client.command.gateway_api_manager import Chain, GatewayChainApiManager, begin_placeholder_mode
+from hummingbot.client.config.config_helpers import refresh_trade_fees_config, save_to_yml
+from hummingbot.client.config.global_config_map import global_config_map
+from hummingbot.client.config.security import Security
 from hummingbot.client.settings import (
     GATEWAY_CONNECTORS,
     GLOBAL_CONFIG_PATH,
-    GatewayConnectionSetting
+    AllConnectorSettings,
+    GatewayConnectionSetting,
 )
+from hummingbot.client.ui.completer import load_completer
 from hummingbot.core.gateway import (
-    docker_ipc,
-    docker_ipc_with_generator,
-    get_gateway_container_name,
-    get_gateway_paths,
     GATEWAY_DOCKER_REPO,
     GATEWAY_DOCKER_TAG,
     GatewayPaths,
+    docker_ipc,
+    docker_ipc_with_generator,
     get_default_gateway_port,
+    get_gateway_container_name,
+    get_gateway_paths,
     start_gateway,
-    stop_gateway
+    stop_gateway,
 )
+from hummingbot.core.gateway.gateway_http_client import GatewayHttpClient
 from hummingbot.core.gateway.status_monitor import Status
 from hummingbot.core.utils.async_utils import safe_ensure_future
 from hummingbot.core.utils.gateway_config_utils import (
-    search_configs,
     build_config_dict_display,
     build_connector_display,
     build_wallet_display,
     native_tokens,
+    search_configs,
 )
-from hummingbot.core.gateway.gateway_http_client import GatewayHttpClient
 from hummingbot.core.utils.ssl_cert import certs_files_exist, create_self_sign_certs
-from hummingbot.client.config.config_helpers import (
-    save_to_yml,
-    refresh_trade_fees_config,
-)
-from hummingbot.client.config.global_config_map import global_config_map
-from hummingbot.client.config.security import Security
-from hummingbot.client.settings import AllConnectorSettings
-from hummingbot.client.ui.completer import load_completer
 
 if TYPE_CHECKING:
     from hummingbot.client.hummingbot_application import HummingbotApplication
 
 
-@contextmanager
-def begin_placeholder_mode(hb: "HummingbotApplication") -> Generator["HummingbotApplication", None, None]:
-    hb.app.clear_input()
-    hb.placeholder_mode = True
-    hb.app.hide_input = True
-    try:
-        yield hb
-    finally:
-        hb.app.to_stop_config = False
-        hb.placeholder_mode = False
-        hb.app.hide_input = False
-        hb.app.change_prompt(prompt=">>> ")
-
-
-class GatewayCommand:
+class GatewayCommand(GatewayChainApiManager):
     def create_gateway(self):
         safe_ensure_future(self._create_gateway(), loop=self.ev_loop)
 
@@ -107,7 +83,7 @@ class GatewayCommand:
     async def _test_connection(self):
         # test that the gateway is running
         if await GatewayHttpClient.get_instance().ping_gateway():
-            self.notify("\nSuccesfully pinged gateway.")
+            self.notify("\nSuccessfully pinged gateway.")
         else:
             self.notify("\nUnable to ping gateway.")
 
@@ -141,47 +117,28 @@ class GatewayCommand:
             self,       # type: HummingbotApplication
             container_id: str, conf_path: str = "/usr/src/app/conf"
     ):
-        with begin_placeholder_mode(self):
-            while True:
-                node_api_key: str = await self.app.prompt(prompt="Enter Infura API Key (required for Ethereum node, "
-                                                          "if you do not have one, make an account at infura.io):  >>> ")
-                self.app.clear_input()
-                if self.app.to_stop_config:
-                    self.app.to_stop_config = False
-                    return
-                try:
-                    # Verifies that the Infura API Key/Project ID is valid by sending a request
-                    async with aiohttp.ClientSession() as tmp_client:
-                        headers = {"Content-Type": "application/json"}
-                        data = {
-                            "jsonrpc": "2.0",
-                            "id": 1,
-                            "method": "eth_blockNumber",
-                            "params": []
-                        }
-                        try:
-                            resp = await tmp_client.post(url=f"https://mainnet.infura.io/v3/{node_api_key}",
-                                                         data=json.dumps(data),
-                                                         headers=headers)
-                            if resp.status != 200:
-                                self.notify("Error occured verifying Infura Node API Key. Please check your API Key and try again.")
-                                continue
-                        except Exception:
-                            raise
+        infura_api_key: Optional[str] = await self._get_api_key(Chain.ETHEREUM)
 
-                    exec_info = await docker_ipc(method_name="exec_create",
-                                                 container=container_id,
-                                                 cmd=f"./setup/generate_conf.sh {conf_path} {node_api_key}",
-                                                 user="hummingbot")
+        try:
+            # generate_conf alters the ethereum.yml file if a second value is
+            # passed to generate_conf.sh
+            if infura_api_key is None:
+                cmd: str = f"./setup/generate_conf.sh {conf_path}"
+            else:
+                cmd: str = f"./setup/generate_conf.sh {conf_path} {infura_api_key}"
+            exec_info = await docker_ipc(method_name="exec_create",
+                                         container=container_id,
+                                         cmd=cmd,
+                                         user="hummingbot")
 
-                    await docker_ipc(method_name="exec_start",
-                                     exec_id=exec_info["Id"],
-                                     detach=True)
-                    return
-                except asyncio.CancelledError:
-                    raise
-                except Exception:
-                    raise
+            await docker_ipc(method_name="exec_start",
+                             exec_id=exec_info["Id"],
+                             detach=True)
+            return
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            raise
 
     async def _create_gateway(self):
         gateway_paths: GatewayPaths = get_gateway_paths()

--- a/hummingbot/client/command/import_command.py
+++ b/hummingbot/client/command/import_command.py
@@ -1,16 +1,18 @@
 import asyncio
 import os
-
-from hummingbot.core.utils.async_utils import safe_ensure_future
-from hummingbot.client.config.global_config_map import global_config_map
-from hummingbot.client.config.config_helpers import (
-    update_strategy_config_map_from_file,
-    short_strategy_name,
-    format_config_file_name,
-    validate_strategy_file
-)
-from hummingbot.client.settings import CONF_FILE_PATH, CONF_PREFIX, required_exchanges
 from typing import TYPE_CHECKING
+
+from hummingbot.client.config.config_helpers import (
+    format_config_file_name,
+    save_previous_strategy_value,
+    short_strategy_name,
+    update_strategy_config_map_from_file,
+    validate_strategy_file,
+)
+from hummingbot.client.config.global_config_map import global_config_map
+from hummingbot.client.settings import CONF_FILE_PATH, CONF_PREFIX, required_exchanges
+from hummingbot.core.utils.async_utils import safe_ensure_future
+
 if TYPE_CHECKING:
     from hummingbot.client.hummingbot_application import HummingbotApplication
 
@@ -32,6 +34,8 @@ class ImportCommand:
         required_exchanges.clear()
         if file_name is None:
             file_name = await self.prompt_a_file_name()
+            if file_name is not None:
+                save_previous_strategy_value(file_name)
         if self.app.to_stop_config:
             self.app.to_stop_config = False
             return

--- a/hummingbot/client/command/previous_strategy_command.py
+++ b/hummingbot/client/command/previous_strategy_command.py
@@ -1,0 +1,80 @@
+from typing import TYPE_CHECKING
+
+from hummingbot.client.config.config_helpers import parse_config_default_to_text, parse_cvar_value
+from hummingbot.client.config.config_validators import validate_bool
+from hummingbot.client.config.config_var import ConfigVar
+from hummingbot.client.config.global_config_map import global_config_map
+from hummingbot.core.utils.async_utils import safe_ensure_future
+
+from .import_command import ImportCommand
+
+if TYPE_CHECKING:
+    from hummingbot.client.hummingbot_application import HummingbotApplication
+
+
+class PreviousCommand:
+    def previous_strategy(
+        self,  # type: HummingbotApplication
+        option: str,
+    ):
+        if option is not None:
+            pass
+
+        previous_strategy_file = global_config_map["previous_strategy"].value
+
+        if previous_strategy_file is not None:
+            safe_ensure_future(self.prompt_for_previous_strategy(previous_strategy_file))
+        else:
+            self.notify("No previous strategy found.")
+
+    async def prompt_for_previous_strategy(
+        self,  # type: HummingbotApplication
+        file_name,
+    ):
+        self.app.clear_input()
+        self.placeholder_mode = True
+        self.app.hide_input = True
+
+        previous_strategy = ConfigVar(
+            key="previous_strategy_answer",
+            prompt=f"Do you want to import the previously stored config? [{file_name}] (Yes/No) >>>",
+            type_str="bool",
+            validator=validate_bool,
+        )
+
+        await self.prompt_answer(previous_strategy)
+        if self.app.to_stop_config:
+            self.app.to_stop_config = False
+            return
+
+        if previous_strategy.value:
+            ImportCommand.import_command(self, file_name)
+
+        # clean
+        self.app.change_prompt(prompt=">>> ")
+
+        # reset input
+        self.placeholder_mode = False
+        self.app.hide_input = False
+
+    async def prompt_answer(
+        self,  # type: HummingbotApplication
+        config: ConfigVar,
+        input_value=None,
+        assign_default=True,
+    ):
+
+        if input_value is None:
+            if assign_default:
+                self.app.set_text(parse_config_default_to_text(config))
+            prompt = await config.get_prompt()
+            input_value = await self.app.prompt(prompt=prompt)
+
+        if self.app.to_stop_config:
+            return
+        config.value = parse_cvar_value(config, input_value)
+        err_msg = await config.validate(input_value)
+        if err_msg is not None:
+            self.notify(err_msg)
+            config.value = None
+            await self.prompt_answer(config)

--- a/hummingbot/client/command/status_command.py
+++ b/hummingbot/client/command/status_command.py
@@ -1,9 +1,8 @@
 import asyncio
 import inspect
 import time
-from collections import deque, OrderedDict
-from typing import Dict, List
-from typing import TYPE_CHECKING
+from collections import OrderedDict, deque
+from typing import TYPE_CHECKING, Dict, List
 
 import pandas as pd
 
@@ -11,7 +10,7 @@ from hummingbot import check_dev_mode
 from hummingbot.client.config.config_helpers import get_strategy_config_map, missing_required_configs
 from hummingbot.client.config.global_config_map import global_config_map
 from hummingbot.client.config.security import Security
-from hummingbot.client.settings import required_exchanges, ethereum_wallet_required
+from hummingbot.client.settings import ethereum_wallet_required, required_exchanges
 from hummingbot.connector.connector_base import ConnectorBase
 from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.core.utils.async_utils import safe_ensure_future
@@ -126,7 +125,7 @@ class StatusCommand:
                     script_status = '\n Status from PMM script would not appear here. ' \
                                     'Simply run the status command without "--live" to see PMM script status.'
                     await self.cls_display_delay(
-                        await self.strategy_status(live=True) + script_status + "\n\n Press escape key to stop update.", 1
+                        await self.strategy_status(live=True) + script_status + "\n\n Press escape key to stop update.", 0.1
                     )
                 self.app.live_updates = False
                 self.notify("Stopped live status display update.")

--- a/hummingbot/client/config/config_helpers.py
+++ b/hummingbot/client/config/config_helpers.py
@@ -1,39 +1,28 @@
-import logging
-from decimal import Decimal
-import ruamel.yaml
-from os import (
-    unlink
-)
-from os.path import (
-    join,
-    isfile
-)
-from collections import OrderedDict, defaultdict
 import json
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-)
-from os import listdir
+import logging
 import shutil
+from collections import OrderedDict, defaultdict
+from decimal import Decimal
+from os import listdir, unlink
+from os.path import isfile, join
+from typing import Any, Callable, Dict, List, Optional
 
+import ruamel.yaml
+
+from hummingbot import get_strategy_list
 from hummingbot.client.config.config_var import ConfigVar
-from hummingbot.client.config.global_config_map import global_config_map
 from hummingbot.client.config.fee_overrides_config_map import fee_overrides_config_map, init_fee_overrides_config
+from hummingbot.client.config.global_config_map import global_config_map
+from hummingbot.client.config.security import Security
 from hummingbot.client.settings import (
-    GLOBAL_CONFIG_PATH,
-    TRADE_FEES_CONFIG_PATH,
-    TEMPLATE_PATH,
     CONF_FILE_PATH,
     CONF_POSTFIX,
     CONF_PREFIX,
+    GLOBAL_CONFIG_PATH,
+    TEMPLATE_PATH,
+    TRADE_FEES_CONFIG_PATH,
     AllConnectorSettings,
 )
-from hummingbot.client.config.security import Security
-from hummingbot import get_strategy_list
 
 # Use ruamel.yaml to preserve order and comments in .yml file
 yaml_parser = ruamel.yaml.YAML()
@@ -204,7 +193,7 @@ def load_required_configs(strategy_name) -> OrderedDict:
 
 
 def strategy_name_from_file(file_path: str) -> str:
-    with open(file_path) as stream:
+    with open(file_path, encoding='utf-8') as stream:
         data = yaml_parser.load(stream) or {}
         strategy = data.get("strategy")
     return strategy
@@ -255,11 +244,11 @@ async def load_yml_into_cm(yml_path: str, template_file_path: str, cm: Dict[str,
         data = {}
         conf_version = -1
         if isfile(yml_path):
-            with open(yml_path) as stream:
+            with open(yml_path, encoding='utf-8') as stream:
                 data = yaml_parser.load(stream) or {}
                 conf_version = data.get("template_version", 0)
 
-        with open(template_file_path, "r") as template_fd:
+        with open(template_file_path, "r", encoding='utf-8') as template_fd:
             template_data = yaml_parser.load(template_fd)
             template_version = template_data.get("template_version", 0)
 
@@ -337,7 +326,7 @@ def save_to_yml(yml_path: str, cm: Dict[str, ConfigVar]):
     Write current config saved a single config map into each a single yml file
     """
     try:
-        with open(yml_path) as stream:
+        with open(yml_path, encoding='utf-8') as stream:
             data = yaml_parser.load(stream) or {}
             for key in cm:
                 cvar = cm.get(key)
@@ -349,7 +338,7 @@ def save_to_yml(yml_path: str, cm: Dict[str, ConfigVar]):
                     data[key] = float(cvar.value)
                 else:
                     data[key] = cvar.value
-            with open(yml_path, "w+") as outfile:
+            with open(yml_path, "w+", encoding='utf-8') as outfile:
                 yaml_parser.dump(data, outfile)
     except Exception as e:
         logging.getLogger().error("Error writing configs: %s" % (str(e),), exc_info=True)
@@ -376,10 +365,10 @@ async def create_yml_files():
 
             # Only overwrite log config. Updating `conf_global.yml` is handled by `read_configs_from_yml`
             if conf_path.endswith("hummingbot_logs.yml"):
-                with open(template_path, "r") as template_fd:
+                with open(template_path, "r", encoding='utf-8') as template_fd:
                     template_data = yaml_parser.load(template_fd)
                     template_version = template_data.get("template_version", 0)
-                with open(conf_path, "r") as conf_fd:
+                with open(conf_path, "r", encoding='utf-8') as conf_fd:
                     conf_version = 0
                     try:
                         conf_data = yaml_parser.load(conf_fd)

--- a/hummingbot/client/config/config_helpers.py
+++ b/hummingbot/client/config/config_helpers.py
@@ -465,3 +465,8 @@ def secondary_market_conversion_rate(strategy) -> Decimal:
     else:
         return Decimal("1")
     return quote_rate / base_rate
+
+
+def save_previous_strategy_value(file_name: str):
+    global_config_map["previous_strategy"].value = file_name
+    save_to_yml(GLOBAL_CONFIG_PATH, global_config_map)

--- a/hummingbot/client/config/global_config_map.py
+++ b/hummingbot/client/config/global_config_map.py
@@ -2,14 +2,14 @@ import os.path
 import random
 import re
 from decimal import Decimal
-from typing import Callable, Optional, Dict
+from typing import Callable, Dict, Optional
 
 from tabulate import tabulate_formats
 
 from hummingbot.client.config.config_methods import using_exchange as using_exchange_pointer
 from hummingbot.client.config.config_validators import validate_bool, validate_decimal
 from hummingbot.client.config.config_var import ConfigVar
-from hummingbot.client.settings import AllConnectorSettings, DEFAULT_KEY_FILE_PATH, DEFAULT_LOG_FILE_PATH
+from hummingbot.client.settings import DEFAULT_KEY_FILE_PATH, DEFAULT_LOG_FILE_PATH, AllConnectorSettings
 from hummingbot.core.rate_oracle.rate_oracle import RateOracle, RateOracleSource
 
 PMM_SCRIPT_ENABLED_KEY = "pmm_script_enabled"
@@ -164,6 +164,11 @@ main_config_map = {
                   prompt="Would you like to send error logs to hummingbot? (Yes/No) >>> ",
                   type_str="bool",
                   default=True),
+    "previous_strategy":
+        ConfigVar(key="previous_strategy",
+                  prompt=None, required_if=lambda: False,
+                  type_str="str",
+                  ),
     # Database options
     "db_engine":
         ConfigVar(key="db_engine",

--- a/hummingbot/client/ui/parser.py
+++ b/hummingbot/client/ui/parser.py
@@ -138,6 +138,10 @@ def load_parser(hummingbot, command_tabs) -> [ThrowingArgumentParser, Any]:
     pmm_script_parser.add_argument("args", nargs="*", default=None, help="Arguments")
     pmm_script_parser.set_defaults(func=hummingbot.pmm_script_command)
 
+    previous_strategy_parser = subparsers.add_parser("previous", help="Imports the last strategy used")
+    previous_strategy_parser.add_argument("option", nargs="?", choices=["Yes,No"], default=None)
+    previous_strategy_parser.set_defaults(func=hummingbot.previous_strategy)
+
     # add shortcuts so they appear in command help
     shortcuts = global_config_map.get("command_shortcuts").value
     if shortcuts is not None:

--- a/hummingbot/connector/exchange_base.pyx
+++ b/hummingbot/connector/exchange_base.pyx
@@ -84,11 +84,10 @@ cdef class ExchangeBase(ConnectorBase):
             OrderBook order_book = self.c_get_order_book(trading_pair)
             object top_price
         try:
-            top_price = Decimal(order_book.c_get_price(is_buy))
+            top_price = Decimal(str(order_book.c_get_price(is_buy)))
         except EnvironmentError as e:
             self.logger().warning(f"{'Ask' if is_buy else 'Bid'} orderbook for {trading_pair} is empty.")
             return s_decimal_NaN
-
         return self.c_quantize_order_price(trading_pair, top_price)
 
     cdef ClientOrderBookQueryResult c_get_vwap_for_volume(self, str trading_pair, bint is_buy, object volume):

--- a/hummingbot/core/gateway/status_monitor.py
+++ b/hummingbot/core/gateway/status_monitor.py
@@ -1,8 +1,7 @@
 import asyncio
 import logging
-
 from enum import Enum
-from typing import Any, Dict, List, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from hummingbot.client.settings import GATEWAY_CONNECTORS
 from hummingbot.client.ui.completer import load_completer
@@ -58,6 +57,18 @@ class StatusMonitor:
         if self._monitor_task is not None:
             self._monitor_task.cancel()
             self._monitor_task = None
+
+    async def wait_for_online_status(self, max_tries=30):
+        """
+        Wait for gateway status to go online with a max number of tries. If it
+        is online before time is up, it returns early, otherwise it returns the
+        current status after the max number of tries.
+        """
+        while True:
+            if self._current_status is Status.ONLINE or max_tries <= 0:
+                return self._current_status
+            await asyncio.sleep(POLL_INTERVAL)
+            max_tries = max_tries - 1
 
     async def _monitor_loop(self):
         while True:

--- a/hummingbot/templates/conf_global_TEMPLATE.yml
+++ b/hummingbot/templates/conf_global_TEMPLATE.yml
@@ -285,3 +285,6 @@ error-label: "#FF0000"
 
 # tabulate table format style (https://github.com/astanin/python-tabulate#table-format)
 tables_format: 'psql'
+
+# previously imported strategy
+previous_strategy:

--- a/test/hummingbot/client/command/test_previous_command.py
+++ b/test/hummingbot/client/command/test_previous_command.py
@@ -1,0 +1,58 @@
+import asyncio
+import unittest
+from typing import Awaitable
+from unittest.mock import MagicMock, patch
+
+from hummingbot.client.config.config_helpers import read_system_configs_from_yml
+from hummingbot.client.config.global_config_map import global_config_map
+from hummingbot.client.hummingbot_application import HummingbotApplication
+
+from test.mock.mock_cli import CLIMockingAssistant  # isort: skip
+
+
+class PreviousCommandUnitTest(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.ev_loop = asyncio.get_event_loop()
+
+        self.async_run_with_timeout(read_system_configs_from_yml())
+        self.app = HummingbotApplication()
+        self.cli_mock_assistant = CLIMockingAssistant(self.app.app)
+        self.cli_mock_assistant.start()
+
+    def tearDown(self) -> None:
+        self.cli_mock_assistant.stop()
+        super().tearDown()
+
+    def async_run_with_timeout(self, coroutine: Awaitable, timeout: float = 1):
+        ret = self.ev_loop.run_until_complete(asyncio.wait_for(coroutine, timeout))
+        return ret
+
+    def mock_user_response(self, config):
+        config.value = "yes"
+
+    def test_no_previous_strategy_found(self):
+        global_config_map["previous_strategy"].value = None
+        self.app.previous_strategy(option="")
+        self.assertTrue(
+            self.cli_mock_assistant.check_log_called_with("No previous strategy found."))
+
+    @patch("hummingbot.client.command.import_command.ImportCommand.import_command")
+    def test_strategy_found_and_user_declines(self, import_command: MagicMock):
+        strategy_name = "conf_1.yml"
+        self.cli_mock_assistant.queue_prompt_reply("No")
+        self.async_run_with_timeout(
+            self.app.prompt_for_previous_strategy(strategy_name)
+        )
+        import_command.assert_not_called()
+
+    @patch("hummingbot.client.command.import_command.ImportCommand.import_command")
+    def test_strategy_found_and_user_accepts(self, import_command: MagicMock):
+        strategy_name = "conf_1.yml"
+        global_config_map["previous_strategy"].value = strategy_name
+        self.cli_mock_assistant.queue_prompt_reply("Yes")
+        self.async_run_with_timeout(
+            self.app.prompt_for_previous_strategy(strategy_name)
+        )
+        import_command.assert_called()
+        self.assertTrue(import_command.call_args[0][1] == strategy_name)

--- a/test/hummingbot/connector/exchange/kucoin/test_kucoin_exchange.py
+++ b/test/hummingbot/connector/exchange/kucoin/test_kucoin_exchange.py
@@ -11,10 +11,7 @@ from aioresponses import aioresponses
 from bidict import bidict
 
 from hummingbot.connector.client_order_tracker import ClientOrderTracker
-from hummingbot.connector.exchange.kucoin import (
-    kucoin_constants as CONSTANTS,
-    kucoin_web_utils as web_utils,
-)
+from hummingbot.connector.exchange.kucoin import kucoin_constants as CONSTANTS, kucoin_web_utils as web_utils
 from hummingbot.connector.exchange.kucoin.kucoin_api_order_book_data_source import KucoinAPIOrderBookDataSource
 from hummingbot.connector.exchange.kucoin.kucoin_exchange import KucoinExchange
 from hummingbot.connector.trading_rule import TradingRule
@@ -46,6 +43,7 @@ class TestKucoinExchange(unittest.TestCase):
         cls.base_asset = "COINALPHA"
         cls.quote_asset = "HBOT"
         cls.trading_pair = f"{cls.base_asset}-{cls.quote_asset}"
+        cls.trading_multipair = (f"{cls.base_asset}-{cls.quote_asset}", f"{cls.base_asset}-{cls.quote_asset}")
         cls.exchange_trading_pair = cls.trading_pair
         cls.api_key = "someKey"
         cls.api_passphrase = "somePassPhrase"
@@ -240,6 +238,43 @@ class TestKucoinExchange(unittest.TestCase):
         regex_url = re.compile(f"^{url}")
         resp = {"data": [
             {"symbol": self.trading_pair,
+             "makerFeeRate": "0.002",
+             "takerFeeRate": "0.002"}]}
+        mocked_api.get(regex_url, body=json.dumps(resp))
+
+        self.async_run_with_timeout(self.exchange._update_trading_fees())
+
+        fee = self.exchange.get_fee(
+            base_currency=self.base_asset,
+            quote_currency=self.quote_asset,
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.BUY,
+            amount=Decimal("10"),
+            price=Decimal("20"),
+        )
+
+        self.assertEqual(Decimal("0.002"), fee.percent)
+
+        fee = self.exchange.get_fee(
+            base_currency="SOME",
+            quote_currency="OTHER",
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.BUY,
+            amount=Decimal("10"),
+            price=Decimal("20"),
+        )
+
+        self.assertEqual(Decimal("0.001"), fee.percent)  # default fee
+
+    @aioresponses()
+    def test_get_multipair_fee_returns_fee_from_exchange_if_available_and_default_if_not(self, mocked_api):
+        url = web_utils.rest_url(CONSTANTS.FEE_PATH_URL)
+        regex_url = re.compile(f"^{url}")
+        resp = {"data": [
+            {"symbol": self.trading_multipair[0],
+             "makerFeeRate": "0.002",
+             "takerFeeRate": "0.002"},
+            {"symbol": self.trading_multipair[1],
              "makerFeeRate": "0.002",
              "takerFeeRate": "0.002"}]}
         mocked_api.get(regex_url, body=json.dumps(resp))

--- a/test/hummingbot/strategy/cross_exchange_market_making/test_cross_exchange_market_making.py
+++ b/test/hummingbot/strategy/cross_exchange_market_making/test_cross_exchange_market_making.py
@@ -21,8 +21,8 @@ from hummingbot.core.event.events import (
     MarketEvent,
     OrderBookTradeEvent,
     OrderFilledEvent,
-    SellOrderCreatedEvent,
     SellOrderCompletedEvent,
+    SellOrderCreatedEvent,
 )
 from hummingbot.strategy.cross_exchange_market_making import CrossExchangeMarketMakingStrategy
 from hummingbot.strategy.cross_exchange_market_making.cross_exchange_market_pair import CrossExchangeMarketPair
@@ -519,7 +519,7 @@ class HedgedMarketMakingUnitTest(unittest.TestCase):
         bid_order: LimitOrder = self.strategy.active_bids[0][1]
         ask_order: LimitOrder = self.strategy.active_asks[0][1]
         # place above top bid (at 0.95)
-        self.assertAlmostEqual(Decimal("0.9500"), bid_order.price)
+        self.assertAlmostEqual(Decimal("0.9501"), bid_order.price)
         # place below top ask (at 1.05)
         self.assertAlmostEqual(Decimal("1.049"), ask_order.price)
         self.assertAlmostEqual(Decimal("3"), round(bid_order.quantity, 4))


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Proposing a workaround of an apparent disconnect in KuCoin API trade-fees method/doc
The documentation states that up to 10 pairs can be in the symbols parameter, however the call SIGN is recognized only when one trading pair is passed as symbols. This could be an issue with the signing method that was not investigated

The hummingbot logs document the failure as:
OSError: The request to Kucoin failed. Error: {"code":"400005","msg":"Invalid KC-API-SIGN"}. Request: RESTRequest(method=GET, url='https://api.kucoin.com/api/v1/trade-fees', endpoint_url=None, params={'symbols': 'ALGO-USDT,AVAX-USDT,DAO-USDT,FEAR-USDT'}

**Tests performed by the developer**:
The liquidity mining strategy was tested with the fix and the error message was no longer reported. The fix was monitored with the debugger and showed live expected behavior of the update_trading_fee() module
A test method was added to the test_kucoin_exchange.py as part of this pull request

**Tips for QA testing**:
