### PR TITLE
(fix) Script (Lite) Strategy incorrect subclass import

### DIFF
--- a/hummingbot/strategy/script_strategy_base.py
+++ b/hummingbot/strategy/script_strategy_base.py
@@ -57,7 +57,7 @@ class ScriptStrategyBase(StrategyPyBase):
         script_module = importlib.import_module(f".{script_name}", package=SCRIPT_STRATEGIES_MODULE)
         try:
             script_class = next((member for member_name, member in inspect.getmembers(script_module)
-                                 if inspect.isclass(member) and issubclass(member, cls)))
+                                 if inspect.isclass(member) and issubclass(member, cls) and member_name != cls.__name__))
         except StopIteration:
             raise InvalidScriptModule(f"The module {script_name} does not contain any subclass of ScriptStrategyBase")
         return script_class

--- a/scripts/test_dca_example.py
+++ b/scripts/test_dca_example.py
@@ -1,0 +1,77 @@
+import logging
+
+from hummingbot.core.event.events import (
+    BuyOrderCompletedEvent,
+    BuyOrderCreatedEvent,
+    MarketOrderFailureEvent,
+    OrderCancelledEvent,
+    OrderFilledEvent,
+    SellOrderCompletedEvent,
+    SellOrderCreatedEvent,
+)
+from hummingbot.strategy.script_strategy_base import Decimal, OrderType, ScriptStrategyBase
+
+
+class TestDCAExample(ScriptStrategyBase):
+    """
+    This example shows how to set up a simple strategy to buy a token on fixed (dollar) amount on a regular basis
+    """
+    #: Define markets to instruct Hummingbot to create connectors on the exchanges and markets you need
+    markets = {"binance_paper_trade": {"BTC-USDT"}}
+    #: The last time the strategy places a buy order
+    last_ordered_ts = 0.
+    #: Buying interval (in seconds)
+    buy_interval = 10.
+    #: Buying amount (in dollars - USDT)
+    buy_quote_amount = Decimal("100")
+
+    def on_tick(self):
+        # Check if it is time to buy
+        if self.last_ordered_ts < (self.current_timestamp - self.buy_interval):
+            # Lets set the order price to the best bid
+            price = self.connectors["binance_paper_trade"].get_price("BTC-USDT", False)
+            amount = self.buy_quote_amount / price
+            self.buy("binance_paper_trade", "BTC-USDT", amount, OrderType.LIMIT, price)
+            self.last_ordered_ts = self.current_timestamp
+
+    def did_create_buy_order(self, event: BuyOrderCreatedEvent):
+        """
+        Method called when the connector notifies a buy order has been created
+        """
+        self.logger().info(logging.INFO, f"The buy order {event.order_id} has been created")
+
+    def did_create_sell_order(self, event: SellOrderCreatedEvent):
+        """
+        Method called when the connector notifies a sell order has been created
+        """
+        self.logger().info(logging.INFO, f"The sell order {event.order_id} has been created")
+
+    def did_fill_order(self, event: OrderFilledEvent):
+        """
+        Method called when the connector notifies that an order has been partially or totally filled (a trade happened)
+        """
+        self.logger().info(logging.INFO, f"The order {event.order_id} has been filled")
+
+    def did_fail_order(self, event: MarketOrderFailureEvent):
+        """
+        Method called when the connector notifies an order has failed
+        """
+        self.logger().info(logging.INFO, f"The order {event.order_id} failed")
+
+    def did_cancel_order(self, event: OrderCancelledEvent):
+        """
+        Method called when the connector notifies an order has been cancelled
+        """
+        self.logger().info(f"The order {event.order_id} has been cancelled")
+
+    def did_complete_buy_order(self, event: BuyOrderCompletedEvent):
+        """
+        Method called when the connector notifies a buy order has been completed (fully filled)
+        """
+        self.logger().info(f"The buy order {event.order_id} has been completed")
+
+    def did_complete_sell_order(self, event: SellOrderCompletedEvent):
+        """
+        Method called when the connector notifies a sell order has been completed (fully filled)
+        """
+        self.logger().info(f"The sell order {event.order_id} has been completed")

--- a/test/hummingbot/strategy/test_script_strategy_base.py
+++ b/test/hummingbot/strategy/test_script_strategy_base.py
@@ -1,6 +1,7 @@
 import unittest
 from decimal import Decimal
 from typing import List
+from unittest.mock import patch
 
 import pandas as pd
 
@@ -61,6 +62,7 @@ class ScriptStrategyBaseTest(unittest.TestCase):
         self.strategy.logger().setLevel(1)
         self.strategy.logger().addHandler(self)
 
+    @patch(f"{ScriptStrategyBase.load_script_class.__module__}.SCRIPT_STRATEGIES_MODULE", 'test.scripts')
     def test_load_valid_script_class(self):
         loaded_class = ScriptStrategyBase.load_script_class("dca_example")
 
@@ -69,8 +71,8 @@ class ScriptStrategyBaseTest(unittest.TestCase):
 
         loaded_class = ScriptStrategyBase.load_script_class("test_dca_example")
 
-        self.assertEqual({"binance_paper_trade": {"BTC-USDT"}}, loaded_class.markets)
-        self.assertEqual(Decimal("100"), loaded_class.buy_quote_amount)
+        self.assertEqual({"binance_paper_trade": {"ETH-USDT"}}, loaded_class.markets)
+        self.assertEqual(Decimal("500"), loaded_class.buy_quote_amount)
 
     def test_load_script_class_raises_exception_for_non_existing_script(self):
         self.assertRaises(ImportError, ScriptStrategyBase.load_script_class, "non_existing_script")

--- a/test/hummingbot/strategy/test_script_strategy_base.py
+++ b/test/hummingbot/strategy/test_script_strategy_base.py
@@ -67,6 +67,11 @@ class ScriptStrategyBaseTest(unittest.TestCase):
         self.assertEqual({"binance_paper_trade": {"BTC-USDT"}}, loaded_class.markets)
         self.assertEqual(Decimal("100"), loaded_class.buy_quote_amount)
 
+        loaded_class = ScriptStrategyBase.load_script_class("test_dca_example")
+
+        self.assertEqual({"binance_paper_trade": {"BTC-USDT"}}, loaded_class.markets)
+        self.assertEqual(Decimal("100"), loaded_class.buy_quote_amount)
+
     def test_load_script_class_raises_exception_for_non_existing_script(self):
         self.assertRaises(ImportError, ScriptStrategyBase.load_script_class, "non_existing_script")
 

--- a/test/scripts/buy_dip_example.py
+++ b/test/scripts/buy_dip_example.py
@@ -1,0 +1,130 @@
+import logging
+import time
+from decimal import Decimal
+from statistics import mean
+from typing import List
+
+import requests
+
+from hummingbot.connector.exchange_base import ExchangeBase
+from hummingbot.connector.utils import split_hb_trading_pair
+from hummingbot.core.data_type.order_candidate import OrderCandidate
+from hummingbot.core.event.events import OrderFilledEvent, OrderType, TradeType
+from hummingbot.core.rate_oracle.rate_oracle import RateOracle
+from hummingbot.strategy.script_strategy_base import ScriptStrategyBase
+
+
+class BuyDipExample(ScriptStrategyBase):
+    """
+    THis strategy buys ETH (with BTC) when the ETH-BTC drops 5% below 50 days moving average (of a previous candle)
+    This example demonstrates:
+      - How to call Binance REST API for candle stick data
+      - How to incorporate external pricing source (Coingecko) into the strategy
+      - How to listen to order filled event
+      - How to structure order execution on a more complex strategy
+    Before running this example, make sure you run `config rate_oracle_source coingecko`
+    """
+    connector_name: str = "binance_paper_trade"
+    trading_pair: str = "ETH-BTC"
+    base_asset, quote_asset = split_hb_trading_pair(trading_pair)
+    conversion_pair: str = f"{quote_asset}-USD"
+    buy_usd_amount: Decimal = Decimal("100")
+    moving_avg_period: int = 50
+    dip_percentage: Decimal = Decimal("0.05")
+    #: A cool off period before the next buy (in seconds)
+    cool_off_interval: float = 10.
+    #: The last buy timestamp
+    last_ordered_ts: float = 0.
+
+    markets = {connector_name: {trading_pair}}
+
+    @property
+    def connector(self) -> ExchangeBase:
+        """
+        The only connector in this strategy, define it here for easy access
+        """
+        return self.connectors[self.connector_name]
+
+    def on_tick(self):
+        """
+        Runs every tick_size seconds, this is the main operation of the strategy.
+        - Create proposal (a list of order candidates)
+        - Check the account balance and adjust the proposal accordingly (lower order amount if needed)
+        - Lastly, execute the proposal on the exchange
+        """
+        proposal: List[OrderCandidate] = self.create_proposal()
+        proposal = self.connector.budget_checker.adjust_candidates(proposal, all_or_none=False)
+        if proposal:
+            self.execute_proposal(proposal)
+
+    def create_proposal(self) -> List[OrderCandidate]:
+        """
+        Creates and returns a proposal (a list of order candidate), in this strategy the list has 1 element at most.
+        """
+        daily_closes = self._get_daily_close_list(self.trading_pair)
+        start_index = (-1 * self.moving_avg_period) - 1
+        # Calculate the average of the 50 element prior to the last element
+        avg_close = mean(daily_closes[start_index:-1])
+        proposal = []
+        # If the current price (the last close) is below the dip, add a new order candidate to the proposal
+        if daily_closes[-1] < avg_close * (Decimal("1") - self.dip_percentage):
+            order_price = self.connector.get_price(self.trading_pair, False) * Decimal("0.9")
+            usd_conversion_rate = RateOracle.get_instance().rate(self.conversion_pair)
+            amount = (self.buy_usd_amount / usd_conversion_rate) / order_price
+            proposal.append(OrderCandidate(self.trading_pair, False, OrderType.LIMIT, TradeType.BUY, amount,
+                                           order_price))
+        return proposal
+
+    def execute_proposal(self, proposal: List[OrderCandidate]):
+        """
+        Places the order candidates on the exchange, if it is not within cool off period and order candidate is valid.
+        """
+        if self.last_ordered_ts > time.time() - self.cool_off_interval:
+            return
+        for order_candidate in proposal:
+            if order_candidate.amount > Decimal("0"):
+                self.buy(self.connector_name, self.trading_pair, order_candidate.amount, order_candidate.order_type,
+                         order_candidate.price)
+                self.last_ordered_ts = time.time()
+
+    def did_fill_order(self, event: OrderFilledEvent):
+        """
+        Listens to fill order event to log it and notify the hummingbot application.
+        If you set up Telegram bot, you will get notification there as well.
+        """
+        msg = (f"({event.trading_pair}) {event.trade_type.name} order (price: {event.price}) of {event.amount} "
+               f"{split_hb_trading_pair(event.trading_pair)[0]} is filled.")
+        self.log_with_clock(logging.INFO, msg)
+        self.notify_hb_app_with_timestamp(msg)
+
+    def _get_daily_close_list(self, trading_pair: str) -> List[Decimal]:
+        """
+        Fetches binance candle stick data and returns a list daily close
+        This is the API response data structure:
+        [
+          [
+            1499040000000,      // Open time
+            "0.01634790",       // Open
+            "0.80000000",       // High
+            "0.01575800",       // Low
+            "0.01577100",       // Close
+            "148976.11427815",  // Volume
+            1499644799999,      // Close time
+            "2434.19055334",    // Quote asset volume
+            308,                // Number of trades
+            "1756.87402397",    // Taker buy base asset volume
+            "28.46694368",      // Taker buy quote asset volume
+            "17928899.62484339" // Ignore.
+          ]
+        ]
+
+        :param trading_pair: A market trading pair to
+
+        :return: A list of daily close
+        """
+
+        url = "https://api.binance.com/api/v3/klines"
+        params = {"symbol": trading_pair.replace("-", ""),
+                  "interval": "1d"}
+        records = requests.get(url=url, params=params).json()
+        return [Decimal(str(record[4])) for record in records]

--- a/test/scripts/dca_example.py
+++ b/test/scripts/dca_example.py
@@ -12,7 +12,7 @@ from hummingbot.core.event.events import (
 from hummingbot.strategy.script_strategy_base import Decimal, OrderType, ScriptStrategyBase
 
 
-class TestDCAExample(ScriptStrategyBase):
+class DCAExample(ScriptStrategyBase):
     """
     This example shows how to set up a simple strategy to buy a token on fixed (dollar) amount on a regular basis
     """

--- a/test/scripts/test_dca_example.py
+++ b/test/scripts/test_dca_example.py
@@ -1,0 +1,77 @@
+import logging
+
+from hummingbot.core.event.events import (
+    BuyOrderCompletedEvent,
+    BuyOrderCreatedEvent,
+    MarketOrderFailureEvent,
+    OrderCancelledEvent,
+    OrderFilledEvent,
+    SellOrderCompletedEvent,
+    SellOrderCreatedEvent,
+)
+from hummingbot.strategy.script_strategy_base import Decimal, OrderType, ScriptStrategyBase
+
+
+class TestDCAExample(ScriptStrategyBase):
+    """
+    This example shows how to set up a simple strategy to buy a token on fixed (dollar) amount on a regular basis
+    """
+    #: Define markets to instruct Hummingbot to create connectors on the exchanges and markets you need
+    markets = {"binance_paper_trade": {"ETH-USDT"}}
+    #: The last time the strategy places a buy order
+    last_ordered_ts = 0.
+    #: Buying interval (in seconds)
+    buy_interval = 10.
+    #: Buying amount (in dollars - USDT)
+    buy_quote_amount = Decimal("500")
+
+    def on_tick(self):
+        # Check if it is time to buy
+        if self.last_ordered_ts < (self.current_timestamp - self.buy_interval):
+            # Lets set the order price to the best bid
+            price = self.connectors["binance_paper_trade"].get_price("BTC-USDT", False)
+            amount = self.buy_quote_amount / price
+            self.buy("binance_paper_trade", "BTC-USDT", amount, OrderType.LIMIT, price)
+            self.last_ordered_ts = self.current_timestamp
+
+    def did_create_buy_order(self, event: BuyOrderCreatedEvent):
+        """
+        Method called when the connector notifies a buy order has been created
+        """
+        self.logger().info(logging.INFO, f"The buy order {event.order_id} has been created")
+
+    def did_create_sell_order(self, event: SellOrderCreatedEvent):
+        """
+        Method called when the connector notifies a sell order has been created
+        """
+        self.logger().info(logging.INFO, f"The sell order {event.order_id} has been created")
+
+    def did_fill_order(self, event: OrderFilledEvent):
+        """
+        Method called when the connector notifies that an order has been partially or totally filled (a trade happened)
+        """
+        self.logger().info(logging.INFO, f"The order {event.order_id} has been filled")
+
+    def did_fail_order(self, event: MarketOrderFailureEvent):
+        """
+        Method called when the connector notifies an order has failed
+        """
+        self.logger().info(logging.INFO, f"The order {event.order_id} failed")
+
+    def did_cancel_order(self, event: OrderCancelledEvent):
+        """
+        Method called when the connector notifies an order has been cancelled
+        """
+        self.logger().info(f"The order {event.order_id} has been cancelled")
+
+    def did_complete_buy_order(self, event: BuyOrderCompletedEvent):
+        """
+        Method called when the connector notifies a buy order has been completed (fully filled)
+        """
+        self.logger().info(f"The buy order {event.order_id} has been completed")
+
+    def did_complete_sell_order(self, event: SellOrderCompletedEvent):
+        """
+        Method called when the connector notifies a sell order has been completed (fully filled)
+        """
+        self.logger().info(f"The sell order {event.order_id} has been completed")


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
The creation of the class for a new subclass of ScriptStrategyBase incorrectly select the base class ScriptStrategyBase when the getmembers() ordering puts the new class lower than ScriptStrategyBase.
This is because in the next() lookup function because issubclass(cls, cls) = True (a class is a subclass of itself in Python)


**Tests performed by the developer**:
Passed the failed import of the user local class ScriptStrategyReload, which fails when hummingbot attempts to initialize the markets, which in ScriptStrategyBase is None


**Tips for QA testing**:
Updated the existing Unittests case with a loading of the test_dca_example.py

