### PR TITLE
(fix) Prevents a user to start --script when a bot is running

### DIFF
--- a/hummingbot/client/command/start_command.py
+++ b/hummingbot/client/command/start_command.py
@@ -179,6 +179,10 @@ class StartCommand(GatewayChainApiManager):
         RateOracle.get_instance().start()
 
     def start_script_strategy(self):
+        if self._in_start_check or (self.strategy_task is not None and not self.strategy_task.done()):
+            self.notify('The bot is already running - please run "stop" first')
+            return
+
         script_strategy = ScriptStrategyBase.load_script_class(self.strategy_file_name)
         markets_list = []
         for conn, pairs in script_strategy.markets.items():


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
The start --script xxx command does not prevent a user to start a bot when another one is already running


**Tests performed by the developer**:
Started a bot and typed 'start --script dca_example.py' to get the message 'The bot is already ...'


**Tips for QA testing**:


