### PR TITLE
hummingbot#5273 fix kucoin exchange exception when retrieving trading fees for multiple pairs

### DIFF
--- a/hummingbot/connector/exchange/kucoin/kucoin_exchange.py
+++ b/hummingbot/connector/exchange/kucoin/kucoin_exchange.py
@@ -812,14 +812,16 @@ class KucoinExchange(ExchangePyBase):
             throttler=self._throttler,
             time_synchronizer=self._time_synchronizer) for trading_pair in self._trading_pairs]
 
-        params = {"symbols": ",".join(trading_symbols)}
-
-        resp = await self._api_request(
-            path_url=CONSTANTS.FEE_PATH_URL,
-            params=params,
-            method=RESTMethod.GET,
-            is_auth_required=True,
-        )
+        resp = {"data": []}
+        for pair in trading_symbols:
+            params = {"symbols": pair}
+            r = await self._api_request(
+                path_url=CONSTANTS.FEE_PATH_URL,
+                params=params,
+                method=RESTMethod.GET,
+                is_auth_required=True,
+            )
+            resp["data"] += r["data"]
 
         fees_json = resp["data"]
         for fee_json in fees_json:

--- a/test/hummingbot/connector/exchange/kucoin/test_kucoin_exchange.py
+++ b/test/hummingbot/connector/exchange/kucoin/test_kucoin_exchange.py
@@ -46,6 +46,7 @@ class TestKucoinExchange(unittest.TestCase):
         cls.base_asset = "COINALPHA"
         cls.quote_asset = "HBOT"
         cls.trading_pair = f"{cls.base_asset}-{cls.quote_asset}"
+        cls.trading_multipair = (f"{cls.base_asset}-{cls.quote_asset}", f"{cls.base_asset}-{cls.quote_asset}")
         cls.exchange_trading_pair = cls.trading_pair
         cls.api_key = "someKey"
         cls.api_passphrase = "somePassPhrase"
@@ -240,6 +241,43 @@ class TestKucoinExchange(unittest.TestCase):
         regex_url = re.compile(f"^{url}")
         resp = {"data": [
             {"symbol": self.trading_pair,
+             "makerFeeRate": "0.002",
+             "takerFeeRate": "0.002"}]}
+        mocked_api.get(regex_url, body=json.dumps(resp))
+
+        self.async_run_with_timeout(self.exchange._update_trading_fees())
+
+        fee = self.exchange.get_fee(
+            base_currency=self.base_asset,
+            quote_currency=self.quote_asset,
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.BUY,
+            amount=Decimal("10"),
+            price=Decimal("20"),
+        )
+
+        self.assertEqual(Decimal("0.002"), fee.percent)
+
+        fee = self.exchange.get_fee(
+            base_currency="SOME",
+            quote_currency="OTHER",
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.BUY,
+            amount=Decimal("10"),
+            price=Decimal("20"),
+        )
+
+        self.assertEqual(Decimal("0.001"), fee.percent)  # default fee
+
+    @aioresponses()
+    def test_get_multipair_fee_returns_fee_from_exchange_if_available_and_default_if_not(self, mocked_api):
+        url = web_utils.rest_url(CONSTANTS.FEE_PATH_URL)
+        regex_url = re.compile(f"^{url}")
+        resp = {"data": [
+            {"symbol": self.trading_multipair[0],
+             "makerFeeRate": "0.002",
+             "takerFeeRate": "0.002"},
+            {"symbol": self.trading_multipair[1],
              "makerFeeRate": "0.002",
              "takerFeeRate": "0.002"}]}
         mocked_api.get(regex_url, body=json.dumps(resp))


### PR DESCRIPTION
**A description of the changes proposed in the pull request**:

Liquidity mining with multiple coin pairs on kucoin causing exception as indicated in https://github.com/hummingbot/hummingbot/issues/5273. This PR includes a fix originally proposed by https://github.com/MementoRC (https://github.com/hummingbot/hummingbot/pull/5323) which loops thru the trading pairs to gather the fees.

**Tests performed by the developer**:

Built from source and tested (on Ubuntu 20) by using trading config that was causing error on v1.3.0. No exceptions found in logs. No further tests performed.
