### PR TITLE
Fix/BitMart Websocket and Market Depth URIs

### DIFF
--- a/hummingbot/connector/exchange/bitmart/bitmart_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/bitmart/bitmart_api_order_book_data_source.py
@@ -222,7 +222,7 @@ class BitmartAPIOrderBookDataSource(OrderBookTrackerDataSource):
                 for trading_pair in self._trading_pairs:
                     ws_message: WSRequest = WSRequest({
                         "op": "subscribe",
-                        "args": [f"spot/depth400:{convert_to_exchange_trading_pair(trading_pair)}"]
+                        "args": [f"spot/depth50:{convert_to_exchange_trading_pair(trading_pair)}"]
                     })
                     await ws.send(ws_message)
 

--- a/hummingbot/connector/exchange/bitmart/bitmart_constants.py
+++ b/hummingbot/connector/exchange/bitmart/bitmart_constants.py
@@ -5,8 +5,8 @@ from hummingbot.core.api_throttler.data_types import RateLimit
 EXCHANGE_NAME = "bitmart"
 REST_URL = "https://api-cloud.bitmart.com"
 REST_URL_HK = "https://api-cloud.bitmart.news"
-WSS_URL = "wss://ws-manager-compress.bitmart.com?protocol=1.1"
-WSS_URL_HK = "wss://ws-manager-compress.bitmart.news?protocol=1.1"
+WSS_URL = "wss://ws-manager-compress.bitmart.com/api?protocol=1.1"
+WSS_URL_HK = "wss://ws-manager-compress.bitmart.com/api?protocol=1.1"
 
 # REST API ENDPOINTS
 CHECK_NETWORK_PATH_URL = "system/service"


### PR DESCRIPTION
WIP - Update Websocket URL and market depth URIs per BitMart API Release Nodes, which resolves most problems.  There is still a strange JSON parsing error I cannot find