### PR TITLE
Fix/script strategy load

### DIFF
--- a/hummingbot/strategy/script_strategy_base.py
+++ b/hummingbot/strategy/script_strategy_base.py
@@ -57,7 +57,9 @@ class ScriptStrategyBase(StrategyPyBase):
         script_module = importlib.import_module(f".{script_name}", package=SCRIPT_STRATEGIES_MODULE)
         try:
             script_class = next((member for member_name, member in inspect.getmembers(script_module)
-                                 if inspect.isclass(member) and issubclass(member, cls)))
+                                 if inspect.isclass(member) and
+                                    issubclass(member, cls) and
+                                    member is not ScriptStrategyBase))
         except StopIteration:
             raise InvalidScriptModule(f"The module {script_name} does not contain any subclass of ScriptStrategyBase")
         return script_class

--- a/hummingbot/strategy/script_strategy_base.py
+++ b/hummingbot/strategy/script_strategy_base.py
@@ -58,8 +58,8 @@ class ScriptStrategyBase(StrategyPyBase):
         try:
             script_class = next((member for member_name, member in inspect.getmembers(script_module)
                                  if inspect.isclass(member) and
-                                    issubclass(member, cls) and
-                                    member is not ScriptStrategyBase))
+                                 issubclass(member, cls) and
+                                 member is not ScriptStrategyBase))
         except StopIteration:
             raise InvalidScriptModule(f"The module {script_name} does not contain any subclass of ScriptStrategyBase")
         return script_class


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
The creation of the class for a new subclass of ScriptStrategyBase incorrectly select the base class ScriptStrategyBase when the getmembers() ordering puts the new class lower than ScriptStrategyBase (i.e. TestScriptStrategyBase).
This is because in the next() lookup function because issubclass(cls, cls) = True (a class is a subclass of itself in Python)


**Tests performed by the developer**:
Passed the previously failing import test_script_strategy_base.py when hummingbot attempts to initialize the markets member of TestScriptStrategyBase class, by selecting ScriptStrategyBase instead, which has uninitialized class member markets


**Tips for QA testing**:

