### PR TITLE
(feat) reload ScriptStrategyBase without exit

### DIFF
--- a/hummingbot/strategy/script_strategy_base.py
+++ b/hummingbot/strategy/script_strategy_base.py
@@ -30,7 +30,7 @@ class ScriptStrategyBase(StrategyPyBase):
     # This class member defines connectors and their trading pairs needed for the strategy operation,
     markets: Dict[str, Set[str]]
     script_name: str = None
-    script_module: ModuleType
+    script_module: ModuleType = None
 
     @classmethod
     def logger(cls) -> HummingbotLogger:
@@ -57,7 +57,7 @@ class ScriptStrategyBase(StrategyPyBase):
 
         :param script_name: name of the module where the script class is defined
         """
-        if cls.script_name is not None and cls.script_module and script_name == cls.script_name:
+        if cls.script_name and cls.script_module and script_name == cls.script_name:
             cls.script_module = importlib.reload(cls.script_module)
         else:
             cls.script_name = script_name

--- a/test/hummingbot/strategy/test_script_strategy_base.py
+++ b/test/hummingbot/strategy/test_script_strategy_base.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import pandas as pd
 
 from hummingbot.connector.exchange.paper_trade.paper_trade_exchange import QuantizationParams
-from hummingbot.connector.mock.mock_paper_exchange import MockPaperExchange
+from hummingbot.connector.test_support.mock_paper_exchange import MockPaperExchange
 from hummingbot.core.clock import Clock
 from hummingbot.core.clock_mode import ClockMode
 from hummingbot.core.event.events import OrderType
@@ -68,17 +68,18 @@ class ScriptStrategyBaseTest(unittest.TestCase):
         self.assertEqual({"binance_paper_trade": {"BTC-USDT"}}, loaded_class.markets)
         self.assertEqual(Decimal("100"), loaded_class.buy_quote_amount)
 
-    @patch('hummingbot.strategy.script_strategy_base.importlib.reload')
-    def test_reload_valid_script_class(self, mock_reload):
-        loaded_class = ScriptStrategyBase.load_script_class("dca_example")
+    def test_reload_valid_script_class(self):
+        ScriptStrategyBase.load_script_class("dca_example")
+        script_module = ScriptStrategyBase.script_module
 
-        # Simulate an update of the strategy file: Add a new market
-        loaded_class.markets = {"binance_paper_trade": {"AVAX-USDT", "BTC-USDT"}}
+        # Simulate an update of the strategy file: Add a new pair to market
+        script_module.DCAExample.markets = {"binance_paper_trade": {"AVAX-USDT", "BTC-USDT"}}
 
-        # Mock the actual reload
-        mock_reload.return_value = loaded_class
+        with patch('hummingbot.strategy.script_strategy_base.importlib.reload') as mock_reload:
+            # Mock the actual reload by setting the return value to the modified 'file'
+            mock_reload.return_value = script_module
+            reloaded_class = ScriptStrategyBase.load_script_class("dca_example")
 
-        reloaded_class = ScriptStrategyBase.load_script_class("dca_example")
         self.assertEqual(1, mock_reload.call_count)
 
         self.assertEqual({"binance_paper_trade": {"AVAX-USDT", "BTC-USDT"}}, reloaded_class.markets)


### PR DESCRIPTION
Helps circumvent the need to exit the bot in order to update a ScriptStrategy module

**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Currently, users need to exit the bot in order to update a ScriptStrategyBase module. This is a bit cumbersome. The proposal adds primarily one importlib.reload() method and its supporting mechanics (saving the current script module and name) to the ScriptStrategyBase class


**Tests performed by the developer**:
Added a test to the test module simulating the import + change + reload mechanic


**Tips for QA testing**:



