### PR TITLE
(fix) Add Thread-Safe wrapping of asyncio.Event class

### DIFF
--- a/hummingbot/client/config/security.py
+++ b/hummingbot/client/config/security.py
@@ -1,22 +1,18 @@
+from os import unlink
+
 from hummingbot.client.config.config_crypt import (
-    list_encrypted_file_paths,
     decrypt_file,
-    secure_config_key,
-    encrypted_file_exists,
     encrypt_n_save_config_value,
-    encrypted_file_path
-)
-from hummingbot.core.utils.wallet_setup import (
-    list_wallets,
-    unlock_wallet,
-    import_and_save_wallet
+    encrypted_file_exists,
+    encrypted_file_path,
+    list_encrypted_file_paths,
+    secure_config_key,
 )
 from hummingbot.client.config.global_config_map import global_config_map
 from hummingbot.client.settings import AllConnectorSettings
-from hummingbot.core.utils.async_utils import safe_ensure_future
 from hummingbot.core.utils.async_call_scheduler import AsyncCallScheduler
-import asyncio
-from os import unlink
+from hummingbot.core.utils.async_utils import EventThreadSafe, safe_ensure_future
+from hummingbot.core.utils.wallet_setup import import_and_save_wallet, list_wallets, unlock_wallet
 
 
 class Security:
@@ -24,7 +20,7 @@ class Security:
     password = None
     _secure_configs = {}
     _private_keys = {}
-    _decryption_done = asyncio.Event()
+    _decryption_done = EventThreadSafe()
 
     @staticmethod
     def new_password_required():

--- a/hummingbot/core/utils/async_utils.py
+++ b/hummingbot/core/utils/async_utils.py
@@ -1,7 +1,20 @@
 import asyncio
+import inspect
 import logging
 import time
-import inspect
+
+
+class EventThreadSafe(asyncio.Event):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self._loop is None:
+            self._loop = asyncio.get_event_loop()
+
+    def set(self):
+        self._loop.call_soon_threadsafe(super().set)
+
+    def clear(self):
+        self._loop.call_soon_threadsafe(super().clear)
 
 
 async def safe_wrapper(c):


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
When setting the AsyncIO debug env. variable PYTHONASYNCIODEBUG=1, hummingbot fails to start, reporting a call to Event.set() from a different thread in security.py


**Tests performed by the developer**:
Started hummingbot with the workaround without errors


**Tips for QA testing**:


