### PR TITLE
(fix) Rate command fails with pair within quotes

### DIFF
--- a/hummingbot/client/command/rate_command.py
+++ b/hummingbot/client/command/rate_command.py
@@ -1,10 +1,9 @@
-from decimal import Decimal
 import threading
-from typing import (
-    TYPE_CHECKING,
-)
-from hummingbot.core.utils.async_utils import safe_ensure_future
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
 from hummingbot.core.rate_oracle.rate_oracle import RateOracle
+from hummingbot.core.utils.async_utils import safe_ensure_future
 from hummingbot.exceptions import OracleRateUnavailable
 
 s_float_0 = float(0)
@@ -39,7 +38,7 @@ class RateCommand:
     @staticmethod
     async def oracle_rate_msg(pair: str,
                               ):
-        pair = pair.upper()
+        pair = eval(pair.upper())
         rate = await RateOracle.rate_async(pair)
         if rate is None:
             raise OracleRateUnavailable


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
The rate command from CLI returns 'Rate is not available' if the pair is enclosed in quotes (single, or double). This is because the pair is captured literally as a string and passed to the show_rate.
The fix proposed is to add an eval in the oracle_rate_msg since that is where the 'upper' is applied, i.e. formatting of the pair to meet the required format, but another solution can be investigated


**Tests performed by the developer**:
Tested in the CLI with 'BTC-USDT', "BTC-USDT" and BTC-USDT


**Tips for QA testing**:


