### PR TITLE
Fix/paper trade fails on empty order book

### DIFF
--- a/hummingbot/connector/exchange/paper_trade/paper_trade_exchange.pyx
+++ b/hummingbot/connector/exchange/paper_trade/paper_trade_exchange.pyx
@@ -14,6 +14,7 @@ from libcpp.vector cimport vector
 
 from hummingbot.connector.budget_checker import BudgetChecker
 from hummingbot.connector.connector_metrics_collector import DummyMetricsCollector
+from hummingbot.connector.constants import s_decimal_NaN
 from hummingbot.connector.exchange.paper_trade.trading_pair import TradingPair
 from hummingbot.connector.exchange_base import ExchangeBase
 from hummingbot.core.clock cimport Clock
@@ -845,6 +846,10 @@ cdef class PaperTradeExchange(ExchangeBase):
             SingleTradingPairLimitOrdersRIterator orders_rit = orders_collection_ptr.rbegin()
             vector[SingleTradingPairLimitOrdersIterator] process_order_its
             const CPPLimitOrder *cpp_limit_order_ptr = NULL
+
+
+        if math.isnan(opposite_order_book_price):
+            return None
 
         if is_buy:
             while orders_rit != orders_collection_ptr.rend():


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
The function c_get_prices() returns s_decimal_NaN when the order book is empty. This causes the c_process_crossed_limit_orders_for_trading_pair() to fail with an uncaught error:
decimal.InvalidOperation: [<class 'decimal.InvalidOperation'>]
The proposal circumvent this by exiting the function early


**Tests performed by the developer**:
The test test-cross_exchange_market_making.py test_empty_order_book actually reports this error (though the test passes?). Once implemented the error no longer occurs


**Tips for QA testing**:


