### PR TITLE
(fix) add kwargs to _place_order method

### DIFF
--- a/hummingbot/connector/exchange/binance/binance_exchange.py
+++ b/hummingbot/connector/exchange/binance/binance_exchange.py
@@ -164,7 +164,8 @@ class BinanceExchange(ExchangePyBase):
                            amount: Decimal,
                            trade_type: TradeType,
                            order_type: OrderType,
-                           price: Decimal) -> Tuple[str, float]:
+                           price: Decimal,
+                           **kwargs) -> Tuple[str, float]:
         order_result = None
         amount_str = f"{amount:f}"
         price_str = f"{price:f}"

--- a/hummingbot/connector/exchange/bitmart/bitmart_exchange.py
+++ b/hummingbot/connector/exchange/bitmart/bitmart_exchange.py
@@ -171,7 +171,8 @@ class BitmartExchange(ExchangePyBase):
                            amount: Decimal,
                            trade_type: TradeType,
                            order_type: OrderType,
-                           price: Decimal) -> Tuple[str, float]:
+                           price: Decimal,
+                           **kwargs) -> Tuple[str, float]:
 
         api_params = {"symbol": await self.exchange_symbol_associated_to_pair(trading_pair),
                       "side": trade_type.name.lower(),

--- a/hummingbot/connector/exchange/gate_io/gate_io_exchange.py
+++ b/hummingbot/connector/exchange/gate_io/gate_io_exchange.py
@@ -176,8 +176,8 @@ class GateIoExchange(ExchangePyBase):
                            amount: Decimal,
                            trade_type: TradeType,
                            order_type: OrderType,
-                           price: Decimal) -> Tuple[str, float]:
-
+                           price: Decimal,
+                           **kwargs) -> Tuple[str, float]:
         order_type_str = order_type.name.lower().split("_")[0]
         symbol = await self.exchange_symbol_associated_to_pair(trading_pair=trading_pair)
 

--- a/hummingbot/connector/exchange/kucoin/kucoin_exchange.py
+++ b/hummingbot/connector/exchange/kucoin/kucoin_exchange.py
@@ -172,7 +172,8 @@ class KucoinExchange(ExchangePyBase):
                            amount: Decimal,
                            trade_type: TradeType,
                            order_type: OrderType,
-                           price: Decimal) -> Tuple[str, float]:
+                           price: Decimal,
+                           **kwargs) -> Tuple[str, float]:
         path_url = CONSTANTS.ORDERS_PATH_URL
         side = trade_type.name.lower()
         order_type_str = "market" if order_type == OrderType.MARKET else "limit"

--- a/hummingbot/connector/exchange/latoken/latoken_exchange.py
+++ b/hummingbot/connector/exchange/latoken/latoken_exchange.py
@@ -131,7 +131,8 @@ class LatokenExchange(ExchangePyBase):
                            amount: Decimal,
                            trade_type: TradeType,
                            order_type: OrderType,
-                           price: Decimal) -> Tuple[str, float]:
+                           price: Decimal,
+                           **kwargs) -> Tuple[str, float]:
         """
         Creates a an order in the exchange using the parameters to configure it
         :param trade_type: the side of the order (BUY of SELL)

--- a/hummingbot/connector/exchange/okx/okx_exchange.py
+++ b/hummingbot/connector/exchange/okx/okx_exchange.py
@@ -168,7 +168,8 @@ class OkxExchange(ExchangePyBase):
                            amount: Decimal,
                            trade_type: TradeType,
                            order_type: OrderType,
-                           price: Decimal) -> Tuple[str, float]:
+                           price: Decimal,
+                           **kwargs) -> Tuple[str, float]:
         data = {
             "clOrdId": order_id,
             "tdMode": "cash",


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Based on issue #5575, I found that the private methods of the exchanges that are SubClass of ExchangePyBase didn't have the **kwargs argument. I added it to all those exchanges.

**Tests performed by the developer**:
Pure market making strategy before and after the changes for Binance.


**Tips for QA testing**:
Test the rest of the connectors:

