### PR TITLE
Suggest last docker instance as docker container to run.

### DIFF
--- a/installation/docker-commands/create.sh
+++ b/installation/docker-commands/create.sh
@@ -86,6 +86,7 @@ create_instance () {
  mkdir $SCRIPTS_FOLDER
  mkdir $GATEWAY_CONF_FOLDER
  mkdir $GATEWAY_LOGS_FOLDER
+ echo "$INSTANCE_NAME" > .last_instance
  # 3) Set required permissions to save hummingbot password the first time
  sudo chmod a+rw $CONF_FOLDER
  # 4) Launch a new instance of hummingbot

--- a/installation/docker-commands/start.sh
+++ b/installation/docker-commands/start.sh
@@ -10,12 +10,19 @@ echo
 docker ps -a
 echo
 echo
-read -p "   Enter the NAME of the Hummingbot instance to start or connect to (default = \"hummingbot-instance\") >>> " INSTANCE_NAME
-if [ "$INSTANCE_NAME" == "" ]
-then
+if [ -f .last_instance ]; then 
+  INSTANCE_NAME=`cat .last_instance` 
+else
   INSTANCE_NAME="hummingbot-instance"
+fi
+# Ask the user for the name of the new instance
+read -p "   Enter the NAME of the Hummingbot instance to start or connect to (default = \"$INSTANCE_NAME\") >>> " TMP_NAME
+if [ "$TMP_NAME" != "" ]
+then
+  INSTANCE_NAME="$TMP_NAME"
 fi
 echo
 # =============================================
 # EXECUTE SCRIPT
+echo "$INSTANCE_NAME" > .last_instance
 docker start $INSTANCE_NAME && docker attach $INSTANCE_NAME


### PR DESCRIPTION
Save in hidden file the name of the last container launched with ./create.sh or ./start.sh
Next time that you run the ./start command, it will offer to start the previous container.




