### PR TITLE
(fix) rollback changes that introduce bugs in the orderbook updates

### DIFF
--- a/hummingbot/connector/exchange_py_base.py
+++ b/hummingbot/connector/exchange_py_base.py
@@ -829,11 +829,12 @@ class ExchangePyBase(ExchangeBase, ABC):
     # === Exchange / Trading logic methods that call the API ===
 
     async def _update_trading_rules(self):
-        exchange_info = await self._initialize_trading_pair_symbol_map()
+        exchange_info = await self._api_get(path_url=self.trading_rules_request_path)
         trading_rules_list = await self._format_trading_rules(exchange_info)
         self._trading_rules.clear()
         for trading_rule in trading_rules_list:
             self._trading_rules[trading_rule.trading_pair] = trading_rule
+        self._initialize_trading_pair_symbols_from_exchange_info(exchange_info=exchange_info)
 
     async def _api_get(self, *args, **kwargs):
         kwargs["method"] = RESTMethod.GET

--- a/hummingbot/core/data_type/order_book_tracker_data_source.py
+++ b/hummingbot/core/data_type/order_book_tracker_data_source.py
@@ -19,11 +19,11 @@ class OrderBookTrackerDataSource(metaclass=ABCMeta):
     def __init__(self, trading_pairs: List[str]):
         self._trade_messages_queue_key = "trade"
         self._diff_messages_queue_key = "order_book_diff"
+        self._snapshot_messages_queue_key = "order_book_snapshot"
 
         self._trading_pairs: List[str] = trading_pairs
         self._order_book_create_function = lambda: OrderBook()
         self._message_queue: Dict[str, asyncio.Queue] = defaultdict(asyncio.Queue)
-        self._message_channels = [self._diff_messages_queue_key, self._trade_messages_queue_key]
 
     @classmethod
     def logger(cls) -> HummingbotLogger:
@@ -204,7 +204,12 @@ class OrderBookTrackerDataSource(metaclass=ABCMeta):
         async for ws_response in websocket_assistant.iter_messages():
             data: Dict[str, Any] = ws_response.data
             channel: str = self._channel_originating_message(event_message=data)
-            if channel in self._message_channels:
+            possible_channels = [
+                self._snapshot_messages_queue_key,
+                self._diff_messages_queue_key,
+                self._trade_messages_queue_key
+            ]
+            if channel in possible_channels:
                 self._message_queue[channel].put_nowait(data)
 
     async def _sleep(self, delay):

--- a/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_derivative.py
@@ -248,8 +248,25 @@ class BybitPerpetualDerivativeTests(AbstractPerpetualDerivativeTests.PerpetualDe
 
     @property
     def trading_rules_request_erroneous_mock_response(self):
-        mock_response = self.all_symbols_request_mock_response
-        del mock_response["result"][0]["base_currency"]
+        mock_response = {
+            "ret_code": 0,
+            "ret_msg": "OK",
+            "ext_code": "",
+            "ext_info": "",
+            "result": [
+                {
+                    "name": self.exchange_trading_pair,
+                    "alias": self.exchange_trading_pair,
+                    "status": "Trading",
+                    "base_currency": self.base_asset,
+                    "quote_currency": self.quote_asset,
+                    "price_scale": 2,
+                    "taker_fee": "0.00075",
+                    "maker_fee": "-0.00025",
+                },
+            ],
+            "time_now": "1615801223.589808",
+        }
         return mock_response
 
     @property

--- a/test/hummingbot/connector/exchange/latoken/test_latoken_exchange.py
+++ b/test/hummingbot/connector/exchange/latoken/test_latoken_exchange.py
@@ -156,6 +156,19 @@ class LatokenExchangeTests(TestCase):
         ticker_url = web_utils.public_rest_url(path_url=CONSTANTS.TICKER_PATH_URL, domain=self.domain)
         currency_url = web_utils.public_rest_url(path_url=CONSTANTS.CURRENCY_PATH_URL, domain=self.domain)
         pair_url = web_utils.public_rest_url(path_url=CONSTANTS.PAIR_PATH_URL, domain=self.domain)
+        ticker_list: List[Dict] = [
+            {"symbol": f"{base}/{quote}", "baseCurrency": self.base_asset,
+             "quoteCurrency": self.quote_asset, "volume24h": "0", "volume7d": "0",
+             "change24h": "0", "change7d": "0", "amount24h": "0", "amount7d": "0", "lastPrice": "0",
+             "lastQuantity": "0", "bestBid": "0", "bestBidQuantity": "0", "bestAsk": "0", "bestAskQuantity": "0",
+             "updateTimestamp": 0},
+            {"symbol": "NECC/USDT", "baseCurrency": "ad48cd21-4834-4b7d-ad32-10d8371bbf3c",
+             "quoteCurrency": "0c3a106d-bde3-4c13-a26e-3fd2394529e5", "volume24h": "0", "volume7d": "0",
+             "change24h": "0", "change7d": "0", "amount24h": "0", "amount7d": "0", "lastPrice": "0",
+             "lastQuantity": "0", "bestBid": "0", "bestBidQuantity": "0", "bestAsk": "0", "bestAskQuantity": "0",
+             "updateTimestamp": 0}
+        ]
+        mock_api.get(ticker_url, body=json.dumps(ticker_list))
         currency_list: List[Dict] = [
             {"id": self.base_asset, "status": "CURRENCY_STATUS_ACTIVE",
              "type": "CURRENCY_TYPE_CRYPTO", "name": base, "tag": base, "description": "", "logo": "", "decimals": 18,
@@ -195,7 +208,6 @@ class LatokenExchangeTests(TestCase):
         ]
 
         mock_api.get(pair_url, body=json.dumps(pair_list))
-        mock_api.get(ticker_url, body=json.dumps(pair_list))
 
         self.async_run_with_timeout(self.exchange._update_trading_rules())
 
@@ -897,7 +909,7 @@ class LatokenExchangeTests(TestCase):
 
     @aioresponses()
     def test_update_trading_rules_ignores_rule_with_error(self, mock_api):
-        pair_url = web_utils.public_rest_url(path_url=CONSTANTS.TICKER_PATH_URL, domain=self.domain)
+        pair_url = web_utils.public_rest_url(path_url=CONSTANTS.PAIR_PATH_URL, domain=self.domain)
 
         pair_list: List[Dict] = [
             {"id": "30a1032d-1e3e-4c28-8ca7-b60f3406fc3e", "status": "PAIR_STATUS_ACTIVE",


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Fix a bug introduced in the codebase that uses the same name for the websocket channels for all the connectors that are subclass of exchange py base.


**Tests performed by the developer**:
Run the script: format_status_example with all the connectors that are subclasses of exchange py base.


**Tips for QA testing**:
Can use the same script to check that, by default the script only has kucoin, gate and binance with ETH-USDT, but you can add more.

