### PR TITLE
Feat/separate buy sell hanging orders avellaneda

### DIFF
--- a/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pxd
+++ b/hummingbot/strategy/avellaneda_market_making/avellaneda_market_making.pxd
@@ -12,6 +12,8 @@ cdef class AvellanedaMarketMakingStrategy(StrategyBase):
         object _price_delegate
         object _minimum_spread
         bint _hanging_orders_enabled
+        bint _hanging_buy_orders_enabled
+        bint _hanging_sell_orders_enabled
         object _hanging_orders_cancel_pct
         object _hanging_orders_tracker
         bint _add_transaction_costs_to_orders

--- a/hummingbot/strategy/hanging_orders_tracker.py
+++ b/hummingbot/strategy/hanging_orders_tracker.py
@@ -94,16 +94,12 @@ class HangingOrdersTracker:
 
     @property
     def hanging_orders_cancel_pct(self):
-        self.logger().warning("The HangingOrder class is asymmetric, select buy or sell method.\n"
-                              "This method is being obsoleted.")
         if self._hanging_buy_orders_cancel_pct != self._hanging_sell_orders_cancel_pct:
             self.logger().error("This method returns an incorrect value for asymmetric HangingOrder.")
         return (self._hanging_buy_orders_cancel_pct + self._hanging_sell_orders_cancel_pct) * Decimal("0.5")
 
     @hanging_orders_cancel_pct.setter
     def hanging_orders_cancel_pct(self, value):
-        self.logger().warning("The HangingOrder class is asymmetric, select buy or sell method.\n"
-                              "This method is being obsoleted.")
         self._hanging_buy_orders_cancel_pct = value
         self._hanging_sell_orders_cancel_pct = value
 
@@ -269,7 +265,7 @@ class HangingOrdersTracker:
                 self._strategy_current_hanging_orders[OrdS.BUY] = self._strategy_current_hanging_orders[OrdS.BUY].union(
                     {o for o in executed_orders if o.is_buy})
             else:
-                self._strategy_current_hanging_orders[OrdS.BUY] = self._strategy_current_hanging_orders[
+                self._strategy_current_hanging_orders[OrdS.SELL] = self._strategy_current_hanging_orders[
                     OrdS.SELL].union(
                     {o for o in executed_orders if not o.is_buy})
 
@@ -297,20 +293,10 @@ class HangingOrdersTracker:
         self.original_orders.clear()
 
     def remove_all_buys(self):
-        to_be_removed = []
-        for order in self.original_orders:
-            if order.is_buy:
-                to_be_removed.append(order)
-        for order in to_be_removed:
-            self.original_orders.remove(order)
+        [self.original_orders.remove(order) for order in self.original_orders if order.is_buy]
 
     def remove_all_sells(self):
-        to_be_removed = []
-        for order in self.original_orders:
-            if not order.is_buy:
-                to_be_removed.append(order)
-        for order in to_be_removed:
-            self.original_orders.remove(order)
+        [self.original_orders.remove(order) for order in self.original_orders if not order.is_buy]
 
     def hanging_order_age(self, hanging_order: HangingOrder) -> float:
         """

--- a/hummingbot/strategy/hanging_orders_tracker.py
+++ b/hummingbot/strategy/hanging_orders_tracker.py
@@ -1,5 +1,6 @@
 import logging
 from decimal import Decimal
+from enum import Enum
 from typing import Dict, List, Optional, Set, Tuple, Union
 
 from hummingbot.connector.connector_base import ConnectorBase
@@ -20,11 +21,12 @@ sb_logger = None
 
 
 class CreatedPairOfOrders:
-    def __init__(self, buy_order: Optional[LimitOrder], sell_order: Optional[LimitOrder]):
+    def __init__(self, buy_order: Optional[LimitOrder], sell_order: Optional[LimitOrder], buy_fill: bool = False,
+                 sell_fill: bool = False):
         self.buy_order = buy_order
         self.sell_order = sell_order
-        self.filled_buy = False
-        self.filled_sell = False
+        self.filled_buy = buy_fill
+        self.filled_sell = sell_fill
 
     def contains_order(self, order_id: str):
         return ((self.buy_order is not None) and (self.buy_order.client_order_id == order_id)) or \
@@ -41,6 +43,11 @@ class CreatedPairOfOrders:
                 return self.sell_order
 
 
+class OrdS(Enum):
+    BUY = 1
+    SELL = 2
+
+
 class HangingOrdersTracker:
 
     @classmethod
@@ -54,16 +61,26 @@ class HangingOrdersTracker:
                  strategy: StrategyBase,
                  hanging_orders_cancel_pct=None,
                  orders: Dict[str, HangingOrder] = None,
-                 trading_pair: str = None):
+                 trading_pair: str = None,
+                 hanging_buy_orders_cancel_pct=None,
+                 hanging_sell_orders_cancel_pct=None,
+                 ):
         self.strategy: StrategyBase = strategy
-        self._hanging_orders_cancel_pct: Decimal = hanging_orders_cancel_pct or Decimal("0.1")
+        self._hanging_buy_orders_cancel_pct: Decimal = hanging_buy_orders_cancel_pct or hanging_orders_cancel_pct or Decimal(
+            "0.1")
+        self._hanging_sell_orders_cancel_pct: Decimal = hanging_sell_orders_cancel_pct or hanging_orders_cancel_pct or Decimal(
+            "0.1")
         self.trading_pair: str = trading_pair or self.strategy.trading_pair
         self.orders_being_renewed: Set[HangingOrder] = set()
         self.orders_being_cancelled: Set[str] = set()
         self.current_created_pairs_of_orders: List[CreatedPairOfOrders] = list()
         self.original_orders: Set[LimitOrder] = orders or set()
-        self.strategy_current_hanging_orders: Set[HangingOrder] = set()
-        self.completed_hanging_orders: Set[HangingOrder] = set()
+        self._strategy_current_hanging_orders: Dict[OrdS, Set[HangingOrder]] = dict()
+        self._strategy_current_hanging_orders[OrdS.BUY]: Set[HangingOrder] = set()
+        self._strategy_current_hanging_orders[OrdS.SELL]: Set[HangingOrder] = set()
+        self._completed_hanging_orders: Dict[OrdS, Set[HangingOrder]] = dict(set())
+        self._completed_hanging_orders[OrdS.BUY]: Set[HangingOrder] = set()
+        self._completed_hanging_orders[OrdS.SELL]: Set[HangingOrder] = set()
 
         self._cancel_order_forwarder: SourceInfoEventForwarder = SourceInfoEventForwarder(self._did_cancel_order)
         self._complete_buy_order_forwarder: SourceInfoEventForwarder = SourceInfoEventForwarder(
@@ -77,11 +94,57 @@ class HangingOrdersTracker:
 
     @property
     def hanging_orders_cancel_pct(self):
-        return self._hanging_orders_cancel_pct
+        self.logger().warning("The HangingOrder class is asymmetric, select buy or sell method.\n"
+                              "This method is being obsoleted.")
+        if self._hanging_buy_orders_cancel_pct != self._hanging_sell_orders_cancel_pct:
+            self.logger().error("This method returns an incorrect value for asymmetric HangingOrder.")
+        return (self._hanging_buy_orders_cancel_pct + self._hanging_sell_orders_cancel_pct) * Decimal("0.5")
 
     @hanging_orders_cancel_pct.setter
     def hanging_orders_cancel_pct(self, value):
-        self._hanging_orders_cancel_pct = value
+        self.logger().warning("The HangingOrder class is asymmetric, select buy or sell method.\n"
+                              "This method is being obsoleted.")
+        self._hanging_buy_orders_cancel_pct = value
+        self._hanging_sell_orders_cancel_pct = value
+
+    @property
+    def hanging_buy_orders_cancel_pct(self):
+        return self._hanging_buy_orders_cancel_pct
+
+    @hanging_buy_orders_cancel_pct.setter
+    def hanging_buy_orders_cancel_pct(self, value: Decimal):
+        if not value.is_nan():
+            self._hanging_buy_orders_cancel_pct = max(s_decimal_zero, value)
+        else:
+            self._hanging_buy_orders_cancel_pct = value
+
+    @property
+    def hanging_sell_orders_cancel_pct(self):
+        return self._hanging_sell_orders_cancel_pct
+
+    @hanging_sell_orders_cancel_pct.setter
+    def hanging_sell_orders_cancel_pct(self, value: Decimal):
+        if not value.is_nan():
+            self._hanging_sell_orders_cancel_pct = max(s_decimal_zero, value)
+        else:
+            self._hanging_sell_orders_cancel_pct = value
+
+    @property
+    def strategy_current_hanging_orders(self):
+        return self._current_ho
+
+    @property
+    def completed_hanging_orders(self):
+        return self._completed_ho
+
+    # Shortcuts
+    @property
+    def _current_ho(self):
+        return self._strategy_current_hanging_orders[OrdS.BUY].union(self._strategy_current_hanging_orders[OrdS.SELL])
+
+    @property
+    def _completed_ho(self):
+        return self._completed_hanging_orders[OrdS.BUY].union(self._completed_hanging_orders[OrdS.SELL])
 
     def register_events(self, markets: List[ConnectorBase]):
         """Start listening to events from the given markets."""
@@ -103,11 +166,17 @@ class HangingOrdersTracker:
         self._process_cancel_as_part_of_renew(event)
 
         self.orders_being_cancelled.discard(event.order_id)
-        order_to_be_removed = next((order for order in self.strategy_current_hanging_orders
-                                    if order.order_id == event.order_id), None)
-        if order_to_be_removed:
-            self.strategy_current_hanging_orders.remove(order_to_be_removed)
-            self.logger().notify(f"({self.trading_pair}) Hanging order {event.order_id} canceled.")
+
+        # Removing buy/sell orders
+        order_to_be_removed = next((o for o in self._current_ho if o.order_id == event.order_id), None)
+
+        if order_to_be_removed in self._strategy_current_hanging_orders[OrdS.BUY]:
+            self._strategy_current_hanging_orders[OrdS.BUY].remove(order_to_be_removed)
+            self.logger().notify(f"({self.trading_pair}) Hanging BUY order {event.order_id} canceled.")
+
+        if order_to_be_removed in self._strategy_current_hanging_orders[OrdS.SELL]:
+            self._strategy_current_hanging_orders[OrdS.SELL].remove(order_to_be_removed)
+            self.logger().notify(f"({self.trading_pair}) Hanging SELL order {event.order_id} canceled.")
 
         limit_order_to_be_removed = next((order for order in self.original_orders
                                           if order.client_order_id == event.order_id), None)
@@ -129,9 +198,7 @@ class HangingOrdersTracker:
     def _did_complete_order(self,
                             event: Union[BuyOrderCompletedEvent, SellOrderCompletedEvent],
                             is_buy: bool):
-        hanging_order = next((hanging_order for hanging_order in self.strategy_current_hanging_orders
-                              if hanging_order.order_id == event.order_id), None)
-
+        hanging_order = next((ho for ho in self._current_ho if ho.order_id == event.order_id), None)
         if hanging_order:
             self._did_complete_hanging_order(hanging_order)
         else:
@@ -143,9 +210,15 @@ class HangingOrdersTracker:
     def _did_complete_hanging_order(self, order: HangingOrder):
 
         if order:
-            order_side = "BUY" if order.is_buy else "SELL"
-            self.completed_hanging_orders.add(order)
-            self.strategy_current_hanging_orders.remove(order)
+            if order.is_buy:
+                order_side = "BUY"
+                self._completed_hanging_orders[OrdS.BUY].add(order)
+                self._strategy_current_hanging_orders[OrdS.BUY].remove(order)
+            else:
+                order_side = "SELL"
+                self._completed_hanging_orders[OrdS.SELL].add(order)
+                self._strategy_current_hanging_orders[OrdS.SELL].remove(order)
+
             self.logger().notify(
                 f"({self.trading_pair}) Hanging maker {order_side} order {order.order_id} "
                 f"({order.trading_pair} {order.amount} @ "
@@ -172,10 +245,17 @@ class HangingOrdersTracker:
     def _process_cancel_as_part_of_renew(self, event: OrderCancelledEvent):
         renewing_order = next((order for order in self.orders_being_renewed if order.order_id == event.order_id), None)
         if renewing_order:
-            self.logger().info(f"({self.trading_pair}) Hanging order {event.order_id} "
-                               f"has been canceled as part of the renew process. "
-                               f"Now the replacing order will be created.")
-            self.strategy_current_hanging_orders.remove(renewing_order)
+            if renewing_order.is_buy:
+                self.logger().info(f"({self.trading_pair}) Hanging BUY order {event.order_id} "
+                                   f"has been canceled as part of the renew process. "
+                                   f"Now the replacing order will be created.")
+                self._strategy_current_hanging_orders[OrdS.BUY].remove(renewing_order)
+            else:
+                self.logger().info(f"({self.trading_pair}) Hanging SELL order {event.order_id} "
+                                   f"has been canceled as part of the renew process. "
+                                   f"Now the replacing order will be created.")
+                self._strategy_current_hanging_orders[OrdS.SELL].remove(renewing_order)
+
             self.orders_being_renewed.remove(renewing_order)
             order_to_be_created = HangingOrder(None,
                                                renewing_order.trading_pair,
@@ -184,8 +264,15 @@ class HangingOrdersTracker:
                                                renewing_order.amount,
                                                self.strategy.current_timestamp)
 
-            executed_orders = self._execute_orders_in_strategy([order_to_be_created])
-            self.strategy_current_hanging_orders = self.strategy_current_hanging_orders.union(executed_orders)
+            executed_orders = self._execute_orders_in_strategy({order_to_be_created})
+            if renewing_order.is_buy:
+                self._strategy_current_hanging_orders[OrdS.BUY] = self._strategy_current_hanging_orders[OrdS.BUY].union(
+                    {o for o in executed_orders if o.is_buy})
+            else:
+                self._strategy_current_hanging_orders[OrdS.BUY] = self._strategy_current_hanging_orders[
+                    OrdS.SELL].union(
+                    {o for o in executed_orders if not o.is_buy})
+
             for new_hanging_order in executed_orders:
                 limit_order_from_hanging_order = next((o for o in self.strategy.active_orders
                                                        if o.client_order_id == new_hanging_order.order_id), None)
@@ -196,7 +283,10 @@ class HangingOrdersTracker:
         self.original_orders.add(order)
 
     def add_as_hanging_order(self, order: LimitOrder):
-        self.strategy_current_hanging_orders.add(self._get_hanging_order_from_limit_order(order))
+        if order.is_buy:
+            self._strategy_current_hanging_orders[OrdS.BUY].add(self._get_hanging_order_from_limit_order(order))
+        else:
+            self._strategy_current_hanging_orders[OrdS.SELL].add(self._get_hanging_order_from_limit_order(order))
         self.add_order(order)
 
     def remove_order(self, order: LimitOrder):
@@ -234,7 +324,7 @@ class HangingOrdersTracker:
         to_be_cancelled: Set[HangingOrder] = set()
         max_order_age = getattr(self.strategy, "max_order_age", None)
         if max_order_age:
-            for order in self.strategy_current_hanging_orders:
+            for order in self._current_ho:
                 if self.hanging_order_age(order) > max_order_age and order not in self.orders_being_renewed:
                     self.logger().info(f"Reached max_order_age={max_order_age}sec hanging order: {order}. Renewing...")
                     to_be_cancelled.add(order)
@@ -247,9 +337,16 @@ class HangingOrdersTracker:
         orders_to_be_removed = set()
         for order in self.original_orders:
             if (order.client_order_id not in self.orders_being_cancelled
-                    and abs(order.price - current_price) / current_price > self._hanging_orders_cancel_pct):
+                    and order.is_buy and abs(
+                        order.price - current_price) / current_price > self._hanging_buy_orders_cancel_pct):
                 self.logger().info(
-                    f"Hanging order passed max_distance from price={self._hanging_orders_cancel_pct * 100}% {order}. Removing...")
+                    f"Hanging BUY order passed max_distance from price={self._hanging_buy_orders_cancel_pct * 100}% {order}. Removing...")
+                orders_to_be_removed.add(order)
+            if (order.client_order_id not in self.orders_being_cancelled
+                    and not order.is_buy and abs(
+                        order.price - current_price) / current_price > self._hanging_sell_orders_cancel_pct):
+                self.logger().info(
+                    f"Hanging SELL order passed max_distance from price={self._hanging_sell_orders_cancel_pct * 100}% {order}. Removing...")
                 orders_to_be_removed.add(order)
 
         self._cancel_multiple_orders_in_strategy([order.client_order_id for order in orders_to_be_removed])
@@ -271,10 +368,10 @@ class HangingOrdersTracker:
         return any((o.order_id == order_id for o in self.completed_hanging_orders))
 
     def is_hanging_order_in_strategy_active_orders(self, order: HangingOrder) -> bool:
-        return any(all(order.trading_pair == o.trading_pair,
-                       order.is_buy == o.is_buy,
-                       order.price == o.price,
-                       order.amount == o.quantity) for o in self.strategy.active_orders)
+        return any(all([order.trading_pair == o.trading_pair,
+                        order.is_buy == o.is_buy,
+                        order.price == o.price,
+                        order.amount == o.quantity]) for o in self.strategy.active_orders)
 
     def is_potential_hanging_order(self, order: LimitOrder) -> bool:
         """Checks if the order is registered as a hanging order."""
@@ -291,8 +388,9 @@ class HangingOrdersTracker:
         self._add_hanging_orders_based_on_partially_executed_pairs()
 
         equivalent_orders = self.equivalent_orders
-        orders_to_create = equivalent_orders.difference(self.strategy_current_hanging_orders)
-        orders_to_cancel = self.strategy_current_hanging_orders.difference(equivalent_orders)
+
+        orders_to_create = equivalent_orders.difference(self._current_ho)
+        orders_to_cancel = self._current_ho.difference(equivalent_orders)
 
         self._cancel_multiple_orders_in_strategy([o.order_id for o in orders_to_cancel])
 
@@ -304,7 +402,10 @@ class HangingOrdersTracker:
             self.logger().info(f"Need to cancel: {orders_to_cancel}")
 
         executed_orders = self._execute_orders_in_strategy(orders_to_create)
-        self.strategy_current_hanging_orders = self.strategy_current_hanging_orders.union(executed_orders)
+        self._strategy_current_hanging_orders[OrdS.BUY] = self._strategy_current_hanging_orders[OrdS.BUY].union(
+            {e for e in executed_orders if e.is_buy})
+        self._strategy_current_hanging_orders[OrdS.SELL] = self._strategy_current_hanging_orders[OrdS.SELL].union(
+            {e for e in executed_orders if not e.is_buy})
 
     def _execute_orders_in_strategy(self, candidate_orders: Set[HangingOrder]):
         new_hanging_orders = set()

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pxd
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pxd
@@ -28,7 +28,6 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         bint _inventory_skew_enabled
         object _inventory_target_base_pct
         object _inventory_range_multiplier
-        bint _hanging_orders_enabled
         bint _hanging_orders_asymmetry_enabled
         bint _hanging_buy_orders_enabled
         bint _hanging_sell_orders_enabled

--- a/hummingbot/strategy/pure_market_making/pure_market_making.pxd
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pxd
@@ -29,6 +29,9 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         object _inventory_target_base_pct
         object _inventory_range_multiplier
         bint _hanging_orders_enabled
+        bint _hanging_orders_asymmetry_enabled
+        bint _hanging_buy_orders_enabled
+        bint _hanging_sell_orders_enabled
         object _hanging_orders_tracker
         bint _order_optimization_enabled
         object _ask_order_optimization_depth

--- a/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
+++ b/hummingbot/strategy/pure_market_making/pure_market_making_config_map.py
@@ -289,7 +289,19 @@ pure_market_making_config_map = {
                   default=60),
     "hanging_orders_enabled":
         ConfigVar(key="hanging_orders_enabled",
-                  prompt="Do you want to enable hanging orders? (Yes/No) >>> ",
+                  prompt="Do you want to enable hanging BUY&SELL orders? (Yes/No) >>> ",
+                  type_str="bool",
+                  default=False,
+                  validator=validate_bool),
+    "hanging_buy_orders_enabled":
+        ConfigVar(key="hanging_buy_orders_enabled",
+                  prompt="Do you want to enable hanging BUY orders? (Yes/No) >>> ",
+                  type_str="bool",
+                  default=False,
+                  validator=validate_bool),
+    "hanging_sell_orders_enabled":
+        ConfigVar(key="hanging_sell_orders_enabled",
+                  prompt="Do you want to enable hanging SELL orders? (Yes/No) >>> ",
                   type_str="bool",
                   default=False,
                   validator=validate_bool),
@@ -297,7 +309,7 @@ pure_market_making_config_map = {
         ConfigVar(key="hanging_orders_cancel_pct",
                   prompt="At what spread percentage (from mid price) will hanging orders be canceled? "
                          "(Enter 1 to indicate 1%) >>> ",
-                  required_if=lambda: pure_market_making_config_map.get("hanging_orders_enabled").value,
+                  required_if=lambda: pure_market_making_config_map.get("hanging_orders_enabled").value or pure_market_making_config_map.get("hanging_buy_orders_enabled").value or pure_market_making_config_map.get("hanging_sell_orders_enabled").value,
                   type_str="decimal",
                   default=Decimal("10"),
                   validator=lambda v: validate_decimal(v, 0, 100, inclusive=False)),

--- a/hummingbot/strategy/pure_market_making/start.py
+++ b/hummingbot/strategy/pure_market_making/start.py
@@ -40,7 +40,8 @@ def start(self):
             c_map.get("inventory_target_base_pct").value / Decimal('100')
         inventory_range_multiplier = c_map.get("inventory_range_multiplier").value
         filled_order_delay = c_map.get("filled_order_delay").value
-        hanging_orders_enabled = c_map.get("hanging_orders_enabled").value
+        hanging_buy_orders_enabled = c_map.get("hanging_buy_orders_enabled").value
+        hanging_sell_orders_enabled = c_map.get("hanging_sell_orders_enabled").value
         hanging_orders_cancel_pct = c_map.get("hanging_orders_cancel_pct").value / Decimal('100')
         order_optimization_enabled = c_map.get("order_optimization_enabled").value
         ask_order_optimization_depth = c_map.get("ask_order_optimization_depth").value
@@ -115,7 +116,8 @@ def start(self):
             inventory_target_base_pct=inventory_target_base_pct,
             inventory_range_multiplier=inventory_range_multiplier,
             filled_order_delay=filled_order_delay,
-            hanging_orders_enabled=hanging_orders_enabled,
+            hanging_buy_orders_enabled=hanging_buy_orders_enabled,
+            hanging_sell_orders_enabled=hanging_sell_orders_enabled,
             order_refresh_time=order_refresh_time,
             max_order_age=max_order_age,
             order_optimization_enabled=order_optimization_enabled,

--- a/hummingbot/templates/conf_pure_market_making_strategy_TEMPLATE.yml
+++ b/hummingbot/templates/conf_pure_market_making_strategy_TEMPLATE.yml
@@ -2,7 +2,7 @@
 ###       Pure market making strategy config         ###
 ########################################################
 
-template_version: 24
+template_version: 25
 strategy: null
 
 # Exchange and token parameters.
@@ -90,6 +90,14 @@ filled_order_delay: null
 # Whether to stop cancellations of orders on the other side (of the order book),
 # when one side is filled (hanging orders feature) (true/false).
 hanging_orders_enabled: null
+
+# Whether to stop cancellations of BUY orders on the other side (of the order book),
+# when one SELL is filled (hanging orders feature) (true/false).
+hanging_buy_orders_enabled: null
+
+# Whether to stop cancellations of SELL orders on the other side (of the order book),
+# when one BUY is filled (hanging orders feature) (true/false).
+hanging_sell_orders_enabled: null
 
 # Spread (from mid price, in percentage) hanging orders will be canceled (Enter 1 to indicate 1%)
 hanging_orders_cancel_pct: null

--- a/hummingbot/templates/conf_pure_market_making_strategy_TEMPLATE.yml
+++ b/hummingbot/templates/conf_pure_market_making_strategy_TEMPLATE.yml
@@ -87,10 +87,6 @@ order_level_spread: null
 # How long to wait before placing the next order in case your order gets filled.
 filled_order_delay: null
 
-# Whether to stop cancellations of orders on the other side (of the order book),
-# when one side is filled (hanging orders feature) (true/false).
-hanging_orders_enabled: null
-
 # Whether to stop cancellations of BUY orders on the other side (of the order book),
 # when one SELL is filled (hanging orders feature) (true/false).
 hanging_buy_orders_enabled: null

--- a/test/hummingbot/strategy/avellaneda_market_making/test_avellaneda_market_making_start.py
+++ b/test/hummingbot/strategy/avellaneda_market_making/test_avellaneda_market_making_start.py
@@ -8,11 +8,11 @@ from hummingbot.client.config.client_config_map import ClientConfigMap
 from hummingbot.client.config.config_helpers import ClientConfigAdapter
 from hummingbot.connector.exchange_base import ExchangeBase
 from hummingbot.connector.utils import combine_to_hb_trading_pair
-from hummingbot.strategy.avellaneda_market_making.avellaneda_market_making_config_map_pydantic import (
+from hummingbot.strategy.avellaneda_market_making.avellaneda_market_making_config_map_pydantic import (  # TrackHangingBuyOrdersOnlyModel,; TrackHangingSellOrdersOnlyModel,
     AvellanedaMarketMakingConfigMap,
     FromDateToDateModel,
     MultiOrderLevelModel,
-    TrackHangingOrdersModel,
+    TrackHangingBuyAndSellOrdersModel,
 )
 
 
@@ -38,7 +38,7 @@ class AvellanedaStartTest(unittest.TestCase):
                 ),
                 order_amount=60,
                 order_refresh_time=60,
-                hanging_orders_mode=TrackHangingOrdersModel(
+                hanging_orders_mode=TrackHangingBuyAndSellOrdersModel(
                     hanging_orders_cancel_pct=1,
                 ),
                 order_levels_mode=MultiOrderLevelModel(

--- a/test/hummingbot/strategy/pure_market_making/test_pmm.py
+++ b/test/hummingbot/strategy/pure_market_making/test_pmm.py
@@ -650,10 +650,10 @@ class PMMUnitTest(unittest.TestCase):
 
     def test_hanging_flag_mechanic(self):
         strategy = self.one_level_strategy
-        strategy.hanging_orders_enabled = True
 
         # Disabling
-        strategy.hanging_orders_enabled = False
+        strategy.hanging_buy_orders_enabled = False
+        strategy.hanging_sell_orders_enabled = False
 
         self.assertFalse(strategy.hanging_orders_enabled)
         # buy/sell are set to False when disabling hanging orders
@@ -664,20 +664,14 @@ class PMMUnitTest(unittest.TestCase):
         strategy.hanging_buy_orders_enabled = True
         self.assertTrue(strategy.hanging_buy_orders_enabled)
         self.assertTrue(strategy.hanging_orders_enabled)
-        # Resetting 'master' to False sets BUY/SELL to False
-        strategy.hanging_orders_enabled = False
-        self.assertFalse(strategy.hanging_buy_orders_enabled)
-        self.assertFalse(strategy.hanging_sell_orders_enabled)
         # Setting SELL True triggers the 'master switch'
         strategy.hanging_sell_orders_enabled = True
         self.assertTrue(strategy.hanging_sell_orders_enabled)
         self.assertTrue(strategy.hanging_orders_enabled)
-        strategy.hanging_orders_enabled = False
-        self.assertFalse(strategy.hanging_buy_orders_enabled)
-        self.assertFalse(strategy.hanging_sell_orders_enabled)
 
         # Enabling
-        strategy.hanging_orders_enabled = True
+        strategy.hanging_buy_orders_enabled = True
+        strategy.hanging_sell_orders_enabled = True
 
         self.assertTrue(strategy.hanging_orders_enabled)
         # buy/sell follows the master switch
@@ -689,7 +683,7 @@ class PMMUnitTest(unittest.TestCase):
         self.assertTrue(Decimal("0.1"), strategy.hanging_orders_cancel_pct)
 
         # Disabling Sell
-        strategy.hanging_orders_enabled = True
+        strategy.hanging_buy_orders_enabled = True
         strategy.hanging_sell_orders_enabled = False
 
         self.assertTrue(strategy.hanging_orders_enabled)
@@ -699,7 +693,7 @@ class PMMUnitTest(unittest.TestCase):
         self.assertTrue(Decimal("0.1"), strategy.hanging_orders_cancel_pct)
 
         # Disabling Buy
-        strategy.hanging_orders_enabled = True
+        strategy.hanging_sell_orders_enabled = True
         strategy.hanging_buy_orders_enabled = False
 
         self.assertTrue(strategy.hanging_orders_enabled)
@@ -722,7 +716,8 @@ class PMMUnitTest(unittest.TestCase):
         strategy = self.one_level_strategy
         strategy.order_refresh_time = 4.0
         strategy.filled_order_delay = 8.0
-        strategy.hanging_orders_enabled = True
+        strategy.hanging_buy_orders_enabled = True
+        strategy.hanging_sell_orders_enabled = True
         strategy.hanging_orders_cancel_pct = Decimal("0.05")
         self.clock.add_iterator(strategy)
         self.clock.backtest_til(self.start_timestamp + 1)
@@ -767,7 +762,7 @@ class PMMUnitTest(unittest.TestCase):
         strategy = self.one_level_strategy
         strategy.order_refresh_time = 4.0
         strategy.filled_order_delay = 8.0
-        strategy.hanging_orders_enabled = True
+        strategy.hanging_buy_orders_enabled = True
         strategy.hanging_sell_orders_enabled = True
         strategy.hanging_orders_cancel_pct = Decimal("0.05")
         self.clock.add_iterator(strategy)
@@ -813,7 +808,7 @@ class PMMUnitTest(unittest.TestCase):
         strategy = self.one_level_strategy
         strategy.order_refresh_time = 4.0
         strategy.filled_order_delay = 8.0
-        strategy.hanging_orders_enabled = True
+        strategy.hanging_buy_orders_enabled = True
         strategy.hanging_orders_cancel_pct = Decimal("0.05")
         strategy.hanging_sell_orders_enabled = False
         self.clock.add_iterator(strategy)
@@ -842,7 +837,7 @@ class PMMUnitTest(unittest.TestCase):
         strategy = self.one_level_strategy
         strategy.order_refresh_time = 4.0
         strategy.filled_order_delay = 8.0
-        strategy.hanging_orders_enabled = True
+        strategy.hanging_buy_orders_enabled = True
         strategy.hanging_sell_orders_enabled = False
         strategy.hanging_orders_cancel_pct = Decimal("0.05")
         self.clock.add_iterator(strategy)
@@ -888,7 +883,7 @@ class PMMUnitTest(unittest.TestCase):
         strategy = self.one_level_strategy
         strategy.order_refresh_time = 4.0
         strategy.filled_order_delay = 8.0
-        strategy.hanging_orders_enabled = True
+        strategy.hanging_sell_orders_enabled = True
         strategy.hanging_buy_orders_enabled = False
         strategy.hanging_orders_cancel_pct = Decimal("0.05")
         self.clock.add_iterator(strategy)
@@ -919,7 +914,6 @@ class PMMUnitTest(unittest.TestCase):
         # be calculated. We manually add the order to to_recreate_hanging_orders and trigger order cancel event here to
         # simulate the recreate.
         strategy = self.one_level_strategy
-        strategy.hanging_orders_enabled = True
         strategy.hanging_sell_orders_enabled = True
 
         self.clock.add_iterator(strategy)
@@ -952,7 +946,6 @@ class PMMUnitTest(unittest.TestCase):
         # be calculated. We manually add the order to to_recreate_hanging_orders and trigger order cancel event here to
         # simulate the recreate.
         strategy = self.one_level_strategy
-        strategy.hanging_orders_enabled = True
         strategy.hanging_buy_orders_enabled = True
 
         self.clock.add_iterator(strategy)
@@ -982,10 +975,9 @@ class PMMUnitTest(unittest.TestCase):
         strategy = self.multi_levels_strategy
         strategy.order_refresh_time = 4.0
         strategy.filled_order_delay = 8.0
-        strategy.hanging_orders_enabled = True
-        strategy.hanging_orders_cancel_pct = Decimal("0.05")
         strategy.hanging_buy_orders_enabled = True
         strategy.hanging_sell_orders_enabled = True
+        strategy.hanging_orders_cancel_pct = Decimal("0.05")
         self.clock.add_iterator(strategy)
         self.clock.backtest_til(self.start_timestamp + 1)
         self.assertEqual(3, len(strategy.active_buys))
@@ -1024,7 +1016,6 @@ class PMMUnitTest(unittest.TestCase):
         self.assertEqual(3, len(strategy.active_buys))
         self.assertEqual(3, len(strategy.active_sells))
         self.assertFalse(any(o.client_order_id in strategy.hanging_order_ids for o in strategy.active_sells))
-        self.assertFalse(any(o.client_order_id in strategy.hanging_sell_order_ids for o in strategy.active_sells))
 
         self.order_fill_logger.clear()
 
@@ -1032,10 +1023,9 @@ class PMMUnitTest(unittest.TestCase):
         strategy = self.multi_levels_strategy
         strategy.order_refresh_time = 4.0
         strategy.filled_order_delay = 8.0
-        strategy.hanging_orders_enabled = True
-        strategy.hanging_orders_cancel_pct = Decimal("0.05")
         strategy.hanging_buy_orders_enabled = True
         strategy.hanging_sell_orders_enabled = False
+        strategy.hanging_orders_cancel_pct = Decimal("0.05")
         self.clock.add_iterator(strategy)
         self.clock.backtest_til(self.start_timestamp + 1)
         self.assertEqual(3, len(strategy.active_buys))
@@ -1071,10 +1061,9 @@ class PMMUnitTest(unittest.TestCase):
         strategy = self.multi_levels_strategy
         strategy.order_refresh_time = 4.0
         strategy.filled_order_delay = 8.0
-        strategy.hanging_orders_enabled = True
-        strategy.hanging_orders_cancel_pct = Decimal("0.05")
         strategy.hanging_buy_orders_enabled = True
         strategy.hanging_sell_orders_enabled = True
+        strategy.hanging_orders_cancel_pct = Decimal("0.05")
         self.clock.add_iterator(strategy)
         self.clock.backtest_til(self.start_timestamp + 1)
         self.assertEqual(3, len(strategy.active_buys))
@@ -1120,10 +1109,9 @@ class PMMUnitTest(unittest.TestCase):
         strategy = self.multi_levels_strategy
         strategy.order_refresh_time = 4.0
         strategy.filled_order_delay = 8.0
-        strategy.hanging_orders_enabled = True
-        strategy.hanging_orders_cancel_pct = Decimal("0.05")
         strategy.hanging_buy_orders_enabled = False
         strategy.hanging_sell_orders_enabled = True
+        strategy.hanging_orders_cancel_pct = Decimal("0.05")
         self.clock.add_iterator(strategy)
         self.clock.backtest_til(self.start_timestamp + 1)
         self.assertEqual(3, len(strategy.active_buys))

--- a/test/hummingbot/strategy/pure_market_making/test_pmm.py
+++ b/test/hummingbot/strategy/pure_market_making/test_pmm.py
@@ -862,6 +862,9 @@ class PMMUnitTest(unittest.TestCase):
 
         self.simulate_maker_market_trade(True, 100, 101.1)
 
+        self.assertEqual(1, len(strategy.active_buys))
+        self.assertEqual(0, len(strategy.active_sells))
+
         # Ask is filled and due to delay is not replenished immediately
         # Bid order is now hanging but is active
         self.clock.backtest_til(self.start_timestamp + strategy.order_refresh_time + 1)
@@ -908,23 +911,27 @@ class PMMUnitTest(unittest.TestCase):
         self.clock.add_iterator(strategy)
         self.clock.backtest_til(self.start_timestamp + 1)
         self.assertEqual(1, len(strategy.active_buys))
+        self.assertEqual(1, len(strategy.active_sells))
 
-        self.simulate_maker_market_trade(False, 100, 101.1)
+        self.simulate_maker_market_trade(True, 100, 101.1)
+
+        self.assertEqual(1, len(strategy.active_buys))
+        self.assertEqual(0, len(strategy.active_sells))
 
         # Bid is filled and due to delay is not replenished immediately
         # Ask order is now hanging but is active
         self.clock.backtest_til(self.start_timestamp + strategy.order_refresh_time + 1)
-        self.assertEqual(0, len(self.order_fill_logger.event_log))
+        self.assertEqual(1, len(self.order_fill_logger.event_log))
         self.assertEqual(0, len(strategy.active_buys))
-        self.assertEqual(1, len(strategy.active_sells))
-        self.assertEqual(1, len(strategy.hanging_order_ids))
+        self.assertEqual(0, len(strategy.active_sells))
+        self.assertEqual(0, len(strategy.hanging_order_ids))
         self.assertEqual(0, len(strategy.hanging_buy_order_ids))
-        self.assertEqual(1, len(strategy.hanging_sell_order_ids))
+        self.assertEqual(0, len(strategy.hanging_sell_order_ids))
 
         # At filled_order_delay, a new set of bid and ask orders (one each) is created
         self.clock.backtest_til(self.start_timestamp + strategy.order_refresh_time * 2 + 2)
-        self.assertEqual(0, len(strategy.active_buys))
-        self.assertEqual(2, len(strategy.active_sells))
+        self.assertEqual(1, len(strategy.active_buys))
+        self.assertEqual(1, len(strategy.active_sells))
 
         self.order_fill_logger.clear()
 
@@ -1079,34 +1086,22 @@ class PMMUnitTest(unittest.TestCase):
         self.assertEqual(0, len(strategy.hanging_sell_order_ids))
         self.assertEqual(0, len(strategy.hanging_buy_order_ids))
 
-        # At order_refresh_time, hanging BUY orders are created.
-        # Hanging orders proposed for the buy side since sells were canceled
+        # At order_refresh_time, hanging orders would be created for sell,
+        # but are not enabled
         self.clock.backtest_til(self.start_timestamp + strategy.order_refresh_time + 1)
 
-        self.assertEqual(2, len(strategy.active_buys))
+        self.assertEqual(0, len(strategy.active_buys))
         self.assertEqual(0, len(strategy.active_sells))
-        self.assertEqual(2, len(strategy.hanging_order_ids))
+        self.assertEqual(0, len(strategy.hanging_order_ids))
         self.assertEqual(0, len(strategy.hanging_sell_order_ids))
-        self.assertEqual(2, len(strategy.hanging_buy_order_ids))
+        self.assertEqual(0, len(strategy.hanging_buy_order_ids))
 
         # At filled_order_delay, a new set of bid and ask orders (one each) is created
         self.clock.backtest_til(self.start_timestamp + strategy.order_refresh_time + strategy.filled_order_delay + 1)
-        self.assertEqual(5, len(strategy.active_buys))
-        self.assertEqual(3, len(strategy.active_sells))
-
-        self.assertTrue(all(id in (order.client_order_id for order in strategy.active_buys)
-                            for id in strategy.hanging_order_ids))
-        self.assertTrue(all(id in (order.client_order_id for order in strategy.active_buys)
-                            for id in strategy.hanging_buy_order_ids))
-
-        simulate_order_book_widening(self.market.order_books[self.trading_pair], 100, 120)
-        # As book bids moving lower, the ask hanging order price spread is now more than the hanging_orders_cancel_pct
-        # Hanging order is canceled and removed from the active list
-        self.clock.backtest_til(self.start_timestamp + strategy.order_refresh_time * 2 + strategy.filled_order_delay + 1)
         self.assertEqual(3, len(strategy.active_buys))
         self.assertEqual(3, len(strategy.active_sells))
-        self.assertFalse(any(o.client_order_id in strategy.hanging_order_ids for o in strategy.active_sells))
-        self.assertFalse(any(o.client_order_id in strategy.hanging_sell_order_ids for o in strategy.active_sells))
+        self.assertEqual(0, len(strategy.hanging_sell_order_ids))
+        self.assertEqual(0, len(strategy.hanging_buy_order_ids))
 
         self.order_fill_logger.clear()
 
@@ -1192,34 +1187,22 @@ class PMMUnitTest(unittest.TestCase):
         self.assertEqual(0, len(strategy.hanging_buy_order_ids))
         self.assertEqual(0, len(strategy.hanging_sell_order_ids))
 
-        # At order_refresh_time, hanging orders are created for SELL,
-        # since active BUY orders are cancelled
+        # At order_refresh_time, hanging orders would be created for buy,
+        # but are not enabled
         self.clock.backtest_til(self.start_timestamp + strategy.order_refresh_time + 1)
 
         self.assertEqual(0, len(strategy.active_buys))
-        self.assertEqual(2, len(strategy.active_sells))
-        self.assertEqual(2, len(strategy.hanging_order_ids))
+        self.assertEqual(0, len(strategy.active_sells))
+        self.assertEqual(0, len(strategy.hanging_order_ids))
         self.assertEqual(0, len(strategy.hanging_buy_order_ids))
-        self.assertEqual(2, len(strategy.hanging_sell_order_ids))
+        self.assertEqual(0, len(strategy.hanging_sell_order_ids))
 
         # At filled_order_delay, a new set of bid and ask orders (one each) is created
         self.clock.backtest_til(self.start_timestamp + strategy.order_refresh_time + strategy.filled_order_delay + 1)
         self.assertEqual(3, len(strategy.active_buys))
-        self.assertEqual(5, len(strategy.active_sells))
-
-        self.assertTrue(all(id in (order.client_order_id for order in strategy.active_sells)
-                            for id in strategy.hanging_order_ids))
-        self.assertTrue(all(id in (order.client_order_id for order in strategy.active_sells)
-                            for id in strategy.hanging_sell_order_ids))
-
-        simulate_order_book_widening(self.market.order_books[self.trading_pair], 80, 100)
-        # As book bids moving lower, the ask hanging order price spread is now more than the hanging_orders_cancel_pct
-        # Hanging order is canceled and removed from the active list
-        self.clock.backtest_til(self.start_timestamp + strategy.order_refresh_time * 2 + strategy.filled_order_delay + 1)
-        self.assertEqual(3, len(strategy.active_buys))
         self.assertEqual(3, len(strategy.active_sells))
-        self.assertFalse(any(o.client_order_id in strategy.hanging_order_ids for o in strategy.active_sells))
-        self.assertFalse(any(o.client_order_id in strategy.hanging_sell_order_ids for o in strategy.active_sells))
+        self.assertEqual(0, len(strategy.hanging_buy_order_ids))
+        self.assertEqual(0, len(strategy.hanging_sell_order_ids))
 
         self.order_fill_logger.clear()
 
@@ -1621,7 +1604,7 @@ class PMMUnitTest(unittest.TestCase):
 
         strategy._sb_order_tracker.in_flight_cancels["OID-1"] = strategy.current_timestamp
 
-        available_base_balance, available_quote_balance = strategy.adjusted_available_balance_for_orders_budget_constrain()
+        available_base_balance, available_quote_balance = strategy.adjusted_available_balance_for_orders_budget_constraint()
 
         self.assertEqual(available_base_balance, base_balance + Decimal(2))
         self.assertEqual(available_quote_balance, quote_balance + (Decimal(1) * Decimal(1000)))

--- a/test/hummingbot/strategy/pure_market_making/test_pmm.py
+++ b/test/hummingbot/strategy/pure_market_making/test_pmm.py
@@ -738,11 +738,8 @@ class PMMUnitTest(unittest.TestCase):
         self.assertEqual(0, len(strategy.active_buys))
         self.assertEqual(1, len(strategy.active_sells))
         self.assertEqual(1, len(strategy.hanging_order_ids))
-        self.assertEqual(0, len(strategy.hanging_buy_order_ids))
-        self.assertEqual(1, len(strategy.hanging_sell_order_ids))
         hanging_sell = strategy.active_sells[0]
         self.assertEqual(hanging_sell.client_order_id, strategy.hanging_order_ids[0])
-        self.assertEqual(hanging_sell.client_order_id, strategy.hanging_sell_order_ids[0])
 
         # At order_refresh_time, hanging order remains.
         self.clock.backtest_til(self.start_timestamp + strategy.order_refresh_time * 2 + 1)
@@ -763,7 +760,6 @@ class PMMUnitTest(unittest.TestCase):
         self.assertEqual(1, len(strategy.active_buys))
         self.assertEqual(1, len(strategy.active_sells))
         self.assertNotIn(strategy.active_sells[0].client_order_id, strategy.hanging_order_ids)
-        self.assertNotIn(strategy.active_sells[0].client_order_id, strategy.hanging_sell_order_ids)
 
         self.order_fill_logger.clear()
 
@@ -788,11 +784,8 @@ class PMMUnitTest(unittest.TestCase):
         self.assertEqual(0, len(strategy.active_buys))
         self.assertEqual(1, len(strategy.active_sells))
         self.assertEqual(1, len(strategy.hanging_order_ids))
-        self.assertEqual(0, len(strategy.hanging_buy_order_ids))
-        self.assertEqual(1, len(strategy.hanging_sell_order_ids))
         hanging_sell = strategy.active_sells[0]
         self.assertEqual(hanging_sell.client_order_id, strategy.hanging_order_ids[0])
-        self.assertEqual(hanging_sell.client_order_id, strategy.hanging_sell_order_ids[0])
 
         # At order_refresh_time, hanging order remains.
         self.clock.backtest_til(self.start_timestamp + strategy.order_refresh_time * 2 + 1)
@@ -813,7 +806,6 @@ class PMMUnitTest(unittest.TestCase):
         self.assertEqual(1, len(strategy.active_buys))
         self.assertEqual(1, len(strategy.active_sells))
         self.assertNotIn(strategy.active_sells[0].client_order_id, strategy.hanging_order_ids)
-        self.assertNotIn(strategy.active_sells[0].client_order_id, strategy.hanging_sell_order_ids)
 
         self.order_fill_logger.clear()
 
@@ -838,8 +830,6 @@ class PMMUnitTest(unittest.TestCase):
         self.assertEqual(0, len(strategy.active_buys))
         self.assertEqual(0, len(strategy.active_sells))
         self.assertEqual(0, len(strategy.hanging_order_ids))
-        self.assertEqual(0, len(strategy.hanging_buy_order_ids))
-        self.assertEqual(0, len(strategy.hanging_sell_order_ids))
 
         # At filled_order_delay, a new set of bid and ask orders (one each) is created
         self.clock.backtest_til(self.start_timestamp + strategy.order_refresh_time * 2 + 2)
@@ -862,9 +852,6 @@ class PMMUnitTest(unittest.TestCase):
 
         self.simulate_maker_market_trade(True, 100, 101.1)
 
-        self.assertEqual(1, len(strategy.active_buys))
-        self.assertEqual(0, len(strategy.active_sells))
-
         # Ask is filled and due to delay is not replenished immediately
         # Bid order is now hanging but is active
         self.clock.backtest_til(self.start_timestamp + strategy.order_refresh_time + 1)
@@ -872,11 +859,8 @@ class PMMUnitTest(unittest.TestCase):
         self.assertEqual(1, len(strategy.active_buys))
         self.assertEqual(0, len(strategy.active_sells))
         self.assertEqual(1, len(strategy.hanging_order_ids))
-        self.assertEqual(1, len(strategy.hanging_buy_order_ids))
-        self.assertEqual(0, len(strategy.hanging_sell_order_ids))
         hanging_buy = strategy.active_buys[0]
         self.assertEqual(hanging_buy.client_order_id, strategy.hanging_order_ids[0])
-        self.assertEqual(hanging_buy.client_order_id, strategy.hanging_buy_order_ids[0])
 
         # At order_refresh_time, hanging order remains.
         self.clock.backtest_til(self.start_timestamp + strategy.order_refresh_time * 2 + 1)
@@ -897,7 +881,6 @@ class PMMUnitTest(unittest.TestCase):
         self.assertEqual(1, len(strategy.active_buys))
         self.assertEqual(1, len(strategy.active_sells))
         self.assertNotIn(strategy.active_buys[0].client_order_id, strategy.hanging_order_ids)
-        self.assertNotIn(strategy.active_buys[0].client_order_id, strategy.hanging_sell_order_ids)
 
         self.order_fill_logger.clear()
 
@@ -910,13 +893,11 @@ class PMMUnitTest(unittest.TestCase):
         strategy.hanging_orders_cancel_pct = Decimal("0.05")
         self.clock.add_iterator(strategy)
         self.clock.backtest_til(self.start_timestamp + 1)
+        self.assertEqual(True, strategy.hanging_sell_orders_enabled)
         self.assertEqual(1, len(strategy.active_buys))
         self.assertEqual(1, len(strategy.active_sells))
 
         self.simulate_maker_market_trade(True, 100, 101.1)
-
-        self.assertEqual(1, len(strategy.active_buys))
-        self.assertEqual(0, len(strategy.active_sells))
 
         # Bid is filled and due to delay is not replenished immediately
         # Ask order is now hanging but is active
@@ -925,8 +906,6 @@ class PMMUnitTest(unittest.TestCase):
         self.assertEqual(0, len(strategy.active_buys))
         self.assertEqual(0, len(strategy.active_sells))
         self.assertEqual(0, len(strategy.hanging_order_ids))
-        self.assertEqual(0, len(strategy.hanging_buy_order_ids))
-        self.assertEqual(0, len(strategy.hanging_sell_order_ids))
 
         # At filled_order_delay, a new set of bid and ask orders (one each) is created
         self.clock.backtest_til(self.start_timestamp + strategy.order_refresh_time * 2 + 2)
@@ -954,11 +933,8 @@ class PMMUnitTest(unittest.TestCase):
         self.assertEqual(0, len(strategy.active_buys))
         self.assertEqual(1, len(strategy.active_sells))
         self.assertEqual(1, len(strategy.hanging_order_ids))
-        self.assertEqual(0, len(strategy.hanging_buy_order_ids))
-        self.assertEqual(1, len(strategy.hanging_sell_order_ids))
         hanging_sell: LimitOrder = strategy.active_sells[0]
         self.assertEqual(hanging_sell.client_order_id, strategy.hanging_order_ids[0])
-        self.assertEqual(hanging_sell.client_order_id, strategy.hanging_sell_order_ids[0])
 
         self.market.trigger_event(MarketEvent.OrderCancelled, OrderCancelledEvent(
             self.market.current_timestamp,
@@ -988,10 +964,8 @@ class PMMUnitTest(unittest.TestCase):
         self.assertEqual(1, len(self.order_fill_logger.event_log))
         self.assertEqual(1, len(strategy.active_buys))
         self.assertEqual(1, len(strategy.hanging_order_ids))
-        self.assertEqual(1, len(strategy.hanging_buy_order_ids))
         hanging_buy: LimitOrder = strategy.active_buys[0]
         self.assertEqual(hanging_buy.client_order_id, strategy.hanging_order_ids[0])
-        self.assertEqual(hanging_buy.client_order_id, strategy.hanging_buy_order_ids[0])
 
         self.market.trigger_event(MarketEvent.OrderCancelled, OrderCancelledEvent(
             self.market.current_timestamp,
@@ -1027,8 +1001,6 @@ class PMMUnitTest(unittest.TestCase):
         self.assertEqual(2, len(strategy.active_buys))
         self.assertEqual(3, len(strategy.active_sells))
         self.assertEqual(0, len(strategy.hanging_order_ids))
-        self.assertEqual(0, len(strategy.hanging_buy_order_ids))
-        self.assertEqual(0, len(strategy.hanging_sell_order_ids))
 
         # At order_refresh_time, hanging orders are created, active orders are cancelled
         self.clock.backtest_til(self.start_timestamp + strategy.order_refresh_time + 1)
@@ -1036,8 +1008,6 @@ class PMMUnitTest(unittest.TestCase):
         self.assertEqual(0, len(strategy.active_buys))
         self.assertEqual(1, len(strategy.active_sells))
         self.assertEqual(1, len(strategy.hanging_order_ids))
-        self.assertEqual(0, len(strategy.hanging_buy_order_ids))
-        self.assertEqual(1, len(strategy.hanging_sell_order_ids))
 
         # At filled_order_delay, a new set of bid and ask orders (one each) is created
         self.clock.backtest_til(self.start_timestamp + strategy.order_refresh_time + strategy.filled_order_delay + 1)
@@ -1046,8 +1016,6 @@ class PMMUnitTest(unittest.TestCase):
 
         self.assertTrue(all(id in (order.client_order_id for order in strategy.active_sells)
                             for id in strategy.hanging_order_ids))
-        self.assertTrue(all(id in (order.client_order_id for order in strategy.active_sells)
-                            for id in strategy.hanging_sell_order_ids))
 
         simulate_order_book_widening(self.market.order_books[self.trading_pair], 80, 100)
         # As book bids moving lower, the ask hanging order price spread is now more than the hanging_orders_cancel_pct
@@ -1083,8 +1051,6 @@ class PMMUnitTest(unittest.TestCase):
         self.assertEqual(2, len(strategy.active_buys))
         self.assertEqual(3, len(strategy.active_sells))
         self.assertEqual(0, len(strategy.hanging_order_ids))
-        self.assertEqual(0, len(strategy.hanging_sell_order_ids))
-        self.assertEqual(0, len(strategy.hanging_buy_order_ids))
 
         # At order_refresh_time, hanging orders would be created for sell,
         # but are not enabled
@@ -1093,15 +1059,11 @@ class PMMUnitTest(unittest.TestCase):
         self.assertEqual(0, len(strategy.active_buys))
         self.assertEqual(0, len(strategy.active_sells))
         self.assertEqual(0, len(strategy.hanging_order_ids))
-        self.assertEqual(0, len(strategy.hanging_sell_order_ids))
-        self.assertEqual(0, len(strategy.hanging_buy_order_ids))
 
         # At filled_order_delay, a new set of bid and ask orders (one each) is created
         self.clock.backtest_til(self.start_timestamp + strategy.order_refresh_time + strategy.filled_order_delay + 1)
         self.assertEqual(3, len(strategy.active_buys))
         self.assertEqual(3, len(strategy.active_sells))
-        self.assertEqual(0, len(strategy.hanging_sell_order_ids))
-        self.assertEqual(0, len(strategy.hanging_buy_order_ids))
 
         self.order_fill_logger.clear()
 
@@ -1128,8 +1090,6 @@ class PMMUnitTest(unittest.TestCase):
         self.assertEqual(3, len(strategy.active_buys))
         self.assertEqual(2, len(strategy.active_sells))
         self.assertEqual(0, len(strategy.hanging_order_ids))
-        self.assertEqual(0, len(strategy.hanging_buy_order_ids))
-        self.assertEqual(0, len(strategy.hanging_sell_order_ids))
 
         # At order_refresh_time, hanging orders are created, active orders are cancelled
         self.clock.backtest_til(self.start_timestamp + strategy.order_refresh_time + 1)
@@ -1137,8 +1097,6 @@ class PMMUnitTest(unittest.TestCase):
         self.assertEqual(1, len(strategy.active_buys))
         self.assertEqual(0, len(strategy.active_sells))
         self.assertEqual(1, len(strategy.hanging_order_ids))
-        self.assertEqual(1, len(strategy.hanging_buy_order_ids))
-        self.assertEqual(0, len(strategy.hanging_sell_order_ids))
 
         # At filled_order_delay, a new set of bid and ask orders (one each) is created
         self.clock.backtest_til(self.start_timestamp + strategy.order_refresh_time + strategy.filled_order_delay + 1)
@@ -1147,8 +1105,6 @@ class PMMUnitTest(unittest.TestCase):
 
         self.assertTrue(all(id in (order.client_order_id for order in strategy.active_buys)
                             for id in strategy.hanging_order_ids))
-        self.assertTrue(all(id in (order.client_order_id for order in strategy.active_buys)
-                            for id in strategy.hanging_buy_order_ids))
 
         simulate_order_book_widening(self.market.order_books[self.trading_pair], 80, 100)
         # As book bids moving lower, the ask hanging order price spread is now more than the hanging_orders_cancel_pct
@@ -1157,7 +1113,6 @@ class PMMUnitTest(unittest.TestCase):
         self.assertEqual(3, len(strategy.active_buys))
         self.assertEqual(3, len(strategy.active_sells))
         self.assertFalse(any(o.client_order_id in strategy.hanging_order_ids for o in strategy.active_sells))
-        self.assertFalse(any(o.client_order_id in strategy.hanging_sell_order_ids for o in strategy.active_sells))
 
         self.order_fill_logger.clear()
 
@@ -1184,8 +1139,6 @@ class PMMUnitTest(unittest.TestCase):
         self.assertEqual(3, len(strategy.active_buys))
         self.assertEqual(2, len(strategy.active_sells))
         self.assertEqual(0, len(strategy.hanging_order_ids))
-        self.assertEqual(0, len(strategy.hanging_buy_order_ids))
-        self.assertEqual(0, len(strategy.hanging_sell_order_ids))
 
         # At order_refresh_time, hanging orders would be created for buy,
         # but are not enabled
@@ -1194,15 +1147,12 @@ class PMMUnitTest(unittest.TestCase):
         self.assertEqual(0, len(strategy.active_buys))
         self.assertEqual(0, len(strategy.active_sells))
         self.assertEqual(0, len(strategy.hanging_order_ids))
-        self.assertEqual(0, len(strategy.hanging_buy_order_ids))
-        self.assertEqual(0, len(strategy.hanging_sell_order_ids))
 
         # At filled_order_delay, a new set of bid and ask orders (one each) is created
         self.clock.backtest_til(self.start_timestamp + strategy.order_refresh_time + strategy.filled_order_delay + 1)
         self.assertEqual(3, len(strategy.active_buys))
         self.assertEqual(3, len(strategy.active_sells))
-        self.assertEqual(0, len(strategy.hanging_buy_order_ids))
-        self.assertEqual(0, len(strategy.hanging_sell_order_ids))
+        self.assertEqual(0, len(strategy.hanging_order_ids))
 
         self.order_fill_logger.clear()
 

--- a/test/hummingbot/strategy/pure_market_making/test_pmm_refresh_tolerance.py
+++ b/test/hummingbot/strategy/pure_market_making/test_pmm_refresh_tolerance.py
@@ -79,7 +79,8 @@ class PMMRefreshToleranceUnitTest(unittest.TestCase):
             order_amount=Decimal("1"),
             order_refresh_time=4,
             filled_order_delay=8,
-            hanging_orders_enabled=True,
+            hanging_buy_orders_enabled=True,
+            hanging_sell_orders_enabled=True,
             hanging_orders_cancel_pct=0.05,
             order_refresh_tolerance_pct=0
         )
@@ -106,7 +107,8 @@ class PMMRefreshToleranceUnitTest(unittest.TestCase):
             order_refresh_time=4,
             filled_order_delay=8,
             order_refresh_tolerance_pct=0,
-            hanging_orders_enabled=True
+            hanging_buy_orders_enabled=True,
+            hanging_sell_orders_enabled=True,
         )
 
     def test_active_orders_are_cancelled_when_mid_price_moves(self):

--- a/test/hummingbot/strategy/pure_market_making/test_pure_market_making_start.py
+++ b/test/hummingbot/strategy/pure_market_making/test_pure_market_making_start.py
@@ -39,7 +39,8 @@ class PureMarketMakingStartTest(unittest.TestCase):
         c_map.get("inventory_target_base_pct").value = Decimal("50")
         c_map.get("inventory_range_multiplier").value = Decimal("2")
         c_map.get("filled_order_delay").value = 45.
-        c_map.get("hanging_orders_enabled").value = True
+        c_map.get("hanging_buy_orders_enabled").value = True
+        c_map.get("hanging_sell_orders_enabled").value = True
         c_map.get("hanging_orders_cancel_pct").value = Decimal("6")
         c_map.get("order_optimization_enabled").value = False
         c_map.get("ask_order_optimization_depth").value = Decimal("0.01")

--- a/test/hummingbot/strategy/test_hanging_orders_tracker.py
+++ b/test/hummingbot/strategy/test_hanging_orders_tracker.py
@@ -85,6 +85,10 @@ class HangingOrdersTrackerTest(unittest.TestCase):
         self.assertEqual(self.tracker._completed_hanging_orders, {OrdS.BUY: set(), OrdS.SELL: set()})
         self.assertEqual(self.tracker.current_created_pairs_of_orders, list())
 
+        # Default values for BUY/SELL enabled
+        self.assertEqual(self.tracker.hanging_buy_orders_enabled, True)
+        self.assertEqual(self.tracker.hanging_sell_orders_enabled, True)
+
         # Value from initialization
         self.assertEqual(self.tracker.hanging_buy_orders_cancel_pct, Decimal("0.2"))
         self.assertEqual(self.tracker.hanging_sell_orders_cancel_pct, Decimal("0.3"))
@@ -110,6 +114,55 @@ class HangingOrdersTrackerTest(unittest.TestCase):
         self.tracker._completed_hanging_orders = {OrdS.BUY: {'BUY_order'}, OrdS.SELL: {'SELL_order'}}
         self.assertEqual(self.tracker._completed_ho, {'BUY_order', 'SELL_order'})
         self.assertEqual(self.tracker.completed_hanging_orders, {'BUY_order', 'SELL_order'})
+
+    def test_hanging_orders_cancel_pct(self):
+        # Getter
+        expected = (self.tracker._hanging_buy_orders_cancel_pct + self.tracker._hanging_sell_orders_cancel_pct) * Decimal("0.5")
+        self.assertEqual(expected, self.tracker.hanging_orders_cancel_pct)
+
+        # Setter
+        self.tracker.hanging_orders_cancel_pct = Decimal("10")
+        self.assertEqual(Decimal("10"), self.tracker.hanging_orders_cancel_pct)
+        self.assertEqual(Decimal("10"), self.tracker._hanging_buy_orders_cancel_pct)
+        self.assertEqual(Decimal("10"), self.tracker._hanging_sell_orders_cancel_pct)
+
+    def test_hanging_buy_orders_cancel_pct(self):
+        # Getter
+        self.assertEqual(self.tracker._hanging_buy_orders_cancel_pct, self.tracker.hanging_buy_orders_cancel_pct)
+
+        # Setter
+        self.tracker.hanging_buy_orders_cancel_pct = Decimal("10")
+        self.assertEqual(Decimal("10"), self.tracker._hanging_buy_orders_cancel_pct)
+        self.assertEqual(Decimal("10"), self.tracker.hanging_buy_orders_cancel_pct)
+
+    def test_hanging_sell_orders_cancel_pct(self):
+        # Getter
+        self.assertEqual(self.tracker._hanging_sell_orders_cancel_pct, self.tracker.hanging_sell_orders_cancel_pct)
+
+        # Setter
+        self.tracker.hanging_sell_orders_cancel_pct = Decimal("10")
+        self.assertEqual(Decimal("10"), self.tracker._hanging_sell_orders_cancel_pct)
+        self.assertEqual(Decimal("10"), self.tracker.hanging_sell_orders_cancel_pct)
+
+    def test_hanging_buy_orders_enabled(self):
+        # Getter
+        self.assertEqual(True, self.tracker._hanging_buy_orders_enabled)
+        self.assertEqual(self.tracker._hanging_buy_orders_enabled, self.tracker.hanging_buy_orders_enabled)
+
+        # Setter
+        self.tracker.hanging_buy_orders_enabled = False
+        self.assertEqual(False, self.tracker._hanging_buy_orders_enabled)
+        self.assertEqual(False, self.tracker.hanging_buy_orders_enabled)
+
+    def test_hanging_sell_orders_enabled(self):
+        # Getter
+        self.assertEqual(True, self.tracker._hanging_sell_orders_enabled)
+        self.assertEqual(self.tracker._hanging_sell_orders_enabled, self.tracker.hanging_sell_orders_enabled)
+
+        # Setter
+        self.tracker.hanging_sell_orders_enabled = False
+        self.assertEqual(False, self.tracker._hanging_sell_orders_enabled)
+        self.assertEqual(False, self.tracker.hanging_sell_orders_enabled)
 
     def test_add_remove_buy_limit_order(self):
         order_to_add = LimitOrder("Order-number-1", "BTC-USDT", True, "BTC", "USDT", Decimal(100), Decimal(1))


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
This is the implementation of https://hummingbot.discourse.group/t/pure-mm-hip-hanging-order-side/148/6 - sponsored by a community member:
Replace “hanging_orders_enabled” with “hanging_orders_buy_enabled” and “hanging_orders_sell_enabled”
   - If “hanging_orders_buy_enabled” is true, hanging orders with “side == buy” are created
   - If “hanging_orders_sell_enabled” is true, hanging orders with “side == sell” are created
   - If these parameters are false, hanging orders on that side are not created
   - Adjust parameters for Pure Market Strategy with hanging_order
HIP:https://snapshot.org/#/hbot-prp.eth/proposal/bafkreidaxvriyvrnacbpky22jludyzbhvnmu5y4cbubkmzijlug7pjqkeu

**Tests performed by the developer**:
Several additional testcases were added to the suite for HangingOrders, PureMarketMaking classes
compile, coverage, pre-commit
Verified the setup of the parameters with status
Limited live testing on PMM - The PR requestor has pulled this PR, testing and providing feedback



**Tips for QA testing**:


