### PR TITLE
(feat) Investigating Cython refactoring

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,5 @@
 [run]
+plugins = Cython.Coverage
 source_pkgs = hummingbot
 omit =
         hummingbot/core/gateway/*

--- a/hummingbot/connector/exchange/beaxy/beaxy_exchange.pyx
+++ b/hummingbot/connector/exchange/beaxy/beaxy_exchange.pyx
@@ -1012,7 +1012,7 @@ cdef class BeaxyExchange(ExchangeBase):
         try:
             assert path_url is not None or url is not None
 
-            url = f'{BeaxyConstants.TradingApi.BASE_URL}{path_url}' if url is None else url
+            url = str(f'{BeaxyConstants.TradingApi.BASE_URL}{path_url}') if url is None else url
 
             data_str = '' if data is None else json.dumps(data, separators=(',', ':'))
 

--- a/hummingbot/connector/exchange/beaxy/beaxy_order_book.pyx
+++ b/hummingbot/connector/exchange/beaxy/beaxy_order_book.pyx
@@ -26,7 +26,7 @@ cdef class BeaxyOrderBook(OrderBook):
         cls,
         msg: Dict[str, any],
         timestamp: float,
-        metadata: Optional[Dict] = None
+        metadata: Optional[Dict[str, any]] = None
     ) -> OrderBookMessage:
         if metadata:
             msg.update(metadata)
@@ -41,7 +41,7 @@ cdef class BeaxyOrderBook(OrderBook):
         cls,
         msg: Dict[str, any],
         timestamp: Optional[float] = None,
-        metadata: Optional[Dict] = None
+        metadata: Optional[Dict[str, any]] = None
     ) -> OrderBookMessage:
         if metadata:
             msg.update(metadata)
@@ -56,7 +56,7 @@ cdef class BeaxyOrderBook(OrderBook):
         cls,
         msg: Dict[str, Any],
         timestamp: Optional[float] = None,
-        metadata: Optional[Dict] = None
+        metadata: Optional[Dict[str, any]] = None
     ) -> OrderBookMessage:
         if metadata:
             msg.update(metadata)

--- a/hummingbot/connector/exchange/bitfinex/bitfinex_exchange.pyx
+++ b/hummingbot/connector/exchange/bitfinex/bitfinex_exchange.pyx
@@ -5,7 +5,7 @@ import logging
 import time
 import uuid
 from decimal import Decimal
-from typing import Any, AsyncIterable, Dict, List, Optional, TYPE_CHECKING
+from typing import Any, AsyncIterable, Dict, List, Optional, TYPE_CHECKING, Union
 
 import aiohttp
 from libc.stdint cimport int64_t
@@ -442,7 +442,7 @@ cdef class BitfinexExchange(ExchangeBase):
     async def _api_private_fn(self,
                               http_method: str,
                               path_url,
-                              data: Optional[Dict[Any]] = None) -> Dict[Any]:
+                              data: Optional[Dict[str, Any]] = None) -> Dict[Any]:
         url = f"{BITFINEX_REST_AUTH_URL}/{path_url}"
         data_str = json.dumps(data)
         #  because BITFINEX_REST_AUTH_URL already have v2  postfix, but v2 need
@@ -459,7 +459,7 @@ cdef class BitfinexExchange(ExchangeBase):
     async def _api_private(self,
                            http_method: str,
                            path_url,
-                           data: Optional[Dict[Any]] = None) -> Dict[Any]:
+                           data: Optional[Dict[str, Any]] = None) -> Dict[Any]:
 
         id = uuid.uuid4()
         self._pending_requests.append(id)
@@ -476,7 +476,7 @@ cdef class BitfinexExchange(ExchangeBase):
                               http_method: str,
                               url,
                               headers,
-                              data_str: Optional[str, list] = None) -> list:
+                              data_str: Optional[Union[str, List[str]]] = None) -> list:
         """
         A wrapper for submitting API requests to Bitfinex
         :returns: json data from the endpoints
@@ -1155,7 +1155,7 @@ cdef class BitfinexExchange(ExchangeBase):
 
     # sqlite
     @property
-    def tracking_states(self) -> Dict[str, any]:
+    def tracking_states(self) -> Dict[str, Any]:
         """
         *required
         :return: Dict[client_order_id: InFlightOrder]
@@ -1166,7 +1166,7 @@ cdef class BitfinexExchange(ExchangeBase):
             for key, value in self._in_flight_orders.items()
         }
 
-    def restore_tracking_states(self, saved_states: Dict[str, any]):
+    def restore_tracking_states(self, saved_states: Dict[str, Any]):
         """
         *required
         Updates inflight order statuses from API results

--- a/hummingbot/connector/exchange/bitfinex/bitfinex_order_book.pyx
+++ b/hummingbot/connector/exchange/bitfinex/bitfinex_order_book.pyx
@@ -30,7 +30,7 @@ cdef class BitfinexOrderBook(OrderBook):
     def snapshot_message_from_exchange(cls,
                                        msg: Dict[str, Any],
                                        timestamp: float,
-                                       metadata: Optional[Dict] = None) -> OrderBookMessage:
+                                       metadata: Optional[Dict[str, Any]] = None) -> OrderBookMessage:
         if metadata:
             msg.update(metadata)
         return BitfinexOrderBookMessage(
@@ -43,7 +43,7 @@ cdef class BitfinexOrderBook(OrderBook):
     def diff_message_from_exchange(cls,
                                    msg: Dict[str, any],
                                    timestamp: Optional[float] = None,
-                                   metadata: Optional[Dict] = None) -> OrderBookMessage:
+                                   metadata: Optional[Dict[str, Any]] = None) -> OrderBookMessage:
         if metadata:
             msg.update(metadata)
         if "time" in msg:
@@ -55,7 +55,7 @@ cdef class BitfinexOrderBook(OrderBook):
             timestamp=timestamp or msg_time)
 
     @classmethod
-    def trade_message_from_exchange(cls, msg: Dict[str, Any], metadata: Optional[Dict] = None):
+    def trade_message_from_exchange(cls, msg: Dict[str, Any], metadata: Optional[Dict[str, Any]] = None):
         if metadata:
             msg.update(metadata)
 

--- a/hummingbot/connector/exchange/bittrex/bittrex_order_book.pyx
+++ b/hummingbot/connector/exchange/bittrex/bittrex_order_book.pyx
@@ -29,7 +29,7 @@ cdef class BittrexOrderBook(OrderBook):
     def snapshot_message_from_exchange(cls,
                                        msg: Dict[str, any],
                                        timestamp: float,
-                                       metadata: Optional[Dict] = None) -> OrderBookMessage:
+                                       metadata: Optional[Dict[str, Any]] = None) -> OrderBookMessage:
         if metadata:
             msg.update(metadata)
         return BittrexOrderBookMessage(
@@ -44,7 +44,7 @@ cdef class BittrexOrderBook(OrderBook):
     def diff_message_from_exchange(cls,
                                    msg: Dict[str, any],
                                    timestamp: Optional[float] = None,
-                                   metadata: Optional[Dict] = None):
+                                   metadata: Optional[Dict[str, Any]] = None):
         if metadata:
             msg.update(metadata)
         return BittrexOrderBookMessage(
@@ -59,7 +59,7 @@ cdef class BittrexOrderBook(OrderBook):
     def trade_message_from_exchange(cls,
                                     msg: Dict[str, Any],
                                     timestamp: Optional[float] = None,
-                                    metadata: Optional[Dict] = None) -> OrderBookMessage:
+                                    metadata: Optional[Dict[str, Any]] = None) -> OrderBookMessage:
         if metadata:
             msg.update(metadata)
         return BittrexOrderBookMessage(

--- a/hummingbot/connector/exchange/blocktane/blocktane_order_book.pyx
+++ b/hummingbot/connector/exchange/blocktane/blocktane_order_book.pyx
@@ -1,7 +1,7 @@
 import logging
 from typing import (
     Dict,
-    Optional
+    Optional, Any
 )
 
 import ujson
@@ -27,9 +27,9 @@ cdef class BlocktaneOrderBook(OrderBook):
 
     @classmethod
     def snapshot_message_from_exchange(cls,
-                                       msg: Dict[str, any],
+                                       msg: Dict[str, Any],
                                        timestamp: float,
-                                       metadata: Optional[Dict] = None) -> OrderBookMessage:
+                                       metadata: Optional[Dict[str, Any]] = None) -> OrderBookMessage:
         if metadata:
             msg.update(metadata)
         return OrderBookMessage(OrderBookMessageType.SNAPSHOT, {
@@ -41,9 +41,9 @@ cdef class BlocktaneOrderBook(OrderBook):
 
     @classmethod
     def diff_message_from_exchange(cls,
-                                   msg: Dict[str, any],
+                                   msg: Dict[str, Any],
                                    timestamp: Optional[float] = None,
-                                   metadata: Optional[Dict] = None) -> OrderBookMessage:
+                                   metadata: Optional[Dict[str, Any]] = None) -> OrderBookMessage:
         def adjust_empty_amounts(levels):
             result = []
             for level in levels:
@@ -65,7 +65,7 @@ cdef class BlocktaneOrderBook(OrderBook):
         }, timestamp=timestamp)
 
     @classmethod
-    def snapshot_message_from_kafka(cls, record: ConsumerRecord, metadata: Optional[Dict] = None) -> OrderBookMessage:
+    def snapshot_message_from_kafka(cls, record: ConsumerRecord, metadata: Optional[Dict[str, Any]] = None) -> OrderBookMessage:
         msg = ujson.loads(record.value.decode("utf-8"))
         if metadata:
             msg.update(metadata)
@@ -77,7 +77,7 @@ cdef class BlocktaneOrderBook(OrderBook):
         }, timestamp=record.timestamp * 1e-3)
 
     @classmethod
-    def diff_message_from_kafka(cls, record: ConsumerRecord, metadata: Optional[Dict] = None) -> OrderBookMessage:
+    def diff_message_from_kafka(cls, record: ConsumerRecord, metadata: Optional[Dict[str, Any]] = None) -> OrderBookMessage:
         msg = ujson.loads(record.value.decode("utf-8"))
         if metadata:
             msg.update(metadata)
@@ -90,7 +90,7 @@ cdef class BlocktaneOrderBook(OrderBook):
         }, timestamp=record.timestamp * 1e-3)
 
     @classmethod
-    def trade_message_from_exchange(cls, msg: Dict[str, any], metadata: Optional[Dict] = None):
+    def trade_message_from_exchange(cls, msg: Dict[str, Any], metadata: Optional[Dict[str, Any]] = None):
         # {'fthusd.trades': {'trades': [{'tid': 9, 'taker_type': 'sell', 'date': 1586958619, 'price': '51.0', 'amount': '0.02'}]}}
         if metadata:
             msg.update(metadata)

--- a/hummingbot/connector/exchange/coinbase_pro/coinbase_pro_order_book.pyx
+++ b/hummingbot/connector/exchange/coinbase_pro/coinbase_pro_order_book.pyx
@@ -1,6 +1,7 @@
 import logging
 from typing import Dict, List, Optional
 
+import cython
 import pandas as pd
 
 from hummingbot.connector.exchange.coinbase_pro.coinbase_pro_order_book_message import CoinbaseProOrderBookMessage
@@ -23,7 +24,7 @@ cdef class CoinbaseProOrderBook(OrderBook):
     def snapshot_message_from_exchange(cls,
                                        msg: Dict[str, any],
                                        timestamp: float,
-                                       metadata: Optional[Dict] = None) -> OrderBookMessage:
+                                       metadata: Optional[Dict[str, any]] = None) -> OrderBookMessage:
         """
         *required
         Convert json snapshot data into standard OrderBookMessage format
@@ -43,7 +44,7 @@ cdef class CoinbaseProOrderBook(OrderBook):
     def diff_message_from_exchange(cls,
                                    msg: Dict[str, any],
                                    timestamp: Optional[float] = None,
-                                   metadata: Optional[Dict] = None) -> OrderBookMessage:
+                                   metadata: Optional[Dict[str, any]] = None) -> OrderBookMessage:
         """
         *required
         Convert json diff data into standard OrderBookMessage format

--- a/hummingbot/connector/exchange/ftx/ftx_order_book.pyx
+++ b/hummingbot/connector/exchange/ftx/ftx_order_book.pyx
@@ -4,7 +4,7 @@ import logging
 import datetime
 from typing import (
     Dict,
-    Optional,
+    Optional, Any,
 )
 from datetime import datetime
 
@@ -29,9 +29,9 @@ cdef class FtxOrderBook(OrderBook):
 
     @classmethod
     def restful_snapshot_message_from_exchange(cls,
-                                               msg: Dict[str, any],
+                                               msg: Dict[str, Any],
                                                timestamp: float,
-                                               metadata: Optional[Dict] = None) -> OrderBookMessage:
+                                               metadata: Optional[Dict[str, Any]] = None) -> OrderBookMessage:
         if metadata:
             msg.update(metadata)
         return OrderBookMessage(OrderBookMessageType.SNAPSHOT, {
@@ -43,9 +43,9 @@ cdef class FtxOrderBook(OrderBook):
 
     @classmethod
     def snapshot_message_from_exchange(cls,
-                                       msg: Dict[str, any],
+                                       msg: Dict[str, Any],
                                        timestamp: float,
-                                       metadata: Optional[Dict] = None) -> OrderBookMessage:
+                                       metadata: Optional[Dict[str, Any]] = None) -> OrderBookMessage:
         if metadata:
             msg.update(metadata)
         return OrderBookMessage(OrderBookMessageType.SNAPSHOT, {
@@ -57,9 +57,9 @@ cdef class FtxOrderBook(OrderBook):
 
     @classmethod
     def diff_message_from_exchange(cls,
-                                   msg: Dict[str, any],
+                                   msg: Dict[str, Any],
                                    timestamp: Optional[float] = None,
-                                   metadata: Optional[Dict] = None) -> OrderBookMessage:
+                                   metadata: Optional[Dict[str, Any]] = None) -> OrderBookMessage:
         if metadata:
             msg.update(metadata)
         return OrderBookMessage(OrderBookMessageType.DIFF, {
@@ -70,7 +70,7 @@ cdef class FtxOrderBook(OrderBook):
         }, timestamp=timestamp)
 
     @classmethod
-    def trade_message_from_exchange(cls, msg: Dict[str, any], metadata: Optional[Dict] = None):
+    def trade_message_from_exchange(cls, msg: Dict[str, Any], metadata: Optional[Dict[str, Any]] = None):
         if metadata:
             msg.update(metadata)
         ts = datetime.timestamp(datetime.strptime(msg["time"], "%Y-%m-%dT%H:%M:%S.%f+00:00"))

--- a/hummingbot/connector/exchange/huobi/huobi_order_book.pyx
+++ b/hummingbot/connector/exchange/huobi/huobi_order_book.pyx
@@ -30,7 +30,7 @@ cdef class HuobiOrderBook(OrderBook):
     def snapshot_message_from_exchange(cls,
                                        msg: Dict[str, Any],
                                        timestamp: Optional[float] = None,
-                                       metadata: Optional[Dict] = None) -> OrderBookMessage:
+                                       metadata: Optional[Dict[str, Any]] = None) -> OrderBookMessage:
         if metadata:
             msg.update(metadata)
         msg_ts = timestamp or int(msg["tick"]["ts"])
@@ -46,7 +46,7 @@ cdef class HuobiOrderBook(OrderBook):
     def trade_message_from_exchange(cls,
                                     msg: Dict[str, Any],
                                     timestamp: Optional[float] = None,
-                                    metadata: Optional[Dict] = None) -> OrderBookMessage:
+                                    metadata: Optional[Dict[str, Any]] = None) -> OrderBookMessage:
         if metadata:
             msg.update(metadata)
         msg_ts = timestamp or int(msg["ts"])
@@ -64,7 +64,7 @@ cdef class HuobiOrderBook(OrderBook):
     def diff_message_from_exchange(cls,
                                    msg: Dict[str, Any],
                                    timestamp: Optional[float] = None,
-                                   metadata: Optional[Dict] = None) -> OrderBookMessage:
+                                   metadata: Optional[Dict[str, Any]] = None) -> OrderBookMessage:
         if metadata:
             msg.update(metadata)
         msg_ts = timestamp or int(msg["tick"]["ts"])
@@ -77,7 +77,7 @@ cdef class HuobiOrderBook(OrderBook):
         return OrderBookMessage(OrderBookMessageType.DIFF, content, timestamp or msg_ts)
 
     @classmethod
-    def snapshot_message_from_kafka(cls, record: ConsumerRecord, metadata: Optional[Dict] = None) -> OrderBookMessage:
+    def snapshot_message_from_kafka(cls, record: ConsumerRecord, metadata: Optional[Dict[str, Any]] = None) -> OrderBookMessage:
         ts = record.timestamp
         msg = ujson.loads(record.value.decode())
         if metadata:
@@ -90,7 +90,7 @@ cdef class HuobiOrderBook(OrderBook):
         }, timestamp=ts)
 
     @classmethod
-    def diff_message_from_kafka(cls, record: ConsumerRecord, metadata: Optional[Dict] = None) -> OrderBookMessage:
+    def diff_message_from_kafka(cls, record: ConsumerRecord, metadata: Optional[Dict[str, Any]] = None) -> OrderBookMessage:
         decompressed = bz2.decompress(record.value)
         msg = ujson.loads(decompressed)
         ts = record.timestamp

--- a/hummingbot/connector/exchange/kraken/kraken_order_book.pyx
+++ b/hummingbot/connector/exchange/kraken/kraken_order_book.pyx
@@ -1,7 +1,7 @@
 import logging
 from typing import (
     Dict,
-    Optional
+    Optional, Any
 )
 
 from hummingbot.core.data_type.common import TradeType
@@ -25,9 +25,9 @@ cdef class KrakenOrderBook(OrderBook):
 
     @classmethod
     def snapshot_message_from_exchange(cls,
-                                       msg: Dict[str, any],
+                                       msg: Dict[str, Any],
                                        timestamp: float,
-                                       metadata: Optional[Dict] = None) -> OrderBookMessage:
+                                       metadata: Optional[Dict[str, Any]] = None) -> OrderBookMessage:
         if metadata:
             msg.update(metadata)
         return OrderBookMessage(OrderBookMessageType.SNAPSHOT, {
@@ -39,9 +39,9 @@ cdef class KrakenOrderBook(OrderBook):
 
     @classmethod
     def diff_message_from_exchange(cls,
-                                   msg: Dict[str, any],
+                                   msg: Dict[str, Any],
                                    timestamp: Optional[float] = None,
-                                   metadata: Optional[Dict] = None) -> OrderBookMessage:
+                                   metadata: Optional[Dict[str, Any]] = None) -> OrderBookMessage:
         if metadata:
             msg.update(metadata)
         return OrderBookMessage(OrderBookMessageType.DIFF, {
@@ -53,9 +53,9 @@ cdef class KrakenOrderBook(OrderBook):
 
     @classmethod
     def snapshot_ws_message_from_exchange(cls,
-                                          msg: Dict[str, any],
+                                          msg: Dict[str, Any],
                                           timestamp: Optional[float] = None,
-                                          metadata: Optional[Dict] = None) -> OrderBookMessage:
+                                          metadata: Optional[Dict[str, Any]] = None) -> OrderBookMessage:
         if metadata:
             msg.update(metadata)
         return OrderBookMessage(OrderBookMessageType.SNAPSHOT, {
@@ -66,7 +66,7 @@ cdef class KrakenOrderBook(OrderBook):
         }, timestamp=timestamp * 1e-3)
 
     @classmethod
-    def trade_message_from_exchange(cls, msg: Dict[str, any], metadata: Optional[Dict] = None):
+    def trade_message_from_exchange(cls, msg: Dict[str, Any], metadata: Optional[Dict[str, Any]] = None):
         if metadata:
             msg.update(metadata)
         ts = float(msg["trade"][2])

--- a/hummingbot/connector/exchange/liquid/liquid_exchange.pyx
+++ b/hummingbot/connector/exchange/liquid/liquid_exchange.pyx
@@ -305,7 +305,7 @@ cdef class LiquidExchange(ExchangeBase):
         """
         assert path_url is not None or url is not None
 
-        url = f"{Constants.BASE_URL}{path_url}" if url is None else url
+        url = str(f"{Constants.BASE_URL}{path_url}") if url is None else url
         data_str = "" if data is None else json.dumps(data)
         headers = self.liquid_auth.get_headers(path_url)
 

--- a/hummingbot/connector/exchange/liquid/liquid_order_book.pyx
+++ b/hummingbot/connector/exchange/liquid/liquid_order_book.pyx
@@ -2,7 +2,7 @@
 import logging
 from typing import (
     Dict,
-    Optional,
+    Optional, Any,
 )
 
 from hummingbot.core.data_type.order_book cimport OrderBook
@@ -22,9 +22,9 @@ cdef class LiquidOrderBook(OrderBook):
 
     @classmethod
     def snapshot_message_from_exchange(cls,
-                                       msg: Dict[str, any],
+                                       msg: Dict[str, Any],
                                        timestamp: float,
-                                       metadata: Optional[Dict] = None) -> (OrderBookMessage):
+                                       metadata: Optional[Dict[str, Any]] = None) -> (OrderBookMessage):
         """
         *required
         Convert json snapshot data into standard OrderBookMessage format
@@ -43,9 +43,9 @@ cdef class LiquidOrderBook(OrderBook):
 
     @classmethod
     def diff_message_from_exchange(cls,
-                                   msg: Dict[str, any],
+                                   msg: Dict[str, Any],
                                    timestamp: Optional[float] = None,
-                                   metadata: Optional[Dict] = None) -> OrderBookMessage:
+                                   metadata: Optional[Dict[str, Any]] = None) -> OrderBookMessage:
         """
         *required
         Convert json diff data into standard OrderBookMessage format

--- a/hummingbot/connector/exchange/loopring/loopring_order_book.pyx
+++ b/hummingbot/connector/exchange/loopring/loopring_order_book.pyx
@@ -2,7 +2,7 @@ import logging
 from typing import (
     Dict,
     List,
-    Optional,
+    Optional, Any,
 )
 
 import ujson
@@ -30,24 +30,24 @@ cdef class LoopringOrderBook(OrderBook):
 
     @classmethod
     def snapshot_message_from_exchange(cls,
-                                       msg: Dict[str, any],
+                                       msg: Dict[str, Any],
                                        timestamp: float,
-                                       metadata: Optional[Dict] = None) -> LoopringOrderBookMessage:
+                                       metadata: Optional[Dict[str, Any]] = None) -> LoopringOrderBookMessage:
         if metadata:
             msg.update(metadata)
         return LoopringOrderBookMessage(OrderBookMessageType.SNAPSHOT, msg, timestamp)
 
     @classmethod
     def diff_message_from_exchange(cls,
-                                   msg: Dict[str, any],
+                                   msg: Dict[str, Any],
                                    timestamp: Optional[float] = None,
-                                   metadata: Optional[Dict] = None) -> OrderBookMessage:
+                                   metadata: Optional[Dict[str, Any]] = None) -> OrderBookMessage:
         if metadata:
             msg.update(metadata)
         return LoopringOrderBookMessage(OrderBookMessageType.DIFF, msg, timestamp)
 
     @classmethod
-    def trade_message_from_exchange(cls, msg: Dict[str, any], metadata: Optional[Dict] = None):
+    def trade_message_from_exchange(cls, msg: Dict[str, Any], metadata: Optional[Dict[str, Any]] = None):
         ts = metadata["ts"]
         return OrderBookMessage(OrderBookMessageType.TRADE, {
             "trading_pair": metadata["topic"]["market"],
@@ -59,12 +59,12 @@ cdef class LoopringOrderBook(OrderBook):
         }, timestamp=ts * 1e-3)
 
     @classmethod
-    def snapshot_message_from_kafka(cls, record: ConsumerRecord, metadata: Optional[Dict] = None) -> OrderBookMessage:
+    def snapshot_message_from_kafka(cls, record: ConsumerRecord, metadata: Optional[Dict[str, Any]] = None) -> OrderBookMessage:
         msg = ujson.loads(record.value.decode())
         return LoopringOrderBookMessage(OrderBookMessageType.SNAPSHOT, msg, timestamp=record.timestamp * 1e-3)
 
     @classmethod
-    def diff_message_from_kafka(cls, record: ConsumerRecord, metadata: Optional[Dict] = None) -> OrderBookMessage:
+    def diff_message_from_kafka(cls, record: ConsumerRecord, metadata: Optional[Dict[str, Any]] = None) -> OrderBookMessage:
         msg = ujson.loads(record.value.decode())
         return LoopringOrderBookMessage(OrderBookMessageType.DIFF, msg)
 

--- a/hummingbot/connector/exchange/paper_trade/paper_trade_exchange.pyx
+++ b/hummingbot/connector/exchange/paper_trade/paper_trade_exchange.pyx
@@ -184,7 +184,7 @@ cdef class PaperTradeExchange(ExchangeBase):
     @classmethod
     def random_order_id(cls, order_side: str, trading_pair: str) -> str:
         vals = [random.choice(range(0, 256)) for i in range(0, 13)]
-        return f"{order_side}://" + trading_pair + "/" + "".join([f"{val:02x}" for val in vals])
+        return f"{order_side}://" + trading_pair + "/" + str("".join([f"{val:02x}" for val in vals]))
 
     def init_paper_trade_market(self):
         for trading_pair_str, order_book in self.order_book_tracker.order_books.items():

--- a/hummingbot/connector/test_support/mock_paper_exchange.pyx
+++ b/hummingbot/connector/test_support/mock_paper_exchange.pyx
@@ -64,8 +64,8 @@ cdef class MockPaperExchange(PaperTradeExchange):
     def ready(self):
         return True
 
-    def split_trading_pair(self, trading_pair: str) -> Tuple[str, str]:
-        return trading_pair.split("-")
+    def split_trading_pair(self, trading_pair: str) -> Tuple[str, ...]:
+        return tuple(trading_pair.split("-"))
 
     def new_empty_order_book(self, trading_pair: str):
         order_book = CompositeOrderBook()

--- a/hummingbot/core/data_type/limit_order.pyx
+++ b/hummingbot/core/data_type/limit_order.pyx
@@ -42,10 +42,10 @@ cdef class LimitOrder:
             long long now_timestamp = int(time.time() * 1e6) if end_time_order_age == 0 else end_time_order_age
         sells.extend(buys)
         for order in sells:
-            order_id_txt = order.client_order_id if len(order.client_order_id) <= 7 else f"...{order.client_order_id[-4:]}"
+            order_id_txt = order.client_order_id if len(order.client_order_id) <= 7 else str(f"...{order.client_order_id[-4:]}")
             type_txt = "buy" if order.is_buy else "sell"
             price = float(order.price)
-            spread_txt = f"{(0 if mid_price == 0 else abs(float(order.price) - mid_price) / mid_price):.2%}"
+            spread_txt = str(f"{(0 if mid_price == 0 else abs(float(order.price) - mid_price) / mid_price):.2%}")
             quantity = float(order.quantity)
             age_txt = "n/a"
             age_seconds = order.age_til(now_timestamp)

--- a/setup/environment-linux-aarch64.yml
+++ b/setup/environment-linux-aarch64.yml
@@ -41,7 +41,7 @@ dependencies:
     - asyncssh==2.7.2
     - cachetools==4.0.0
     - cryptography==2.8
-    - cython==3.0a7
+    - cython==3.0.0a10
     - cytoolz==0.11.0
     - diff-cover==5.1.2
     - docker==5.0.3
@@ -57,6 +57,7 @@ dependencies:
     - flake8==3.7.9
     - hexbytes==0.2.0
     - importlib-metadata==0.23
+    - line_profiler>=3.5.1
     - mypy-extensions==0.4.3
     - pre-commit==2.18.1
     - psutil==5.7.2

--- a/setup/environment-linux.yml
+++ b/setup/environment-linux.yml
@@ -33,15 +33,16 @@ dependencies:
     - 0x-contract-wrappers==2.0.0
     - 0x-order-utils==4.0.0
     - aiohttp==3.7.4.post0
-    - aiokafka==0.7.
+    - aiokafka==0.7.1
     - aioprocessing==2.0.0
     - aioresponses==0.7.2
     - appdirs==1.4.3
     - async-timeout==3.0.1
     - asyncssh==2.7.2
     - cachetools==4.0.0
+    - coincurve==13.0.0
     - cryptography==2.8
-    - cython==3.0a7
+    - cython==3.0.0a10
     - cytoolz==0.11.0
     - diff-cover==5.1.2
     - docker==5.0.3
@@ -57,6 +58,7 @@ dependencies:
     - flake8==3.7.9
     - hexbytes==0.2.0
     - importlib-metadata==0.23
+    - line_profiler>=3.5.1
     - mypy-extensions==0.4.3
     - pre-commit==2.18.1
     - psutil==5.7.2

--- a/setup/environment-win64.yml
+++ b/setup/environment-win64.yml
@@ -40,7 +40,7 @@ dependencies:
     - cachetools==4.0.0
     - coincurve==13.0.0
     - cryptography==2.8
-    - cython==3.0a7
+    - cython==3.0.0a10
     - cytoolz==0.11.0
     - diff-cover==5.1.2
     - docker==5.0.3
@@ -56,6 +56,7 @@ dependencies:
     - flake8==3.7.9
     - hexbytes==0.2.0
     - importlib-metadata==0.23
+    - line_profiler>=3.5.1
     - mypy-extensions==0.4.3
     - pre-commit==2.18.1
     - psutil==5.7.2

--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -42,7 +42,7 @@ dependencies:
     - asyncssh==2.7.2
     - cachetools==4.0.0
     - cryptography==2.8
-    - cython==3.0a7
+    - cython==3.0.0a10
     - cytoolz==0.11.0
     - diff-cover==5.1.2
     - docker==5.0.3
@@ -58,6 +58,7 @@ dependencies:
     - flake8==3.7.9
     - hexbytes==0.2.0
     - importlib-metadata==0.23
+    - line_profiler>=3.5.1
     - mypy-extensions==0.4.3
     - pre-commit==2.18.1
     - psutil==5.7.2

--- a/test/hummingbot/connector/exchange/ftx/test_ftx_exchange.py
+++ b/test/hummingbot/connector/exchange/ftx/test_ftx_exchange.py
@@ -271,6 +271,7 @@ class FtxExchangeTests(TestCase):
             f"{order.order_type_description} order {order.client_order_id}"
         ))
 
+        print(self.log_records)
         self.assertTrue(self._is_logged(
             "INFO",
             f"The market buy order {order.client_order_id} has completed according to user stream."

--- a/test/hummingbot/connector/exchange/kraken/test_kraken_in_flight_order.py
+++ b/test/hummingbot/connector/exchange/kraken/test_kraken_in_flight_order.py
@@ -9,7 +9,7 @@ class KrakenInFlightOrderTests(TestCase):
     def test_order_is_local_after_creation(self):
         order = KrakenInFlightOrder(
             client_order_id="someId",
-            exchange_order_id=None,
+            exchange_order_id='',
             trading_pair="BTC-USDT",
             order_type=OrderType.LIMIT,
             trade_type=TradeType.BUY,

--- a/test/hummingbot/core/data_type/test_limit_order.py
+++ b/test/hummingbot/core/data_type/test_limit_order.py
@@ -1,6 +1,7 @@
+import time
 import unittest
 from decimal import Decimal
-import time
+
 from hummingbot.core.data_type.limit_order import LimitOrder
 from hummingbot.core.event.events import LimitOrderStatus
 
@@ -45,14 +46,14 @@ class LimitOrderUnitTest(unittest.TestCase):
         self.assertEqual(LimitOrderStatus.OPEN, order.status)
         self.assertEqual(100, order.age())
         end_time = created + (50 * 1e6)
-        self.assertEqual(50, order.age_til(end_time))
+        self.assertEqual(50, order.age_til(int(end_time)))
         end_time = created - (50 * 1e6)
-        self.assertEqual(-1, order.age_til(end_time))
+        self.assertEqual(-1, order.age_til(int(end_time)))
 
     def test_to_pandas(self):
         # Fix the timestamp here so that we can test order age accurately
-        created = 1625835199511442
-        now_ts = created + 100 * 1e6
+        created: int = 1625835199511442
+        now_ts: int = int(created + 100 * 1e6)
         self.maxDiff = None
         orders = [
             LimitOrder("HBOT_1", "A-B", True, "A", "B", Decimal("1"), Decimal("1.5")),

--- a/test/hummingbot/strategy/dev_simple_trade/test_simple_trade.py
+++ b/test/hummingbot/strategy/dev_simple_trade/test_simple_trade.py
@@ -40,7 +40,7 @@ class SimpleTradeUnitTest(unittest.TestCase):
         )
         self.mid_price = 100
         self.time_delay = 15
-        self.cancel_order_wait_time = 45
+        self.cancel_order_wait_time = 45.0
         self.market.set_balanced_order_book(self.maker_trading_pairs[0],
                                             mid_price=self.mid_price, min_price=1,
                                             max_price=200, price_step_size=1, volume_step_size=10)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:
This is PR is not intended to be included into HB, but as a demonstration of alternative to cython .pyx

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
"Augmented Pure Python" mode of coding to migrate HB to Pure Python without loss of performance
   - Introducing Augmented Pure Python mode in PMM/inventory_skew with rudimentary performance tests
   - Augmented Pure Python is .py+.pxd. It allows the maintain uncompiled/debug Python code that is compiled with the updated setup.py
   - A few cases/examples for in-file cython framework with decorators rather than non-python (.pyx) syntax
   - One caveats is that cython-3.0.0a8 is needed for its bugfix of .pyd changes detection
   - The introduction of cython-3.0.0a8 highlights unicode -> str conversion issues in several exchange code that were worked-around in this commit



**Tests performed by the developer**:
Ran several tests related to the Augmented Pure Python. Added a few profile tests in the test_pmm.py for that purpose
   - Tested that non-compiled .py+.pyd files are functional and in Pure Python, step-able line by line with debugger
   - Tested that the compiled/non-compiled with cython.py flag `is_compiled`
   - Tested that once compiled the performance is on-par with cython (.pyx) version - in fact faster! but the code is of course no-longer debuggable


**Tips for QA testing**:


