### PR TITLE
Feat/tick size config

### DIFF
--- a/hummingbot/client/command/config_command.py
+++ b/hummingbot/client/command/config_command.py
@@ -66,7 +66,8 @@ client_configs_to_display = ["autofill_import",
                              "commands_timeout",
                              "create_command_timeout",
                              "other_commands_timeout",
-                             "tables_format"]
+                             "tables_format",
+                             "tick_size"]
 color_settings_to_display = ["top_pane",
                              "bottom_pane",
                              "output_pane",

--- a/hummingbot/client/command/start_command.py
+++ b/hummingbot/client/command/start_command.py
@@ -56,18 +56,16 @@ class StartCommand(GatewayChainApiManager):
               log_level: Optional[str] = None,
               restore: Optional[bool] = False,
               script: Optional[str] = None,
-              tick_size: Optional[float] = None,
               is_quickstart: Optional[bool] = False):
         if threading.current_thread() != threading.main_thread():
             self.ev_loop.call_soon_threadsafe(self.start, log_level, restore)
             return
-        safe_ensure_future(self.start_check(log_level, restore, script, tick_size, is_quickstart), loop=self.ev_loop)
+        safe_ensure_future(self.start_check(log_level, restore, script, is_quickstart), loop=self.ev_loop)
 
     async def start_check(self,  # type: HummingbotApplication
                           log_level: Optional[str] = None,
                           restore: Optional[bool] = False,
                           script: Optional[str] = None,
-                          tick_size: Optional[float] = None,
                           is_quickstart: Optional[bool] = False):
 
         if self._in_start_check or (self.strategy_task is not None and not self.strategy_task.done()):
@@ -186,7 +184,7 @@ class StartCommand(GatewayChainApiManager):
                             "Refer to our Github page for more info: https://github.com/hummingbot/hummingbot")
 
         self.notify(f"\nStatus check complete. Starting '{self.strategy_name}' strategy...")
-        await self.start_market_making(restore, tick_size)
+        await self.start_market_making(restore)
 
         self._in_start_check = False
 
@@ -206,17 +204,10 @@ class StartCommand(GatewayChainApiManager):
         return script_file_name.exists()
 
     async def start_market_making(self,  # type: HummingbotApplication
-                                  restore: Optional[bool] = False,
-                                  tick_size: Optional[float] = None):
+                                  restore: Optional[bool] = False):
         try:
             self.start_time = time.time() * 1e3  # Time in milliseconds
-            if tick_size:
-                if tick_size < 0.1:
-                    self.logger().info("The tick size selected is lower than the min tick size (0.1)"
-                                       "\nAdjusting tick size to the conf_client value")
-                    tick_size = self.client_config_map.tick_size
-            else:
-                tick_size = self.client_config_map.tick_size
+            tick_size = self.client_config_map.tick_size
             self.logger().info(f"Creating the clock with tick size: {tick_size}")
             self.clock = Clock(ClockMode.REALTIME, tick_size=tick_size)
             for market in self.markets.values():

--- a/hummingbot/client/config/config_helpers.py
+++ b/hummingbot/client/config/config_helpers.py
@@ -610,6 +610,7 @@ def load_client_config_map_from_file() -> ClientConfigAdapter:
     if len(config_validation_errors) > 0:
         all_errors = "\n".join(config_validation_errors)
         raise ConfigValidationError(f"There are errors in the client global configuration (\n{all_errors})")
+    save_to_yml(yml_path, config_map)
 
     return config_map
 

--- a/hummingbot/client/config/config_validators.py
+++ b/hummingbot/client/config/config_validators.py
@@ -122,6 +122,32 @@ def validate_int(value: str, min_value: int = None, max_value: int = None, inclu
             return f"Value must be less than {max_value}."
 
 
+def validate_float(value: str, min_value: float = None, max_value: float = None, inclusive=True) -> Optional[str]:
+    """
+    Parse an float value from a string. This value can also be clamped.
+    """
+    try:
+        float_value = float(value)
+    except Exception:
+        return f"{value} is not in integer format."
+    if inclusive:
+        if min_value is not None and max_value is not None:
+            if not (min_value <= float_value <= max_value):
+                return f"Value must be between {min_value} and {max_value}."
+        elif min_value is not None and not float_value >= min_value:
+            return f"Value cannot be less than {min_value}."
+        elif max_value is not None and not float_value <= max_value:
+            return f"Value cannot be more than {max_value}."
+    else:
+        if min_value is not None and max_value is not None:
+            if not (min_value < float_value < max_value):
+                return f"Value must be between {min_value} and {max_value} (exclusive)."
+        elif min_value is not None and not float_value > min_value:
+            return f"Value must be more than {min_value}."
+        elif max_value is not None and not float_value < max_value:
+            return f"Value must be less than {max_value}."
+
+
 def validate_datetime_iso_string(value: str) -> Optional[str]:
     try:
         datetime.strptime(value, '%Y-%m-%d %H:%M:%S')

--- a/hummingbot/client/ui/parser.py
+++ b/hummingbot/client/ui/parser.py
@@ -72,7 +72,6 @@ def load_parser(hummingbot: "HummingbotApplication", command_tabs) -> [ThrowingA
     start_parser.add_argument("--restore", default=False, action="store_true", dest="restore", help="Restore and maintain any active orders.")
     # start_parser.add_argument("--log-level", help="Level of logging")
     start_parser.add_argument("--script", type=str, dest="script", help="Script strategy file name")
-    start_parser.add_argument("--tick-size", type=float, dest="tick_size", help="Tick size used by the clock")
 
     start_parser.set_defaults(func=hummingbot.start)
 

--- a/hummingbot/client/ui/parser.py
+++ b/hummingbot/client/ui/parser.py
@@ -72,6 +72,7 @@ def load_parser(hummingbot: "HummingbotApplication", command_tabs) -> [ThrowingA
     start_parser.add_argument("--restore", default=False, action="store_true", dest="restore", help="Restore and maintain any active orders.")
     # start_parser.add_argument("--log-level", help="Level of logging")
     start_parser.add_argument("--script", type=str, dest="script", help="Script strategy file name")
+    start_parser.add_argument("--tick-size", type=float, dest="tick_size", help="Tick size used by the clock")
 
     start_parser.set_defaults(func=hummingbot.start)
 

--- a/test/hummingbot/client/command/test_config_command.py
+++ b/test/hummingbot/client/command/test_config_command.py
@@ -79,6 +79,7 @@ class ConfigCommandTest(unittest.TestCase):
                            "    | ∟ create_command_timeout | 10                   |\n"
                            "    | ∟ other_commands_timeout | 30                   |\n"
                            "    | tables_format            | psql                 |\n"
+                           "    | tick_size                | 1.0                  |\n"
                            "    +--------------------------+----------------------+")
 
         self.assertEqual(df_str_expected, captures[1])

--- a/test/hummingbot/client/config/test_config_validators.py
+++ b/test/hummingbot/client/config/test_config_validators.py
@@ -2,11 +2,10 @@
 import unittest
 
 import hummingbot.client.config.config_validators as config_validators
-
 from hummingbot.client.settings import AllConnectorSettings
 
 
-class TimestampValidationTests(unittest.TestCase):
+class ConfigValidatorsTests(unittest.TestCase):
     def test_validation_does_not_fail_with_valid_timestamp_string(self):
         timestamp_string = "2021-06-23 10:15:20"
 
@@ -49,3 +48,241 @@ class TimestampValidationTests(unittest.TestCase):
 
         validation_error = config_validators.validate_connector(non_existant_connector)
         self.assertEqual(validation_error, f"Invalid connector, please choose value from {AllConnectorSettings.get_connector_settings().keys()}")
+
+    def test_validate_bool_succeed(self):
+        valid_values = ['true', 'yes', 'y', 'false', 'no', 'n']
+
+        validations = [config_validators.validate_bool(value) for value in valid_values]
+        for validation in validations:
+            self.assertIsNone(validation)
+
+    def test_validate_bool_fails(self):
+        wrong_value = "ye"
+        valid_values = ('true', 'yes', 'y', 'false', 'no', 'n')
+
+        validation_error = config_validators.validate_bool(wrong_value)
+        self.assertEqual(validation_error, f"Invalid value, please choose value from {valid_values}")
+
+    def test_validate_int_without_min_and_max_succeed(self):
+        value = 1
+
+        validation = config_validators.validate_int(value)
+        self.assertIsNone(validation)
+
+    def test_validate_int_wrong_value_fails(self):
+        value = "wrong_value"
+
+        validation = config_validators.validate_int(value)
+        self.assertEqual(validation, f"{value} is not in integer format.")
+
+    def test_validate_int_with_min_and_max_exclusive_succeed(self):
+        value = 1
+        min_value = 0
+        max_value = 2
+        inclusive = False
+
+        validation = config_validators.validate_int(value, min_value=min_value, max_value=max_value, inclusive=inclusive)
+        self.assertIsNone(validation)
+
+    def test_validate_int_with_min_and_max_inclusive_succeed(self):
+        value = 1
+        min_value = 0
+        max_value = 1
+        inclusive = True
+
+        validation = config_validators.validate_int(value, min_value=min_value, max_value=max_value, inclusive=inclusive)
+        self.assertIsNone(validation)
+
+    def test_validate_int_with_min_and_max_exclusive_fails(self):
+        value = 1
+        min_value = 0
+        max_value = 1
+        inclusive = False
+
+        validation = config_validators.validate_int(value, min_value=min_value, max_value=max_value, inclusive=inclusive)
+        self.assertEqual(validation, f"Value must be between {min_value} and {max_value} (exclusive).")
+
+    def test_validate_int_with_min_and_max_inclusive_fails(self):
+        value = 5
+        min_value = 0
+        max_value = 1
+        inclusive = True
+
+        validation = config_validators.validate_int(value, min_value=min_value, max_value=max_value, inclusive=inclusive)
+        self.assertEqual(validation, f"Value must be between {min_value} and {max_value}.")
+
+    def test_validate_int_with_min_exclusive_succeed(self):
+        value = 1
+        min_value = 0
+        inclusive = False
+
+        validation = config_validators.validate_int(value, min_value=min_value, inclusive=inclusive)
+        self.assertIsNone(validation)
+
+    def test_validate_int_with_min_inclusive_succeed(self):
+        value = 1
+        min_value = 0
+        inclusive = True
+
+        validation = config_validators.validate_int(value, min_value=min_value, inclusive=inclusive)
+        self.assertIsNone(validation)
+
+    def test_validate_int_with_min_exclusive_fails(self):
+        value = 1
+        min_value = 1
+        inclusive = False
+
+        validation = config_validators.validate_int(value, min_value=min_value, inclusive=inclusive)
+        self.assertEqual(validation, f"Value must be more than {min_value}.")
+
+    def test_validate_int_with_min_inclusive_fails(self):
+        value = 1
+        min_value = 2
+        inclusive = True
+
+        validation = config_validators.validate_int(value, min_value=min_value, inclusive=inclusive)
+        self.assertEqual(validation, f"Value cannot be less than {min_value}.")
+
+    def test_validate_int_with_max_exclusive_succeed(self):
+        value = 1
+        max_value = 2
+        inclusive = False
+
+        validation = config_validators.validate_int(value, max_value=max_value, inclusive=inclusive)
+        self.assertIsNone(validation)
+
+    def test_validate_int_with_max_inclusive_succeed(self):
+        value = 1
+        max_value = 1
+        inclusive = True
+
+        validation = config_validators.validate_int(value, max_value=max_value, inclusive=inclusive)
+        self.assertIsNone(validation)
+
+    def test_validate_int_with_max_exclusive_fails(self):
+        value = 1
+        max_value = 1
+        inclusive = False
+
+        validation = config_validators.validate_int(value, max_value=max_value, inclusive=inclusive)
+        self.assertEqual(validation, f"Value must be less than {max_value}.")
+
+    def test_validate_int_with_max_inclusive_fails(self):
+        value = 5
+        max_value = 1
+        inclusive = True
+
+        validation = config_validators.validate_int(value, max_value=max_value, inclusive=inclusive)
+        self.assertEqual(validation, f"Value cannot be more than {max_value}.")
+
+    def test_validate_float_without_min_and_max_succeed(self):
+        value = 1.0
+
+        validation = config_validators.validate_float(value)
+        self.assertIsNone(validation)
+
+    def test_validate_float_wrong_value_fails(self):
+        value = "wrong_value"
+
+        validation = config_validators.validate_float(value)
+        self.assertEqual(validation, f"{value} is not in integer format.")
+
+    def test_validate_float_with_min_and_max_exclusive_succeed(self):
+        value = 1.0
+        min_value = 0.0
+        max_value = 2.0
+        inclusive = False
+
+        validation = config_validators.validate_float(value, min_value=min_value, max_value=max_value, inclusive=inclusive)
+        self.assertIsNone(validation)
+
+    def test_validate_float_with_min_and_max_inclusive_succeed(self):
+        value = 1.0
+        min_value = 0.0
+        max_value = 1.0
+        inclusive = True
+
+        validation = config_validators.validate_float(value, min_value=min_value, max_value=max_value, inclusive=inclusive)
+        self.assertIsNone(validation)
+
+    def test_validate_float_with_min_and_max_exclusive_fails(self):
+        value = 1.0
+        min_value = 0.0
+        max_value = 1.0
+        inclusive = False
+
+        validation = config_validators.validate_float(value, min_value=min_value, max_value=max_value, inclusive=inclusive)
+        self.assertEqual(validation, f"Value must be between {min_value} and {max_value} (exclusive).")
+
+    def test_validate_float_with_min_and_max_inclusive_fails(self):
+        value = 5.0
+        min_value = 0.0
+        max_value = 1.0
+        inclusive = True
+
+        validation = config_validators.validate_float(value, min_value=min_value, max_value=max_value, inclusive=inclusive)
+        self.assertEqual(validation, f"Value must be between {min_value} and {max_value}.")
+
+    def test_validate_float_with_min_exclusive_succeed(self):
+        value = 1.0
+        min_value = 0.0
+        inclusive = False
+
+        validation = config_validators.validate_float(value, min_value=min_value, inclusive=inclusive)
+        self.assertIsNone(validation)
+
+    def test_validate_float_with_min_inclusive_succeed(self):
+        value = 1.0
+        min_value = 0.0
+        inclusive = True
+
+        validation = config_validators.validate_float(value, min_value=min_value, inclusive=inclusive)
+        self.assertIsNone(validation)
+
+    def test_validate_float_with_min_exclusive_fails(self):
+        value = 1.0
+        min_value = 1.0
+        inclusive = False
+
+        validation = config_validators.validate_float(value, min_value=min_value, inclusive=inclusive)
+        self.assertEqual(validation, f"Value must be more than {min_value}.")
+
+    def test_validate_float_with_min_inclusive_fails(self):
+        value = 1.0
+        min_value = 2.0
+        inclusive = True
+
+        validation = config_validators.validate_float(value, min_value=min_value, inclusive=inclusive)
+        self.assertEqual(validation, f"Value cannot be less than {min_value}.")
+
+    def test_validate_float_with_max_exclusive_succeed(self):
+        value = 1.0
+        max_value = 2.0
+        inclusive = False
+
+        validation = config_validators.validate_float(value, max_value=max_value, inclusive=inclusive)
+        self.assertIsNone(validation)
+
+    def test_validate_float_with_max_inclusive_succeed(self):
+        value = 1.0
+        max_value = 1.0
+        inclusive = True
+
+        validation = config_validators.validate_float(value, max_value=max_value, inclusive=inclusive)
+        self.assertIsNone(validation)
+
+    def test_validate_float_with_max_exclusive_fails(self):
+        value = 1.0
+        max_value = 1.0
+        inclusive = False
+
+        validation = config_validators.validate_float(value, max_value=max_value, inclusive=inclusive)
+        self.assertEqual(validation, f"Value must be less than {max_value}.")
+
+    def test_validate_float_with_max_inclusive_fails(self):
+        value = 5.0
+        max_value = 1.0
+        inclusive = True
+
+        validation = config_validators.validate_float(value, max_value=max_value, inclusive=inclusive)
+        self.assertEqual(validation, f"Value cannot be more than {max_value}.")


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
- Fix the issue #5648 .
- Add the tick_size as a variable in the ClientConfigMap, this means that you will be able to change the value of the tick size in the conf_client.yml or by running config tick_size.
- Add an argument in the start command that let you override the tick size.
- Add parameter to the config command and the test related.

**CHANGES**: Based on the Discord poll, the improvement that let you change the tick_size with an argument the start was removed.


**Tests performed by the developer**:
For the issue:
1. Delete the conf_client.yml if it is created.
2. Start the client and fill the password
3. Exit the client
4. Check that the conf_client.yml file exist.

For the tick size conf:
1. Check that the conf_client.yml file after doing the steps of the issue, has the tick_size parameter at the end of the file and the value is 1.0
2. Start the client.
3. Run config and check that the tick size appear as a new config
4. Run: config tick_size and select a value higher than 0.1 - Check that the tick size change in the conf_client.yml and in the ui
5. Run: config tick_size and select a value lower than 0.1 - Check that a warning appears and ask you for the value again.
6. Start a script strategy like log_price_example, and check that the logs appear every tick_size

More details: https://www.loom.com/share/138d49d3ceb34da9943f114d848dbe77

**Tips for QA testing**:
Reproduce the same steps and test it also in a normal strategy.
