### PR TITLE
(fix) Coinbase Pro Order Book fails

### DIFF
--- a/hummingbot/connector/exchange/coinbase_pro/coinbase_pro_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/coinbase_pro/coinbase_pro_api_order_book_data_source.py
@@ -181,6 +181,10 @@ class CoinbaseProAPIOrderBookDataSource(OrderBookTrackerDataSource):
         finally:
             await ws.disconnect()
 
+    async def listen_for_subscriptions(self):
+        # Trade messages are received from the order book web socket
+        pass
+
     async def listen_for_trades(self, ev_loop: asyncio.BaseEventLoop, output: asyncio.Queue):
         # Trade messages are received from the order book web socket
         pass


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Addressing the error observed in:
https://github.com/hummingbot/hummingbot/pull/5599
This seems to be due to a refactoring of the OrderBookDataTracker class that added a method 'listen_for_subscription()' that seems to be unnecessary for the Coinbase Pro connector. The solution adopted is to override it with 'pass'


**Tests performed by the developer**:
Implemented the test case provided in the merged PR and did not observe the OderBook failure


**Tips for QA testing**:


