### PR TITLE
Feat/binance perps cancel order

### DIFF
--- a/hummingbot/connector/derivative/binance_perpetual/binance_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/binance_perpetual/binance_perpetual_derivative.py
@@ -1320,7 +1320,7 @@ class BinancePerpetualDerivative(ExchangeBase, PerpetualTrading):
         try:
             # Checks if order is not being tracked or order is waiting for created confirmation.
             # If so, ignores cancel request.
-            tracked_order: Optional[InFlightOrder] = self._client_order_tracker.fetch_order(client_order_id)
+            tracked_order: Optional[InFlightOrder] = self._client_order_tracker.fetch_tracked_order(client_order_id)
             if not tracked_order or tracked_order.is_pending_create:
                 return
 

--- a/hummingbot/connector/derivative/binance_perpetual/binance_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/binance_perpetual/binance_perpetual_derivative.py
@@ -1341,7 +1341,7 @@ class BinancePerpetualDerivative(ExchangeBase, PerpetualTrading):
                 is_auth_required=True,
                 return_err=True,
             )
-            if response.get("code") == -2011 or "Unknown order sent" in response.get("msg", ""):
+            if response.get("code") == -2011 and "Unknown order sent" in response.get("msg", ""):
                 self.logger().debug(f"The order {client_order_id} does not exist on Binance Perpetuals. "
                                     f"No cancelation needed.")
                 self.stop_tracking_order(client_order_id)

--- a/hummingbot/connector/derivative/coinflex_perpetual/coinflex_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/coinflex_perpetual/coinflex_perpetual_derivative.py
@@ -1293,7 +1293,7 @@ class CoinflexPerpetualDerivative(ExchangeBase, PerpetualTrading):
         try:
             # Checks if order is not being tracked or order is waiting for created confirmation.
             # If so, ignores cancel request.
-            tracked_order: Optional[InFlightOrder] = self._client_order_tracker.fetch_order(client_order_id)
+            tracked_order: Optional[InFlightOrder] = self._client_order_tracker.fetch_tracked_order(client_order_id)
             if not tracked_order or tracked_order.is_pending_create:
                 return
 

--- a/hummingbot/connector/exchange_py_base.py
+++ b/hummingbot/connector/exchange_py_base.py
@@ -475,6 +475,7 @@ class ExchangePyBase(ExchangeBase, ABC):
                                   f"minimum notional size {trading_rule.min_notional_size}. "
                                   "The order will not be created.")
             self._update_order_after_failure(order_id=order_id, trading_pair=trading_pair)
+            return
 
         try:
             exchange_order_id, update_timestamp = await self._place_order(


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
The method _execute_cancel, was requesting the in_flight_orders + cached orders. I changed it to just check for the active orders and also the logic to stop tracking orders was changed based on the docs. (the code -2011 can have more than one error message so the two conditions needs to be present to stop tracking the order)

<img width="713" alt="image" src="https://user-images.githubusercontent.com/36869960/189338332-814c26de-2e46-445d-9946-942d3fa69d0a.png">



**Tests performed by the developer**:
run a perpetual market making and check that the behavior is the expected


**Tips for QA testing**:
Test Perpetual Market Making for 2-3 days and check if the issue is solved

