### PR TITLE
(fix) do not accept blank password.

### DIFF
--- a/hummingbot/client/ui/__init__.py
+++ b/hummingbot/client/ui/__init__.py
@@ -22,6 +22,7 @@ with open(realpath(join(dirname(__file__), '../../VERSION'))) as version_file:
 def login_prompt(secrets_manager_cls: Type[BaseSecretsManager], style: Style):
     err_msg = None
     secrets_manager = None
+    blank_attemps = 0
     if Security.new_password_required() and legacy_confs_exist():
         secrets_manager = migrate_configs_prompt(secrets_manager_cls, style)
     if Security.new_password_required():
@@ -39,7 +40,25 @@ def login_prompt(secrets_manager_cls: Type[BaseSecretsManager], style: Style):
     Enter your new password:""",
             password=True,
             style=style).run()
-        if password is None:
+        while password is str() and blank_attemps < 5:
+            password = input_dialog(
+                title="Set Password Again",
+                text="""
+   Password must have at least one character.
+
+   Create a password to protect your sensitive data.
+   This password is not shared with us nor with anyone else, so please store it securely.
+
+   If you have used hummingbot before and already have secure configs stored,
+   input your previous password in this prompt. The next step will automatically
+   migrate your existing configs.
+
+   Enter your new password:""",
+                password=True,
+                style=style).run()
+            if password == str():
+                blank_attemps += 1
+        if password is None or password is str():
             return None
         re_password = input_dialog(
             title="Set Password",

--- a/test/hummingbot/client/ui/test_login_prompt.py
+++ b/test/hummingbot/client/ui/test_login_prompt.py
@@ -62,3 +62,23 @@ class LoginPromptTest(unittest.TestCase):
         self.assertTrue(login_prompt(ETHKeyFileSecretManger, style=load_style(self.client_config_map)))
         self.assertEqual(2, len(login_mock.mock_calls))
         message_dialog_mock.assert_called()
+
+    @patch("hummingbot.client.ui.message_dialog")
+    @patch("hummingbot.client.ui.input_dialog")
+    @patch("hummingbot.client.config.security.Security.new_password_required")
+    def test_iterate_or_skip_through_blank_password(
+        self,
+        new_password_required_mock: MagicMock,
+        input_dialog_mock: MagicMock,
+        message_dialog_mock: MagicMock,
+    ):
+        new_password_required_mock.return_value = True
+        run_mock = MagicMock()
+        run_mock.run.return_value = None
+        input_dialog_mock.return_value = run_mock
+        message_dialog_mock.return_value = run_mock
+
+        self.assertEqual(login_prompt(ETHKeyFileSecretManger, style=load_style(self.client_config_map)), None)
+
+        run_mock.run.return_value = str()
+        self.assertEqual(login_prompt(ETHKeyFileSecretManger, style=load_style(self.client_config_map)), None)


### PR DESCRIPTION
Utopically should be a perpetual while, but since it's not possible test an infinite conditional while loops (such as password == str()) I defined five iterations before app exits.

**A description of the changes proposed in the pull request**:
Currently and as mentioned in #5211, when user skips entering a new password by pressing ok  the app allows him to set a blank password. This fix loops over this scenario five times and then it closes the app.


**Tests performed by the developer**:
test_iterate_or_skip_through_blank_password (test/hummingbot/client/ui/test_login_prompt.py)


**Tips for QA testing**:
Pass a blank pass five times when prompt asks user to set a new password, it should close the app

