### PR TITLE
(fix) change name of trading_pairs property

### DIFF
--- a/hummingbot/connector/exchange/paper_trade/paper_trade_exchange.pyx
+++ b/hummingbot/connector/exchange/paper_trade/paper_trade_exchange.pyx
@@ -201,6 +201,10 @@ cdef class PaperTradeExchange(ExchangeBase):
 
     #  <editor-fold desc="Property">
     @property
+    def trading_pair(self) -> Dict[str, TradingPair]:
+        return self._trading_pairs
+
+    @property
     def trading_pairs(self) -> List[str]:
         return [trading_pair for trading_pair in self._trading_pairs]
 

--- a/hummingbot/connector/exchange/paper_trade/paper_trade_exchange.pyx
+++ b/hummingbot/connector/exchange/paper_trade/paper_trade_exchange.pyx
@@ -201,8 +201,8 @@ cdef class PaperTradeExchange(ExchangeBase):
 
     #  <editor-fold desc="Property">
     @property
-    def trading_pair(self) -> Dict[str, TradingPair]:
-        return self._trading_pairs
+    def trading_pairs(self) -> List[str]:
+        return [trading_pair for trading_pair in self._trading_pairs]
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
This PR Closes #5720 
Now the property trading_pairs is available in the paper_trade exchange and returns a list of trading pairs.


**Tests performed by the developer**:
Run the same script of the issue and check that it's returning the same list


**Tips for QA testing**:
Test the pure market making strategies with paper trade for 5 minutes and check if all is working ok.

