### PR TITLE
Fix/okx cancel order error code

### DIFF
--- a/hummingbot/connector/exchange/okx/okx_exchange.py
+++ b/hummingbot/connector/exchange/okx/okx_exchange.py
@@ -207,8 +207,11 @@ class OkxExchange(ExchangePyBase):
         )
         if cancel_result["data"][0]["sCode"] == "0":
             final_result = True
-        elif cancel_result["data"][0]["sCode"] == "5140":
-            # Cancelation failed because the order does not exist anymore
+        elif cancel_result["data"][0]["sCode"] == "51400":
+            # Cancelation failed because the order does not exist
+            final_result = True
+        elif cancel_result["data"][0]["sCode"] == "51401":
+            # Cancelation failed because order has been cancelled
             final_result = True
         else:
             raise IOError(cancel_result["msg"])

--- a/hummingbot/connector/exchange/okx/okx_exchange.py
+++ b/hummingbot/connector/exchange/okx/okx_exchange.py
@@ -214,7 +214,7 @@ class OkxExchange(ExchangePyBase):
             # Cancelation failed because order has been cancelled
             final_result = True
         else:
-            raise IOError(cancel_result["msg"])
+            raise IOError(f"Error cancelling order {order_id}: {cancel_result}")
 
         return final_result
 


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

1. Fixed a bug on okx exchange error code handling. When an cancel order API request is sent and the order does not exist. The previously expected error code value is 5140. However, according to okx [documentation](https://www.okx.com/docs-v5/en/#error-code-rest-public), the error codes are 51400 (order does not exist) and 51401 (order has already been cancelled).

2. Added API response data in error log message for easier troubleshooting of data. Previous `cancel_result['msg']` was showing only `"Operation Failed"` which was not very helpful.

**Tests performed by the developer**:
1. Ran the xemm with 2 trading pairs on okx exchange for 6 hours, did not face the cancel order error logs which were showing up before the code changes
2. When troubleshooting issue mentioned in point 1, logging `cancel_result` showed the error code which okx API was returning.

**Tips for QA testing**:
- NA

