### PR TITLE
(fix) add new endpoint to request funding info

### DIFF
--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_api_order_book_data_source.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_api_order_book_data_source.py
@@ -42,13 +42,15 @@ class BybitPerpetualAPIOrderBookDataSource(PerpetualAPIOrderBookDataSource):
 
     async def get_funding_info(self, trading_pair: str) -> FundingInfo:
         funding_info_response = await self._request_complete_funding_info(trading_pair)
-        symbol_info: Dict[str, Any] = (funding_info_response["result"][0])
+        general_info = funding_info_response[0]["result"][0]
+        predicted_funding = funding_info_response[1]["result"]
+
         funding_info = FundingInfo(
             trading_pair=trading_pair,
-            index_price=Decimal(str(symbol_info["index_price"])),
-            mark_price=Decimal(str(symbol_info["mark_price"])),
-            next_funding_utc_timestamp=int(pd.Timestamp(symbol_info["next_funding_time"]).timestamp()),
-            rate=Decimal(str(symbol_info["predicted_funding_rate"])),
+            index_price=Decimal(str(general_info["index_price"])),
+            mark_price=Decimal(str(general_info["mark_price"])),
+            next_funding_utc_timestamp=int(pd.Timestamp(general_info["next_funding_time"]).timestamp()),
+            rate=Decimal(str(predicted_funding["predicted_funding_rate"])),
         )
         return funding_info
 
@@ -238,22 +240,35 @@ class BybitPerpetualAPIOrderBookDataSource(PerpetualAPIOrderBookDataSource):
                     )
                 message_queue.put_nowait(info_update)
 
-    async def _request_complete_funding_info(self, trading_pair: str) -> Dict[str, Any]:
+    async def _request_complete_funding_info(self, trading_pair: str):
+        tasks = []
         params = {
             "symbol": await self._connector.exchange_symbol_associated_to_pair(trading_pair=trading_pair),
         }
 
         rest_assistant = await self._api_factory.get_rest_assistant()
-        endpoint = CONSTANTS.LATEST_SYMBOL_INFORMATION_ENDPOINT
-        url = web_utils.get_rest_url_for_endpoint(endpoint=endpoint, trading_pair=trading_pair, domain=self._domain)
-        limit_id = web_utils.get_rest_api_limit_id_for_endpoint(endpoint)
-        data = await rest_assistant.execute_request(
-            url=url,
+        endpoint_info = CONSTANTS.LATEST_SYMBOL_INFORMATION_ENDPOINT
+        url_info = web_utils.get_rest_url_for_endpoint(endpoint=endpoint_info, trading_pair=trading_pair, domain=self._domain)
+        limit_id = web_utils.get_rest_api_limit_id_for_endpoint(endpoint_info)
+        tasks.append(rest_assistant.execute_request(
+            url=url_info,
             throttler_limit_id=limit_id,
             params=params,
             method=RESTMethod.GET,
-        )
-        return data
+        ))
+        endpoint_predicted = CONSTANTS.GET_PREDICTED_FUNDING_RATE_PATH_URL
+        url_predicted = web_utils.get_rest_url_for_endpoint(endpoint=endpoint_predicted, trading_pair=trading_pair, domain=self._domain)
+        limit_id_predicted = web_utils.get_rest_api_limit_id_for_endpoint(endpoint_predicted, trading_pair)
+        tasks.append(rest_assistant.execute_request(
+            url=url_predicted,
+            throttler_limit_id=limit_id_predicted,
+            params=params,
+            method=RESTMethod.GET,
+            is_auth_required=True
+        ))
+
+        responses = await asyncio.gather(*tasks)
+        return responses
 
     async def _order_book_snapshot(self, trading_pair: str) -> OrderBookMessage:
         snapshot_response = await self._request_order_book_snapshot(trading_pair)

--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_constants.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_constants.py
@@ -64,6 +64,10 @@ SET_LEVERAGE_PATH_URL = {
 GET_LAST_FUNDING_RATE_PATH_URL = {
     LINEAR_MARKET: "private/linear/funding/prev-funding",
     NON_LINEAR_MARKET: f"{REST_API_VERSION}/private/funding/prev-funding"}
+GET_PREDICTED_FUNDING_RATE_PATH_URL = {
+    LINEAR_MARKET: "/private/linear/funding/predicted-funding",
+    NON_LINEAR_MARKET: f"{REST_API_VERSION}/private/funding/predicted-funding"
+}
 GET_POSITIONS_PATH_URL = {
     LINEAR_MARKET: "private/linear/position/list",
     NON_LINEAR_MARKET: f"{REST_API_VERSION}/private/position/list"}

--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_web_utils.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_web_utils.py
@@ -274,6 +274,16 @@ def _build_private_pair_specific_non_linear_rate_limits(trading_pair: str) -> Li
         ),
         RateLimit(
             limit_id=get_pair_specific_limit_id(
+                base_limit_id=CONSTANTS.GET_PREDICTED_FUNDING_RATE_PATH_URL[CONSTANTS.NON_LINEAR_MARKET],
+                trading_pair=trading_pair,
+            ),
+            limit=120,
+            time_interval=60,
+            linked_limits=[LinkedLimitWeightPair(CONSTANTS.GET_LIMIT_ID),
+                           LinkedLimitWeightPair(pair_specific_non_linear_private_bucket_120_c_limit_id)],
+        ),
+        RateLimit(
+            limit_id=get_pair_specific_limit_id(
                 base_limit_id=CONSTANTS.GET_POSITIONS_PATH_URL[CONSTANTS.NON_LINEAR_MARKET], trading_pair=trading_pair
             ),
             limit=120,
@@ -356,6 +366,16 @@ def _build_private_pair_specific_linear_rate_limits(trading_pair: str) -> List[R
         RateLimit(
             limit_id=get_pair_specific_limit_id(
                 base_limit_id=CONSTANTS.GET_LAST_FUNDING_RATE_PATH_URL[CONSTANTS.LINEAR_MARKET],
+                trading_pair=trading_pair,
+            ),
+            limit=120,
+            time_interval=60,
+            linked_limits=[LinkedLimitWeightPair(CONSTANTS.GET_LIMIT_ID),
+                           LinkedLimitWeightPair(pair_specific_linear_private_bucket_120_a_limit_id)],
+        ),
+        RateLimit(
+            limit_id=get_pair_specific_limit_id(
+                base_limit_id=CONSTANTS.GET_PREDICTED_FUNDING_RATE_PATH_URL[CONSTANTS.LINEAR_MARKET],
                 trading_pair=trading_pair,
             ),
             limit=120,


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Based on the last changelog (https://bybit-exchange.github.io/docs/futuresV2/inverse/#2022-10-12) the general endpoint is not going to offer the predicted funding rate anymore.
That's why the connector wasn't working as expected because the information was missing.
The solution adds a new endpoint to request this information for linear and inverse perpetuals

**Tests performed by the developer**:
All unit test, and perpetual market making.


**Tips for QA testing**:
Test for some time a perpetual market making strategy for linear and inverse perpetuals.

