### PR TITLE
Fix/gateway testing methods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 .PHONY: development-diff-cover
 
 test:
-	coverage run -m nose --exclude-dir="test/connector" --exclude-dir="test/debug" --exclude-dir="test/mock" --exclude-dir="test/hummingbot/connector/gateway"
+	coverage run -m nose --exclude-dir="test/connector" --exclude-dir="test/debug" --exclude-dir="test/mock"
 
 run_coverage: test
 	coverage report

--- a/test/hummingbot/connector/gateway/amm/test_gateway_cancel.py
+++ b/test/hummingbot/connector/gateway/amm/test_gateway_cancel.py
@@ -35,7 +35,7 @@ TRADING_PAIR = "WETH-DAI"
 MAX_FEE_PER_GAS = 2000
 MAX_PRIORITY_FEE_PER_GAS = 200
 
-ev_loop: asyncio.AbstractEventLoop = asyncio.get_event_loop()
+ev_loop: asyncio.AbstractEventLoop = asyncio.new_event_loop()
 
 
 class GatewayCancelUnitTest(unittest.TestCase):
@@ -78,6 +78,7 @@ class GatewayCancelUnitTest(unittest.TestCase):
     @classmethod
     def tearDownClass(cls) -> None:
         cls._patch_stack.close()
+        ev_loop.close()
 
     def tearDown(self) -> None:
         self._connector._order_tracker.all_orders.clear()

--- a/test/hummingbot/connector/gateway/amm/test_gateway_evm_amm.py
+++ b/test/hummingbot/connector/gateway/amm/test_gateway_evm_amm.py
@@ -32,7 +32,7 @@ from hummingbot.core.event.events import (
 from hummingbot.core.gateway.gateway_http_client import GatewayHttpClient
 from hummingbot.core.utils.async_utils import safe_ensure_future
 
-ev_loop: asyncio.AbstractEventLoop = asyncio.get_event_loop()
+ev_loop: asyncio.AbstractEventLoop = asyncio.new_event_loop()
 s_decimal_0: Decimal = Decimal(0)
 
 
@@ -79,6 +79,7 @@ class GatewayEVMAMMConnectorUnitTest(unittest.TestCase):
         cls._patch_stack.close()
         GatewayHttpClient.__instance = None
         super().tearDownClass()
+        ev_loop.close()
 
     def setUp(self) -> None:
         super().setUp()

--- a/test/hummingbot/connector/gateway/amm/test_gateway_evm_amm_lp.py
+++ b/test/hummingbot/connector/gateway/amm/test_gateway_evm_amm_lp.py
@@ -31,7 +31,7 @@ from hummingbot.core.event.events import (
 from hummingbot.core.gateway.gateway_http_client import GatewayHttpClient
 from hummingbot.core.utils.async_utils import safe_ensure_future
 
-ev_loop: asyncio.AbstractEventLoop = asyncio.get_event_loop()
+ev_loop: asyncio.AbstractEventLoop = asyncio.new_event_loop()
 s_decimal_0: Decimal = Decimal(0)
 
 
@@ -74,6 +74,7 @@ class GatewayEVMAMMLPConnectorUnitTest(unittest.TestCase):
     @classmethod
     def tearDownClass(cls) -> None:
         cls._patch_stack.close()
+        ev_loop.close()
 
     def setUp(self) -> None:
         self._http_player.replay_timestamp_ms = None

--- a/test/hummingbot/connector/gateway/clob/test_gateway_cancel.py
+++ b/test/hummingbot/connector/gateway/clob/test_gateway_cancel.py
@@ -27,7 +27,7 @@ TRADING_PAIR = "SOL-USDC"
 MAX_FEE_PER_GAS = 2000
 MAX_PRIORITY_FEE_PER_GAS = 200
 
-ev_loop: asyncio.AbstractEventLoop = asyncio.get_event_loop()
+ev_loop: asyncio.AbstractEventLoop = asyncio.new_event_loop()
 
 
 class GatewayCancelUnitTest(unittest.TestCase):
@@ -69,6 +69,7 @@ class GatewayCancelUnitTest(unittest.TestCase):
     @classmethod
     def tearDownClass(cls) -> None:
         cls._patch_stack.close()
+        ev_loop.close()
 
     def tearDown(self) -> None:
         self._connector._order_tracker.all_orders.clear()

--- a/test/hummingbot/core/mock_api/test_mock_web_socket_server.py
+++ b/test/hummingbot/core/mock_api/test_mock_web_socket_server.py
@@ -1,58 +1,62 @@
-import aiohttp
-from aiounittest import async_test
 import asyncio
-import unittest.mock
 import json
+import unittest.mock
+
+import aiohttp
 
 from hummingbot.core.mock_api.mock_web_socket_server import MockWebSocketServerFactory
 
-ev_loop: asyncio.AbstractEventLoop = asyncio.get_event_loop()
 
-
-class MockWebSocketServerFactoryTest(unittest.TestCase):
+class MockWebSocketServerFactoryTest(unittest.IsolatedAsyncioTestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.ws_server = MockWebSocketServerFactory.start_new_server("wss://www.google.com/ws/")
-        cls._patcher = unittest.mock.patch("aiohttp.client.ClientSession.ws_connect", autospec=True)
-        cls._mock = cls._patcher.start()
-        cls._mock.side_effect = MockWebSocketServerFactory.reroute_ws_connect
+
+    async def asyncSetUp(self) -> None:
+        self.session = aiohttp.ClientSession()
+        MockWebSocketServerFactory._orig_ws_connect = self.session.ws_connect
+
+        self._patcher = unittest.mock.patch("aiohttp.client.ClientSession.ws_connect", autospec=True)
+        self._mock = self._patcher.start()
+        self._mock.side_effect = MockWebSocketServerFactory.reroute_ws_connect
+
         # need to wait a bit for the server to be available
-        ev_loop.run_until_complete(asyncio.wait_for(cls.ws_server.wait_til_started(), 1))
+        await asyncio.wait_for(MockWebSocketServerFactoryTest.ws_server.wait_til_started(), 1)
+
+    async def asyncTearDown(self) -> None:
+        self._patcher.stop()
 
     @classmethod
     def tearDownClass(cls) -> None:
         cls.ws_server.stop()
-        cls._patcher.stop()
 
-    @async_test(loop=ev_loop)
     async def test_web_socket(self):
         uri = "wss://www.google.com/ws/"
 
         # Retry up to 3 times if there is any error connecting to the mock server address and port
-        async with aiohttp.ClientSession() as client:
-            for retry_attempt in range(3):
-                try:
-                    async with client.ws_connect(uri) as websocket:
-                        await MockWebSocketServerFactory.send_str(uri, "aaa")
-                        answer = await websocket.receive_str()
-                        self.assertEqual("aaa", answer)
+        for retry_attempt in range(3):
+            try:
+                async with self.session.ws_connect(uri) as websocket:
+                    await MockWebSocketServerFactory.send_str(uri, "aaa")
+                    answer = await websocket.receive_str()
+                    self.assertEqual("aaa", answer)
 
-                        await MockWebSocketServerFactory.send_json(uri, data={"foo": "bar"})
-                        answer = await websocket.receive_str()
-                        answer = json.loads(answer)
-                        self.assertEqual(answer["foo"], "bar")
+                    await MockWebSocketServerFactory.send_json(uri, data={"foo": "bar"})
+                    answer = await websocket.receive_str()
+                    answer = json.loads(answer)
+                    self.assertEqual(answer["foo"], "bar")
 
-                        await self.ws_server.websocket.send_str("xxx")
-                        answer = await websocket.receive_str()
-                        self.assertEqual("xxx", answer)
-                except OSError:
-                    if retry_attempt == 2:
-                        raise
-                    # Continue retrying
-                    continue
+                    await self.ws_server.websocket.send_str("xxx")
+                    answer = await websocket.receive_str()
+                    self.assertEqual("xxx", answer)
+            except OSError:
+                if retry_attempt == 2:
+                    raise
+                # Continue retrying
+                continue
 
-                # Stop the retries cycle
-                break
+            # Stop the retries cycle
+            break
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
There is a few very subtle (at least for me) sub-optimal constructs in the MockWebSocketServer module:
   - The aiohttp.ClientSession is created outside an async - still works but will cause issues with closing the session
   - In fact there seems to be no need for a session in the server factory (It seems that is it just an artifact to get the correct ws_connect address)
   - Creating the ws_connect address at this stage, effectively requires to have a global EventLoop, but this does not seem necessary
   - The server stop is creating also attempting to benefit from the global ev_loop, even though it has its own new_event_loop
 
In this proposal:
   - Simplify the factory to re-use its even loop (it runs in its own thread, with its own event loop called with new_event_loop)
   - Remove the session, which allows to not have the need for a global session, and thus global ev_loop
   - Correct the testcase to create the session in async with each test (sessions are opened and closed for each tests)
   - Record the ws_connect before starting the patcher


**Tests performed by the developer**:
Pass the tests - Note that this will likely break other tests, which ideally should not be the case, agreed?


**Tips for QA testing**:


