### PR TITLE
(fix) fix base asset balance in asset ratio config

### DIFF
--- a/hummingbot/client/command/config_command.py
+++ b/hummingbot/client/command/config_command.py
@@ -327,7 +327,7 @@ class ConfigCommand:
             exchange = config_map.exchange
             market = config_map.market
             base, quote = split_hb_trading_pair(market)
-            balances = await UserBalances.instance().balances(exchange, base, quote)
+            balances = await UserBalances.instance().balances(exchange, config_map, base, quote)
             if balances is None:
                 return
             base_ratio = await UserBalances.base_amount_ratio(exchange, market, balances)
@@ -364,7 +364,7 @@ class ConfigCommand:
             exchange = config_map['exchange'].value
             market = config_map["market"].value
             base, quote = market.split("-")
-            balances = await UserBalances.instance().balances(exchange, base, quote)
+            balances = await UserBalances.instance().balances(exchange, config_map, base, quote)
             if balances is None:
                 return
             base_ratio = await UserBalances.base_amount_ratio(exchange, market, balances)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**: When modifying the inventory asset ratio configuration, Hummingbot was always showing a base asset balance of 0 even when the balance command showed otherwise. This is because only the quote asset was having its balance checked, and this fix includes the base asset in the balance check which resolves the issue.



**Tests performed by the developer**: I created several different strategies and tried modifying the inventory asset ratio with inventory skew enabled as well as disabled. In every scenario, the correct results were returned with the fix applied. I verified this by comparing the values returned with the return from the "balance" command.



**Tips for QA testing**: It would appear this bug only appears in pure market making and Avellaneda strategies. It may also require inventory skew being enabled.
