### PR TITLE
Fix/xemm taker queries

### DIFF
--- a/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.py
+++ b/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.py
@@ -1154,7 +1154,7 @@ class CrossExchangeMarketMakingStrategy(StrategyPyBase):
             else:
                 try:
                     taker_price = taker_market.get_price_for_quote_volume(
-                        taker_trading_pair, True, size
+                        taker_trading_pair, True, taker_balance_in_quote
                     ).result_price
                 except ZeroDivisionError:
                     assert size == s_decimal_zero

--- a/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.py
+++ b/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.py
@@ -1585,7 +1585,7 @@ class CrossExchangeMarketMakingStrategy(StrategyPyBase):
             taker_slippage_adjustment_factor = Decimal("1") + self.slippage_buffer
 
             base_asset_amount = maker_market.get_balance(market_pair.maker.base_asset)
-            quote_asset_amount = taker_market.get_balance(market_pair.taker.quote_asset) * quote_rate
+            quote_asset_amount = taker_market.get_balance(market_pair.taker.quote_asset)
 
             if self.is_gateway_market(market_pair.taker):
                 taker_price = await taker_market.get_order_price(taker_trading_pair,
@@ -1600,7 +1600,6 @@ class CrossExchangeMarketMakingStrategy(StrategyPyBase):
                     taker_trading_pair, True, quote_asset_amount
                 ).result_price
 
-            taker_price *= self.markettaker_to_maker_base_conversion_rate(market_pair)
             adjusted_taker_price = taker_price * taker_slippage_adjustment_factor
             order_size_limit = min(base_asset_amount, quote_asset_amount / adjusted_taker_price)
 

--- a/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.py
+++ b/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.py
@@ -1600,7 +1600,7 @@ class CrossExchangeMarketMakingStrategy(StrategyPyBase):
                     taker_trading_pair, True, quote_asset_amount
                 ).result_price
 
-            adjusted_taker_price = taker_price * taker_slippage_adjustment_factor
+            adjusted_taker_price = (taker_price / base_rate) * taker_slippage_adjustment_factor
             order_size_limit = min(base_asset_amount, quote_asset_amount / adjusted_taker_price)
 
         quantized_size_limit = maker_market.quantize_order_amount(active_order.trading_pair, order_size_limit)

--- a/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.py
+++ b/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.py
@@ -1597,7 +1597,7 @@ class CrossExchangeMarketMakingStrategy(StrategyPyBase):
                     return False
             else:
                 taker_price = taker_market.get_price_for_quote_volume(
-                    taker_trading_pair, True, size
+                    taker_trading_pair, True, quote_asset_amount
                 ).result_price
 
             taker_price *= self.markettaker_to_maker_base_conversion_rate(market_pair)


### PR DESCRIPTION
**A description of the changes proposed in the pull request**:

With the recent changes on xemm different base/quote rates, https://github.com/hummingbot/hummingbot/pull/5812#issuecomment-1328340223 reported on the pull request.

Order size in base asset (of maker) was used to query the order book of taker, which should instead be the quote asset(of the taker).

**Tests performed by the developer**:

I have run the configuration posted in https://github.com/hummingbot/hummingbot/pull/5812#issuecomment-1328340223 + 2 other configs for different base and quote assests for 4-5 days with filled trades.

[tested_confs.zip](https://github.com/hummingbot/hummingbot/files/10147080/tested_confs.zip)


**Tips for QA testing**:


