### PR TITLE
Fixes import command crashing prompt when given file_name is wrong + …

### DIFF
--- a/hummingbot/client/command/import_command.py
+++ b/hummingbot/client/command/import_command.py
@@ -39,7 +39,15 @@ class ImportCommand:
             self.app.to_stop_config = False
             return
         strategy_path = STRATEGIES_CONF_DIR_PATH / file_name
-        config_map = await load_strategy_config_map_from_file(strategy_path)
+        try:
+            config_map = await load_strategy_config_map_from_file(strategy_path)
+        except Exception as e:
+            self.notify(f'Strategy import error: {str(e)}')
+            # Reset prompt settings
+            self.placeholder_mode = False
+            self.app.hide_input = False
+            self.app.change_prompt(prompt=">>> ")
+            raise
         self.strategy_file_name = file_name
         self.strategy_name = (
             config_map.strategy

--- a/hummingbot/client/command/import_command.py
+++ b/hummingbot/client/command/import_command.py
@@ -13,7 +13,7 @@ from hummingbot.client.settings import CONF_PREFIX, STRATEGIES_CONF_DIR_PATH, re
 from hummingbot.core.utils.async_utils import safe_ensure_future
 
 if TYPE_CHECKING:
-    from hummingbot.client.hummingbot_application import HummingbotApplication
+    from hummingbot.client.hummingbot_application import HummingbotApplication  # noqa: F401
 
 
 class ImportCommand:


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Fixes https://github.com/hummingbot/hummingbot/issues/3376.

![Hummingbot_PR_fix_import_command](https://user-images.githubusercontent.com/4770702/210576744-4f4b36c7-9230-4370-912b-450753769915.gif)


**Tests performed by the developer**:

Implemented a test for wrong `file_name` passed to the import command: https://github.com/klpanagi/hummingbot/blob/fix/import_wrong_file_name/test/hummingbot/client/command/test_import_command.py#L207

Unittests passed locally.

**Tips for QA testing**:

Check the open issue for more info: Fixes https://github.com/hummingbot/hummingbot/issues/3376

Steps to reproduce:

- Run import endpoint test by calling the non-existing strategy file: Import error appears  on notification and log panels
- Run any command: Prompt works as expected
