### PR TITLE
Remove suspend and restore feature from start and exit commands respe…

### DIFF
--- a/hummingbot/client/command/exit_command.py
+++ b/hummingbot/client/command/exit_command.py
@@ -11,22 +11,22 @@ if TYPE_CHECKING:
 
 class ExitCommand:
     def exit(self,  # type: HummingbotApplication
-             ):
-        safe_ensure_future(self.exit_loop(), loop=self.ev_loop)
+             force: bool = False):
+        safe_ensure_future(self.exit_loop(force), loop=self.ev_loop)
 
     async def exit_loop(self,  # type: HummingbotApplication
-                        ):
+                        force: bool = False):
         if self.strategy_task is not None and not self.strategy_task.cancelled():
             self.strategy_task.cancel()
-        success = await self._cancel_outstanding_orders()
-        if not success:
-            self.notify(
-                'Wind down process terminated: Failed to cancel all outstanding orders. '
-                '\nYou may need to manually cancel remaining orders by logging into your chosen exchanges'
-            )
-            return
-        # Freeze screen 1 second for better UI
-        await asyncio.sleep(1)
+        if force is False and self._trading_required:
+            success = await self._cancel_outstanding_orders()
+            if not success:
+                self.notify('Wind down process terminated: Failed to cancel all outstanding orders. '
+                            '\nYou may need to manually cancel remaining orders by logging into your chosen exchanges'
+                            '\n\nTo force exit the app, enter "exit -f"')
+                return
+            # Freeze screen 1 second for better UI
+            await asyncio.sleep(1)
 
         if self._gateway_monitor is not None:
             self._gateway_monitor.stop()

--- a/hummingbot/client/command/exit_command.py
+++ b/hummingbot/client/command/exit_command.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 from hummingbot.core.utils.async_utils import safe_ensure_future
 
 if TYPE_CHECKING:
-    from hummingbot.client.hummingbot_application import HummingbotApplication
+    from hummingbot.client.hummingbot_application import HummingbotApplication  # noqa: F401
 
 
 class ExitCommand:

--- a/hummingbot/client/command/exit_command.py
+++ b/hummingbot/client/command/exit_command.py
@@ -1,31 +1,32 @@
 #!/usr/bin/env python
 
 import asyncio
+from typing import TYPE_CHECKING
+
 from hummingbot.core.utils.async_utils import safe_ensure_future
 
-from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from hummingbot.client.hummingbot_application import HummingbotApplication
 
 
 class ExitCommand:
     def exit(self,  # type: HummingbotApplication
-             force: bool = False):
-        safe_ensure_future(self.exit_loop(force), loop=self.ev_loop)
+             ):
+        safe_ensure_future(self.exit_loop(), loop=self.ev_loop)
 
     async def exit_loop(self,  # type: HummingbotApplication
-                        force: bool = False):
+                        ):
         if self.strategy_task is not None and not self.strategy_task.cancelled():
             self.strategy_task.cancel()
-        if force is False and self._trading_required:
-            success = await self._cancel_outstanding_orders()
-            if not success:
-                self.notify('Wind down process terminated: Failed to cancel all outstanding orders. '
-                            '\nYou may need to manually cancel remaining orders by logging into your chosen exchanges'
-                            '\n\nTo force exit the app, enter "exit -f"')
-                return
-            # Freeze screen 1 second for better UI
-            await asyncio.sleep(1)
+        success = await self._cancel_outstanding_orders()
+        if not success:
+            self.notify(
+                'Wind down process terminated: Failed to cancel all outstanding orders. '
+                '\nYou may need to manually cancel remaining orders by logging into your chosen exchanges'
+            )
+            return
+        # Freeze screen 1 second for better UI
+        await asyncio.sleep(1)
 
         if self._gateway_monitor is not None:
             self._gateway_monitor.stop()

--- a/hummingbot/client/command/start_command.py
+++ b/hummingbot/client/command/start_command.py
@@ -54,17 +54,15 @@ class StartCommand(GatewayChainApiManager):
 
     def start(self,  # type: HummingbotApplication
               log_level: Optional[str] = None,
-              restore: Optional[bool] = False,
               script: Optional[str] = None,
               is_quickstart: Optional[bool] = False):
         if threading.current_thread() != threading.main_thread():
-            self.ev_loop.call_soon_threadsafe(self.start, log_level, restore)
+            self.ev_loop.call_soon_threadsafe(self.start, log_level)
             return
-        safe_ensure_future(self.start_check(log_level, restore, script, is_quickstart), loop=self.ev_loop)
+        safe_ensure_future(self.start_check(log_level, script, is_quickstart), loop=self.ev_loop)
 
     async def start_check(self,  # type: HummingbotApplication
                           log_level: Optional[str] = None,
-                          restore: Optional[bool] = False,
                           script: Optional[str] = None,
                           is_quickstart: Optional[bool] = False):
 
@@ -184,7 +182,7 @@ class StartCommand(GatewayChainApiManager):
                             "Refer to our Github page for more info: https://github.com/hummingbot/hummingbot")
 
         self.notify(f"\nStatus check complete. Starting '{self.strategy_name}' strategy...")
-        await self.start_market_making(restore)
+        await self.start_market_making()
 
         self._in_start_check = False
 
@@ -204,7 +202,7 @@ class StartCommand(GatewayChainApiManager):
         return script_file_name.exists()
 
     async def start_market_making(self,  # type: HummingbotApplication
-                                  restore: Optional[bool] = False):
+                                  ):
         try:
             self.start_time = time.time() * 1e3  # Time in milliseconds
             tick_size = self.client_config_map.tick_size
@@ -215,11 +213,8 @@ class StartCommand(GatewayChainApiManager):
                     self.clock.add_iterator(market)
                     self.markets_recorder.restore_market_states(self.strategy_file_name, market)
                     if len(market.limit_orders) > 0:
-                        if restore is False:
-                            self.notify(f"Canceling dangling limit orders on {market.name}...")
-                            await market.cancel_all(5.0)
-                        else:
-                            self.notify(f"Restored {len(market.limit_orders)} limit orders on {market.name}...")
+                        self.notify(f"Canceling dangling limit orders on {market.name}...")
+                        await market.cancel_all(5.0)
             if self.strategy:
                 self.clock.add_iterator(self.strategy)
             try:

--- a/hummingbot/client/command/start_command.py
+++ b/hummingbot/client/command/start_command.py
@@ -22,7 +22,7 @@ from hummingbot.strategy.script_strategy_base import ScriptStrategyBase
 from hummingbot.user.user_balances import UserBalances
 
 if TYPE_CHECKING:
-    from hummingbot.client.hummingbot_application import HummingbotApplication
+    from hummingbot.client.hummingbot_application import HummingbotApplication  # noqa: F401
 
 
 GATEWAY_READY_TIMEOUT = 300  # seconds

--- a/hummingbot/client/ui/parser.py
+++ b/hummingbot/client/ui/parser.py
@@ -125,6 +125,8 @@ def load_parser(hummingbot: "HummingbotApplication", command_tabs) -> [ThrowingA
     gateway_test_parser.set_defaults(func=hummingbot.test_connection)
 
     exit_parser = subparsers.add_parser("exit", help="Exit and cancel all outstanding orders")
+    exit_parser.add_argument("-f", "--force", action="store_true", help="Force exit without canceling outstanding orders",
+                             default=False)
     exit_parser.set_defaults(func=hummingbot.exit)
 
     export_parser = subparsers.add_parser("export", help="Export secure information")

--- a/hummingbot/client/ui/parser.py
+++ b/hummingbot/client/ui/parser.py
@@ -69,7 +69,6 @@ def load_parser(hummingbot: "HummingbotApplication", command_tabs) -> [ThrowingA
     config_parser.set_defaults(func=hummingbot.config)
 
     start_parser = subparsers.add_parser("start", help="Start the current bot")
-    start_parser.add_argument("--restore", default=False, action="store_true", dest="restore", help="Restore and maintain any active orders.")
     # start_parser.add_argument("--log-level", help="Level of logging")
     start_parser.add_argument("--script", type=str, dest="script", help="Script strategy file name")
 
@@ -126,8 +125,6 @@ def load_parser(hummingbot: "HummingbotApplication", command_tabs) -> [ThrowingA
     gateway_test_parser.set_defaults(func=hummingbot.test_connection)
 
     exit_parser = subparsers.add_parser("exit", help="Exit and cancel all outstanding orders")
-    exit_parser.add_argument("-f", "--force", "--suspend", action="store_true", help="Force exit without canceling outstanding orders",
-                             default=False)
     exit_parser.set_defaults(func=hummingbot.exit)
 
     export_parser = subparsers.add_parser("export", help="Export secure information")


### PR DESCRIPTION

**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Remove pause and restore features from the Hummingbot client, as described by the relevant bounty: https://github.com/orgs/hummingbot/projects/7/views/1?pane=issue&itemId=17905944

**Tests performed by the developer**:

- Upstream Unitests
- exit / start and capture behavior

**Tips for QA testing**:


