### PR TITLE
Apply Epoch 3 Poll changes to connectors

### DIFF
--- a/hummingbot/client/command/connect_command.py
+++ b/hummingbot/client/command/connect_command.py
@@ -8,8 +8,6 @@ from hummingbot.client.config.security import Security
 from hummingbot.client.settings import AllConnectorSettings
 from hummingbot.client.ui.interface_utils import format_df_for_printout
 from hummingbot.connector.connector_status import get_connector_status
-from hummingbot.connector.other.celo.celo_cli import CeloCLI
-from hummingbot.connector.other.celo.celo_data_types import KEYS as CELO_KEYS
 from hummingbot.core.utils.async_utils import safe_ensure_future
 from hummingbot.user.user_balances import UserBalances
 
@@ -17,7 +15,7 @@ if TYPE_CHECKING:
     from hummingbot.client.hummingbot_application import HummingbotApplication
 
 OPTIONS = {cs.name for cs in AllConnectorSettings.get_connector_settings().values()
-           if not cs.use_ethereum_wallet and not cs.uses_gateway_generic_connector()}.union({"celo"})
+           if not cs.use_ethereum_wallet and not cs.uses_gateway_generic_connector()}
 
 
 class ConnectCommand:
@@ -25,30 +23,25 @@ class ConnectCommand:
                 option: str):
         if option is None:
             safe_ensure_future(self.show_connections())
-        elif option == "ethereum":
-            safe_ensure_future(self.connect_ethereum())
         else:
             safe_ensure_future(self.connect_exchange(option))
 
     async def connect_exchange(self,  # type: HummingbotApplication
                                connector_name):
         # instruct users to use gateway connect if connector is a gateway connector
-        if (
-            connector_name != "celo"
-            and AllConnectorSettings.get_connector_settings()[connector_name].uses_gateway_generic_connector()
-        ):
+        if AllConnectorSettings.get_connector_settings()[connector_name].uses_gateway_generic_connector():
             self.notify("This is a gateway connector. Use `gateway connect` command instead.")
             return
 
         self.app.clear_input()
         self.placeholder_mode = True
         self.app.hide_input = True
+
         if connector_name == "kraken":
             self.notify("Reminder: Please ensure your Kraken API Key Nonce Window is at least 10.")
-        if connector_name == "celo":
-            connector_config = ClientConfigAdapter(CELO_KEYS)
-        else:
-            connector_config = ClientConfigAdapter(AllConnectorSettings.get_connector_config_keys(connector_name))
+
+        connector_config = ClientConfigAdapter(AllConnectorSettings.get_connector_config_keys(connector_name))
+
         if Security.connector_config_file_exists(connector_name):
             await Security.wait_til_decryption_done()
             api_key_config = [
@@ -89,7 +82,7 @@ class ConnectCommand:
     async def connection_df(self  # type: HummingbotApplication
                             ):
         await Security.wait_til_decryption_done()
-        columns = ["Exchange", "  Keys Added", "  Keys Confirmed", "  Status"]
+        columns = ["Exchange", "  Keys Added", "  Keys Confirmed", "  Tier"]
         data = []
         failed_msgs = {}
         network_timeout = float(self.client_config_map.commands_timeout.other_commands_timeout)
@@ -104,50 +97,20 @@ class ConnectCommand:
             keys_added = "No"
             keys_confirmed = "No"
             status = get_connector_status(option)
-            if option == "celo":
-                celo_config = Security.decrypted_value(option)
-                if celo_config is not None:
-                    keys_added = "Yes"
-                    err_msg = await self.validate_n_connect_celo(True)
-                    if err_msg is not None:
-                        failed_msgs[option] = err_msg
-                    else:
-                        keys_confirmed = "Yes"
-            else:
-                api_keys = (
-                    Security.api_keys(option).values()
-                    if not UserBalances.instance().is_gateway_market(option)
-                    else {}
-                )
-                if len(api_keys) > 0:
-                    keys_added = "Yes"
-                    err_msg = err_msgs.get(option)
-                    if err_msg is not None:
-                        failed_msgs[option] = err_msg
-                    else:
-                        keys_confirmed = "Yes"
+            api_keys = (
+                Security.api_keys(option).values()
+                if not UserBalances.instance().is_gateway_market(option)
+                else {}
+            )
+            if len(api_keys) > 0:
+                keys_added = "Yes"
+                err_msg = err_msgs.get(option)
+                if err_msg is not None:
+                    failed_msgs[option] = err_msg
+                else:
+                    keys_confirmed = "Yes"
             data.append([option, keys_added, keys_confirmed, status])
         return pd.DataFrame(data=data, columns=columns), failed_msgs
-
-    async def connect_ethereum(self,  # type: HummingbotApplication
-                               ):
-        self.notify("\nError: Feature deprecated. Use 'gateway connect' instead.")
-
-    async def validate_n_connect_celo(self, to_reconnect: bool = False) -> Optional[str]:
-        await Security.wait_til_decryption_done()
-        celo_config = Security.decrypted_value(key="celo")
-        if celo_config is None:
-            return "No Celo connection has been configured."
-        if CeloCLI.unlocked and not to_reconnect:
-            return None
-        try:
-            err_msg = CeloCLI.validate_node_synced()
-        except FileNotFoundError:
-            err_msg = "Celo CLI not installed."
-        if err_msg is not None:
-            return err_msg
-        err_msg = CeloCLI.unlock_account(celo_config.celo_address, celo_config.celo_password.get_secret_value())
-        return err_msg
 
     async def validate_n_connect_connector(
         self,  # type: HummingbotApplication
@@ -178,10 +141,8 @@ class ConnectCommand:
             self.app.to_stop_config = False
             return
         Security.update_secure_config(connector_config)
-        if connector_name == "celo":
-            err_msg = await self.validate_n_connect_celo(to_reconnect=True)
-        else:
-            err_msg = await self.validate_n_connect_connector(connector_name)
+        
+        err_msg = await self.validate_n_connect_connector(connector_name)
         if err_msg is None:
             self.notify(f"\nYou are now connected to {connector_name}.")
         else:

--- a/hummingbot/client/config/client_config_map.py
+++ b/hummingbot/client/config/client_config_map.py
@@ -87,7 +87,7 @@ class ColorConfigMap(BaseClientModel):
         ),
     )
     primary_label: str = Field(
-        default="#5FFFD7",
+        default="#FFD700",
         client_data=ClientFieldData(
             prompt=lambda cm: "What is the background color for primary label?",
         ),
@@ -111,7 +111,7 @@ class ColorConfigMap(BaseClientModel):
         ),
     )
     info_label: str = Field(
-        default="#5FD7FF",
+        default="#C0C0C0",
         client_data=ClientFieldData(
             prompt=lambda cm: "What is the background color for info label?",
         ),

--- a/hummingbot/client/ui/style.py
+++ b/hummingbot/client/ui/style.py
@@ -159,10 +159,9 @@ def hex_to_ansi(color_hex):
 
 
 text_ui_style = {
-    "&cGREEN": "success_label",
-    "&cYELLOW": "warning_label",
-    "&cRED": "error_label",
-    "&cMISSING_AND_REQUIRED": "error_label",
+    "&cGOLD": "success_label",
+    "&cSILVER": "info_label",
+    "&cBRONZE": "warning_label",
 }
 
 default_ui_style = {

--- a/hummingbot/connector/connector_status.py
+++ b/hummingbot/connector/connector_status.py
@@ -1,60 +1,43 @@
 #!/usr/bin/env python
 
 connector_status = {
-    'altmarkets': 'green',
-    'ascend_ex': 'yellow',
-    'balancer': 'green',
-    'beaxy': 'green',
-    'binance': 'green',
-    'binance_perpetual': 'yellow',
-    'binance_perpetual_testnet': 'yellow',
-    'binance_us': 'green',
-    'bitfinex': 'yellow',
-    'bitget_perpetual': 'yellow',
-    'bitmart': 'yellow',
-    'bittrex': 'yellow',
-    'bitmex': 'green',
-    'bitmex_perpetual': 'green',
-    'bitmex_testnet': 'yellow',
-    'bitmex_perpetual_testnet': 'yellow',
-    'btc_markets': 'yellow',
-    'bybit_perpetual': 'green',
-    'bybit_perpetual_testnet': 'yellow',
-    'bybit_testnet': 'yellow',
-    'bybit': 'green',
-    'celo': 'yellow',
-    'coinbase_pro': 'yellow',
-    'coinzoom': 'yellow',
-    'crypto_com': 'green',
-    'digifinex': "yellow",
-    'dydx_perpetual': 'yellow',
-    'ethereum': 'red',
-    'eve': 'yellow',
-    'eve_staging': 'yellow',
-    'gate_io': 'yellow',
-    'gate_io_perpetual': 'yellow',
-    'hitbtc': 'green',
-    'huobi': 'green',
-    'kraken': 'green',
-    'kucoin': 'yellow',
-    'kucoin_testnet': 'yellow',
-    'k2': 'red',
-    'latoken': 'green',
-    'lbank': 'yellow',
-    'liquid': 'green',
-    'loopring': 'yellow',
-    'mexc': 'yellow',
-    'ndax': 'yellow',
-    'ndax_testnet': 'yellow',
-    'okx': 'green',
-    'perpetual_finance': 'yellow',
-    'probit': 'yellow',
-    'probit_kr': 'yellow',
-    'terra': 'red',
-    'uniswap': 'yellow',
-    'uniswap_v3': 'yellow',
-    'wazirx': 'yellow',
-    'whitebit': 'yellow'
+    'altmarkets': 'bronze',
+    'ascend_ex': 'silver',
+    'binance': 'gold',
+    'binance_perpetual': 'gold',
+    'binance_perpetual_testnet': 'gold',
+    'binance_us': 'bronze',
+    'bitfinex': 'bronze',
+    'bitget_perpetual': 'bronze',
+    'bitmart': 'bronze',
+    'bittrex': 'bronze',
+    'bitmex': 'bronze',
+    'bitmex_perpetual': 'bronze',
+    'bitmex_testnet': 'bronze',
+    'bitmex_perpetual_testnet': 'bronze',
+    'bybit_perpetual': 'bronze',
+    'bybit_perpetual_testnet': 'bronze',
+    'bybit_testnet': 'bronze',
+    'bybit': 'bronze',
+    'coinbase_pro': 'bronze',
+    'crypto_com': 'bronze',
+    'dydx_perpetual': 'silver',
+    'gate_io': 'silver',
+    'gate_io_perpetual': 'silver',
+    'hitbtc': 'bronze',
+    'huobi': 'bronze',
+    'kraken': 'bronze',
+    'kucoin': 'silver',
+    'kucoin_testnet': 'silver',
+    'lbank': 'bronze',
+    'loopring': 'bronze',
+    'mexc': 'bronze',
+    'ndax': 'bronze',
+    'ndax_testnet': 'bronze',
+    'okx': 'bronze',
+    'perpetual_finance': 'bronze',
+    'probit': 'bronze',
+    'whitebit': 'bronze'
 }
 
 warning_messages = {
@@ -63,11 +46,7 @@ warning_messages = {
 
 def get_connector_status(connector_name: str) -> str:
     """
-    Indicator whether a connector is working properly or not.
-    UNKNOWN means the connector is not in connector_status dict.
-    RED means a connector doesn't work.
-    YELLOW means the connector is either new or has one or more issues.
-    GREEN means a connector is working properly.
+    Indicator for the connector tier: GOLD / SILVER / BRONZE / UNKNOWN 
     """
     if connector_name not in connector_status.keys():
         status = "UNKNOWN"


### PR DESCRIPTION
This PR contains changes related to the Epoch 3 polls, which sorted CEX and DEX connectors into GOLD / SILVER / BRONZE tiers.

Changes so far:
* Removed `celo` and `ethereum` logic from `connect` command
* Changed the Status column to Tier when `connect` is run
* Added GOLD / SILVER / BRONZE for each exchange
* Changed default colors used for the labels`primary` (GOLD) `info` (SILVER) and `warning` (BRONZE)

