### PR TITLE
(feat) create conf/connectors folder to fix docker issues on start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,9 +89,9 @@ RUN ln -s /conf /home/hummingbot/conf && \
   ln -s /scripts /home/hummingbot/scripts
 
 # Create mount points
-RUN mkdir -p /conf /logs /data /pmm_scripts /scripts /certs && \
-  chown -R hummingbot:hummingbot /conf /logs /data /pmm_scripts /scripts /certs
-VOLUME /conf /logs /data /pmm_scripts /scripts /certs
+RUN mkdir -p /conf /conf/connectors /logs /data /pmm_scripts /scripts /certs && \
+  chown -R hummingbot:hummingbot /conf /conf/connectors /logs /data /pmm_scripts /scripts /certs
+VOLUME /conf /conf/connectors /logs /data /pmm_scripts /scripts /certs
 
 # Pre-populate pmm_scripts/ volume with default pmm_scripts
 COPY --chown=hummingbot:hummingbot pmm_scripts/ pmm_scripts/

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -89,9 +89,9 @@ RUN ln -s /conf /home/hummingbot/conf && \
   ln -s /scripts /home/hummingbot/scripts
 
 # Create mount points
-RUN mkdir -p /conf /logs /data /pmm_scripts /scripts /certs && \
-  chown -R hummingbot:hummingbot /conf /logs /data /pmm_scripts /scripts /certs
-VOLUME /conf /logs /data /pmm_scripts /scripts /certs
+RUN mkdir -p /conf /conf/connectors /logs /data /pmm_scripts /scripts /certs && \
+  chown -R hummingbot:hummingbot /conf /conf/connectors /logs /data /pmm_scripts /scripts /certs
+VOLUME /conf /conf/connectors /logs /data /pmm_scripts /scripts /certs
 
 # Pre-populate pmm_scripts/ volume with default pmm_scripts
 COPY --chown=hummingbot:hummingbot pmm_scripts/ pmm_scripts/


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
When running hummingbot without any folder, it throws an error if the folder /conf/connectors is not created.
This solves the issue and improves the UX.


**Tests performed by the developer**:



**Tips for QA testing**:


