### PR TITLE
(fix) Adds an order hash manager reset on Gateway place order failure

### DIFF
--- a/hummingbot/connector/gateway/clob_spot/data_sources/injective/injective_api_data_source.py
+++ b/hummingbot/connector/gateway/clob_spot/data_sources/injective/injective_api_data_source.py
@@ -193,17 +193,21 @@ class InjectiveAPIDataSource(GatewayCLOBAPIDataSourceBase):
                 f" {self._order_hash_manager.current_nonce - 1}"
             )  # todo: remove
 
-            order_result: Dict[str, Any] = await self._get_gateway_instance().clob_place_order(
-                connector=self._connector_name,
-                chain=self._chain,
-                network=self._network,
-                trading_pair=order.trading_pair,
-                address=self._sub_account_id,
-                trade_type=order.trade_type,
-                order_type=order.order_type,
-                price=order.price,
-                size=order.amount,
-            )
+            try:
+                order_result: Dict[str, Any] = await self._get_gateway_instance().clob_place_order(
+                    connector=self._connector_name,
+                    chain=self._chain,
+                    network=self._network,
+                    trading_pair=order.trading_pair,
+                    address=self._sub_account_id,
+                    trade_type=order.trade_type,
+                    order_type=order.order_type,
+                    price=order.price,
+                    size=order.amount,
+                )
+            except Exception:
+                await self._update_account_address_and_create_order_hash_manager()
+                raise
 
             transaction_hash: Optional[str] = order_result.get("txHash")
 


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Adds a safety-precaution to reset the Injective order hash manager on Gateway order-submit call failure that raises an exception.

**Tests performed by the developer**:

I tested by modifying the Gateway code to throw an exception on one of the order creation requests

**Tips for QA testing**:

N/A — there is no easy way to test this by QA.

Link to PRP: https://snapshot.org/#/hbot-prp.eth/proposal/0xb65cf3177df35e9cfbbda475cc1799333c2af66f8f7faf3b86ce87d4aeb9bdfa