### PR TITLE
fix: restore in flight order for gateway orders

### DIFF
--- a/hummingbot/connector/gateway/amm/gateway_evm_amm.py
+++ b/hummingbot/connector/gateway/amm/gateway_evm_amm.py
@@ -223,7 +223,10 @@ class GatewayEVMAMM(ConnectorBase):
         when it disconnects.
         :param saved_states: The saved tracking_states.
         """
-        self._order_tracker.restore_tracking_states(tracking_states=saved_states)
+        for value in saved_states.values():
+            order = GatewayInFlightOrder.from_json(value)
+            if order.is_open or order.is_pending_approval:
+                self._order_tracker.start_tracking_order(order)
 
     def create_approval_order_id(self, token_symbol: str) -> str:
         return f"approve-{self.connector_name}-{token_symbol}"


### PR DESCRIPTION
**A description of the changes proposed in the pull request**:
Fix #6081 

Restore `AmmArbStrategy` tracked orders as `GatewayInFlightOrder`

**Tests performed by the developer**:


**Tips for QA testing**:


