### PR TITLE
(fix) fix parsing binance trading pair rule

### DIFF
--- a/hummingbot/connector/exchange/binance/binance_exchange.py
+++ b/hummingbot/connector/exchange/binance/binance_exchange.py
@@ -259,7 +259,7 @@ class BinanceExchange(ExchangePyBase):
                 filters = rule.get("filters")
                 price_filter = [f for f in filters if f.get("filterType") == "PRICE_FILTER"][0]
                 lot_size_filter = [f for f in filters if f.get("filterType") == "LOT_SIZE"][0]
-                min_notional_filter = [f for f in filters if f.get("filterType") == "MIN_NOTIONAL"][0]
+                min_notional_filter = [f for f in filters if f.get("filterType") in ["MIN_NOTIONAL", "NOTIONAL"]][0]
 
                 min_order_size = Decimal(lot_size_filter.get("minQty"))
                 tick_size = price_filter.get("tickSize")

--- a/test/hummingbot/connector/exchange/binance/test_binance_exchange.py
+++ b/test/hummingbot/connector/exchange/binance/test_binance_exchange.py
@@ -1157,6 +1157,76 @@ class BinanceExchangeTests(AbstractExchangeConnectorTests.ExchangeConnectorTests
                 price=Decimal("2"),
             ))
 
+    def test_format_trading_rules__min_notional_present(self):
+        trading_rules = [{
+            "symbol": "COINALPHAHBOT",
+            "baseAssetPrecision": 8,
+            "status": "TRADING",
+            "quotePrecision": 8,
+            "orderTypes": ["LIMIT", "MARKET"],
+            "filters": [
+                {
+                    "filterType": "PRICE_FILTER",
+                    "minPrice": "0.00000100",
+                    "maxPrice": "100000.00000000",
+                    "tickSize": "0.00000100"
+                }, {
+                    "filterType": "LOT_SIZE",
+                    "minQty": "0.00100000",
+                    "maxQty": "100000.00000000",
+                    "stepSize": "0.00100000"
+                }, {
+                    "filterType": "MIN_NOTIONAL",
+                    "minNotional": "0.00100000"
+                }
+            ],
+            "permissions": [
+                "SPOT"
+            ]
+        }]
+        exchange_info = {"symbols": trading_rules}
+
+        result = self.async_run_with_timeout(self.exchange._format_trading_rules(exchange_info))
+
+        self.assertEqual(result[0].min_notional_size, Decimal("0.00100000"))
+
+    def test_format_trading_rules__notional_but_no_min_notional_present(self):
+        trading_rules = [{
+            "symbol": "COINALPHAHBOT",
+            "baseAssetPrecision": 8,
+            "status": "TRADING",
+            "quotePrecision": 8,
+            "orderTypes": ["LIMIT", "MARKET"],
+            "filters": [
+                {
+                    "filterType": "PRICE_FILTER",
+                    "minPrice": "0.00000100",
+                    "maxPrice": "100000.00000000",
+                    "tickSize": "0.00000100"
+                }, {
+                    "filterType": "LOT_SIZE",
+                    "minQty": "0.00100000",
+                    "maxQty": "100000.00000000",
+                    "stepSize": "0.00100000"
+                }, {
+                    "filterType": "NOTIONAL",
+                    "minNotional": "10.00000000",
+                    "applyMinToMarket": False,
+                    "maxNotional": "10000.00000000",
+                    "applyMaxToMarket": False,
+                    "avgPriceMins": 5
+                }
+            ],
+            "permissions": [
+                "SPOT"
+            ]
+        }]
+        exchange_info = {"symbols": trading_rules}
+
+        result = self.async_run_with_timeout(self.exchange._format_trading_rules(exchange_info))
+
+        self.assertEqual(result[0].min_notional_size, Decimal("10"))
+
     def _validate_auth_credentials_taking_parameters_from_argument(self,
                                                                    request_call_tuple: RequestCall,
                                                                    params: Dict[str, Any]):


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
It appears binance stopped sending "MIN_NOTIONAL" filter for many pairs, but the same information seems to be available in "NOTIONAL" filter. Proposed change looks into any of these 2 and uses first one found

**Tests performed by the developer**:
Unit tests cover 2 cases: 
- when there is MIN_NOTIONAL present but no NOTIONAL
- when there is NOTIONAL present but no MIN_NOTIONAL
Also, built hummingbot locally and run it against my binance connection without errors

**Tips for QA testing**:
Build locally with my change and try any of the pairs mentioned in issues #6230, #6240 and observe no errors

