### PR TITLE
(fix) change example pair for kucoin_perpetual from BTC-USD to XBT-USDT

### DIFF
--- a/hummingbot/connector/derivative/kucoin_perpetual/kucoin_perpetual_utils.py
+++ b/hummingbot/connector/derivative/kucoin_perpetual/kucoin_perpetual_utils.py
@@ -14,7 +14,7 @@ DEFAULT_FEES = TradeFeeSchema(
 
 CENTRALIZED = True
 
-EXAMPLE_PAIR = "BTC-USD"
+EXAMPLE_PAIR = "XBT-USDT"
 
 
 def is_exchange_information_valid(exchange_info: Dict[str, Any]) -> bool:


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")


**A description of the changes proposed in the pull request**:
Fix example pair since kucoin_perpetual do not have BTC-USD in available pairs

![image](https://github.com/hummingbot/hummingbot/assets/83953535/0319b21b-ba1c-4f37-a192-205202171a7a)
![image](https://github.com/hummingbot/hummingbot/assets/83953535/11045cdb-2273-4941-b706-0e9f2de80c09)

However it place order to BTC-USDT if you chose XBT-USDT

![image](https://github.com/hummingbot/hummingbot/assets/83953535/3f4e58c9-7a27-4267-a8fd-3804e0690184)
![image](https://github.com/hummingbot/hummingbot/assets/83953535/71617b77-80dc-4ecf-afd6-2a066453a352)


**Tests performed by the developer**:



**Tips for QA testing**:


