### PR TITLE
(refactor) dockerfile setup folder permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | b
     rm -rf /home/hummingbot/.cache
 
 # Copy environment only to optimize build caching, so changes in sources will not cause conda env invalidation
-COPY --chown=hummingbot:hummingbot setup/environment-linux.yml setup/
+COPY --chown=hummingbot:hummingbot setup setup/
 
 # ./install | create hummingbot environment
 RUN ~/miniconda3/bin/conda env create -f setup/environment-linux.yml && \

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -38,7 +38,7 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | b
     rm -rf /home/hummingbot/.cache
 
 # Copy environment only to optimize build caching, so changes in sources will not cause conda env invalidation
-COPY --chown=hummingbot:hummingbot setup/environment-linux-aarch64.yml setup/
+COPY --chown=hummingbot:hummingbot setup setup/
 
 # ./install | create hummingbot environment
 RUN ~/miniconda3/bin/conda env create -f setup/environment-linux-aarch64.yml && \


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
When I am building hummingbot with [kaniko](https://github.com/GoogleContainerTools/kaniko) I get the following error 
```
# >>>>>>>>>>>>>>>>>>>>>> ERROR REPORT <<<<<<<<<<<<<<<<<<<<<<

    Traceback (most recent call last):
      File "/home/hummingbot/miniconda3/lib/python3.8/site-packages/conda/exceptions.py", line 1079, in __call__
        return func(*args, **kwargs)
      File "/home/hummingbot/miniconda3/lib/python3.8/site-packages/conda_env/cli/main.py", line 80, in do_call
        exit_code = getattr(module, func_name)(args, parser)
      File "/home/hummingbot/miniconda3/lib/python3.8/site-packages/conda_env/cli/main_create.py", line 141, in execute
        result[installer_type] = installer.install(prefix, pkg_specs, args, env)
      File "/home/hummingbot/miniconda3/lib/python3.8/site-packages/conda_env/installers/pip.py", line 70, in install
        return _pip_install_via_requirements(*args, **kwargs)
      File "/home/hummingbot/miniconda3/lib/python3.8/site-packages/conda_env/installers/pip.py", line 44, in _pip_install_via_requirements
        requirements = Utf8NamedTemporaryFile(mode='w',
      File "/home/hummingbot/miniconda3/lib/python3.8/site-packages/conda/_vendor/auxlib/compat.py", line 81, in Utf8NamedTemporaryFile
        return NamedTemporaryFile(mode=mode, buffering=buffering, encoding=encoding,
      File "/home/hummingbot/miniconda3/lib/python3.8/tempfile.py", line 540, in NamedTemporaryFile
        (fd, name) = _mkstemp_inner(dir, prefix, suffix, flags, output_type)
      File "/home/hummingbot/miniconda3/lib/python3.8/tempfile.py", line 250, in _mkstemp_inner
        fd = _os.open(file, flags, 0o600)
    PermissionError: [Errno 13] Permission denied: '/home/hummingbot/setup/condaenv.w232cu2c.requirements.txt'

`$ /home/hummingbot/miniconda3/bin/conda-env create -f setup/environment-linux.yml`
```
I was able to fix it by copying whole folder. 
Please let me know if you would like to change the aproach. e.g. with `mkdir setup` 
I am attaching the build logs from the `development` and this branch.

**Tests performed by the developer**:

I've run the tests.


**Tips for QA testing**:
None

[development.log](https://github.com/hummingbot/hummingbot/files/11682060/development.log)
[refactor_dockerfile_permission_error.log](https://github.com/hummingbot/hummingbot/files/11682061/refactor_dockerfile_permission_error.log)
