### PR TITLE
(fix) wrong calculation of max records

### DIFF
--- a/scripts/download_candles.py
+++ b/scripts/download_candles.py
@@ -28,7 +28,7 @@ class DownloadCandles(ScriptStrategyBase):
         conversion = {"m": 1, "h": 60, "d": 1440}
         unit = interval[-1]
         quantity = int(interval[:-1])
-        return int(days_to_download * 24 * 60 * quantity / conversion[unit])
+        return int(days_to_download * 24 * 60 / (quantity * conversion[unit]))
 
     def __init__(self, connectors: Dict[str, ConnectorBase]):
         super().__init__(connectors)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
The calculation of the max records to download was wrong.


**Tests performed by the developer**:
Run the download candles script and check that the correct quantity of candles are downloaded based on the days requested.


**Tips for QA testing**:
Run the example. Ask me for calculations.

