### PR TITLE
fix/MEXC exchange, when the token price is super small

### DIFF
--- a/hummingbot/connector/exchange/mexc/mexc_exchange.py
+++ b/hummingbot/connector/exchange/mexc/mexc_exchange.py
@@ -617,8 +617,8 @@ class MexcExchange(ExchangeBase):
             'order_type': order_type_str,
             'trade_type': "BID" if is_buy else "ASK",
             'symbol': convert_to_exchange_trading_pair(trading_pair),
-            'quantity': str(amount),
-            'price': str(price)
+            'quantity': format(Decimal(str(amount)), "f"),
+            'price': format(Decimal(str(price)), "f")
         }
 
         exchange_order_id = await self._api_request(


### PR DESCRIPTION
Before submitting this PR, please make sure:

[*] Your code builds clean without any errors or warnings
[*] You are using approved title ("feat/", "fix/", "docs/", "refactor/")
A description of the changes proposed in the pull request:

Fix the bug in mexc exchange, when the token price is super small, which has many zero after the decimal point, you will not able to place order on the mexc, since the number will be converted to scientific notation.

Tests performed by the developer:

Tested with mexc, and it is able to place order which has price like 0.000000001

Tips for QA testing: