### PR TITLE
Fix/leverage type (from decimal to int)

### DIFF
--- a/hummingbot/smart_components/position_executor/data_types.py
+++ b/hummingbot/smart_components/position_executor/data_types.py
@@ -29,7 +29,7 @@ class PositionConfig(BaseModel):
     take_profit_order_type: OrderType = OrderType.MARKET
     stop_loss_order_type: OrderType = OrderType.MARKET
     time_limit_order_type: OrderType = OrderType.MARKET
-    leverage: Decimal = Decimal("1")
+    leverage: int = 1
 
 
 class PositionExecutorStatus(Enum):

--- a/hummingbot/smart_components/position_executor/data_types.py
+++ b/hummingbot/smart_components/position_executor/data_types.py
@@ -1,4 +1,3 @@
-import time
 from enum import Enum
 from typing import Optional
 
@@ -15,6 +14,7 @@ class TrailingStop(BaseModel):
 
 
 class PositionConfig(BaseModel):
+    timestamp: float
     trading_pair: str
     exchange: str
     side: TradeType
@@ -24,7 +24,6 @@ class PositionConfig(BaseModel):
     trailing_stop: Optional[TrailingStop] = None
     time_limit: Optional[int] = None
     entry_price: Optional[Decimal] = None
-    timestamp: float = time.time()
     open_order_type: OrderType = OrderType.MARKET
     take_profit_order_type: OrderType = OrderType.MARKET
     stop_loss_order_type: OrderType = OrderType.MARKET

--- a/hummingbot/strategy/directional_strategy_base.py
+++ b/hummingbot/strategy/directional_strategy_base.py
@@ -171,8 +171,8 @@ class DirectionalStrategyBase(ScriptStrategyBase):
                 exchange=self.exchange,
                 side=side,
                 amount=self.order_amount_usd / price,
-                take_profit=self.take_profit,
-                stop_loss=self.stop_loss,
+                take_profit=Decimal(self.take_profit),
+                stop_loss=Decimal(self.stop_loss),
                 time_limit=self.time_limit,
                 entry_price=price,
                 open_order_type=self.open_order_type,
@@ -180,8 +180,8 @@ class DirectionalStrategyBase(ScriptStrategyBase):
                 stop_loss_order_type=self.stop_loss_order_type,
                 time_limit_order_type=self.time_limit_order_type,
                 trailing_stop=TrailingStop(
-                    activation_price_delta=self.trailing_stop_activation_delta,
-                    trailing_delta=self.trailing_stop_trailing_delta
+                    activation_price_delta=Decimal(self.trailing_stop_activation_delta),
+                    trailing_delta=Decimal(self.trailing_stop_trailing_delta)
                 ),
                 leverage=self.leverage,
             )


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
The type hint of the position config invites you to use a Decimal value for the leverage when it's an integer.
If you use a decimal you get an error in the database when trying to query the orders with the market recorder.

```
Traceback (most recent call last):
  File "/Users/dardonacci/anaconda3/envs/hummingbot/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1905, in _execute_context
    self.dialect.do_execute(
  File "/Users/dardonacci/anaconda3/envs/hummingbot/lib/python3.10/site-packages/sqlalchemy/engine/default.py", line 736, in do_execute
    cursor.execute(statement, parameters)
sqlite3.InterfaceError: Error binding parameter 10 - probably unsupported type.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "hummingbot/core/pubsub.pyx", line 165, in hummingbot.core.pubsub.PubSub.c_trigger_event
  File "hummingbot/core/event/event_listener.pyx", line 25, in hummingbot.core.event.event_listener.EventListener.c_call
  File "/Users/dardonacci/Documents/work/hummingbot/hummingbot/core/event/event_forwarder.py", line 24, in __call__
    self._to_function(self.current_event_tag, self.current_event_caller, arg)
  File "/Users/dardonacci/Documents/work/hummingbot/hummingbot/connector/markets_recorder.py", line 278, in _did_create_order
    self.save_market_states(self._config_file_path, market, session=session)
  File "/Users/dardonacci/Documents/work/hummingbot/hummingbot/connector/markets_recorder.py", line 211, in save_market_states
    market_states: Optional[MarketState] = self.get_market_states(config_file_path, market, session=session)
  File "/Users/dardonacci/Documents/work/hummingbot/hummingbot/connector/markets_recorder.py", line 239, in get_market_states
    market_states: Optional[MarketState] = query.one_or_none()
  File "/Users/dardonacci/anaconda3/envs/hummingbot/lib/python3.10/site-packages/sqlalchemy/orm/query.py", line 2850, in one_or_none
    return self._iter().one_or_none()
  File "/Users/dardonacci/anaconda3/envs/hummingbot/lib/python3.10/site-packages/sqlalchemy/orm/query.py", line 2916, in _iter
    result = self.session.execute(
  File "/Users/dardonacci/anaconda3/envs/hummingbot/lib/python3.10/site-packages/sqlalchemy/orm/session.py", line 1665, in execute
    ) = compile_state_cls.orm_pre_session_exec(
  File "/Users/dardonacci/anaconda3/envs/hummingbot/lib/python3.10/site-packages/sqlalchemy/orm/context.py", line 312, in orm_pre_session_exec
    session._autoflush()
  File "/Users/dardonacci/anaconda3/envs/hummingbot/lib/python3.10/site-packages/sqlalchemy/orm/session.py", line 2264, in _autoflush
    util.raise_(e, with_traceback=sys.exc_info()[2])
  File "/Users/dardonacci/anaconda3/envs/hummingbot/lib/python3.10/site-packages/sqlalchemy/util/compat.py", line 211, in raise_
    raise exception
  File "/Users/dardonacci/anaconda3/envs/hummingbot/lib/python3.10/site-packages/sqlalchemy/orm/session.py", line 2253, in _autoflush
    self.flush()
  File "/Users/dardonacci/anaconda3/envs/hummingbot/lib/python3.10/site-packages/sqlalchemy/orm/session.py", line 3449, in flush
    self._flush(objects)
  File "/Users/dardonacci/anaconda3/envs/hummingbot/lib/python3.10/site-packages/sqlalchemy/orm/session.py", line 3588, in _flush
    with util.safe_reraise():
  File "/Users/dardonacci/anaconda3/envs/hummingbot/lib/python3.10/site-packages/sqlalchemy/util/langhelpers.py", line 70, in __exit__
    compat.raise_(
  File "/Users/dardonacci/anaconda3/envs/hummingbot/lib/python3.10/site-packages/sqlalchemy/util/compat.py", line 211, in raise_
    raise exception
  File "/Users/dardonacci/anaconda3/envs/hummingbot/lib/python3.10/site-packages/sqlalchemy/orm/session.py", line 3549, in _flush
    flush_context.execute()
  File "/Users/dardonacci/anaconda3/envs/hummingbot/lib/python3.10/site-packages/sqlalchemy/orm/unitofwork.py", line 456, in execute
    rec.execute(self)
  File "/Users/dardonacci/anaconda3/envs/hummingbot/lib/python3.10/site-packages/sqlalchemy/orm/unitofwork.py", line 630, in execute
    util.preloaded.orm_persistence.save_obj(
  File "/Users/dardonacci/anaconda3/envs/hummingbot/lib/python3.10/site-packages/sqlalchemy/orm/persistence.py", line 245, in save_obj
    _emit_insert_statements(
  File "/Users/dardonacci/anaconda3/envs/hummingbot/lib/python3.10/site-packages/sqlalchemy/orm/persistence.py", line 1097, in _emit_insert_statements
    c = connection._execute_20(
  File "/Users/dardonacci/anaconda3/envs/hummingbot/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1710, in _execute_20
    return meth(self, args_10style, kwargs_10style, execution_options)
  File "/Users/dardonacci/anaconda3/envs/hummingbot/lib/python3.10/site-packages/sqlalchemy/sql/elements.py", line 334, in _execute_on_connection
    return connection._execute_clauseelement(
  File "/Users/dardonacci/anaconda3/envs/hummingbot/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1577, in _execute_clauseelement
    ret = self._execute_context(
  File "/Users/dardonacci/anaconda3/envs/hummingbot/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1948, in _execute_context
    self._handle_dbapi_exception(
  File "/Users/dardonacci/anaconda3/envs/hummingbot/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 2129, in _handle_dbapi_exception
    util.raise_(
  File "/Users/dardonacci/anaconda3/envs/hummingbot/lib/python3.10/site-packages/sqlalchemy/util/compat.py", line 211, in raise_
    raise exception
  File "/Users/dardonacci/anaconda3/envs/hummingbot/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1905, in _execute_context
    self.dialect.do_execute(
  File "/Users/dardonacci/anaconda3/envs/hummingbot/lib/python3.10/site-packages/sqlalchemy/engine/default.py", line 736, in do_execute
    cursor.execute(statement, parameters)
sqlalchemy.exc.InterfaceError: (raised as a result of Query-invoked autoflush; consider using a session.no_autoflush block if this flush is occurring prematurely)
(sqlite3.InterfaceError) Error binding parameter 10 - probably unsupported type.
[SQL: INSERT INTO "Order" (id, config_file_path, strategy, market, symbol, base_asset, quote_asset, creation_timestamp, order_type, amount, leverage, price, last_status, last_update_timestamp, exchange_order_id, position) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)]
[parameters: ('x-3QreWesyBMCUT60140517985b4bbb4', 'stat_arb', 'stat_arb', 'binance_perpetual', 'MATIC-USDT', 'MATIC', 'USDT', 1690225616000, 'MARKET', 89000000, Decimal('10'), 724500, 'BuyOrderCreated', 1690225616000, '26982771130', 'OPEN')]
(Background on this error at: https://sqlalche.me/e/14/rvf5)
```



**Tests performed by the developer**:
Run a directional strategy that uses leverage Decimal("10") instead of 10


**Tips for QA testing**:


