### PR TITLE
Fix/mac intel segmentation fault

### DIFF
--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -1,15 +1,10 @@
 name: hummingbot
 channels:
-  - conda-forge
   - defaults
 dependencies:
-  - aiounittest=1.4.1
   - bidict
   - coverage=5.5
-  - gql
-  - grpcio
-  - grpcio-tools
-  - nomkl=1.0
+  - nomkl
   - nose=1.3.7
   - nose-exclude
   - numpy=1.23.5
@@ -17,8 +12,8 @@ dependencies:
   - pandas=1.5.3
   - pip=23.1.2
   - prompt_toolkit=3.0.20
-  - pydantic=1.9.2
-  - pytest==7.3.2
+  - pydantic=1.9.*
+  - pytest
   - python=3.10.12
   - pytables=3.8.0
   - scipy=1.10.1
@@ -31,6 +26,7 @@ dependencies:
     - aiohttp==3.*
     - aioprocessing==2.0
     - aioresponses
+    - aiounittest
     - appdirs==1.4.3
     - async-timeout
     - asyncssh==2.13.1
@@ -46,6 +42,9 @@ dependencies:
     - eip712-structs==1.1.0
     - ethsnarks-loopring==0.1.5
     - flake8==3.7.9
+    - gql
+    - grpcio
+    - grpcio-tools
     - importlib-metadata==0.23
     - injective-py==0.7.*
     - mypy-extensions==0.4.3


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Changed the source of gRPC dependencies to solve segmentation fault issue in Mac Intel


**Tests performed by the developer**:
All unit tests passing in green.
The bot runs without issues in a Mac with Intel processor


**Tips for QA testing**:
Run the bot in a Mac with Intel processor

