### PR TITLE
feat/upgrade cython version

### DIFF
--- a/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.py
+++ b/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.py
@@ -247,7 +247,7 @@ class CrossExchangeMarketMakingStrategy(StrategyPyBase):
         return market_info.market.name in AllConnectorSettings.get_gateway_amm_connector_names()
 
     def get_conversion_rates(self, market_pair: MarketTradingPairTuple):
-        quote_pair, quote_rate_source, quote_rate, base_pair, base_rate_source, base_rate, gas_pair, gas_rate_source,\
+        quote_pair, quote_rate_source, quote_rate, base_pair, base_rate_source, base_rate, gas_pair, gas_rate_source, \
             gas_rate = self._config_map.conversion_rate_mode.get_conversion_rates(market_pair)
         if quote_rate is None:
             self.logger().warning(f"Can't find a conversion rate for {quote_pair}")
@@ -255,12 +255,12 @@ class CrossExchangeMarketMakingStrategy(StrategyPyBase):
             self.logger().warning(f"Can't find a conversion rate for {base_pair}")
         if gas_rate is None:
             self.logger().warning(f"Can't find a conversion rate for {gas_pair}")
-        return quote_pair, quote_rate_source, quote_rate, base_pair, base_rate_source, base_rate, gas_pair,\
+        return quote_pair, quote_rate_source, quote_rate, base_pair, base_rate_source, base_rate, gas_pair, \
             gas_rate_source, gas_rate
 
     def log_conversion_rates(self):
         for market_pair in self._market_pairs.values():
-            quote_pair, quote_rate_source, quote_rate, base_pair, base_rate_source, base_rate, gas_pair,\
+            quote_pair, quote_rate_source, quote_rate, base_pair, base_rate_source, base_rate, gas_pair, \
                 gas_rate_source, gas_rate = self.get_conversion_rates(market_pair)
             if quote_pair.split("-")[0] != quote_pair.split("-")[1]:
                 self.logger().info(f"{quote_pair} ({quote_rate_source}) conversion rate: {PerformanceMetrics.smart_round(quote_rate)}")
@@ -274,7 +274,7 @@ class CrossExchangeMarketMakingStrategy(StrategyPyBase):
         columns = ["Source", "Pair", "Rate"]
         data = []
         for market_pair in self._market_pairs.values():
-            quote_pair, quote_rate_source, quote_rate, base_pair, base_rate_source, base_rate, gas_pair,\
+            quote_pair, quote_rate_source, quote_rate, base_pair, base_rate_source, base_rate, gas_pair, \
                 gas_rate_source, gas_rate = self.get_conversion_rates(market_pair)
             if quote_pair.split("-")[0] != quote_pair.split("-")[1]:
                 data.extend([

--- a/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.py
+++ b/hummingbot/strategy/cross_exchange_market_making/cross_exchange_market_making.py
@@ -345,7 +345,7 @@ class CrossExchangeMarketMakingStrategy(StrategyPyBase):
                 limit_orders = list(tracked_maker_orders[market_pair].values())
                 bid, ask = self.get_top_bid_ask(market_pair)
                 mid_price = (bid + ask) / 2
-                df = LimitOrder.to_pandas(limit_orders, mid_price)
+                df = LimitOrder.to_pandas(limit_orders, float(mid_price))
                 df_lines = str(df).split("\n")
                 lines.extend(["", "  Active maker market orders:"] +
                              ["    " + line for line in df_lines])

--- a/hummingbot/strategy/twap/twap.py
+++ b/hummingbot/strategy/twap/twap.py
@@ -1,24 +1,16 @@
-from datetime import datetime
-from decimal import Decimal
 import logging
 import statistics
-from typing import (
-    List,
-    Tuple,
-    Optional,
-    Dict
-)
+from datetime import datetime
+from decimal import Decimal
+from typing import Dict, List, Optional, Tuple
 
 from hummingbot.client.performance import PerformanceMetrics
 from hummingbot.connector.exchange_base import ExchangeBase
 from hummingbot.core.clock import Clock
+from hummingbot.core.data_type.common import OrderType, TradeType
 from hummingbot.core.data_type.limit_order import LimitOrder
 from hummingbot.core.data_type.order_book import OrderBook
-from hummingbot.core.event.events import (MarketOrderFailureEvent,
-                                          OrderCancelledEvent,
-                                          OrderExpiredEvent,
-                                          )
-from hummingbot.core.data_type.common import OrderType, TradeType
+from hummingbot.core.event.events import MarketOrderFailureEvent, OrderCancelledEvent, OrderExpiredEvent
 from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.logger import HummingbotLogger
 from hummingbot.strategy.conditional_execution_state import ConditionalExecutionState, RunAlwaysExecutionState
@@ -167,7 +159,7 @@ class TwapTradeStrategy(StrategyPyBase):
                 for market_info in self._market_infos.values():
                     price_provider = market_info
                 if price_provider is not None:
-                    df = LimitOrder.to_pandas(active_orders, mid_price=price_provider.get_mid_price())
+                    df = LimitOrder.to_pandas(active_orders, mid_price=float(price_provider.get_mid_price()))
                     if self._is_buy:
                         # Descend from the price closest to the mid price
                         df = df.sort_values(by=['Price'], ascending=False)

--- a/setup.py
+++ b/setup.py
@@ -117,13 +117,14 @@ def main():
 
     cython_sources = ["hummingbot/**/*.pyx"]
 
+    compiler_directives = {
+        "annotation_typing": False,
+    }
     if os.environ.get('WITHOUT_CYTHON_OPTIMIZATIONS'):
-        compiler_directives = {
+        compiler_directives.update({
             "optimize.use_switch": False,
             "optimize.unpack_method_calls": False,
-        }
-    else:
-        compiler_directives = {}
+        })
 
     if is_posix:
         cython_kwargs["nthreads"] = cpu_count

--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   - bidict
   - coverage
+  - cython=3.0
   - grpcio-tools
   - nomkl
   - nose=1.3.7
@@ -36,7 +37,6 @@ dependencies:
     - cachetools==4.0.0
     - commlib-py==0.10.6
     - cryptography==3.4.7
-    - cython==3.0.0a10
     - diff-cover
     - docker==5.0.3
     - eip712-structs==1.1.0

--- a/test/hummingbot/strategy/test_market_trading_pair_tuple.py
+++ b/test/hummingbot/strategy/test_market_trading_pair_tuple.py
@@ -275,14 +275,14 @@ class MarketTradingPairTupleUnitTest(unittest.TestCase):
 
     def test_vwap_for_volume(self):
         # Check VWAP on BUY sell
-        order_volume: Decimal = Decimal("15")
+        order_volume = 15
         filled_orders: List[OrderBookRow] = self.market.get_order_book(self.trading_pair).simulate_buy(order_volume)
         expected_vwap: Decimal = sum([Decimal(o.price) * Decimal(o.amount) for o in filled_orders]) / order_volume
 
         self.assertAlmostEqual(expected_vwap, self.market_info.get_vwap_for_volume(True, order_volume).result_price, 3)
 
         # Check VWAP on SELL side
-        order_volume: Decimal = Decimal("15")
+        order_volume = 15
         filled_orders: List[OrderBookRow] = self.market.get_order_book(self.trading_pair).simulate_sell(order_volume)
         expected_vwap: Decimal = sum([Decimal(o.price) * Decimal(o.amount) for o in filled_orders]) / order_volume
 
@@ -290,14 +290,14 @@ class MarketTradingPairTupleUnitTest(unittest.TestCase):
 
     def test_get_price_for_volume(self):
         # Check price on BUY sell
-        order_volume: Decimal = Decimal("15")
+        order_volume = 15
         filled_orders: List[OrderBookRow] = self.market.get_order_book(self.trading_pair).simulate_buy(order_volume)
         expected_buy_price: Decimal = max([Decimal(o.price) for o in filled_orders])
 
         self.assertAlmostEqual(expected_buy_price, self.market_info.get_price_for_volume(True, order_volume).result_price, 3)
 
         # Check price on SELL side
-        order_volume: Decimal = Decimal("15")
+        order_volume = 15
         filled_orders: List[OrderBookRow] = self.market.get_order_book(self.trading_pair).simulate_sell(order_volume)
         expected_sell_price: Decimal = min([Decimal(o.price) for o in filled_orders])
 


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Modified the `environment.yml` dependencies to upgrade Cython to the latest 3.0 version (to move out from the alpha version the project is currently depending on).
Upgrading to the latest version allow Hummingbot to include all latest bugfixes. It will also allow the community to add the new functionality included in Cython 3.0 to generate a compiled Cythonized version of a pure Python module by just adding some Cython decorators to classes/functions.

I had to add a compiler configuration `"annotation_typing": False` to maintain backwards compatibility with the .pyx files in the project that include standard Python type hinting in pure Python functions. By default in Cython version 3 the developer is expected to use the Cython type hinting. I will let the Foundation decide if they prefer to remove/replace the standard Python type hinting in `pyx` files, and if so then remove the compiler configuration in `setup.py`


**Tests performed by the developer**:
Hummingbot conda environment installation and project compilation without issues.
All unit tests passing in green.
Executed a bot trading with Avellaneda strategy using Binance paper trade without issues.
Executed a bot trading with PMM strategy using Binance paper trade without issues.


**Tips for QA testing**:
Run the bot with any strategy implemented in Cython.

