### PR TITLE
Feat/migrate to injective v08

### DIFF
--- a/hummingbot/connector/derivative/injective_v2_perpetual/injective_v2_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/injective_v2_perpetual/injective_v2_perpetual_derivative.py
@@ -378,15 +378,16 @@ class InjectiveV2PerpetualDerivative(PerpetualDerivativePyBase):
         :param position_action: is the order opening or closing a position
         """
         try:
-            if price is None:
+            if price is None or price.is_nan():
                 calculated_price = self.get_price_for_volume(
                     trading_pair=trading_pair,
                     is_buy=trade_type == TradeType.BUY,
                     volume=amount,
                 ).result_price
-                calculated_price = self.quantize_order_price(trading_pair, calculated_price)
             else:
                 calculated_price = price
+
+            calculated_price = self.quantize_order_price(trading_pair, calculated_price)
 
             await super()._create_order(
                 trade_type=trade_type,

--- a/hummingbot/connector/exchange/injective_v2/account_delegation_script.py
+++ b/hummingbot/connector/exchange/injective_v2/account_delegation_script.py
@@ -1,8 +1,7 @@
 import asyncio
 
 from pyinjective.async_client import AsyncClient
-from pyinjective.composer import Composer
-from pyinjective.constant import Network
+from pyinjective.core.network import Network
 from pyinjective.transaction import Transaction
 from pyinjective.wallet import PrivateKey
 
@@ -26,10 +25,9 @@ SECONDS_PER_DAY = 60 * 60 * 24
 
 
 async def main() -> None:
-    composer = Composer(network=NETWORK.string())
-
     # initialize grpc client
     client = AsyncClient(NETWORK, insecure=False)
+    composer = await client.composer()
     await client.sync_timeout_height()
 
     # load account

--- a/hummingbot/connector/exchange/injective_v2/data_sources/injective_data_source.py
+++ b/hummingbot/connector/exchange/injective_v2/data_sources/injective_data_source.py
@@ -1,12 +1,10 @@
 import asyncio
 import logging
-import os
 import time
 from abc import ABC, abstractmethod
 from decimal import Decimal
 from enum import Enum
 from functools import partial
-from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from google.protobuf import any_pb2
@@ -66,11 +64,6 @@ class InjectiveDataSource(ABC):
 
     @property
     @abstractmethod
-    def composer(self) -> Composer:
-        raise NotImplementedError
-
-    @property
-    @abstractmethod
     def order_creation_lock(self) -> asyncio.Lock:
         raise NotImplementedError
 
@@ -112,6 +105,10 @@ class InjectiveDataSource(ABC):
     @property
     @abstractmethod
     def network_name(self) -> str:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def composer(self) -> Composer:
         raise NotImplementedError
 
     @abstractmethod
@@ -265,8 +262,6 @@ class InjectiveDataSource(ABC):
     async def stop(self):
         for task in self.events_listening_tasks():
             task.cancel()
-        cookie_file_path = Path(self._chain_cookie_file_path())
-        cookie_file_path.unlink(missing_ok=True)
 
     def add_listener(self, event_tag: Enum, listener: EventListener):
         self.publisher.add_listener(event_tag=event_tag, listener=listener)
@@ -486,7 +481,7 @@ class InjectiveDataSource(ABC):
                     ))
                 else:
                     market_id = await self.market_id_for_spot_trading_pair(trading_pair=order.trading_pair)
-                    order_data = self._generate_injective_order_data(order=order, market_id=market_id)
+                    order_data = await self._generate_injective_order_data(order=order, market_id=market_id)
                     spot_orders_data.append(order_data)
                     orders_with_hash.append(order)
 
@@ -499,12 +494,12 @@ class InjectiveDataSource(ABC):
                     ))
                 else:
                     market_id = await self.market_id_for_derivative_trading_pair(trading_pair=order.trading_pair)
-                    order_data = self._generate_injective_order_data(order=order, market_id=market_id)
+                    order_data = await self._generate_injective_order_data(order=order, market_id=market_id)
                     derivative_orders_data.append(order_data)
                     orders_with_hash.append(order)
 
             if len(orders_with_hash) > 0:
-                delegated_message = self._order_cancel_message(
+                delegated_message = await self._order_cancel_message(
                     spot_orders_to_cancel=spot_orders_data,
                     derivative_orders_to_cancel=derivative_orders_data,
                 )
@@ -544,7 +539,7 @@ class InjectiveDataSource(ABC):
         spot_markets_ids = spot_markets_ids or []
         perpetual_markets_ids = perpetual_markets_ids or []
 
-        delegated_message = self._all_subaccount_orders_cancel_message(
+        delegated_message = await self._all_subaccount_orders_cancel_message(
             spot_markets_ids=spot_markets_ids,
             derivative_markets_ids=perpetual_markets_ids,
         )
@@ -763,7 +758,7 @@ class InjectiveDataSource(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def _order_cancel_message(
+    async def _order_cancel_message(
             self,
             spot_orders_to_cancel: List[injective_exchange_tx_pb.OrderData],
             derivative_orders_to_cancel: List[injective_exchange_tx_pb.OrderData]
@@ -771,7 +766,7 @@ class InjectiveDataSource(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def _all_subaccount_orders_cancel_message(
+    async def _all_subaccount_orders_cancel_message(
             self,
             spot_markets_ids: List[str],
             derivative_markets_ids: List[str]
@@ -779,7 +774,7 @@ class InjectiveDataSource(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def _generate_injective_order_data(self, order: GatewayInFlightOrder, market_id: str) -> injective_exchange_tx_pb.OrderData:
+    async def _generate_injective_order_data(self, order: GatewayInFlightOrder, market_id: str) -> injective_exchange_tx_pb.OrderData:
         raise NotImplementedError
 
     @abstractmethod
@@ -795,9 +790,6 @@ class InjectiveDataSource(ABC):
             exception: Optional[Exception] = None,
     ) -> List[PlaceOrderResult]:
         raise NotImplementedError
-
-    def _chain_cookie_file_path(self) -> str:
-        return f"{os.path.join(os.path.dirname(__file__), '../.injective_cookie')}"
 
     async def _last_traded_price(self, market_id: str) -> Decimal:
         price = Decimal("nan")
@@ -1041,8 +1033,9 @@ class InjectiveDataSource(ABC):
                     await self.initialize_trading_account()
                 raise
 
+        composer = await self.composer()
         gas_limit = int(simulation_result["gasInfo"]["gasUsed"]) + CONSTANTS.EXTRA_TRANSACTION_GAS
-        fee = [self.composer.Coin(
+        fee = [composer.Coin(
             amount=gas_limit * CONSTANTS.DEFAULT_GAS_PRICE,
             denom=self.fee_denom,
         )]
@@ -1299,8 +1292,9 @@ class InjectiveDataSource(ABC):
         self.publisher.trigger_event(event_tag=InjectiveEvent.ChainTransactionEvent, message=transaction_event)
 
     async def _create_spot_order_definition(self, order: GatewayInFlightOrder):
+        composer = await self.composer()
         market_id = await self.market_id_for_spot_trading_pair(order.trading_pair)
-        definition = self.composer.SpotOrder(
+        definition = composer.SpotOrder(
             market_id=market_id,
             subaccount_id=self.portfolio_account_subaccount_id,
             fee_recipient=self.portfolio_account_injective_address,
@@ -1312,8 +1306,9 @@ class InjectiveDataSource(ABC):
         return definition
 
     async def _create_derivative_order_definition(self, order: GatewayPerpetualInFlightOrder):
+        composer = await self.composer()
         market_id = await self.market_id_for_derivative_trading_pair(order.trading_pair)
-        definition = self.composer.DerivativeOrder(
+        definition = composer.DerivativeOrder(
             market_id=market_id,
             subaccount_id=self.portfolio_account_subaccount_id,
             fee_recipient=self.portfolio_account_injective_address,

--- a/hummingbot/connector/exchange/injective_v2/data_sources/injective_vaults_data_source.py
+++ b/hummingbot/connector/exchange/injective_v2/data_sources/injective_vaults_data_source.py
@@ -10,7 +10,7 @@ from google.protobuf import any_pb2, json_format
 from pyinjective import Transaction
 from pyinjective.async_client import AsyncClient
 from pyinjective.composer import Composer, injective_exchange_tx_pb
-from pyinjective.constant import Network
+from pyinjective.core.network import Network
 from pyinjective.orderhash import OrderHashManager
 from pyinjective.wallet import Address, PrivateKey
 
@@ -50,9 +50,8 @@ class InjectiveVaultsDataSource(InjectiveDataSource):
         self._client = AsyncClient(
             network=self._network,
             insecure=not use_secure_connection,
-            chain_cookie_location=self._chain_cookie_file_path(),
         )
-        self._composer = Composer(network=self._network.string())
+        self._composer = None
         self._query_executor = PythonSDKInjectiveQueryExecutor(sdk_client=self._client)
 
         self._private_key = None
@@ -100,10 +99,6 @@ class InjectiveVaultsDataSource(InjectiveDataSource):
         return self._query_executor
 
     @property
-    def composer(self) -> Composer:
-        return self._composer
-
-    @property
     def order_creation_lock(self) -> asyncio.Lock:
         return self._order_creation_lock
 
@@ -138,6 +133,11 @@ class InjectiveVaultsDataSource(InjectiveDataSource):
     @property
     def network_name(self) -> str:
         return self._network.string()
+
+    async def composer(self) -> Composer:
+        if self._composer is None:
+            self._composer = await self._client.composer()
+        return self._composer
 
     def events_listening_tasks(self) -> List[asyncio.Task]:
         return self._events_listening_tasks.copy()
@@ -461,7 +461,7 @@ class InjectiveVaultsDataSource(InjectiveDataSource):
             spot_orders_to_create: List[GatewayInFlightOrder],
             derivative_orders_to_create: List[GatewayPerpetualInFlightOrder],
     ) -> Tuple[List[any_pb2.Any], List[str], List[str]]:
-        composer = self.composer
+        composer = await self.composer()
         spot_order_definitions = []
         derivative_order_definitions = []
 
@@ -497,12 +497,12 @@ class InjectiveVaultsDataSource(InjectiveDataSource):
 
         return [execute_contract_message], [], []
 
-    def _order_cancel_message(
+    async def _order_cancel_message(
             self,
             spot_orders_to_cancel: List[injective_exchange_tx_pb.OrderData],
             derivative_orders_to_cancel: List[injective_exchange_tx_pb.OrderData]
     ) -> any_pb2.Any:
-        composer = self.composer
+        composer = await self.composer()
 
         message = composer.MsgBatchUpdateOrders(
             sender=self.portfolio_account_injective_address,
@@ -528,12 +528,12 @@ class InjectiveVaultsDataSource(InjectiveDataSource):
 
         return execute_contract_message
 
-    def _all_subaccount_orders_cancel_message(
+    async def _all_subaccount_orders_cancel_message(
             self,
             spot_markets_ids: List[str],
             derivative_markets_ids: List[str]
     ) -> any_pb2.Any:
-        composer = self.composer
+        composer = await self.composer()
 
         message = composer.MsgBatchUpdateOrders(
             sender=self.portfolio_account_injective_address,
@@ -560,8 +560,9 @@ class InjectiveVaultsDataSource(InjectiveDataSource):
 
         return execute_contract_message
 
-    def _generate_injective_order_data(self, order: GatewayInFlightOrder, market_id: str) -> injective_exchange_tx_pb.OrderData:
-        order_data = self.composer.OrderData(
+    async def _generate_injective_order_data(self, order: GatewayInFlightOrder, market_id: str) -> injective_exchange_tx_pb.OrderData:
+        composer = await self.composer()
+        order_data = composer.OrderData(
             market_id=market_id,
             subaccount_id=str(self.portfolio_account_subaccount_index),
             order_hash=order.exchange_order_id,
@@ -575,7 +576,8 @@ class InjectiveVaultsDataSource(InjectiveDataSource):
         # Both price and quantity have to be adjusted because the vaults expect to receive those values without
         # the extra 18 zeros that the chain backend expects for direct trading messages
         market_id = await self.market_id_for_spot_trading_pair(order.trading_pair)
-        definition = self.composer.SpotOrder(
+        composer = await self.composer()
+        definition = composer.SpotOrder(
             market_id=market_id,
             subaccount_id=str(self.portfolio_account_subaccount_index),
             fee_recipient=self.portfolio_account_injective_address,
@@ -593,7 +595,8 @@ class InjectiveVaultsDataSource(InjectiveDataSource):
         # Price, quantity and margin have to be adjusted because the vaults expect to receive those values without
         # the extra 18 zeros that the chain backend expects for direct trading messages
         market_id = await self.market_id_for_derivative_trading_pair(order.trading_pair)
-        definition = self.composer.DerivativeOrder(
+        composer = await self.composer()
+        definition = composer.DerivativeOrder(
             market_id=market_id,
             subaccount_id=str(self.portfolio_account_subaccount_index),
             fee_recipient=self.portfolio_account_injective_address,

--- a/hummingbot/connector/exchange/injective_v2/injective_constants.py
+++ b/hummingbot/connector/exchange/injective_v2/injective_constants.py
@@ -137,8 +137,8 @@ ENDPOINTS_RATE_LIMITS = [
 ]
 
 PUBLIC_NODE_RATE_LIMITS = [
-    RateLimit(limit_id=CHAIN_ENDPOINTS_GROUP_LIMIT_ID, limit=20, time_interval=ONE_SECOND),
-    RateLimit(limit_id=INDEXER_ENDPOINTS_GROUP_LIMIT_ID, limit=50, time_interval=ONE_SECOND),
+    RateLimit(limit_id=CHAIN_ENDPOINTS_GROUP_LIMIT_ID, limit=30, time_interval=ONE_SECOND),
+    RateLimit(limit_id=INDEXER_ENDPOINTS_GROUP_LIMIT_ID, limit=40, time_interval=ONE_SECOND),
 ]
 PUBLIC_NODE_RATE_LIMITS.extend(ENDPOINTS_RATE_LIMITS)
 

--- a/hummingbot/connector/exchange/injective_v2/injective_constants.py
+++ b/hummingbot/connector/exchange/injective_v2/injective_constants.py
@@ -137,8 +137,8 @@ ENDPOINTS_RATE_LIMITS = [
 ]
 
 PUBLIC_NODE_RATE_LIMITS = [
-    RateLimit(limit_id=CHAIN_ENDPOINTS_GROUP_LIMIT_ID, limit=30, time_interval=ONE_SECOND),
-    RateLimit(limit_id=INDEXER_ENDPOINTS_GROUP_LIMIT_ID, limit=40, time_interval=ONE_SECOND),
+    RateLimit(limit_id=CHAIN_ENDPOINTS_GROUP_LIMIT_ID, limit=20, time_interval=ONE_SECOND),
+    RateLimit(limit_id=INDEXER_ENDPOINTS_GROUP_LIMIT_ID, limit=50, time_interval=ONE_SECOND),
 ]
 PUBLIC_NODE_RATE_LIMITS.extend(ENDPOINTS_RATE_LIMITS)
 

--- a/hummingbot/connector/exchange/injective_v2/injective_v2_exchange.py
+++ b/hummingbot/connector/exchange/injective_v2/injective_v2_exchange.py
@@ -323,15 +323,16 @@ class InjectiveV2Exchange(ExchangePyBase):
         :param price: the order price
         """
         try:
-            if price is None:
+            if price is None or price.is_nan():
                 calculated_price = self.get_price_for_volume(
                     trading_pair=trading_pair,
                     is_buy=trade_type == TradeType.BUY,
                     volume=amount,
                 ).result_price
-                calculated_price = self.quantize_order_price(trading_pair, calculated_price)
             else:
                 calculated_price = price
+
+            calculated_price = self.quantize_order_price(trading_pair, calculated_price)
 
             await super()._create_order(
                 trade_type=trade_type,

--- a/hummingbot/connector/exchange/injective_v2/injective_v2_utils.py
+++ b/hummingbot/connector/exchange/injective_v2/injective_v2_utils.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Dict, List, Union
 
 from pydantic import Field, SecretStr
 from pydantic.class_validators import validator
-from pyinjective.constant import Network
+from pyinjective.core.network import Network
 
 from hummingbot.client.config.config_data_types import BaseClientModel, BaseConnectorConfigMap, ClientFieldData
 from hummingbot.connector.exchange.injective_v2 import injective_constants as CONSTANTS

--- a/hummingbot/connector/exchange/injective_v2/injective_v2_utils.py
+++ b/hummingbot/connector/exchange/injective_v2/injective_v2_utils.py
@@ -31,7 +31,6 @@ DEFAULT_FEES = TradeFeeSchema(
     taker_percent_fee_decimal=Decimal("0"),
 )
 
-MAINNET_NODES = ["lb", "sentry0", "sentry1", "sentry3"]
 TESTNET_NODES = ["lb", "sentry"]
 
 
@@ -47,28 +46,14 @@ class InjectiveNetworkMode(BaseClientModel, ABC):
 
 class InjectiveMainnetNetworkMode(InjectiveNetworkMode):
 
-    node: str = Field(
-        default="lb",
-        client_data=ClientFieldData(
-            prompt=lambda cm: (f"Enter the mainnet node you want to connect to ({'/'.join(MAINNET_NODES)})"),
-            prompt_on_new=True
-        ),
-    )
-
     class Config:
         title = "mainnet_network"
 
-    @validator("node", pre=True)
-    def validate_node(cls, v: str):
-        if v not in MAINNET_NODES:
-            raise ValueError(f"{v} is not a valid node ({MAINNET_NODES})")
-        return v
-
     def network(self) -> Network:
-        return Network.mainnet(node=self.node)
+        return Network.mainnet()
 
     def use_secure_connection(self) -> bool:
-        return self.node == "lb"
+        return True
 
     def rate_limits(self) -> List[RateLimit]:
         return CONSTANTS.PUBLIC_NODE_RATE_LIMITS

--- a/hummingbot/connector/gateway/clob_perp/data_sources/injective_perpetual/injective_perpetual_constants.py
+++ b/hummingbot/connector/gateway/clob_perp/data_sources/injective_perpetual/injective_perpetual_constants.py
@@ -4,11 +4,11 @@ from decimal import Decimal
 from typing import Dict, Tuple
 
 from pyinjective.constant import (
-    Network,
     devnet_config as DEVNET_TOKEN_META_CONFIG,
     mainnet_config as MAINNET_TOKEN_META_CONFIG,
     testnet_config as TESTNET_TOKEN_META_CONFIG,
 )
+from pyinjective.core.network import Network
 
 from hummingbot.connector.constants import MINUTE, SECOND
 from hummingbot.core.api_throttler.data_types import LinkedLimitWeightPair, RateLimit

--- a/hummingbot/connector/gateway/clob_spot/data_sources/injective/injective_api_data_source.py
+++ b/hummingbot/connector/gateway/clob_spot/data_sources/injective/injective_api_data_source.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Mapping, Optional, Tuple
 from grpc.aio import UnaryStreamCall
 from pyinjective.async_client import AsyncClient
 from pyinjective.composer import Composer as ProtoMsgComposer
-from pyinjective.constant import Network
+from pyinjective.core.network import Network
 from pyinjective.proto.exchange.injective_accounts_rpc_pb2 import StreamSubaccountBalanceResponse
 from pyinjective.proto.exchange.injective_explorer_rpc_pb2 import GetTxByTxHashResponse, StreamTxsResponse
 from pyinjective.proto.exchange.injective_portfolio_rpc_pb2 import (

--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -44,7 +44,7 @@ dependencies:
     - flake8==3.7.9
     - gql
     - importlib-metadata==0.23
-    - injective-py==0.8
+    - injective-py==0.8.*
     - mypy-extensions==0.4.3
     - pandas_ta==0.3.14b
     - pre-commit==2.18.1

--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -44,7 +44,7 @@ dependencies:
     - flake8==3.7.9
     - gql
     - importlib-metadata==0.23
-    - injective-py==0.7.*
+    - injective-py==0.8
     - mypy-extensions==0.4.3
     - pandas_ta==0.3.14b
     - pre-commit==2.18.1

--- a/test/hummingbot/connector/derivative/injective_v2_perpetual/test_injective_v2_perpetual_derivative_for_delegated_account.py
+++ b/test/hummingbot/connector/derivative/injective_v2_perpetual/test_injective_v2_perpetual_derivative_for_delegated_account.py
@@ -515,6 +515,12 @@ class InjectiveV2PerpetualDerivativeTests(AbstractPerpetualDerivativeTests.Perpe
         exchange._data_source._query_executor = ProgrammableQueryExecutor()
         exchange._data_source._spot_market_and_trading_pair_map = bidict()
         exchange._data_source._derivative_market_and_trading_pair_map = bidict({self.market_id: self.trading_pair})
+
+        exchange._data_source._client._tokens = {}
+        exchange._data_source._client._spot_markets = {}
+        exchange._data_source._client._derivative_markets = {}
+        exchange._data_source._client._binary_option_markets = {}
+
         return exchange
 
     def validate_auth_credentials_present(self, request_call: RequestCall):

--- a/test/hummingbot/connector/derivative/injective_v2_perpetual/test_injective_v2_perpetual_derivative_for_delegated_account.py
+++ b/test/hummingbot/connector/derivative/injective_v2_perpetual/test_injective_v2_perpetual_derivative_for_delegated_account.py
@@ -13,6 +13,7 @@ from aioresponses.core import RequestCall
 from bidict import bidict
 from grpc import RpcError
 from pyinjective import Address, PrivateKey
+from pyinjective.composer import Composer
 from pyinjective.orderhash import OrderHashResponse
 
 from hummingbot.client.config.client_config_map import ClientConfigMap
@@ -516,10 +517,7 @@ class InjectiveV2PerpetualDerivativeTests(AbstractPerpetualDerivativeTests.Perpe
         exchange._data_source._spot_market_and_trading_pair_map = bidict()
         exchange._data_source._derivative_market_and_trading_pair_map = bidict({self.market_id: self.trading_pair})
 
-        exchange._data_source._client._tokens = {}
-        exchange._data_source._client._spot_markets = {}
-        exchange._data_source._client._derivative_markets = {}
-        exchange._data_source._client._binary_option_markets = {}
+        exchange._data_source._composer = Composer(network=exchange._data_source.network_name)
 
         return exchange
 

--- a/test/hummingbot/connector/derivative/injective_v2_perpetual/test_injective_v2_perpetual_derivative_for_offchain_vault.py
+++ b/test/hummingbot/connector/derivative/injective_v2_perpetual/test_injective_v2_perpetual_derivative_for_offchain_vault.py
@@ -504,6 +504,12 @@ class InjectiveV2PerpetualDerivativeForOffChainVaultTests(AbstractPerpetualDeriv
         exchange._data_source._query_executor = ProgrammableQueryExecutor()
         exchange._data_source._spot_market_and_trading_pair_map = bidict()
         exchange._data_source._derivative_market_and_trading_pair_map = bidict({self.market_id: self.trading_pair})
+
+        exchange._data_source._client._tokens = {}
+        exchange._data_source._client._spot_markets = {}
+        exchange._data_source._client._derivative_markets = {}
+        exchange._data_source._client._binary_option_markets = {}
+
         return exchange
 
     def validate_auth_credentials_present(self, request_call: RequestCall):

--- a/test/hummingbot/connector/derivative/injective_v2_perpetual/test_injective_v2_perpetual_derivative_for_offchain_vault.py
+++ b/test/hummingbot/connector/derivative/injective_v2_perpetual/test_injective_v2_perpetual_derivative_for_offchain_vault.py
@@ -14,6 +14,7 @@ from aioresponses.core import RequestCall
 from bidict import bidict
 from grpc import RpcError
 from pyinjective import Address, PrivateKey
+from pyinjective.composer import Composer
 
 from hummingbot.client.config.client_config_map import ClientConfigMap
 from hummingbot.client.config.config_helpers import ClientConfigAdapter
@@ -505,10 +506,7 @@ class InjectiveV2PerpetualDerivativeForOffChainVaultTests(AbstractPerpetualDeriv
         exchange._data_source._spot_market_and_trading_pair_map = bidict()
         exchange._data_source._derivative_market_and_trading_pair_map = bidict({self.market_id: self.trading_pair})
 
-        exchange._data_source._client._tokens = {}
-        exchange._data_source._client._spot_markets = {}
-        exchange._data_source._client._derivative_markets = {}
-        exchange._data_source._client._binary_option_markets = {}
+        exchange._data_source._composer = Composer(network=exchange._data_source.network_name)
 
         return exchange
 

--- a/test/hummingbot/connector/exchange/injective_v2/data_sources/test_injective_data_source.py
+++ b/test/hummingbot/connector/exchange/injective_v2/data_sources/test_injective_data_source.py
@@ -7,7 +7,7 @@ from typing import Awaitable, Optional, Union
 from unittest import TestCase
 from unittest.mock import patch
 
-from pyinjective.constant import Network
+from pyinjective.core.network import Network
 from pyinjective.wallet import Address, PrivateKey
 
 from hummingbot.connector.exchange.injective_v2 import injective_constants as CONSTANTS
@@ -495,7 +495,8 @@ class InjectiveVaultsDataSourceTests(TestCase):
         market = self._inj_usdt_market_info()
 
         orders_data = []
-        order_data = self.data_source.composer.OrderData(
+        composer = asyncio.get_event_loop().run_until_complete(self.data_source.composer())
+        order_data = composer.OrderData(
             market_id=market["marketId"],
             subaccount_id="1",
             order_hash="0xba954bc613a81cd712b9ec0a3afbfc94206cf2ff8c60d1868e031d59ea82bf27",  # noqa: mock"

--- a/test/hummingbot/connector/exchange/injective_v2/data_sources/test_injective_data_source.py
+++ b/test/hummingbot/connector/exchange/injective_v2/data_sources/test_injective_data_source.py
@@ -7,6 +7,7 @@ from typing import Awaitable, Optional, Union
 from unittest import TestCase
 from unittest.mock import patch
 
+from pyinjective.composer import Composer
 from pyinjective.core.network import Network
 from pyinjective.wallet import Address, PrivateKey
 
@@ -391,6 +392,8 @@ class InjectiveVaultsDataSourceTests(TestCase):
         self.query_executor = ProgrammableQueryExecutor()
         self.data_source._query_executor = self.query_executor
 
+        self.data_source._composer = Composer(network=self.data_source.network_name)
+
     def tearDown(self) -> None:
         self.async_run_with_timeout(self.data_source.stop())
         for task in self.async_tasks:
@@ -505,9 +508,11 @@ class InjectiveVaultsDataSourceTests(TestCase):
         )
         orders_data.append(order_data)
 
-        message = self.data_source._order_cancel_message(
-            spot_orders_to_cancel=orders_data,
-            derivative_orders_to_cancel=[],
+        message = self.async_run_with_timeout(
+            self.data_source._order_cancel_message(
+                spot_orders_to_cancel=orders_data,
+                derivative_orders_to_cancel=[],
+            )
         )
 
         pub_key = self._grantee_private_key.to_public_key()

--- a/test/hummingbot/connector/exchange/injective_v2/test_injective_v2_exchange_for_delegated_account.py
+++ b/test/hummingbot/connector/exchange/injective_v2/test_injective_v2_exchange_for_delegated_account.py
@@ -12,6 +12,7 @@ from aioresponses import aioresponses
 from aioresponses.core import RequestCall
 from bidict import bidict
 from grpc import RpcError
+from pyinjective.composer import Composer
 from pyinjective.orderhash import OrderHashManager, OrderHashResponse
 from pyinjective.wallet import Address, PrivateKey
 
@@ -407,10 +408,7 @@ class InjectiveV2ExchangeTests(AbstractExchangeConnectorTests.ExchangeConnectorT
         exchange._data_source._spot_market_and_trading_pair_map = bidict({self.market_id: self.trading_pair})
         exchange._data_source._derivative_market_and_trading_pair_map = bidict()
 
-        exchange._data_source._client._tokens = {}
-        exchange._data_source._client._spot_markets = {}
-        exchange._data_source._client._derivative_markets = {}
-        exchange._data_source._client._binary_option_markets = {}
+        exchange._data_source._composer = Composer(network=exchange._data_source.network_name)
 
         return exchange
 

--- a/test/hummingbot/connector/exchange/injective_v2/test_injective_v2_exchange_for_delegated_account.py
+++ b/test/hummingbot/connector/exchange/injective_v2/test_injective_v2_exchange_for_delegated_account.py
@@ -406,6 +406,12 @@ class InjectiveV2ExchangeTests(AbstractExchangeConnectorTests.ExchangeConnectorT
         exchange._data_source._query_executor = ProgrammableQueryExecutor()
         exchange._data_source._spot_market_and_trading_pair_map = bidict({self.market_id: self.trading_pair})
         exchange._data_source._derivative_market_and_trading_pair_map = bidict()
+
+        exchange._data_source._client._tokens = {}
+        exchange._data_source._client._spot_markets = {}
+        exchange._data_source._client._derivative_markets = {}
+        exchange._data_source._client._binary_option_markets = {}
+
         return exchange
 
     def validate_auth_credentials_present(self, request_call: RequestCall):

--- a/test/hummingbot/connector/exchange/injective_v2/test_injective_v2_exchange_for_offchain_vault.py
+++ b/test/hummingbot/connector/exchange/injective_v2/test_injective_v2_exchange_for_offchain_vault.py
@@ -397,6 +397,12 @@ class InjectiveV2ExchangeForOffChainVaultTests(AbstractExchangeConnectorTests.Ex
         exchange._data_source._query_executor = ProgrammableQueryExecutor()
         exchange._data_source._spot_market_and_trading_pair_map = bidict({self.market_id: self.trading_pair})
         exchange._data_source._derivative_market_and_trading_pair_map = bidict()
+
+        exchange._data_source._client._tokens = {}
+        exchange._data_source._client._spot_markets = {}
+        exchange._data_source._client._derivative_markets = {}
+        exchange._data_source._client._binary_option_markets = {}
+
         return exchange
 
     def validate_auth_credentials_present(self, request_call: RequestCall):

--- a/test/hummingbot/connector/exchange/injective_v2/test_injective_v2_exchange_for_offchain_vault.py
+++ b/test/hummingbot/connector/exchange/injective_v2/test_injective_v2_exchange_for_offchain_vault.py
@@ -12,6 +12,7 @@ from aioresponses import aioresponses
 from aioresponses.core import RequestCall
 from bidict import bidict
 from grpc import RpcError
+from pyinjective.composer import Composer
 from pyinjective.wallet import Address, PrivateKey
 
 from hummingbot.client.config.client_config_map import ClientConfigMap
@@ -398,10 +399,7 @@ class InjectiveV2ExchangeForOffChainVaultTests(AbstractExchangeConnectorTests.Ex
         exchange._data_source._spot_market_and_trading_pair_map = bidict({self.market_id: self.trading_pair})
         exchange._data_source._derivative_market_and_trading_pair_map = bidict()
 
-        exchange._data_source._client._tokens = {}
-        exchange._data_source._client._spot_markets = {}
-        exchange._data_source._client._derivative_markets = {}
-        exchange._data_source._client._binary_option_markets = {}
+        exchange._data_source._composer = Composer(network=exchange._data_source.network_name)
 
         return exchange
 

--- a/test/hummingbot/connector/exchange/injective_v2/test_injective_v2_utils.py
+++ b/test/hummingbot/connector/exchange/injective_v2/test_injective_v2_utils.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from pyinjective import Address, PrivateKey
-from pyinjective.constant import Network
+from pyinjective.core.network import Network
 
 import hummingbot.connector.exchange.injective_v2.injective_v2_utils as utils
 from hummingbot.connector.exchange.injective_v2 import injective_constants as CONSTANTS

--- a/test/hummingbot/connector/exchange/injective_v2/test_injective_v2_utils.py
+++ b/test/hummingbot/connector/exchange/injective_v2/test_injective_v2_utils.py
@@ -3,7 +3,6 @@ from unittest import TestCase
 from pyinjective import Address, PrivateKey
 from pyinjective.core.network import Network
 
-import hummingbot.connector.exchange.injective_v2.injective_v2_utils as utils
 from hummingbot.connector.exchange.injective_v2 import injective_constants as CONSTANTS
 from hummingbot.connector.exchange.injective_v2.data_sources.injective_grantee_data_source import (
     InjectiveGranteeDataSource,
@@ -25,7 +24,6 @@ class InjectiveConfigMapTests(TestCase):
 
     def test_mainnet_network_config_creation(self):
         network_config = InjectiveMainnetNetworkMode()
-        network_config.node = "lb"
 
         network = network_config.network()
         expected_network = Network.mainnet(node="lb")
@@ -33,31 +31,6 @@ class InjectiveConfigMapTests(TestCase):
         self.assertEqual(expected_network.string(), network.string())
         self.assertEqual(expected_network.lcd_endpoint, network.lcd_endpoint)
         self.assertTrue(network_config.use_secure_connection())
-
-        network_config = InjectiveMainnetNetworkMode()
-        network_config.node = "sentry0"
-
-        network = network_config.network()
-        expected_network = Network.mainnet(node="sentry0")
-
-        self.assertEqual(expected_network.string(), network.string())
-        self.assertEqual(expected_network.lcd_endpoint, network.lcd_endpoint)
-        self.assertFalse(network_config.use_secure_connection())
-
-    def test_mainnet_network_config_creation_fails_with_wrong_node(self):
-        network_config = InjectiveMainnetNetworkMode()
-        network_config.node = "lb"
-        network_config.node = "sentry0"
-        network_config.node = "sentry1"
-        network_config.node = "sentry3"
-
-        with self.assertRaises(ValueError) as exception_context:
-            network_config.node = "invalid"
-
-        self.assertIn(
-            f"invalid is not a valid node ({utils.MAINNET_NODES})",
-            str(exception_context.exception)
-        )
 
     def test_testnet_network_config_creation(self):
         network_config = InjectiveTestnetNetworkMode(testnet_node="sentry")
@@ -142,7 +115,6 @@ class InjectiveConfigMapTests(TestCase):
 
     def test_injective_config_creation(self):
         network_config = InjectiveMainnetNetworkMode()
-        network_config.node = "lb"
 
         _, grantee_private_key = PrivateKey.generate()
         _, granter_private_key = PrivateKey.generate()

--- a/test/hummingbot/connector/gateway/clob_spot/data_sources/injective/test_injective_utils.py
+++ b/test/hummingbot/connector/gateway/clob_spot/data_sources/injective/test_injective_utils.py
@@ -1,0 +1,48 @@
+from decimal import Decimal
+from unittest import TestCase
+
+from pyinjective.constant import Denom
+
+from hummingbot.connector.gateway.clob_spot.data_sources.injective.injective_utils import (
+    derivative_price_to_backend,
+    derivative_quantity_to_backend,
+    floor_to,
+)
+
+
+class InjectiveUtilsTests(TestCase):
+
+    def test_floor_to_utility_method(self):
+        original_value = Decimal("123.0123456789")
+
+        result = floor_to(value=original_value, target=Decimal("0.001"))
+        self.assertEqual(Decimal("123.012"), result)
+
+        result = floor_to(value=original_value, target=Decimal("1"))
+        self.assertEqual(Decimal("123"), result)
+
+    def test_derivative_quantity_to_backend_utility_method(self):
+        denom = Denom(
+            description="Fixed denom",
+            base=2,
+            quote=6,
+            min_price_tick_size=1000,
+            min_quantity_tick_size=100,
+        )
+
+        backend_quantity = derivative_quantity_to_backend(quantity=Decimal("1"), denom=denom)
+
+        self.assertEqual(100000000000000000000, backend_quantity)
+
+    def test_derivative_price_to_backend_utility_method(self):
+        denom = Denom(
+            description="Fixed denom",
+            base=2,
+            quote=6,
+            min_price_tick_size=1000,
+            min_quantity_tick_size=100,
+        )
+
+        backend_quantity = derivative_price_to_backend(price=Decimal("123.45"), denom=denom)
+
+        self.assertEqual(123450000000000000000000000, backend_quantity)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
- Adapted the Injective connector's configuration to be able tu use the SDK v 0.8.*
- Added a fix to correctly handle the case when the connector is requested to create a market order without a price, or with price being NaN (the default case for market orders in most of the strategies).
- Changed network configuration for Injective connector to support only the `lb` node for mainnet


**Tests performed by the developer**:
All tests running in green.
The connector can be configured when running the client for the mainnet network.


**Tips for QA testing**:
- Connector can be correctly configured for mainnet network.
- Connector can be used without issues in delegated account mode to create market orders. If the order book is not complete the strategy is required to provide a reference price, because the connector can't calculate one based on the orderbook.

