### PR TITLE
fix/ position_executor close_price() returns None if take profit type is LIMIT

### DIFF
--- a/hummingbot/smart_components/position_executor/position_executor.py
+++ b/hummingbot/smart_components/position_executor/position_executor.py
@@ -112,6 +112,8 @@ class PositionExecutor(SmartComponentBase):
         elif self.executor_status == PositionExecutorStatus.ACTIVE_POSITION:
             price_type = PriceType.BestBid if self.side == TradeType.BUY else PriceType.BestAsk
             return self.get_price(self.exchange, self.trading_pair, price_type=price_type)
+        elif self.take_profit_order_type.is_limit_type():
+            return self.take_profit_order.average_executed_price
         else:
             return self.close_order.average_executed_price
 


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
If take_profit_order_type is `OrderType.LIMIT`, `self.close_order.average_executed_price` returns `None`.
it causes `TypeError` in all dependent methods (take_profit_condition, stop_loss_condition etc.).

In PR `self.take_profit_order` is used instead of `self.close_order` if take profit order type is LIMIT.
**Tests performed by the developer**:



**Tips for QA testing**:


