### PR TITLE
Fix/upgrade injective sdk version

### DIFF
--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -45,7 +45,7 @@ dependencies:
     - flake8==3.7.9
     - gql
     - importlib-metadata==0.23
-    - injective-py==0.8.*
+    - injective-py==0.9.*
     - jsonpickle==3.0.1
     - mypy-extensions==0.4.3
     - pandas_ta==0.3.14b


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Change in environment.yml file to allow Hummingbot to use 0.9 version of the Injective SDK. Version 0.9.2 of the SDK in particular includes a fix to prevent an error that was caused by the latest `grpcio` versions in Macs with M1 and M2 chipsets.


**Tests performed by the developer**:
All tests passing in green


**Tips for QA testing**:
Not required. Only changed the environment.yml file

