### PR TITLE
Fix/phemex perpetual api endpoints 

### DIFF
--- a/hummingbot/connector/derivative/phemex_perpetual/phemex_perpetual_constants.py
+++ b/hummingbot/connector/derivative/phemex_perpetual/phemex_perpetual_constants.py
@@ -17,12 +17,12 @@ BASE_URLS = {
 }
 
 WSS_URLS = {
-    DEFAULT_DOMAIN: "wss://phemex.com",
+    DEFAULT_DOMAIN: "wss://ws.phemex.com",
     TESTNET_DOMAIN: "wss://testnet.phemex.com",
 }
 
-PUBLIC_WS_ENDPOINT = "/ws"
-PRIVATE_WS_ENDPOINT = "/ws"
+PUBLIC_WS_ENDPOINT = ""
+PRIVATE_WS_ENDPOINT = ""
 
 WS_HEARTBEAT = 5  # https://phemex-docs.github.io/#heartbeat
 


### PR DESCRIPTION
**A description of the changes proposed in the pull request**:
Minor change to the Phemex perpetual exchange endpoints that were made by Phemex on Oct 2023.  Resolve https 410 errors.

refer to: https://phemex.com/announcements/phemex-updates-api-entry-endpoints

**Tests performed by the developer**:
Executed scripts/fixed-grid.py to verify proper websocket network activity.


**Tips for QA testing**:
Test using scripts/fixed-grid.py 

