### PR TITLE
(fix) account for single order level in linear distribution

### DIFF
--- a/hummingbot/smart_components/utils/distributions.py
+++ b/hummingbot/smart_components/utils/distributions.py
@@ -21,6 +21,9 @@ class Distributions:
         Returns:
         List[Decimal]: A list containing the generated linear sequence.
         """
+        if n_levels == 1:
+            return [Decimal(start)]
+
         return [Decimal(start) + (Decimal(end) - Decimal(start)) * Decimal(i) / (Decimal(n_levels) - 1) for i in range(n_levels)]
 
     @classmethod


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [X] Your code builds clean without any errors or warnings
- [X] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

* accounts for case where `n_levels` equals 1 in linear distribution


