### PR TITLE
(fix) fix default button color

### DIFF
--- a/hummingbot/client/ui/hummingbot_cli.py
+++ b/hummingbot/client/ui/hummingbot_cli.py
@@ -65,7 +65,7 @@ class HummingbotCLI(PubSub):
         self.log_field = create_log_field(self.search_field)
         self.right_pane_toggle = create_log_toggle(self.toggle_right_pane)
         self.live_field = create_live_field()
-        self.log_field_button = create_tab_button("Log-pane", self.log_button_clicked)
+        self.log_field_button = create_tab_button("logs", self.log_button_clicked)
         self.timer = create_timer()
         self.process_usage = create_process_monitor()
         self.trade_monitor = create_trade_monitor()

--- a/hummingbot/client/ui/style.py
+++ b/hummingbot/client/ui/style.py
@@ -199,7 +199,7 @@ default_ui_style = {
     "dialog frame.label": "bg:#FFFFFF #000000",
     "dialog.body": "bg:#000000 ",
     "dialog shadow": "bg:#171E2B",
-    "button": "bg:#000000",
+    "button": "bg:#FFFFFF #000000",
     "text-area": "bg:#000000 #FFFFFF",
 }
 
@@ -223,6 +223,6 @@ win32_code_style = {
     "dialog frame.label": "bg:#ansiwhite #ansiblack",
     "dialog.body": "bg:#ansiblack ",
     "dialog shadow": "bg:#ansigreen",
-    "button": "bg:#ansigreen",
+    "button": "bg:#ansiwhite #ansiblack",
     "text-area": "bg:#ansiblack #ansigreen",
 }

--- a/test/hummingbot/client/ui/test_style.py
+++ b/test/hummingbot/client/ui/test_style.py
@@ -59,7 +59,7 @@ class StyleTest(unittest.TestCase):
                 "dialog frame.label": "bg:#FCFCFC #000000",
                 "dialog.body": "bg:#000000 #FCFCFC",
                 "dialog shadow": "bg:#171E2B",
-                "button": "bg:#000000",
+                "button": "bg:#FFFFFF #000000",
                 "text-area": "bg:#000000 #FCFCFC",
                 # Label bg and font color
                 "primary_label": "bg:#5FFFD7 #FAFAFA",
@@ -115,7 +115,7 @@ class StyleTest(unittest.TestCase):
                 "dialog frame.label": "bg:#ansiwhite #ansiblack",
                 "dialog.body": "bg:#ansiblack #ansiwhite",
                 "dialog shadow": "bg:#ansigreen",
-                "button": "bg:#ansigreen",
+                "button": "bg:#ansiwhite #ansiblack",
                 "text-area": "bg:#ansiblack #ansiwhite",
                 # Label bg and font color
                 "primary_label": "bg:#ansicyan #ansiwhite",
@@ -171,7 +171,7 @@ class StyleTest(unittest.TestCase):
                 "dialog frame.label": "bg:#5FFFD7 #000000",
                 "dialog.body": "bg:#000000 #5FFFD7",
                 "dialog shadow": "bg:#171E2B",
-                "button": "bg:#000000",
+                "button": "bg:#FFFFFF #000000",
                 "text-area": "bg:#000000 #5FFFD7",
                 # Label bg and font color
                 "primary_label": "bg:#5FFFD7 #262626",


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [X] Your code builds clean without any errors or warnings
- [X] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

- This fixes the default button color, which was previously had a black background and led to the log pane buttons being invisible on certain machines.
- Now they should be visible in all environments:

<img width="700" alt="Screen Shot 2023-11-25 at 12 04 42 PM" src="https://github.com/hummingbot/hummingbot/assets/1795030/3658e26c-3d92-4488-b62b-bdd324e776de">

