### PR TITLE
fix/ #6646 amm_trade function do not work correctly with small prices.

### DIFF
--- a/hummingbot/core/gateway/gateway_http_client.py
+++ b/hummingbot/core/gateway/gateway_http_client.py
@@ -492,7 +492,7 @@ class GatewayHttpClient:
             "quote": quote_asset,
             "side": side.name,
             "amount": f"{amount:.18f}",
-            "limitPrice": str(price),
+            "limitPrice": '{:f}'.format(price),
             "allowedSlippage": "0/1",  # hummingbot applies slippage itself
         }
         if nonce is not None:


### PR DESCRIPTION
**A description of the changes proposed in the pull request:**

The pull request modifies the amm_trade function in the gateway_http_client.py file to handle very small price values more accurately. Previously, the price value was converted to a string using the standard str() function. However, for very small Decimal values, this could result in a string representation in scientific notation.
The change proposed in this pull request is to use the format function with fixed point notation for the string conversion of price. This ensures that very small price values are correctly converted to a string representation that avoids scientific notation.

To fix this, the PR changes the string conversion to use the format function with fixed point notation. This should correctly handle very small values and avoid scientific notation.

**Tests performed by the developer:**

 Tested the changes locally and confirmed that the amm_trade function now correctly handles very small price values.
