### PR TITLE
(doc) add instructions to run tests locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,8 @@ If the Foundation team requests changes, make more commits to your branch to add
 
 A minimum of 75% unit test coverage is required for all changes included in a pull request. However, some components, like UI components, are excluded from this validation.
 
+To run tests locally, run `make test` after activating the environment.
+
 To calculate the diff-coverage locally on your computer, run `make development-diff-cover` after running all tests.
 
 ## Checklist


### PR DESCRIPTION
This is a documentation change.

CONTRIBUTING.md is not specifying how to run tests locally, and I fixed that.