### PR TITLE
fix / add order_refresh_time to dmanv2_with_config script

### DIFF
--- a/scripts/v2_dman_v2_with_config.py
+++ b/scripts/v2_dman_v2_with_config.py
@@ -36,7 +36,7 @@ class DManV2ScriptConfig(BaseClientModel):
     start_spread: float = Field(1.0, client_data=ClientFieldData(prompt_on_new=True, prompt=lambda mi: "Set the start spread as a multiple of the NATR (e.g., 1.0 for 1x NATR):"))
     step_between_orders: float = Field(0.8, client_data=ClientFieldData(prompt_on_new=True, prompt=lambda mi: "Define the step between orders as a multiple of the NATR (e.g., 0.8 for 0.8x NATR):"))
     cooldown_time: int = Field(5, client_data=ClientFieldData(prompt_on_new=False, prompt=lambda mi: "Specify the cooldown time in seconds between order placements (e.g., 5):"))
-    order_refresh_time: int = Field(5, client_data=ClientFieldData(prompt_on_new=False, prompt=lambda mi: "How often do you want to cancel or replace orders? (in seconds):"))
+    order_refresh_time: int = Field(900, client_data=ClientFieldData(prompt_on_new=False, prompt=lambda mi: "How often do you want to cancel or replace orders? (in seconds):"))
 
     # Triple barrier configuration
     stop_loss: Decimal = Field(0.2, client_data=ClientFieldData(prompt_on_new=True, prompt=lambda mi: "Set the stop loss percentage (e.g., 0.2 for 20% loss):"))

--- a/scripts/v2_dman_v2_with_config.py
+++ b/scripts/v2_dman_v2_with_config.py
@@ -36,6 +36,7 @@ class DManV2ScriptConfig(BaseClientModel):
     start_spread: float = Field(1.0, client_data=ClientFieldData(prompt_on_new=True, prompt=lambda mi: "Set the start spread as a multiple of the NATR (e.g., 1.0 for 1x NATR):"))
     step_between_orders: float = Field(0.8, client_data=ClientFieldData(prompt_on_new=True, prompt=lambda mi: "Define the step between orders as a multiple of the NATR (e.g., 0.8 for 0.8x NATR):"))
     cooldown_time: int = Field(5, client_data=ClientFieldData(prompt_on_new=False, prompt=lambda mi: "Specify the cooldown time in seconds between order placements (e.g., 5):"))
+    order_refresh_time: int = Field(5, client_data=ClientFieldData(prompt_on_new=False, prompt=lambda mi: "How often do you want to cancel or replace orders? (in seconds):"))
 
     # Triple barrier configuration
     stop_loss: Decimal = Field(0.2, client_data=ClientFieldData(prompt_on_new=True, prompt=lambda mi: "Set the stop loss percentage (e.g., 0.2 for 20% loss):"))

--- a/scripts/v2_dman_v2_with_config.py
+++ b/scripts/v2_dman_v2_with_config.py
@@ -36,7 +36,7 @@ class DManV2ScriptConfig(BaseClientModel):
     start_spread: float = Field(1.0, client_data=ClientFieldData(prompt_on_new=True, prompt=lambda mi: "Set the start spread as a multiple of the NATR (e.g., 1.0 for 1x NATR):"))
     step_between_orders: float = Field(0.8, client_data=ClientFieldData(prompt_on_new=True, prompt=lambda mi: "Define the step between orders as a multiple of the NATR (e.g., 0.8 for 0.8x NATR):"))
     cooldown_time: int = Field(5, client_data=ClientFieldData(prompt_on_new=False, prompt=lambda mi: "Specify the cooldown time in seconds between order placements (e.g., 5):"))
-    order_refresh_time: int = Field(900, client_data=ClientFieldData(prompt_on_new=False, prompt=lambda mi: "How often do you want to cancel or replace orders? (in seconds):"))
+    order_refresh_time: int = Field(900, client_data=ClientFieldData(prompt_on_new=True, prompt=lambda mi: "How often do you want to cancel or replace orders? (in seconds):"))
 
     # Triple barrier configuration
     stop_loss: Decimal = Field(0.2, client_data=ClientFieldData(prompt_on_new=True, prompt=lambda mi: "Set the stop loss percentage (e.g., 0.2 for 20% loss):"))


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Add `order_refresh_time` to `v2_dman_v2_with_config.py` to fix error below on development branch

```
2024-01-15 21:14:10,277 - 24382 - hummingbot.core.utils.async_utils - ERROR - Unhandled error in background task: 'DManV2ScriptConfig' object has no attribute 'order_refresh_time'
Traceback (most recent call last):
  File "/Users/rapcomia/github/hummingbot/development/hummingbot/core/utils/async_utils.py", line 9, in safe_wrapper
    return await c
  File "/Users/rapcomia/github/hummingbot/development/hummingbot/client/command/start_command.py", line 125, in start_check
    self._initialize_strategy(self.strategy_name)
  File "/Users/rapcomia/github/hummingbot/development/hummingbot/client/command/start_command.py", line 292, in _initialize_strategy
    self.start_script_strategy()
  File "/Users/rapcomia/github/hummingbot/development/hummingbot/client/command/start_command.py", line 209, in start_script_strategy
    self.strategy = script_strategy(self.markets, config)
  File "/Users/rapcomia/github/hummingbot/development/scripts/v2_dman_v2_with_config.py", line 75, in __init__
    order_refresh_time=config.order_refresh_time,
AttributeError: 'DManV2ScriptConfig' object has no attribute 'order_refresh_time'
```

**Tests performed by the developer**:
na

**Tips for QA testing**:
na

