### PR TITLE
(fix) The MEXC Content-type in the header of API calls must be set to  application/json.

### DIFF
--- a/hummingbot/core/web_assistant/rest_assistant.py
+++ b/hummingbot/core/web_assistant/rest_assistant.py
@@ -73,8 +73,7 @@ class RESTAssistant:
 
         headers = headers or {}
 
-        local_headers = {
-            "Content-Type": ("application/json" if method != RESTMethod.GET else "application/x-www-form-urlencoded")}
+        local_headers = {"Content-Type": "application/json"}
 
         local_headers.update(headers)
 


### PR DESCRIPTION
The MEXC API Content-type in the header of API calls must be set to application/json.
MEXC will intercept illegal requests (Content-type: the network file type transmitted between the client and the server).
The above optimization measures will be implemented on February 22, 2024, at 08:00 (UTC).

see: https://www.mexc.com/support/articles/17827791513387