### PR TITLE
Fix (unwrap_token_symbol): Support WMATIC

### DIFF
--- a/hummingbot/core/gateway/utils.py
+++ b/hummingbot/core/gateway/utils.py
@@ -2,7 +2,7 @@ import re
 from typing import List, Match, Optional, Pattern
 
 # W{TOKEN} only applies to a few special tokens. It should NOT match all W-prefixed token names like WAVE or WOW.
-CAPITAL_W_SYMBOLS_PATTERN = re.compile(r"^W(BTC|ETH|AVAX|ALBT|XRP)")
+CAPITAL_W_SYMBOLS_PATTERN = re.compile(r"^W(BTC|ETH|AVAX|ALBT|XRP|MATIC)")
 
 # w{TOKEN} generally means a wrapped token on the Ethereum network. e.g. wNXM, wDGLD.
 SMALL_W_SYMBOLS_PATTERN = re.compile(r"^w(\w+)")


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using the approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
I started getting this error for WMATIC with all the rate oracles that are supported
```
2024-03-10 13:48:24,027 - 15 - hummingbot.strategy.amm_arb.data_types - WARNING - The arbitrage proposal profitability could not be calculated due to a missing rate (LINK-LINK=1, USDT-WMATIC=None)
```
Upon digging, found a fix to include MATIC in the list of symbols that are unwrapped for price queries.


**Tests performed by the developer**:
Tested using commands `rate --pair WMATIC-USDT` and `rate --pair USDT-WMATIC`
