### PR TITLE
bumped injective-py to 1.4.x

### DIFF
--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -47,7 +47,7 @@ dependencies:
     - gql
     - grpcio-tools
     - importlib-metadata==0.23
-    - injective-py==1.3.*
+    - injective-py==1.4.*
     - jsonpickle==3.0.1
     - mypy-extensions==0.4.3
     - pandas_ta==0.3.14b


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Updating injective-py to accomodate https://github.com/hummingbot/hummingbot/pull/6905

**Tests performed by the developer**:

- My trading bot runs injective_v2 with 1.4.1 and making/updating/canceling orders still works. No warnings about deprecated functions appear in the logs. There seems to be no updates needed on this front.

**Tips for QA testing**:
