### PR TITLE
(feat) Allow setting gas price multiplier in injective_v2

### DIFF
--- a/hummingbot/connector/exchange/injective_v2/injective_v2_utils.py
+++ b/hummingbot/connector/exchange/injective_v2/injective_v2_utils.py
@@ -59,6 +59,10 @@ class InjectiveSimulatedTransactionFeeCalculatorMode(InjectiveFeeCalculatorMode)
         const=True,
         client_data=ClientFieldData(),
     )
+    gas_limit_adjustment_multiplier: float = Field(
+        default=None,
+        client_data=ClientFieldData(),
+    )
 
     class Config:
         title = "simulated_transaction_fee_calculator"
@@ -70,6 +74,8 @@ class InjectiveSimulatedTransactionFeeCalculatorMode(InjectiveFeeCalculatorMode)
             gas_price: Optional[int] = None,
             gas_limit_adjustment_multiplier: Optional[Decimal] = None,
     ) -> TransactionFeeCalculator:
+        if gas_limit_adjustment_multiplier is None and self.gas_limit_adjustment_multiplier is not None:
+            gas_limit_adjustment_multiplier = Decimal(self.gas_limit_adjustment_multiplier)
         return SimulatedTransactionFeeCalculator(
             client=client,
             composer=composer,
@@ -84,6 +90,10 @@ class InjectiveMessageBasedTransactionFeeCalculatorMode(InjectiveFeeCalculatorMo
         const=True,
         client_data=ClientFieldData(),
     )
+    gas_limit_adjustment_multiplier: float = Field(
+        default=None,
+        client_data=ClientFieldData(),
+    )
 
     class Config:
         title = "message_based_transaction_fee_calculator"
@@ -95,6 +105,8 @@ class InjectiveMessageBasedTransactionFeeCalculatorMode(InjectiveFeeCalculatorMo
             gas_price: Optional[int] = None,
             gas_limit_adjustment_multiplier: Optional[Decimal] = None,
     ) -> TransactionFeeCalculator:
+        if gas_limit_adjustment_multiplier is None and self.gas_limit_adjustment_multiplier is not None:
+            gas_limit_adjustment_multiplier = Decimal(self.gas_limit_adjustment_multiplier)
         return MessageBasedTransactionFeeCalculator(
             client=client,
             composer=composer,


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

![inj_pat](https://cdn.discordapp.com/emojis/1166310371280302140.gif?size=128&quality=lossless)

Injective orders often fail with errors like these:

> out of gas in location: ReadPerByte; gasWanted: 72041, gasUsed: 72372: out of gas

This change allows users to set a gas price multiplier to accommodate for orders during network congestion, and, ultimately, saving on gas (note that the out of gas error also costs gas fees, see [this transaction](https://www.mintscan.io/injective/tx/2ECFDF9A9680D42E69B8B8A7B2B59DD6C957A956B8B3E7A2C8148AECDA294B50?height=63529451), and the bot will keep trying to make that order and keep failing).

This change does not change default behavior - if the user does not supply a `gas_limit_adjustment_multiplier`, the default behavior will continue.

A demo config looks like this:

```yml
###############################
###   injective_v2 config   ###
###############################

connector: injective_v2

receive_connector_configuration: true

network: {}

account_type:
  private_key: ....
  subaccount_index: 0
  granter_address: inj...
  granter_subaccount_index: 0

fee_calculator:
  name: simulated_transaction_fee_calculator
  gas_limit_adjustment_multiplier: 1.5
```

**Tests performed by the developer**:

Trading bot still runs, tested building Docker, transactions coming through now.

Before the change (notice gas price error): https://www.mintscan.io/injective/tx/2ECFDF9A9680D42E69B8B8A7B2B59DD6C957A956B8B3E7A2C8148AECDA294B50?height=63529451

After: https://www.mintscan.io/injective/tx/CDAD08FCDE340BE6B7183D94049B0613C6DD939D379A2E89B119A1615AE650FF?height=63529423

**Tips for QA testing**:


