### PR TITLE
feat/injective_fee_calculator_multiplier_config

### DIFF
--- a/hummingbot/connector/exchange/injective_v2/data_sources/injective_grantee_data_source.py
+++ b/hummingbot/connector/exchange/injective_v2/data_sources/injective_grantee_data_source.py
@@ -506,10 +506,15 @@ class InjectiveGranteeDataSource(InjectiveDataSource):
         await super()._process_transaction_update(transaction_event=transaction_event)
 
     async def _configure_gas_fee_for_transaction(self, transaction: Transaction):
+        multiplier = (None
+                      if CONSTANTS.GAS_LIMIT_ADJUSTMENT_MULTIPLIER is None
+                      else Decimal(str(CONSTANTS.GAS_LIMIT_ADJUSTMENT_MULTIPLIER)))
         if self._fee_calculator is None:
             self._fee_calculator = self._fee_calculator_mode.create_calculator(
                 client=self._client,
                 composer=await self.composer(),
+                gas_price=CONSTANTS.TX_GAS_PRICE,
+                gas_limit_adjustment_multiplier=multiplier,
             )
 
         await self._fee_calculator.configure_gas_fee_for_transaction(

--- a/hummingbot/connector/exchange/injective_v2/data_sources/injective_vaults_data_source.py
+++ b/hummingbot/connector/exchange/injective_v2/data_sources/injective_vaults_data_source.py
@@ -536,10 +536,15 @@ class InjectiveVaultsDataSource(InjectiveDataSource):
         await super()._process_transaction_update(transaction_event=transaction_event)
 
     async def _configure_gas_fee_for_transaction(self, transaction: Transaction):
+        multiplier = (None
+                      if CONSTANTS.GAS_LIMIT_ADJUSTMENT_MULTIPLIER is None
+                      else Decimal(str(CONSTANTS.GAS_LIMIT_ADJUSTMENT_MULTIPLIER)))
         if self._fee_calculator is None:
             self._fee_calculator = self._fee_calculator_mode.create_calculator(
                 client=self._client,
                 composer=await self.composer(),
+                gas_price=CONSTANTS.TX_GAS_PRICE,
+                gas_limit_adjustment_multiplier=multiplier,
             )
 
         await self._fee_calculator.configure_gas_fee_for_transaction(

--- a/hummingbot/connector/exchange/injective_v2/injective_constants.py
+++ b/hummingbot/connector/exchange/injective_v2/injective_constants.py
@@ -14,8 +14,8 @@ MAX_ORDER_ID_LEN = 36  # Injective supports uuid style client ids (36 characters
 HBOT_ORDER_ID_PREFIX = "HBOT"
 
 DEFAULT_SUBACCOUNT_INDEX = 0
-EXTRA_TRANSACTION_GAS = pyinjective.constant.GAS_FEE_BUFFER_AMOUNT
-DEFAULT_GAS_PRICE = pyinjective.constant.GAS_PRICE
+TX_GAS_PRICE = pyinjective.constant.GAS_PRICE
+GAS_LIMIT_ADJUSTMENT_MULTIPLIER = None  # Leave as None to use the default value from the SDK. Otherwise, a float value.
 
 EXPECTED_BLOCK_TIME = 1.5
 TRANSACTIONS_CHECK_INTERVAL = 3 * EXPECTED_BLOCK_TIME


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
- Added possibility to configure the multiplier the gas fee estimator with simulation uses to estimate the gas amount for a TX


**Tests performed by the developer**:
All unit tests passing


**Tips for QA testing**:
Not much to test. Just configuring the new value in the constant module (hummingbot/connector/exchange/injective_v2/injective_constants.py):
- GAS_LIMIT_ADJUSTMENT_MULTIPLIER

