### PR TITLE
fix #6934: Update Vertex's hostnames

### DIFF
--- a/hummingbot/connector/exchange/vertex/vertex_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/vertex/vertex_api_order_book_data_source.py
@@ -163,7 +163,7 @@ class VertexAPIOrderBookDataSource(OrderBookTrackerDataSource):
                 self._last_ws_message_sent_timestamp = ping_time
 
     async def _connected_websocket_assistant(self) -> WSAssistant:
-        ws_url = f"{CONSTANTS.WSS_URLS[self._domain]}{CONSTANTS.WS_SUBSCRIBE_PATH_URL}"
+        ws_url = f"{CONSTANTS.WS_SUBSCRIBE_URLS[self._domain]}"
 
         self._ping_interval = CONSTANTS.HEARTBEAT_TIME_INTERVAL
 

--- a/hummingbot/connector/exchange/vertex/vertex_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/vertex/vertex_api_user_stream_data_source.py
@@ -39,7 +39,7 @@ class VertexAPIUserStreamDataSource(UserStreamTrackerDataSource):
         self._last_ws_message_sent_timestamp = 0
 
     async def _connected_websocket_assistant(self) -> WSAssistant:
-        ws_url = f"{CONSTANTS.WSS_URLS[self._domain]}{CONSTANTS.WS_SUBSCRIBE_PATH_URL}"
+        ws_url = f"{CONSTANTS.WS_SUBSCRIBE_URLS[self._domain]}"
         self._ping_interval = CONSTANTS.HEARTBEAT_TIME_INTERVAL
 
         ws: WSAssistant = await self._api_factory.get_ws_assistant()

--- a/hummingbot/connector/exchange/vertex/vertex_constants.py
+++ b/hummingbot/connector/exchange/vertex/vertex_constants.py
@@ -63,6 +63,7 @@ TIME_IN_FORCE_POSTONLY = "POSTONLY"  # PostOnly
 # API PATHS
 POST_PATH_URL = "/execute"
 QUERY_PATH_URL = "/query"
+INDEXER_PATH_URL = "/indexer"
 SYMBOLS_PATH_URL = "/symbols"
 
 # POST METHODS
@@ -180,7 +181,7 @@ ALL_ENDPOINTS_LIMIT = "All"
 RATE_LIMITS = [
     RateLimit(limit_id=ALL_ENDPOINTS_LIMIT, limit=600, time_interval=10),
     RateLimit(
-        limit_id=ARCHIVE_INDEXER_URLS[DEFAULT_DOMAIN], limit=60, time_interval=1, linked_limits=[LinkedLimitWeightPair(ALL_ENDPOINTS_LIMIT)]
+        limit_id=INDEXER_PATH_URL, limit=60, time_interval=1, linked_limits=[LinkedLimitWeightPair(ALL_ENDPOINTS_LIMIT)]
     ),
     RateLimit(
         limit_id=STATUS_REQUEST_TYPE,

--- a/hummingbot/connector/exchange/vertex/vertex_constants.py
+++ b/hummingbot/connector/exchange/vertex/vertex_constants.py
@@ -21,12 +21,22 @@ TESTNET_DOMAIN = "vertex_testnet"
 QUOTE = "USDC"
 
 BASE_URLS = {
-    DEFAULT_DOMAIN: "https://prod.vertexprotocol-backend.com",
+    DEFAULT_DOMAIN: "https://gateway.prod.vertexprotocol.com/v1",
     TESTNET_DOMAIN: "https://test.vertexprotocol-backend.com",
 }
 
 WSS_URLS = {
-    DEFAULT_DOMAIN: "wss://prod.vertexprotocol-backend.com",
+    DEFAULT_DOMAIN: "wss://gateway.prod.vertexprotocol.com/v1/ws",
+    TESTNET_DOMAIN: "wss://test.vertexprotocol-backend.com",
+}
+
+ARCHIVE_INDEXER_URLS = {
+    DEFAULT_DOMAIN: "https://archive.prod.vertexprotocol.com/v1",
+    TESTNET_DOMAIN: "https://test.vertexprotocol-backend.com",
+}
+
+WS_SUBSCRIBE_URLS = {
+    DEFAULT_DOMAIN: "wss://gateway.prod.vertexprotocol.com/v1/subscribe",
     TESTNET_DOMAIN: "wss://test.vertexprotocol-backend.com",
 }
 
@@ -53,10 +63,7 @@ TIME_IN_FORCE_POSTONLY = "POSTONLY"  # PostOnly
 # API PATHS
 POST_PATH_URL = "/execute"
 QUERY_PATH_URL = "/query"
-INDEXER_PATH_URL = "/indexer"
 SYMBOLS_PATH_URL = "/symbols"
-WS_PATH_URL = "/ws"
-WS_SUBSCRIBE_PATH_URL = "/subscribe"
 
 # POST METHODS
 PLACE_ORDER_METHOD = "place_order"
@@ -173,7 +180,7 @@ ALL_ENDPOINTS_LIMIT = "All"
 RATE_LIMITS = [
     RateLimit(limit_id=ALL_ENDPOINTS_LIMIT, limit=600, time_interval=10),
     RateLimit(
-        limit_id=INDEXER_PATH_URL, limit=60, time_interval=1, linked_limits=[LinkedLimitWeightPair(ALL_ENDPOINTS_LIMIT)]
+        limit_id=ARCHIVE_INDEXER_URLS[DEFAULT_DOMAIN], limit=60, time_interval=1, linked_limits=[LinkedLimitWeightPair(ALL_ENDPOINTS_LIMIT)]
     ),
     RateLimit(
         limit_id=STATUS_REQUEST_TYPE,

--- a/hummingbot/connector/exchange/vertex/vertex_constants.py
+++ b/hummingbot/connector/exchange/vertex/vertex_constants.py
@@ -22,22 +22,22 @@ QUOTE = "USDC"
 
 BASE_URLS = {
     DEFAULT_DOMAIN: "https://gateway.prod.vertexprotocol.com/v1",
-    TESTNET_DOMAIN: "https://test.vertexprotocol-backend.com",
+    TESTNET_DOMAIN: "https://gateway.sepolia-test.vertexprotocol.com/v1",
 }
 
 WSS_URLS = {
     DEFAULT_DOMAIN: "wss://gateway.prod.vertexprotocol.com/v1/ws",
-    TESTNET_DOMAIN: "wss://test.vertexprotocol-backend.com",
+    TESTNET_DOMAIN: "wss://gateway.sepolia-test.vertexprotocol.com/v1/ws",
 }
 
 ARCHIVE_INDEXER_URLS = {
     DEFAULT_DOMAIN: "https://archive.prod.vertexprotocol.com/v1",
-    TESTNET_DOMAIN: "https://test.vertexprotocol-backend.com",
+    TESTNET_DOMAIN: "https://archive.sepolia-test.vertexprotocol.com/v1",
 }
 
 WS_SUBSCRIBE_URLS = {
     DEFAULT_DOMAIN: "wss://gateway.prod.vertexprotocol.com/v1/subscribe",
-    TESTNET_DOMAIN: "wss://test.vertexprotocol-backend.com",
+    TESTNET_DOMAIN: "wss://gateway.vertexprotocol-vertexprotocol.com/v1/subscribe",
 }
 
 CONTRACTS = {

--- a/hummingbot/connector/exchange/vertex/vertex_exchange.py
+++ b/hummingbot/connector/exchange/vertex/vertex_exchange.py
@@ -516,9 +516,9 @@ class VertexExchange(ExchangePyBase):
             product_id = utils.trading_pair_to_product_id(order.trading_pair, self._exchange_market_info[self._domain])
 
             matches_response = await self._api_post(
-                path_url=CONSTANTS.ARCHIVE_INDEXER_URLS[self._domain],
+                path_url=CONSTANTS.INDEXER_PATH_URL,
                 data={"matches": {"product_ids": [product_id], "subaccount": self.sender_address}},
-                limit_id=CONSTANTS.ARCHIVE_INDEXER_URLS[self._domain],
+                limit_id=CONSTANTS.INDEXER_PATH_URL,
             )
 
             matches_data = matches_response.get("matches", [])
@@ -600,7 +600,7 @@ class VertexExchange(ExchangePyBase):
                     "orders": {"digests": [tracked_order.exchange_order_id]},
                 }
                 indexed_order_data = await self._api_post(
-                    path_url=CONSTANTS.ARCHIVE_INDEXER_URLS[self._domain], data=data, limit_id=CONSTANTS.ARCHIVE_INDEXER_URLS[self._domain]
+                    path_url=CONSTANTS.INDEXER_PATH_URL, data=data, limit_id=CONSTANTS.INDEXER_PATH_URL
                 )
                 orders = indexed_order_data.get("orders", [])
                 if len(orders) > 0:
@@ -731,9 +731,9 @@ class VertexExchange(ExchangePyBase):
         try:
             data = {"matches": {"product_ids": [product_id], "limit": 5}}
             matches_response = await self._api_post(
-                path_url=CONSTANTS.ARCHIVE_INDEXER_URLS[self._domain],
+                path_url=CONSTANTS.INDEXER_PATH_URL,
                 data=data,
-                limit_id=CONSTANTS.ARCHIVE_INDEXER_URLS[self._domain],
+                limit_id=CONSTANTS.INDEXER_PATH_URL
             )
             matches = matches_response.get("matches", [])
             if matches and len(matches) > 0:

--- a/hummingbot/connector/exchange/vertex/vertex_exchange.py
+++ b/hummingbot/connector/exchange/vertex/vertex_exchange.py
@@ -516,9 +516,9 @@ class VertexExchange(ExchangePyBase):
             product_id = utils.trading_pair_to_product_id(order.trading_pair, self._exchange_market_info[self._domain])
 
             matches_response = await self._api_post(
-                path_url=CONSTANTS.INDEXER_PATH_URL,
+                path_url=CONSTANTS.ARCHIVE_INDEXER_URLS[self._domain],
                 data={"matches": {"product_ids": [product_id], "subaccount": self.sender_address}},
-                limit_id=CONSTANTS.INDEXER_PATH_URL,
+                limit_id=CONSTANTS.ARCHIVE_INDEXER_URLS[self._domain],
             )
 
             matches_data = matches_response.get("matches", [])
@@ -600,7 +600,7 @@ class VertexExchange(ExchangePyBase):
                     "orders": {"digests": [tracked_order.exchange_order_id]},
                 }
                 indexed_order_data = await self._api_post(
-                    path_url=CONSTANTS.INDEXER_PATH_URL, data=data, limit_id=CONSTANTS.INDEXER_PATH_URL
+                    path_url=CONSTANTS.ARCHIVE_INDEXER_URLS[self._domain], data=data, limit_id=CONSTANTS.ARCHIVE_INDEXER_URLS[self._domain]
                 )
                 orders = indexed_order_data.get("orders", [])
                 if len(orders) > 0:
@@ -731,9 +731,9 @@ class VertexExchange(ExchangePyBase):
         try:
             data = {"matches": {"product_ids": [product_id], "limit": 5}}
             matches_response = await self._api_post(
-                path_url=CONSTANTS.INDEXER_PATH_URL,
+                path_url=CONSTANTS.ARCHIVE_INDEXER_URLS[self._domain],
                 data=data,
-                limit_id=CONSTANTS.INDEXER_PATH_URL,
+                limit_id=CONSTANTS.ARCHIVE_INDEXER_URLS[self._domain],
             )
             matches = matches_response.get("matches", [])
             if matches and len(matches) > 0:

--- a/hummingbot/connector/exchange/vertex/vertex_web_utils.py
+++ b/hummingbot/connector/exchange/vertex/vertex_web_utils.py
@@ -15,7 +15,10 @@ def public_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> st
 
     :return: the full URL to the endpoint
     """
-    return CONSTANTS.BASE_URLS[domain] + path_url
+    if "/indexer" in path_url:
+        return CONSTANTS.ARCHIVE_INDEXER_URLS[domain]
+    else:
+        return CONSTANTS.BASE_URLS[domain] + path_url
 
 
 def private_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:

--- a/test/hummingbot/connector/exchange/vertex/test_vertex_exchange.py
+++ b/test/hummingbot/connector/exchange/vertex/test_vertex_exchange.py
@@ -1150,7 +1150,7 @@ class TestVertexExchange(unittest.TestCase):
         )
         order: InFlightOrder = self.exchange.in_flight_orders[digest]
 
-        matches_url = web_utils.public_rest_url(CONSTANTS.ARCHIVE_INDEXER_URLS[self._domain], domain=self.domain)
+        matches_url = web_utils.public_rest_url(CONSTANTS.INDEXER_PATH_URL, domain=self.domain)
         matches_response = self.get_matches_filled_mock()
         mock_api.post(matches_url, body=json.dumps(matches_response))
 
@@ -1195,7 +1195,7 @@ class TestVertexExchange(unittest.TestCase):
         )
         order: InFlightOrder = self.exchange.in_flight_orders[digest]
 
-        matches_url = web_utils.public_rest_url(CONSTANTS.ARCHIVE_INDEXER_URLS[self._domain], domain=self.domain)
+        matches_url = web_utils.public_rest_url(CONSTANTS.INDEXER_PATH_URL, domain=self.domain)
         matches_response = self.get_matches_unfilled_mock()
         mock_api.post(matches_url, body=json.dumps(matches_response))
 
@@ -1229,7 +1229,7 @@ class TestVertexExchange(unittest.TestCase):
         )
         order: InFlightOrder = self.exchange.in_flight_orders[digest]
 
-        matches_url = web_utils.public_rest_url(CONSTANTS.ARCHIVE_INDEXER_URLS[self._domain], domain=self.domain)
+        matches_url = web_utils.public_rest_url(CONSTANTS.INDEXER_PATH_URL, domain=self.domain)
         matches_response = self.get_matches_unfilled_mock()
         mock_api.post(matches_url, body=json.dumps(matches_response))
 
@@ -1289,7 +1289,7 @@ class TestVertexExchange(unittest.TestCase):
         )
         order: InFlightOrder = self.exchange.in_flight_orders[digest]
 
-        matches_url = web_utils.public_rest_url(CONSTANTS.ARCHIVE_INDEXER_URLS[self._domain], domain=self.domain)
+        matches_url = web_utils.public_rest_url(CONSTANTS.INDEXER_PATH_URL, domain=self.domain)
         matches_response = self.get_matches_unfilled_mock()
         mock_api.post(matches_url, body=json.dumps(matches_response))
 
@@ -1332,7 +1332,7 @@ class TestVertexExchange(unittest.TestCase):
         )
         order: InFlightOrder = self.exchange.in_flight_orders[digest]
 
-        matches_url = web_utils.public_rest_url(CONSTANTS.ARCHIVE_INDEXER_URLS[self._domain], domain=self.domain)
+        matches_url = web_utils.public_rest_url(CONSTANTS.INDEXER_PATH_URL, domain=self.domain)
         matches_response = self.get_matches_unfilled_mock()
         mock_api.post(matches_url, body=json.dumps(matches_response))
 

--- a/test/hummingbot/connector/exchange/vertex/test_vertex_exchange.py
+++ b/test/hummingbot/connector/exchange/vertex/test_vertex_exchange.py
@@ -1150,7 +1150,7 @@ class TestVertexExchange(unittest.TestCase):
         )
         order: InFlightOrder = self.exchange.in_flight_orders[digest]
 
-        matches_url = web_utils.public_rest_url(CONSTANTS.INDEXER_PATH_URL, domain=self.domain)
+        matches_url = web_utils.public_rest_url(CONSTANTS.ARCHIVE_INDEXER_URLS[self._domain], domain=self.domain)
         matches_response = self.get_matches_filled_mock()
         mock_api.post(matches_url, body=json.dumps(matches_response))
 
@@ -1195,7 +1195,7 @@ class TestVertexExchange(unittest.TestCase):
         )
         order: InFlightOrder = self.exchange.in_flight_orders[digest]
 
-        matches_url = web_utils.public_rest_url(CONSTANTS.INDEXER_PATH_URL, domain=self.domain)
+        matches_url = web_utils.public_rest_url(CONSTANTS.ARCHIVE_INDEXER_URLS[self._domain], domain=self.domain)
         matches_response = self.get_matches_unfilled_mock()
         mock_api.post(matches_url, body=json.dumps(matches_response))
 
@@ -1229,7 +1229,7 @@ class TestVertexExchange(unittest.TestCase):
         )
         order: InFlightOrder = self.exchange.in_flight_orders[digest]
 
-        matches_url = web_utils.public_rest_url(CONSTANTS.INDEXER_PATH_URL, domain=self.domain)
+        matches_url = web_utils.public_rest_url(CONSTANTS.ARCHIVE_INDEXER_URLS[self._domain], domain=self.domain)
         matches_response = self.get_matches_unfilled_mock()
         mock_api.post(matches_url, body=json.dumps(matches_response))
 
@@ -1289,7 +1289,7 @@ class TestVertexExchange(unittest.TestCase):
         )
         order: InFlightOrder = self.exchange.in_flight_orders[digest]
 
-        matches_url = web_utils.public_rest_url(CONSTANTS.INDEXER_PATH_URL, domain=self.domain)
+        matches_url = web_utils.public_rest_url(CONSTANTS.ARCHIVE_INDEXER_URLS[self._domain], domain=self.domain)
         matches_response = self.get_matches_unfilled_mock()
         mock_api.post(matches_url, body=json.dumps(matches_response))
 
@@ -1332,7 +1332,7 @@ class TestVertexExchange(unittest.TestCase):
         )
         order: InFlightOrder = self.exchange.in_flight_orders[digest]
 
-        matches_url = web_utils.public_rest_url(CONSTANTS.INDEXER_PATH_URL, domain=self.domain)
+        matches_url = web_utils.public_rest_url(CONSTANTS.ARCHIVE_INDEXER_URLS[self._domain], domain=self.domain)
         matches_response = self.get_matches_unfilled_mock()
         mock_api.post(matches_url, body=json.dumps(matches_response))
 


### PR DESCRIPTION
Vertex's API endpoint hostnames & paths changed so need to be migrated to the new ones as per the doc: https://docs.vertexprotocol.com/developer-resources/api/endpoints#migration

Fix for https://github.com/hummingbot/hummingbot/issues/6934
