### PR TITLE
Fix: Cube exchange was falsely rate limited

### DIFF
--- a/hummingbot/connector/exchange/cube/cube_constants.py
+++ b/hummingbot/connector/exchange/cube/cube_constants.py
@@ -1,4 +1,6 @@
-from hummingbot.core.api_throttler.data_types import LinkedLimitWeightPair, RateLimit
+import sys
+
+from hummingbot.core.api_throttler.data_types import RateLimit
 from hummingbot.core.data_type.in_flight_order import OrderState, OrderType
 
 EXCHANGE_NAME = "cube"
@@ -84,41 +86,20 @@ TIME_IN_FORCE_GTC = 1
 TIME_IN_FORCE_FOK = 2
 
 # Rate Limits
+NO_LIMIT = sys.maxsize
 RATE_LIMITS = [
-    RateLimit(limit_id=REQUEST_WEIGHT, limit=6000, time_interval=ONE_MINUTE),
-    RateLimit(limit_id=ORDERS, limit=50, time_interval=10 * ONE_SECOND),
-    RateLimit(limit_id=ORDERS_24HR, limit=160000, time_interval=ONE_DAY),
-    RateLimit(limit_id=RAW_REQUESTS, limit=61000, time_interval= 5 * ONE_MINUTE),
+    RateLimit(limit_id=REQUEST_WEIGHT, limit=NO_LIMIT, time_interval=1),
+    RateLimit(limit_id=ORDERS, limit=NO_LIMIT, time_interval=1),
+    RateLimit(limit_id=ORDERS_24HR, limit=NO_LIMIT, time_interval=1),
+    RateLimit(limit_id=RAW_REQUESTS, limit=NO_LIMIT, time_interval=1),
     # Weighted Limits
-    RateLimit(limit_id=TICKER_BOOK_PATH_URL, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
-              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT, 4),
-                             LinkedLimitWeightPair(RAW_REQUESTS, 1)]),
-    RateLimit(limit_id=EXCHANGE_INFO_PATH_URL, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
-              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT, 20),
-                             LinkedLimitWeightPair(RAW_REQUESTS, 1)]),
-    RateLimit(limit_id=SNAPSHOT_LM_ID, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
-              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT, 100),
-                             LinkedLimitWeightPair(RAW_REQUESTS, 1)]),
-    RateLimit(limit_id=USER_STREAM_LM_ID, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
-              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT, 2),
-                             LinkedLimitWeightPair(RAW_REQUESTS, 1)]),
-    RateLimit(limit_id=PING_PATH_URL, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
-              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT, 1),
-                             LinkedLimitWeightPair(RAW_REQUESTS, 1)]),
-    RateLimit(limit_id=ACCOUNTS_PATH_URL, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
-              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT, 20),
-                             LinkedLimitWeightPair(RAW_REQUESTS, 1)]),
-    RateLimit(limit_id=FILLS_PATH_URL, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
-              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT, 20),
-                             LinkedLimitWeightPair(RAW_REQUESTS, 1)]),
-    RateLimit(limit_id=ORDER_PATH_URL, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
-              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT, 4),
-                             LinkedLimitWeightPair(ORDERS, 1),
-                             LinkedLimitWeightPair(ORDERS_24HR, 1),
-                             LinkedLimitWeightPair(RAW_REQUESTS, 1)]),
-    RateLimit(limit_id=POST_ORDER_PATH_URL, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
-              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT, 4),
-                             LinkedLimitWeightPair(ORDERS, 1),
-                             LinkedLimitWeightPair(ORDERS_24HR, 1),
-                             LinkedLimitWeightPair(RAW_REQUESTS, 1)])
+    RateLimit(limit_id=TICKER_BOOK_PATH_URL, limit=NO_LIMIT, time_interval=1),
+    RateLimit(limit_id=EXCHANGE_INFO_PATH_URL, limit=NO_LIMIT, time_interval=1),
+    RateLimit(limit_id=SNAPSHOT_LM_ID, limit=NO_LIMIT, time_interval=1),
+    RateLimit(limit_id=USER_STREAM_LM_ID, limit=NO_LIMIT, time_interval=1),
+    RateLimit(limit_id=PING_PATH_URL, limit=NO_LIMIT, time_interval=1),
+    RateLimit(limit_id=ACCOUNTS_PATH_URL, limit=NO_LIMIT, time_interval=1),
+    RateLimit(limit_id=FILLS_PATH_URL, limit=NO_LIMIT, time_interval=1),
+    RateLimit(limit_id=ORDER_PATH_URL, limit=NO_LIMIT, time_interval=1),
+    RateLimit(limit_id=POST_ORDER_PATH_URL, limit=NO_LIMIT, time_interval=1),
 ]


### PR DESCRIPTION
Removing rate limits, as Cube exchange currently, and in forseeable future, does not rate limit its API endpoints.