### PR TITLE
fix/improve_injective_tests_exec_time

### DIFF
--- a/test/hummingbot/connector/derivative/injective_v2_perpetual/test_injective_v2_perpetual_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/injective_v2_perpetual/test_injective_v2_perpetual_order_book_data_source.py
@@ -89,6 +89,11 @@ class InjectiveV2APIOrderBookDataSourceTests(TestCase):
             ".InjectiveGranteeDataSource.initialize_trading_account"
         )
         self.initialize_trading_account_patch.start()
+        self._initialize_timeout_height_patch = patch(
+            "hummingbot.connector.exchange.injective_v2.data_sources.injective_grantee_data_source"
+            ".AsyncClient.sync_timeout_height"
+        )
+        self._initialize_timeout_height_patch.start()
 
         self.query_executor = ProgrammableQueryExecutor()
         self.connector._data_source._query_executor = self.query_executor
@@ -106,6 +111,7 @@ class InjectiveV2APIOrderBookDataSourceTests(TestCase):
 
     def tearDown(self) -> None:
         self.async_run_with_timeout(self.data_source._data_source.stop())
+        self._initialize_timeout_height_patch.stop()
         self.initialize_trading_account_patch.stop()
         for task in self.async_tasks:
             task.cancel()

--- a/test/hummingbot/connector/exchange/injective_v2/data_sources/test_injective_data_source.py
+++ b/test/hummingbot/connector/exchange/injective_v2/data_sources/test_injective_data_source.py
@@ -39,6 +39,11 @@ class InjectiveGranteeDataSourceTests(TestCase):
 
     @patch("hummingbot.core.utils.trading_pair_fetcher.TradingPairFetcher.fetch_all")
     def setUp(self, _) -> None:
+        self._initialize_timeout_height_sync_task = patch(
+            "hummingbot.connector.exchange.injective_v2.data_sources.injective_grantee_data_source"
+            ".AsyncClient._initialize_timeout_height_sync_task"
+        )
+        self._initialize_timeout_height_sync_task.start()
         super().setUp()
         self._original_async_loop = asyncio.get_event_loop()
         self.async_loop = asyncio.new_event_loop()
@@ -75,6 +80,7 @@ class InjectiveGranteeDataSourceTests(TestCase):
         # Since the event loop will change we need to remove the logs event created in the old event loop
         self._logs_event = None
         asyncio.set_event_loop(self._original_async_loop)
+        self._initialize_timeout_height_sync_task.stop()
         super().tearDown()
 
     def async_run_with_timeout(self, coroutine: Awaitable, timeout: float = 1):
@@ -228,6 +234,11 @@ class InjectiveVaultsDataSourceTests(TestCase):
 
     @patch("hummingbot.core.utils.trading_pair_fetcher.TradingPairFetcher.fetch_all")
     def setUp(self, _) -> None:
+        self._initialize_timeout_height_sync_task = patch(
+            "hummingbot.connector.exchange.injective_v2.data_sources.injective_grantee_data_source"
+            ".AsyncClient._initialize_timeout_height_sync_task"
+        )
+        self._initialize_timeout_height_sync_task.start()
         super().setUp()
         self._original_async_loop = asyncio.get_event_loop()
         self.async_loop = asyncio.new_event_loop()
@@ -262,6 +273,7 @@ class InjectiveVaultsDataSourceTests(TestCase):
         # Since the event loop will change we need to remove the logs event created in the old event loop
         self._logs_event = None
         asyncio.set_event_loop(self._original_async_loop)
+        self._initialize_timeout_height_sync_task.stop()
         super().tearDown()
 
     def async_run_with_timeout(self, coroutine: Awaitable, timeout: float = 1):

--- a/test/hummingbot/connector/exchange/injective_v2/test_injective_v2_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/injective_v2/test_injective_v2_api_order_book_data_source.py
@@ -86,6 +86,11 @@ class InjectiveV2APIOrderBookDataSourceTests(TestCase):
             ".InjectiveGranteeDataSource.initialize_trading_account"
         )
         self.initialize_trading_account_patch.start()
+        self._initialize_timeout_height_patch = patch(
+            "hummingbot.connector.exchange.injective_v2.data_sources.injective_grantee_data_source"
+            ".AsyncClient.sync_timeout_height"
+        )
+        self._initialize_timeout_height_patch.start()
 
         self.query_executor = ProgrammableQueryExecutor()
         self.connector._data_source._query_executor = self.query_executor
@@ -103,6 +108,7 @@ class InjectiveV2APIOrderBookDataSourceTests(TestCase):
 
     def tearDown(self) -> None:
         self.async_run_with_timeout(self.data_source._data_source.stop())
+        self._initialize_timeout_height_patch.stop()
         self.initialize_trading_account_patch.stop()
         for task in self.async_tasks:
             task.cancel()

--- a/test/hummingbot/connector/exchange/injective_v2/test_injective_v2_exchange_for_delegated_account.py
+++ b/test/hummingbot/connector/exchange/injective_v2/test_injective_v2_exchange_for_delegated_account.py
@@ -79,6 +79,11 @@ class InjectiveV2ExchangeTests(AbstractExchangeConnectorTests.ExchangeConnectorT
             ".AsyncClient._initialize_timeout_height_sync_task"
         )
         self._initialize_timeout_height_sync_task.start()
+        self._initialize_timeout_height_patch = patch(
+            "hummingbot.connector.exchange.injective_v2.data_sources.injective_grantee_data_source"
+            ".AsyncClient.sync_timeout_height"
+        )
+        self._initialize_timeout_height_patch.start()
         super().setUp()
         self._original_async_loop = asyncio.get_event_loop()
         self.async_loop = asyncio.new_event_loop()
@@ -92,6 +97,7 @@ class InjectiveV2ExchangeTests(AbstractExchangeConnectorTests.ExchangeConnectorT
 
     def tearDown(self) -> None:
         super().tearDown()
+        self._initialize_timeout_height_patch.stop()
         self._initialize_timeout_height_sync_task.stop()
         self.async_loop.stop()
         self.async_loop.close()


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
- Refactored Injective V2 connectors' tests to prevent the need of initializing the timeout height in the Injective AsyncClient


**Tests performed by the developer**:
All tests running in green


**Tips for QA testing**:
No QA testing required. Changes do not impact the connectors' logic, only the tests

