### PR TITLE
Added support for API wallets (see: https://app.hyperliquid.xyz/API)

### DIFF
--- a/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_derivative.py
@@ -49,6 +49,7 @@ class HyperliquidPerpetualDerivative(PerpetualDerivativePyBase):
             client_config_map: "ClientConfigAdapter",
             hyperliquid_perpetual_api_secret: str = None,
             use_vault: bool = False,
+            use_api_wallet: bool = False,
             hyperliquid_perpetual_api_key: str = None,
             trading_pairs: Optional[List[str]] = None,
             trading_required: bool = True,
@@ -57,6 +58,7 @@ class HyperliquidPerpetualDerivative(PerpetualDerivativePyBase):
         self.hyperliquid_perpetual_api_key = hyperliquid_perpetual_api_key
         self.hyperliquid_perpetual_secret_key = hyperliquid_perpetual_api_secret
         self._use_vault = use_vault
+        self._use_api_wallet = use_api_wallet
         self._trading_required = trading_required
         self._trading_pairs = trading_pairs
         self._domain = domain


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

# Intro

[Someone pointed out to me](https://app.hyperliquid.xyz/API) that you can create API accounts. These are like delegated accounts in Injective - the private key on HummingBot allows trading, but not take out the money. This is much more secure and should be encouraged.

With this PR, support for API accounts is added to HyperLiquid, allowing people to trade on the DEX similarly to Injective, without exposing their private key.

For people like me this is a huge win, my server runs in my bedroom, and I'm away a lot, fearing that it could get stolen when I'm on the go. With this, the actual private key doesn't have to be stored on the server.

# What needs to be done

Testnet doesn't have this feature yet. I will add this once the feedback is positive - I haven't modified connectors before, so this is something I like to run by the team first.

**Tests performed by the developer**:

I ran `make test` prior to submitting this PR, and also tested both normal accounts, API accounts and vaults.

I also checked for backwards compatibility: Old config files from before this commit still work and default behaviour is asserted.
