### PR TITLE
Fix/Fix pylint warning `unspecified-encoding`

### DIFF
--- a/hummingbot/__init__.py
+++ b/hummingbot/__init__.py
@@ -119,7 +119,7 @@ def get_logging_conf(conf_filename: str = 'hummingbot_logs.yml'):
     yaml_parser: YAML = YAML()
     if not path.exists(file_path):
         return {}
-    with open(file_path) as fd:
+    with open(file_path, encoding='utf-8') as fd:
         yml_source: str = fd.read()
         io_stream: io.StringIO = io.StringIO(yml_source)
         config_dict: Dict = yaml_parser.load(io_stream)
@@ -150,7 +150,7 @@ def init_logging(conf_filename: str,
 
     file_path: str = join(prefix_path(), "conf", conf_filename)
     yaml_parser: YAML = YAML()
-    with open(file_path) as fd:
+    with open(file_path, encoding='utf-8') as fd:
         yml_source: str = fd.read()
         yml_source = yml_source.replace("$PROJECT_DIR", prefix_path())
         yml_source = yml_source.replace("$DATETIME", pd.Timestamp.now().strftime("%Y-%m-%d-%H-%M-%S"))

--- a/hummingbot/client/command/create_command.py
+++ b/hummingbot/client/command/create_command.py
@@ -158,7 +158,7 @@ class CreateCommand:
             return dumper.represent_dict(data.items())
 
         OrderedDumper.add_representer(OrderedDict, _dict_representer)
-        with open(config_path, 'w') as file:
+        with open(config_path, 'w', encoding='utf-8') as file:
             yaml.dump(ordered_config_data, file, Dumper=OrderedDumper, default_flow_style=False)
 
         return file_name

--- a/hummingbot/client/command/silly_commands.py
+++ b/hummingbot/client/command/silly_commands.py
@@ -55,8 +55,8 @@ class SillyCommands:
         await self.text_n_wait("I'm well and busy coding for you all.", 2)
         await self.text_n_wait("Get in touch @nullably on Github and Twitter.", 2.5)
         await self.text_n_wait("Happy trading and don't get rekt.", 2.5)
-        jack_1 = open(f"{RESOURCES_PATH}jack_1.txt").readlines()
-        jack_2 = open(f"{RESOURCES_PATH}jack_2.txt").readlines()
+        jack_1 = open(f"{RESOURCES_PATH}jack_1.txt", encoding="utf-8").readlines()
+        jack_2 = open(f"{RESOURCES_PATH}jack_2.txt", encoding="utf-8").readlines()
         await self.cls_display_delay(jack_1, 1.5)
         await self.cls_display_delay(jack_2, 1.5)
         self.placeholder_mode = False
@@ -66,9 +66,9 @@ class SillyCommands:
                          ):
         self.placeholder_mode = True
         self.app.hide_input = True
-        stay_calm = open(f"{RESOURCES_PATH}hodl_stay_calm.txt").readlines()
-        and_hodl = open(f"{RESOURCES_PATH}hodl_and_hodl.txt").readlines()
-        bitcoin = open(f"{RESOURCES_PATH}hodl_bitcoin.txt").readlines()
+        stay_calm = open(f"{RESOURCES_PATH}hodl_stay_calm.txt", encoding="utf-8").readlines()
+        and_hodl = open(f"{RESOURCES_PATH}hodl_and_hodl.txt", encoding="utf-8").readlines()
+        bitcoin = open(f"{RESOURCES_PATH}hodl_bitcoin.txt", encoding="utf-8").readlines()
         await self.cls_display_delay(stay_calm, 1.75)
         await self.cls_display_delay(and_hodl, 1.75)
         for _ in range(3):
@@ -84,10 +84,10 @@ class SillyCommands:
         self.app.hide_input = True
         for _ in range(0, 3):
             await self.cls_display_delay(self.display_alert())
-        hb_with_flower_1 = open(f"{RESOURCES_PATH}hb_with_flower_1.txt").readlines()
-        hb_with_flower_2 = open(f"{RESOURCES_PATH}hb_with_flower_2.txt").readlines()
-        hb_with_flower_up_close_1 = open(f"{RESOURCES_PATH}hb_with_flower_up_close_1.txt").readlines()
-        hb_with_flower_up_close_2 = open(f"{RESOURCES_PATH}hb_with_flower_up_close_2.txt").readlines()
+        hb_with_flower_1 = open(f"{RESOURCES_PATH}hb_with_flower_1.txt", encoding="utf-8").readlines()
+        hb_with_flower_2 = open(f"{RESOURCES_PATH}hb_with_flower_2.txt", encoding="utf-8").readlines()
+        hb_with_flower_up_close_1 = open(f"{RESOURCES_PATH}hb_with_flower_up_close_1.txt", encoding="utf-8").readlines()
+        hb_with_flower_up_close_2 = open(f"{RESOURCES_PATH}hb_with_flower_up_close_2.txt", encoding="utf-8").readlines()
         for _ in range(0, 2):
             for _ in range(0, 5):
                 await self.cls_display_delay(hb_with_flower_1, 0.125)
@@ -104,10 +104,10 @@ class SillyCommands:
         self.app.hide_input = True
         for _ in range(0, 3):
             await self.cls_display_delay(self.display_alert("roger"))
-        roger_1 = open(f"{RESOURCES_PATH}roger_1.txt").readlines()
-        roger_2 = open(f"{RESOURCES_PATH}roger_2.txt").readlines()
-        roger_3 = open(f"{RESOURCES_PATH}roger_3.txt").readlines()
-        roger_4 = open(f"{RESOURCES_PATH}roger_4.txt").readlines()
+        roger_1 = open(f"{RESOURCES_PATH}roger_1.txt", encoding="utf-8").readlines()
+        roger_2 = open(f"{RESOURCES_PATH}roger_2.txt", encoding="utf-8").readlines()
+        roger_3 = open(f"{RESOURCES_PATH}roger_3.txt", encoding="utf-8").readlines()
+        roger_4 = open(f"{RESOURCES_PATH}roger_4.txt", encoding="utf-8").readlines()
         for _ in range(0, 2):
             for _ in range(0, 3):
                 await self.cls_display_delay(roger_1, 0.1)
@@ -129,8 +129,8 @@ class SillyCommands:
                            ):
         self.placeholder_mode = True
         self.app.hide_input = True
-        hb_with_flower_1 = open(f"{RESOURCES_PATH}money-fly_1.txt").readlines()
-        hb_with_flower_2 = open(f"{RESOURCES_PATH}money-fly_2.txt").readlines()
+        hb_with_flower_1 = open(f"{RESOURCES_PATH}money-fly_1.txt", encoding="utf-8").readlines()
+        hb_with_flower_2 = open(f"{RESOURCES_PATH}money-fly_2.txt", encoding="utf-8").readlines()
         for _ in range(0, 5):
             for _ in range(0, 5):
                 await self.cls_display_delay(hb_with_flower_1, 0.125)
@@ -145,9 +145,9 @@ class SillyCommands:
         self.app.hide_input = True
         for _ in range(0, 2):
             await self.cls_display_delay(self.display_alert("rein"))
-        rein_1 = open(f"{RESOURCES_PATH}rein_1.txt").readlines()
-        rein_2 = open(f"{RESOURCES_PATH}rein_2.txt").readlines()
-        rein_3 = open(f"{RESOURCES_PATH}rein_3.txt").readlines()
+        rein_1 = open(f"{RESOURCES_PATH}rein_1.txt", encoding="utf-8").readlines()
+        rein_2 = open(f"{RESOURCES_PATH}rein_2.txt", encoding="utf-8").readlines()
+        rein_3 = open(f"{RESOURCES_PATH}rein_3.txt", encoding="utf-8").readlines()
         for _ in range(0, 2):
             await self.cls_display_delay(rein_1, 0.5)
             await self.cls_display_delay(rein_2, 0.5)
@@ -164,20 +164,20 @@ class SillyCommands:
                            ):
         self.placeholder_mode = True
         self.app.hide_input = True
-        dennis_loading_1 = open(f"{RESOURCES_PATH}dennis_loading_1.txt").readlines()
-        dennis_loading_2 = open(f"{RESOURCES_PATH}dennis_loading_2.txt").readlines()
-        dennis_loading_3 = open(f"{RESOURCES_PATH}dennis_loading_3.txt").readlines()
-        dennis_loading_4 = open(f"{RESOURCES_PATH}dennis_loading_4.txt").readlines()
+        dennis_loading_1 = open(f"{RESOURCES_PATH}dennis_loading_1.txt", encoding="utf-8").readlines()
+        dennis_loading_2 = open(f"{RESOURCES_PATH}dennis_loading_2.txt", encoding="utf-8").readlines()
+        dennis_loading_3 = open(f"{RESOURCES_PATH}dennis_loading_3.txt", encoding="utf-8").readlines()
+        dennis_loading_4 = open(f"{RESOURCES_PATH}dennis_loading_4.txt", encoding="utf-8").readlines()
         for _ in range(0, 1):
             await self.cls_display_delay(dennis_loading_1, 1)
             await self.cls_display_delay(dennis_loading_2, 1)
             await self.cls_display_delay(dennis_loading_3, 1)
             await self.cls_display_delay(dennis_loading_4, 1)
             # await asyncio.sleep(0.5)
-        dennis_1 = open(f"{RESOURCES_PATH}dennis_1.txt").readlines()
-        dennis_2 = open(f"{RESOURCES_PATH}dennis_2.txt").readlines()
-        dennis_3 = open(f"{RESOURCES_PATH}dennis_3.txt").readlines()
-        dennis_4 = open(f"{RESOURCES_PATH}dennis_4.txt").readlines()
+        dennis_1 = open(f"{RESOURCES_PATH}dennis_1.txt", encoding="utf-8").readlines()
+        dennis_2 = open(f"{RESOURCES_PATH}dennis_2.txt", encoding="utf-8").readlines()
+        dennis_3 = open(f"{RESOURCES_PATH}dennis_3.txt", encoding="utf-8").readlines()
+        dennis_4 = open(f"{RESOURCES_PATH}dennis_4.txt", encoding="utf-8").readlines()
         for _ in range(0, 1):
             await self.cls_display_delay(dennis_1, 1)
             await self.cls_display_delay(dennis_2, 1)
@@ -198,7 +198,7 @@ class SillyCommands:
             self.app.live_updates = False
             await asyncio.sleep(1)
 
-    def display_alert(self, custom_alert = None):
+    def display_alert(self, custom_alert=None):
         alert = """
                                 ====================================
                                 ║                                  ║
@@ -208,8 +208,9 @@ class SillyCommands:
         """
         if custom_alert is not None:
             try:
-                lines = open(f"{RESOURCES_PATH}{custom_alert}_alert.txt").readlines()
-                alert = "".join(lines)
+                with open(f"{RESOURCES_PATH}{custom_alert}_alert.txt", "r", encoding="utf-8") as file:
+                    lines = file.readlines()
+                    alert = "".join(lines)
             except Exception:
                 pass
         return f"{alert}" + ("\n" * 18)

--- a/hummingbot/client/command/start_command.py
+++ b/hummingbot/client/command/start_command.py
@@ -232,7 +232,7 @@ class StartCommand(GatewayChainApiManager):
 
     @staticmethod
     def load_script_yaml_config(config_file_path: str) -> dict:
-        with open(settings.SCRIPT_STRATEGY_CONF_DIR_PATH / config_file_path, 'r') as file:
+        with open(settings.SCRIPT_STRATEGY_CONF_DIR_PATH / config_file_path, 'r', encoding='utf-8') as file:
             return yaml.safe_load(file)
 
     def is_current_strategy_script_strategy(self) -> bool:

--- a/hummingbot/client/config/conf_migration.py
+++ b/hummingbot/client/config/conf_migration.py
@@ -93,7 +93,7 @@ def migrate_global_config() -> List[str]:
     global_config_path = CONF_DIR_PATH / "conf_global.yml"
     errors = []
     if global_config_path.exists():
-        with open(str(global_config_path), "r") as f:
+        with open(str(global_config_path), "r", encoding="utf-8") as f:
             data = yaml.safe_load(f)
         del data["template_version"]
         client_config_map = ClientConfigAdapter(ClientConfigMap())
@@ -273,7 +273,7 @@ def migrate_strategy_confs_paths():
     logging.getLogger().info("\nMigrating strategies...")
     for child in conf_dir_path.iterdir():
         if child.is_file() and child.name.endswith(".yml"):
-            with open(str(child), "r") as f:
+            with open(str(child), "r", encoding="utf-8") as f:
                 conf = yaml.safe_load(f)
             if "strategy" in conf and _has_connector_field(conf):
                 new_path = strategies_conf_dir_path / child.name
@@ -427,7 +427,7 @@ def _maybe_migrate_encrypted_confs(config_keys: BaseConnectorConfigMap) -> List[
         if el.client_field_data is not None:
             key_path = conf_dir_path / f"{encrypted_conf_prefix}{el.attr}{encrypted_conf_postfix}"
             if key_path.exists():
-                with open(key_path, 'r') as f:
+                with open(key_path, 'r', encoding='utf-8') as f:
                     json_str = f.read()
                 value = binascii.hexlify(json_str.encode()).decode()
                 if not el.client_field_data.is_secure:

--- a/hummingbot/client/config/config_crypt.py
+++ b/hummingbot/client/config/config_crypt.py
@@ -63,13 +63,13 @@ class ETHKeyFileSecretManger(BaseSecretsManager):
 
 def store_password_verification(secrets_manager: BaseSecretsManager):
     encrypted_word = secrets_manager.encrypt_secret_value(PASSWORD_VERIFICATION_WORD, PASSWORD_VERIFICATION_WORD)
-    with open(PASSWORD_VERIFICATION_PATH, "w") as f:
+    with open(PASSWORD_VERIFICATION_PATH, "w", encoding="utf-8") as f:
         f.write(encrypted_word)
 
 
 def validate_password(secrets_manager: BaseSecretsManager) -> bool:
     valid = False
-    with open(PASSWORD_VERIFICATION_PATH, "r") as f:
+    with open(PASSWORD_VERIFICATION_PATH, "r", encoding="utf-8") as f:
         encrypted_word = f.read()
     try:
         decrypted_word = secrets_manager.decrypt_secret_value(PASSWORD_VERIFICATION_WORD, encrypted_word)

--- a/hummingbot/client/settings.py
+++ b/hummingbot/client/settings.py
@@ -84,14 +84,14 @@ class GatewayConnectionSetting:
     def load() -> List[Dict[str, str]]:
         connections_conf_path: str = GatewayConnectionSetting.conf_path()
         if exists(connections_conf_path):
-            with open(connections_conf_path) as fd:
+            with open(connections_conf_path, encoding='utf-8') as fd:
                 return json.load(fd)
         return []
 
     @staticmethod
     def save(settings: List[Dict[str, str]]):
         connections_conf_path: str = GatewayConnectionSetting.conf_path()
-        with open(connections_conf_path, "w") as fd:
+        with open(connections_conf_path, "w", encoding="utf-8") as fd:
             json.dump(settings, fd)
 
     @staticmethod

--- a/hummingbot/client/ui/__init__.py
+++ b/hummingbot/client/ui/__init__.py
@@ -15,7 +15,7 @@ from hummingbot.client.settings import CONF_DIR_PATH
 sys.path.insert(0, str(root_path()))
 
 
-with open(realpath(join(dirname(__file__), '../../VERSION'))) as version_file:
+with open(realpath(join(dirname(__file__), '../../VERSION')), encoding='utf-8') as version_file:
     version = version_file.read().strip()
 
 

--- a/hummingbot/client/ui/layout.py
+++ b/hummingbot/client/ui/layout.py
@@ -76,7 +76,7 @@ Useful Commands:
 
 """
 
-with open(realpath(join(dirname(__file__), '../../VERSION'))) as version_file:
+with open(realpath(join(dirname(__file__), '../../VERSION')), encoding='utf-8') as version_file:
     version = version_file.read().strip()
 
 

--- a/hummingbot/connector/connector_metrics_collector.py
+++ b/hummingbot/connector/connector_metrics_collector.py
@@ -18,7 +18,7 @@ from hummingbot.logger.log_server_client import LogServerClient
 if TYPE_CHECKING:
     from hummingbot.connector.connector_base import ConnectorBase
 
-with open(realpath(join(dirname(__file__), '../VERSION'))) as version_file:
+with open(realpath(join(dirname(__file__), '../VERSION')), encoding='utf-8') as version_file:
     CLIENT_VERSION = version_file.read().strip()
 
 

--- a/hummingbot/strategy/strategy_v2_base.py
+++ b/hummingbot/strategy/strategy_v2_base.py
@@ -89,7 +89,7 @@ class StrategyV2ConfigBase(BaseClientModel):
         loaded_configs = []
         for config_path in self.controllers_config:
             full_path = os.path.join(settings.CONTROLLERS_CONF_DIR_PATH, config_path)
-            with open(full_path, 'r') as file:
+            with open(full_path, 'r', encoding='utf-8') as file:
                 config_data = yaml.safe_load(file)
 
             controller_type = config_data.get('controller_type')

--- a/hummingbot/strategy_v2/utils/config_encoder_decoder.py
+++ b/hummingbot/strategy_v2/utils/config_encoder_decoder.py
@@ -44,9 +44,9 @@ class ConfigEncoderDecoder:
         return self.recursive_decode(json.loads(s))
 
     def yaml_dump(self, d, file_path):
-        with open(file_path, 'w') as file:
+        with open(file_path, 'w', encoding='utf-8') as file:
             yaml.dump(self.recursive_encode(d), file)
 
     def yaml_load(self, file_path):
-        with open(file_path, 'r') as file:
+        with open(file_path, 'r', encoding='utf-8') as file:
             return self.recursive_decode(yaml.safe_load(file))

--- a/pmm_scripts/spreads_adjusted_on_volatility_script.py
+++ b/pmm_scripts/spreads_adjusted_on_volatility_script.py
@@ -11,7 +11,7 @@ SCRIPT_LOG_FILE = f"{LOGS_PATH}/logs_script.log"
 
 
 def log_to_file(file_name, message):
-    with open(file_name, "a+") as f:
+    with open(file_name, "a+", encoding="utf-8") as f:
         f.write(datetime.now().strftime("%Y-%m-%d %H:%M:%S") + " - " + message + "\n")
 
 

--- a/scripts/community/spot_perp_arb.py
+++ b/scripts/community/spot_perp_arb.py
@@ -79,7 +79,7 @@ class SpotPerpArb(ScriptStrategyBase):
 
     def init_order_book_csv(self) -> None:
         self.logger().info("Preparing order book csv...")
-        with open(self.order_book_csv, "a") as f_object:
+        with open(self.order_book_csv, "a", newline="", encoding="utf-8") as f_object:
             writer = csv_writer(f_object)
             writer.writerow(
                 [
@@ -116,7 +116,7 @@ class SpotPerpArb(ScriptStrategyBase):
             str(perp_best_bid_price),
             str(perp_best_ask_price),
         ]
-        with open(self.order_book_csv, "a", newline="") as f_object:
+        with open(self.order_book_csv, "a", newline="", encoding="utf-8") as f_object:
             writer = csv_writer(f_object)
             writer.writerow(row)
         self.logger().info(f"Order book csv updated: {self.order_book_csv}")

--- a/scripts/utility/download_order_book_and_trades.py
+++ b/scripts/utility/download_order_book_and_trades.py
@@ -82,7 +82,7 @@ class DownloadTradesAndOrderBookSnapshots(ScriptStrategyBase):
     @staticmethod
     def get_file(exchange: str, trading_pair: str, source_type: str, current_date: str):
         file_path = data_path() + f"/{exchange}_{trading_pair}_{source_type}_{current_date}.txt"
-        return open(file_path, "a")
+        return open(file_path, "a", encoding="utf-8")
 
     def _process_public_trade(self, event_tag: int, market: ConnectorBase, event: OrderBookTradeEvent):
         self.trades_temp_storage[event.trading_pair].append({


### PR DESCRIPTION
Changes Made:

- Applied automated fixes for the pylint warning unspecified-encoding.
"It is better to specify an encoding when opening documents. Using the system default implicitly can create problems on other operating systems. See [https://peps.python.org/pep-0597/](https://peps.python.org/pep-0597/)"

Note:

This pull request is part of a research project conducted by researchers from TU Delft, titled "PyWarnFixer: Using ML to Fix Pylint Warnings." The goal of this study is to investigate the perceptions and practices of code quality among developers in Python open-source projects and to develop a tool that uses AI to automatically fix pylint warnings.

### Research Study Information:
This pull request is part of a research project. For more information about the study, please visit the [project's information page](https://github.com/RatishT/PyWarnFixer/blob/main/README.md).

### Consent to Participate:
If you review this pull request, you are invited to participate in our study. Your participation is voluntary. To provide your consent, just open an issue in our repository with the provided template using the following link: [consent issue template](https://github.com/RatishT/PyWarnFixer/issues/new/choose) .

---

Thank you for considering participation in our research. Your feedback is crucial and highly valued. If you have any questions or concerns, please contact the Responsible Researcher at R.K.Thakoersingh@student.tudelft.nl.