### PR TITLE
fix/Mexc - Unable to submit close market order due to TypeError: unsupported operand type(s)

### DIFF
--- a/hummingbot/connector/exchange/mexc/mexc_exchange.py
+++ b/hummingbot/connector/exchange/mexc/mexc_exchange.py
@@ -189,13 +189,13 @@ class MexcExchange(ExchangePyBase):
             price_str = f"{price:f}"
             api_params["price"] = price_str
         else:
-            if trade_type.name.lower() == 'buy':
+            if trade_type == TradeType.BUY:
                 if price.is_nan():
                     price = self.get_price_for_volume(
                         trading_pair,
                         True,
                         amount
-                    )
+                    ).result_price
                 del api_params['quantity']
                 api_params.update({
                     "quoteOrderQty": f"{price * amount:f}",

--- a/test/hummingbot/connector/exchange/mexc/test_mexc_exchange.py
+++ b/test/hummingbot/connector/exchange/mexc/test_mexc_exchange.py
@@ -17,8 +17,10 @@ from hummingbot.connector.trading_rule import TradingRule
 from hummingbot.connector.utils import get_new_client_order_id
 from hummingbot.core.data_type.common import OrderType, TradeType
 from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState
+from hummingbot.core.data_type.order_book import OrderBook
+from hummingbot.core.data_type.order_book_row import OrderBookRow
 from hummingbot.core.data_type.trade_fee import DeductedFromReturnsTradeFee, TokenAmount, TradeFeeBase
-from hummingbot.core.event.events import MarketOrderFailureEvent, OrderFilledEvent
+from hummingbot.core.event.events import BuyOrderCreatedEvent, MarketOrderFailureEvent, OrderFilledEvent
 
 
 class MexcExchangeTests(AbstractExchangeConnectorTests.ExchangeConnectorTests):
@@ -1090,6 +1092,48 @@ class MexcExchangeTests(AbstractExchangeConnectorTests.ExchangeConnectorTests):
                 order_type=OrderType.LIMIT,
                 price=Decimal("2"),
             ))
+
+    @aioresponses()
+    def test_create_market_order_price_is_nan(self, mock_api):
+        self._simulate_trading_rules_initialized()
+        request_sent_event = asyncio.Event()
+        self.exchange._set_current_timestamp(1640780000)
+
+        resp = self.order_creation_request_successful_mock_response
+        url = self.order_creation_url
+        mock_api.post(url,
+                      body=json.dumps(resp),
+                      status=201,
+                      callback=lambda *args, **kwargs: request_sent_event.set())
+
+        order_book = OrderBook()
+        self.exchange.order_book_tracker._order_books[self.trading_pair] = order_book
+        order_book.apply_snapshot(
+            bids=[OrderBookRow(price=5.0, amount=10, update_id=1)],
+            asks=[OrderBookRow(price=5.1, amount=10, update_id=1)],
+            update_id=1,
+        )
+
+        order_id = self.place_buy_order(
+            amount=Decimal("1"), price=Decimal("NaN"), order_type=OrderType.MARKET
+        )
+        self.async_run_with_timeout(request_sent_event.wait(), timeout=3)
+
+        order_request = self._all_executed_requests(mock_api, url)[0]
+        request_data = order_request.kwargs["data"]
+        self.assertIn(order_id, self.exchange.in_flight_orders)
+        self.assertEqual("5.1000000", request_data["quoteOrderQty"])
+        self.assertEqual("MARKET", request_data["type"])
+        self.assertEqual("BUY", request_data["side"])
+
+        self.assertEqual(1, len(self.buy_order_created_logger.event_log))
+        create_event: BuyOrderCreatedEvent = self.buy_order_created_logger.event_log[0]
+        self.assertEqual(self.exchange.current_timestamp, create_event.timestamp)
+        self.assertEqual(self.trading_pair, create_event.trading_pair)
+        self.assertEqual(OrderType.MARKET, create_event.type)
+        self.assertEqual(Decimal("1"), create_event.amount)
+        self.assertEqual(order_id, create_event.order_id)
+        self.assertEqual(str(resp["orderId"]), create_event.exchange_order_id)
 
     def test_format_trading_rules__min_notional_present(self):
         trading_rules = [{


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Fixes issue #7090, also added a unit test for this scenario.

**Tests performed by the developer**:
Reproduced the issue with a unit test.


**Tips for QA testing**:


