### PR TITLE
(fix) fix connector and testcase for August 16 MEXC API Update

### DIFF
--- a/hummingbot/connector/exchange/mexc/mexc_utils.py
+++ b/hummingbot/connector/exchange/mexc/mexc_utils.py
@@ -22,7 +22,7 @@ def is_exchange_information_valid(exchange_info: Dict[str, Any]) -> bool:
     :param exchange_info: the exchange information for a trading pair
     :return: True if the trading pair is enabled, False otherwise
     """
-    return exchange_info.get("status", None) == "ENABLED" and "SPOT" in exchange_info.get("permissions", list()) \
+    return exchange_info.get("status", None) == "1" and "SPOT" in exchange_info.get("permissions", list()) \
         and exchange_info.get("isSpotTradingAllowed", True) is True
 
 

--- a/test/hummingbot/connector/exchange/mexc/test_mexc_exchange.py
+++ b/test/hummingbot/connector/exchange/mexc/test_mexc_exchange.py
@@ -65,7 +65,7 @@ class MexcExchangeTests(AbstractExchangeConnectorTests.ExchangeConnectorTests):
             "symbols": [
                 {
                     "symbol": self.exchange_symbol_for_tokens(self.base_asset, self.quote_asset),
-                    "status": "ENABLED",
+                    "status": "1",
                     "baseAsset": self.base_asset,
                     "baseSizePrecision": 1e-8,
                     "quotePrecision": 8,
@@ -132,7 +132,7 @@ class MexcExchangeTests(AbstractExchangeConnectorTests.ExchangeConnectorTests):
             "symbols": [
                 {
                     "symbol": self.exchange_symbol_for_tokens(self.base_asset, self.quote_asset),
-                    "status": "ENABLED",
+                    "status": "1",
                     "baseAsset": self.base_asset,
                     "baseSizePrecision": 1e-8,
                     "quotePrecision": 8,
@@ -161,7 +161,7 @@ class MexcExchangeTests(AbstractExchangeConnectorTests.ExchangeConnectorTests):
                 },
                 {
                     "symbol": self.exchange_symbol_for_tokens("INVALID", "PAIR"),
-                    "status": "ENABLED",
+                    "status": "1",
                     "baseAsset": "INVALID",
                     "baseSizePrecision": 1e-8,
                     "quotePrecision": 8,
@@ -207,7 +207,7 @@ class MexcExchangeTests(AbstractExchangeConnectorTests.ExchangeConnectorTests):
             "symbols": [
                 {
                     "symbol": self.exchange_symbol_for_tokens(self.base_asset, self.quote_asset),
-                    "status": "ENABLED",
+                    "status": "1",
                     "baseAsset": self.base_asset,
                     "baseSizePrecision": 1e-8,
                     "quotePrecision": 8,
@@ -255,7 +255,7 @@ class MexcExchangeTests(AbstractExchangeConnectorTests.ExchangeConnectorTests):
             "symbols": [
                 {
                     "symbol": self.exchange_symbol_for_tokens(self.base_asset, self.quote_asset),
-                    "status": "ENABLED",
+                    "status": "1",
                     "baseAsset": self.base_asset,
                     "baseAssetPrecision": 8,
                     "quoteAsset": self.quote_asset,
@@ -1131,7 +1131,7 @@ class MexcExchangeTests(AbstractExchangeConnectorTests.ExchangeConnectorTests):
             "baseSizePrecision": 1e-8,
             "quotePrecision": 8,
             "baseAssetPrecision": 8,
-            "status": "ENABLED",
+            "status": "1",
             "quoteAmountPrecision": "0.001",
             "orderTypes": ["LIMIT", "MARKET"],
             "filters": [

--- a/test/hummingbot/connector/exchange/mexc/test_mexc_utils.py
+++ b/test/hummingbot/connector/exchange/mexc/test_mexc_utils.py
@@ -30,14 +30,14 @@ class MexcUtilTestCases(unittest.TestCase):
         self.assertFalse(utils.is_exchange_information_valid(invalid_info_2))
 
         invalid_info_3 = {
-            "status": "ENABLED",
+            "status": "1",
             "permissions": ["MARGIN"],
         }
 
         self.assertFalse(utils.is_exchange_information_valid(invalid_info_3))
 
         invalid_info_4 = {
-            "status": "ENABLED",
+            "status": "1",
             "permissions": ["SPOT"],
         }
 


### PR DESCRIPTION
> MEXC exchange has an API update on August 16
> 
> which caused order-book fetch to fail in hummingbot as described in Issue: #7174.
> 
> More details about the API update: https://mexcdevelop.github.io/apidocs/spot_v3_en/#2024-08-16

This is a follow-up pull request of https://github.com/hummingbot/hummingbot/pull/7175 with the test case fixed and a better standard workflow as instructed.

I updated the connector and test case and tested them on local deployment.  

@cardosofede @nikspz @rapcmia 