### PR TITLE
Feat/Hyperliquid spot connector

### DIFF
--- a/hummingbot/connector/exchange/hyperliquid/dummy.pxd
+++ b/hummingbot/connector/exchange/hyperliquid/dummy.pxd
@@ -1,0 +1,2 @@
+cdef class dummy():
+    pass

--- a/hummingbot/connector/exchange/hyperliquid/dummy.pyx
+++ b/hummingbot/connector/exchange/hyperliquid/dummy.pyx
@@ -1,0 +1,2 @@
+cdef class dummy():
+    pass

--- a/hummingbot/connector/exchange/hyperliquid/hyperliquid_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/hyperliquid/hyperliquid_api_order_book_data_source.py
@@ -1,0 +1,162 @@
+import asyncio
+import time
+from collections import defaultdict
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional
+
+import hummingbot.connector.exchange.hyperliquid.hyperliquid_constants as CONSTANTS
+import hummingbot.connector.exchange.hyperliquid.hyperliquid_web_utils as web_utils
+from hummingbot.core.data_type.common import TradeType
+from hummingbot.core.data_type.funding_info import FundingInfo, FundingInfoUpdate
+from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
+from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
+from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+from hummingbot.core.web_assistant.ws_assistant import WSAssistant
+from hummingbot.logger import HummingbotLogger
+
+if TYPE_CHECKING:
+    from hummingbot.connector.exchange.hyperliquid.hyperliquid_exchange import HyperliquidExchange
+
+
+class HyperliquidAPIOrderBookDataSource(OrderBookTrackerDataSource):
+    _bpobds_logger: Optional[HummingbotLogger] = None
+    _trading_pair_symbol_map: Dict[str, Mapping[str, str]] = {}
+    _mapping_initialization_lock = asyncio.Lock()
+
+    def __init__(
+            self,
+            trading_pairs: List[str],
+            connector: 'HyperliquidExchange',
+            api_factory: WebAssistantsFactory,
+            domain: str = CONSTANTS.DOMAIN
+    ):
+        super().__init__(trading_pairs)
+        self._connector = connector
+        self._api_factory = api_factory
+        self._domain = domain
+        self._trading_pairs: List[str] = trading_pairs
+        self._message_queue: Dict[str, asyncio.Queue] = defaultdict(asyncio.Queue)
+        self._snapshot_messages_queue_key = "order_book_snapshot"
+
+    async def get_last_traded_prices(self,
+                                     trading_pairs: List[str],
+                                     domain: Optional[str] = None) -> Dict[str, float]:
+        return await self._connector.get_last_traded_prices(trading_pairs=trading_pairs)
+
+    async def _request_order_book_snapshot(self, trading_pair: str) -> Dict[str, Any]:
+        ex_trading_pair = await self._connector.exchange_symbol_associated_to_pair(trading_pair=trading_pair)
+        coin = ex_trading_pair.split("-")[0]
+        params = {
+            "type": 'l2Book',
+            "coin": coin
+        }
+
+        data = await self._connector._api_post(
+            path_url=CONSTANTS.SNAPSHOT_REST_URL,
+            data=params)
+        return data
+
+    async def _order_book_snapshot(self, trading_pair: str) -> OrderBookMessage:
+        snapshot_response: Dict[str, Any] = await self._request_order_book_snapshot(trading_pair)
+        snapshot_response.update({"trading_pair": trading_pair})
+        snapshot_msg: OrderBookMessage = OrderBookMessage(OrderBookMessageType.SNAPSHOT, {
+            "trading_pair": snapshot_response["trading_pair"],
+            "update_id": int(snapshot_response['time']),
+            "bids": [[float(i['px']), float(i['sz'])] for i in snapshot_response['levels'][0]],
+            "asks": [[float(i['px']), float(i['sz'])] for i in snapshot_response['levels'][1]],
+        }, timestamp=int(snapshot_response['time']))
+        return snapshot_msg
+
+    async def _connected_websocket_assistant(self) -> WSAssistant:
+        url = f"{web_utils.wss_url(self._domain)}"
+        ws: WSAssistant = await self._api_factory.get_ws_assistant()
+        await ws.connect(ws_url=url, ping_timeout=CONSTANTS.HEARTBEAT_TIME_INTERVAL)
+        return ws
+
+    async def _subscribe_channels(self, ws: WSAssistant):
+        """
+        Subscribes to the trade events and diff orders events through the provided websocket connection.
+
+        :param ws: the websocket assistant used to connect to the exchange
+        """
+        try:
+            for trading_pair in self._trading_pairs:
+                ex_trading_pair = await self._connector.exchange_symbol_associated_to_pair(trading_pair=trading_pair)
+                coin = ex_trading_pair.split("-")[0]
+                trades_payload = {
+                    "method": "subscribe",
+                    "subscription": {
+                        "type": CONSTANTS.TRADES_ENDPOINT_NAME,
+                        "coin": ex_trading_pair,
+                    }
+                }
+                subscribe_trade_request: WSJSONRequest = WSJSONRequest(payload=trades_payload)
+
+                order_book_payload = {
+                    "method": "subscribe",
+                    "subscription": {
+                        "type": CONSTANTS.DEPTH_ENDPOINT_NAME,
+                        "coin": coin,
+                    }
+                }
+                subscribe_orderbook_request: WSJSONRequest = WSJSONRequest(payload=order_book_payload)
+
+                await ws.send(subscribe_trade_request)
+                await ws.send(subscribe_orderbook_request)
+
+                self.logger().info("Subscribed to public order book, trade channels...")
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self.logger().error("Unexpected error occurred subscribing to order book data streams.")
+            raise
+
+    def _channel_originating_message(self, event_message: Dict[str, Any]) -> str:
+        channel = ""
+        if "result" not in event_message:
+            stream_name = event_message.get("channel")
+            if "l2Book" in stream_name:
+                channel = self._snapshot_messages_queue_key
+            elif "trades" in stream_name:
+                channel = self._trade_messages_queue_key
+        return channel
+
+    async def _parse_order_book_diff_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
+        timestamp: float = raw_message["data"]["time"] * 1e-3
+        trading_pair = raw_message["data"]["coin"]
+        data = raw_message["data"]
+        order_book_message: OrderBookMessage = OrderBookMessage(OrderBookMessageType.DIFF, {
+            "trading_pair": trading_pair,
+            "update_id": data["time"],
+            "bids": [[float(i['px']), float(i['sz'])] for i in data["levels"][0]],
+            "asks": [[float(i['px']), float(i['sz'])] for i in data["levels"][1]],
+        }, timestamp=timestamp)
+        message_queue.put_nowait(order_book_message)
+
+    async def _parse_order_book_snapshot_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
+        timestamp: float = raw_message["data"]["time"] * 1e-3
+        trading_pair = raw_message["data"]["coin"]
+        data = raw_message["data"]
+        order_book_message: OrderBookMessage = OrderBookMessage(OrderBookMessageType.SNAPSHOT, {
+            "trading_pair": trading_pair,
+            "update_id": data["time"],
+            "bids": [[float(i['px']), float(i['sz'])] for i in data["levels"][0]],
+            "asks": [[float(i['px']), float(i['sz'])] for i in data["levels"][1]],
+        }, timestamp=timestamp)
+        message_queue.put_nowait(order_book_message)
+
+    async def _parse_trade_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
+        data = raw_message["data"]
+        for trade_data in data:
+            trading_pair = trade_data["coin"]
+            trade_message: OrderBookMessage = OrderBookMessage(OrderBookMessageType.TRADE, {
+                "trading_pair": trading_pair,
+                "trade_type": float(TradeType.SELL.value) if trade_data["side"] == "A" else float(
+                    TradeType.BUY.value),
+                "trade_id": trade_data["hash"],
+                "price": float(trade_data["px"]),
+                "amount": float(trade_data["sz"])
+            }, timestamp=trade_data["time"] * 1e-3)
+
+            message_queue.put_nowait(trade_message)

--- a/hummingbot/connector/exchange/hyperliquid/hyperliquid_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/hyperliquid/hyperliquid_api_user_stream_data_source.py
@@ -1,0 +1,137 @@
+import asyncio
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+import hummingbot.connector.exchange.hyperliquid.hyperliquid_constants as CONSTANTS
+import hummingbot.connector.exchange.hyperliquid.hyperliquid_web_utils as web_utils
+from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
+from hummingbot.core.utils.async_utils import safe_ensure_future
+from hummingbot.core.web_assistant.auth import AuthBase
+from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+from hummingbot.core.web_assistant.ws_assistant import WSAssistant
+from hummingbot.logger import HummingbotLogger
+
+if TYPE_CHECKING:
+    from hummingbot.connector.exchange.hyperliquid.hyperliquid_exchange import HyperliquidExchange
+
+
+class HyperliquidUserStreamDataSource(UserStreamTrackerDataSource):
+    LISTEN_KEY_KEEP_ALIVE_INTERVAL = 1800  # Recommended to Ping/Update listen key to keep connection alive
+    HEARTBEAT_TIME_INTERVAL = 30.0
+    _logger: Optional[HummingbotLogger] = None
+
+    def __init__(
+            self,
+            auth: AuthBase,
+            trading_pairs: List[str],
+            connector: 'HyperliquidExchange',
+            api_factory: WebAssistantsFactory,
+            domain: str = CONSTANTS.DOMAIN,
+    ):
+
+        super().__init__()
+        self._domain = domain
+        self._api_factory = api_factory
+        self._auth = auth
+        self._ws_assistants: List[WSAssistant] = []
+        self._connector = connector
+        self._current_listen_key = None
+        self._listen_for_user_stream_task = None
+        self._last_listen_key_ping_ts = None
+        self._trading_pairs: List[str] = trading_pairs
+
+        self.token = None
+
+    @property
+    def last_recv_time(self) -> float:
+        if self._ws_assistant:
+            return self._ws_assistant.last_recv_time
+        return 0
+    
+    async def _get_ws_assistant(self) -> WSAssistant:
+        if self._ws_assistant is None:
+            self._ws_assistant = await self._api_factory.get_ws_assistant()
+        return self._ws_assistant
+    
+    async def _connected_websocket_assistant(self) -> WSAssistant:
+        """
+        Creates an instance of WSAssistant connected to the exchange
+        """
+        ws: WSAssistant = await self._get_ws_assistant()
+        url = f"{web_utils.wss_url(self._domain)}"
+        await ws.connect(ws_url=url, ping_timeout=self.HEARTBEAT_TIME_INTERVAL)
+        safe_ensure_future(self._ping_thread(ws))
+        return ws
+    
+    async def _subscribe_channels(self, websocket_assistant: WSAssistant):
+        """
+        Subscribes to order events.
+
+        :param websocket_assistant: the websocket assistant used to connect to the exchange
+        """
+        try:
+            orders_change_payload = {
+                "method": "subscribe",
+                "subscription": {
+                    "type": "orderUpdates",
+                    "user": self._connector.hyperliquid_api_key,
+                }
+            }
+            subscribe_order_change_request: WSJSONRequest = WSJSONRequest(
+                payload=orders_change_payload,
+                is_auth_required=True)
+
+            positions_payload = {
+                "method": "subscribe",
+                "subscription": {
+                    "type": "user",
+                    "user": self._connector.hyperliquid_api_key,
+                }
+            }
+            subscribe_positions_request: WSJSONRequest = WSJSONRequest(
+                payload=positions_payload,
+                is_auth_required=True)
+            await websocket_assistant.send(subscribe_order_change_request)
+            await websocket_assistant.send(subscribe_positions_request)
+
+            self.logger().info("Subscribed to private order and trades changes channels...")
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self.logger().exception("Unexpected error occurred subscribing to user streams...")
+            raise
+
+    async def _process_event_message(self, event_message: Dict[str, Any], queue: asyncio.Queue):
+        self.logger().debug(f"Processing event message: {event_message}")
+        try:
+            if event_message.get("error") is not None:
+                err_msg = event_message.get("error", {}).get("message", event_message.get("error"))
+                self.logger().error(f"WebSocket error received: {err_msg}")
+                raise IOError(f"Error received via websocket - {err_msg}.")
+            elif event_message.get("channel") in [
+                CONSTANTS.USER_ORDERS_ENDPOINT_NAME,
+                CONSTANTS.USEREVENT_ENDPOINT_NAME,
+            ]:
+                queue.put_nowait(event_message)
+        except Exception as e:
+            self.logger().error(f"Error processing event message: {event_message}, {str(e)}", exc_info=True)
+            raise
+
+    async def _ping_thread(self, websocket_assistant: WSAssistant,):
+        try:
+            while True:
+                ping_request = WSJSONRequest(payload={"method": "ping"})
+                await asyncio.sleep(CONSTANTS.HEARTBEAT_TIME_INTERVAL)
+                await websocket_assistant.send(ping_request)
+        except Exception as e:
+            self.logger().debug(f'ping error {e}')
+
+    async def _process_websocket_messages(self, websocket_assistant: WSAssistant, queue: asyncio.Queue):
+        while True:
+            try:
+                await super()._process_websocket_messages(
+                    websocket_assistant=websocket_assistant,
+                    queue=queue)
+            except asyncio.TimeoutError:
+                ping_request = WSJSONRequest(payload={"method": "ping"})
+                await websocket_assistant.send(ping_request)

--- a/hummingbot/connector/exchange/hyperliquid/hyperliquid_auth.py
+++ b/hummingbot/connector/exchange/hyperliquid/hyperliquid_auth.py
@@ -1,0 +1,169 @@
+import json
+import time
+from collections import OrderedDict
+
+import eth_account
+import msgpack
+from eth_account.messages import encode_structured_data
+from eth_utils import keccak, to_hex
+
+from hummingbot.connector.exchange.hyperliquid import hyperliquid_constants as CONSTANTS
+from hummingbot.connector.exchange.hyperliquid.hyperliquid_web_utils import order_spec_to_order_wire
+from hummingbot.core.web_assistant.auth import AuthBase
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod, RESTRequest, WSRequest
+
+
+class HyperliquidAuth(AuthBase):
+    """
+    Auth class required by Hyperliquid API
+    """
+
+    def __init__(self, api_key: str, api_secret: str, use_vault: bool):
+        self._api_key: str = api_key
+        self._api_secret: str = api_secret
+        self._use_vault: bool = use_vault
+        self.wallet = eth_account.Account.from_key(api_secret)
+
+    @classmethod
+    def address_to_bytes(cls, address):
+        return bytes.fromhex(address[2:] if address.startswith("0x") else address)
+
+    @classmethod
+    def action_hash(cls, action, vault_address, nonce):
+        data = msgpack.packb(action)
+        data += nonce.to_bytes(8, "big")
+        if vault_address is None:
+            data += b"\x00"
+        else:
+            data += b"\x01"
+            data += cls.address_to_bytes(vault_address)
+        return keccak(data)
+
+    def sign_inner(self, wallet, data):
+        structured_data = encode_structured_data(data)
+        signed = wallet.sign_message(structured_data)
+        return {"r": to_hex(signed["r"]), "s": to_hex(signed["s"]), "v": signed["v"]}
+
+    def construct_phantom_agent(self, hash, is_mainnet):
+        return {"source": "a" if is_mainnet else "b", "connectionId": hash}
+
+    def sign_l1_action(self, wallet, action, active_pool, nonce, is_mainnet):
+        _hash = self.action_hash(action, active_pool, nonce)
+        phantom_agent = self.construct_phantom_agent(_hash, is_mainnet)
+
+        data = {
+            "domain": {
+                "chainId": 1337,
+                "name": "Exchange",
+                "verifyingContract": "0x0000000000000000000000000000000000000000",
+                "version": "1",
+            },
+            "types": {
+                "Agent": [
+                    {"name": "source", "type": "string"},
+                    {"name": "connectionId", "type": "bytes32"},
+                ],
+                "EIP712Domain": [
+                    {"name": "name", "type": "string"},
+                    {"name": "version", "type": "string"},
+                    {"name": "chainId", "type": "uint256"},
+                    {"name": "verifyingContract", "type": "address"},
+                ],
+            },
+            "primaryType": "Agent",
+            "message": phantom_agent,
+        }
+        return self.sign_inner(wallet, data)
+    
+    async def rest_authenticate(self, request: RESTRequest) -> RESTRequest:
+        base_url = request.url
+        if request.method == RESTMethod.POST:
+            request.data = self.add_auth_to_params_post(request.data, base_url)
+        return request
+
+    async def ws_authenticate(self, request: WSRequest) -> WSRequest:
+        return request  # pass-through
+
+    def _sign_update_leverage_params(self, params, base_url, timestamp):
+        signature = self.sign_l1_action(
+            self.wallet,
+            params,
+            None if not self._use_vault else self._api_key,
+            timestamp,
+            CONSTANTS.BASE_URL in base_url,
+        )
+        payload = {
+            "action": params,
+            "nonce": timestamp,
+            "signature": signature,
+            "vaultAddress": self._api_key if self._use_vault else None,
+        }
+        return payload
+
+    def _sign_cancel_params(self, params, base_url, timestamp):
+        order_action = {
+            "type": "cancelByCloid",
+            "cancels": [params["cancels"]],
+        }
+        signature = self.sign_l1_action(
+            self.wallet,
+            order_action,
+            None if not self._use_vault else self._api_key,
+            timestamp,
+            CONSTANTS.BASE_URL in base_url,
+        )
+        payload = {
+            "action": order_action,
+            "nonce": timestamp,
+            "signature": signature,
+            "vaultAddress": self._api_key if self._use_vault else None,
+
+        }
+        return payload
+
+    def _sign_order_params(self, params, base_url, timestamp):
+
+        order = params["orders"]
+        grouping = params["grouping"]
+        order_action = {
+            "type": "order",
+            "orders": [order_spec_to_order_wire(order)],
+            "grouping": grouping,
+        }
+        signature = self.sign_l1_action(
+            self.wallet,
+            order_action,
+            None if not self._use_vault else self._api_key,
+            timestamp,
+            CONSTANTS.BASE_URL in base_url,
+        )
+
+        payload = {
+            "action": order_action,
+            "nonce": timestamp,
+            "signature": signature,
+            "vaultAddress": self._api_key if self._use_vault else None,
+
+        }
+        return payload
+
+    def add_auth_to_params_post(self, params: str, base_url):
+        timestamp = int(self._get_timestamp() * 1e3)
+        payload = {}
+        data = json.loads(params) if params is not None else {}
+
+        request_params = OrderedDict(data or {})
+
+        request_type = request_params.get("type")
+        if request_type == "order":
+            payload = self._sign_order_params(request_params, base_url, timestamp)
+        elif request_type == "cancel":
+            payload = self._sign_cancel_params(request_params, base_url, timestamp)
+        elif request_type == "updateLeverage":
+            payload = self._sign_update_leverage_params(request_params, base_url, timestamp)
+        payload = json.dumps(payload)
+        return payload
+
+    @staticmethod
+    def _get_timestamp():
+        return time.time()

--- a/hummingbot/connector/exchange/hyperliquid/hyperliquid_constants.py
+++ b/hummingbot/connector/exchange/hyperliquid/hyperliquid_constants.py
@@ -1,0 +1,102 @@
+from hummingbot.core.api_throttler.data_types import LinkedLimitWeightPair, RateLimit
+from hummingbot.core.data_type.in_flight_order import OrderState
+
+EXCHANGE_NAME = "hyperliquid"
+BROKER_ID = "HBOT"
+MAX_ORDER_ID_LEN = 32
+
+MARKET_ORDER_SLIPPAGE = 0.05
+
+DOMAIN = EXCHANGE_NAME
+TESTNET_DOMAIN = "hyperliquid_testnet"
+
+BASE_URL = "https://api.hyperliquid.xyz"
+
+TESTNET_BASE_URL = "https://api.hyperliquid-testnet.xyz"
+
+WS_URL = "wss://api.hyperliquid.xyz/ws"
+
+TESTNET_WS_URL = "wss://api.hyperliquid-testnet.xyz/ws"
+
+CURRENCY = "USD"
+
+META_INFO = "spotMeta"
+
+ASSET_CONTEXT_TYPE = "spotMetaAndAssetCtxs"
+
+TRADES_TYPE = "userFills"
+
+ORDER_STATUS_TYPE = "orderStatus"
+
+USER_STATE_TYPE = "spotClearinghouseState"
+
+# yes
+TICKER_PRICE_CHANGE_URL = "/info"
+# yes
+SNAPSHOT_REST_URL = "/info"
+
+EXCHANGE_INFO_URL = "/info"
+
+CANCEL_ORDER_URL = "/exchange"
+
+CREATE_ORDER_URL = "/exchange"
+
+ACCOUNT_TRADE_LIST_URL = "/info"
+
+ORDER_URL = "/info"
+
+ACCOUNT_INFO_URL = "/info"
+
+POSITION_INFORMATION_URL = "/info"
+
+PING_URL = "/info"
+
+TRADES_ENDPOINT_NAME = "trades"
+DEPTH_ENDPOINT_NAME = "l2Book"
+
+
+USER_ORDERS_ENDPOINT_NAME = "orderUpdates"
+USEREVENT_ENDPOINT_NAME = "user"
+
+# Order Statuses
+ORDER_STATE = {
+    "open": OrderState.OPEN,
+    "resting": OrderState.OPEN,
+    "filled": OrderState.FILLED,
+    "canceled": OrderState.CANCELED,
+    "rejected": OrderState.FAILED,
+}
+
+HEARTBEAT_TIME_INTERVAL = 30.0
+
+MAX_REQUEST = 1_200
+ALL_ENDPOINTS_LIMIT = "All"
+
+RATE_LIMITS = [
+    RateLimit(ALL_ENDPOINTS_LIMIT, limit=MAX_REQUEST, time_interval=60),
+
+    # Weight Limits for individual endpoints
+    RateLimit(limit_id=SNAPSHOT_REST_URL, limit=MAX_REQUEST, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(ALL_ENDPOINTS_LIMIT)]),
+    RateLimit(limit_id=TICKER_PRICE_CHANGE_URL, limit=MAX_REQUEST, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(ALL_ENDPOINTS_LIMIT)]),
+    RateLimit(limit_id=EXCHANGE_INFO_URL, limit=MAX_REQUEST, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(ALL_ENDPOINTS_LIMIT)]),
+    RateLimit(limit_id=PING_URL, limit=MAX_REQUEST, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(ALL_ENDPOINTS_LIMIT)]),
+    RateLimit(limit_id=ORDER_URL, limit=MAX_REQUEST, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(ALL_ENDPOINTS_LIMIT)]),
+    RateLimit(limit_id=CREATE_ORDER_URL, limit=MAX_REQUEST, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(ALL_ENDPOINTS_LIMIT)]),
+    RateLimit(limit_id=CANCEL_ORDER_URL, limit=MAX_REQUEST, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(ALL_ENDPOINTS_LIMIT)]),
+    RateLimit(limit_id=ACCOUNT_TRADE_LIST_URL, limit=MAX_REQUEST, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(ALL_ENDPOINTS_LIMIT)]),
+    RateLimit(limit_id=ACCOUNT_INFO_URL, limit=MAX_REQUEST, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(ALL_ENDPOINTS_LIMIT)]),
+    RateLimit(limit_id=POSITION_INFORMATION_URL, limit=MAX_REQUEST, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(ALL_ENDPOINTS_LIMIT)]),
+
+]
+ORDER_NOT_EXIST_MESSAGE = "order"
+UNKNOWN_ORDER_MESSAGE = "Order was never placed, already canceled, or filled"

--- a/hummingbot/connector/exchange/hyperliquid/hyperliquid_exchange.py
+++ b/hummingbot/connector/exchange/hyperliquid/hyperliquid_exchange.py
@@ -1,0 +1,690 @@
+import asyncio
+import hashlib
+import time
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any, AsyncIterable, Dict, List, Optional, Tuple
+
+from bidict import bidict
+
+from hummingbot.connector.constants import s_decimal_NaN
+from hummingbot.connector.exchange.hyperliquid import (
+    hyperliquid_constants as CONSTANTS,
+    hyperliquid_web_utils as web_utils,
+)
+from hummingbot.connector.exchange.hyperliquid.hyperliquid_api_order_book_data_source import (
+    HyperliquidAPIOrderBookDataSource,
+)
+from hummingbot.connector.exchange.hyperliquid.hyperliquid_api_user_stream_data_source import (
+    HyperliquidUserStreamDataSource,
+)
+from hummingbot.connector.exchange.hyperliquid.hyperliquid_auth import HyperliquidAuth
+from hummingbot.connector.exchange_py_base import ExchangePyBase
+from hummingbot.connector.trading_rule import TradingRule
+from hummingbot.connector.utils import get_new_client_order_id
+from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from hummingbot.core.api_throttler.data_types import RateLimit
+from hummingbot.core.data_type.common import OrderType, PositionAction, PositionMode, TradeType
+from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderUpdate, TradeUpdate
+from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
+from hummingbot.core.data_type.trade_fee import TokenAmount, TradeFeeBase
+from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
+from hummingbot.core.utils.async_utils import safe_ensure_future, safe_gather
+from hummingbot.core.utils.estimate_fee import build_trade_fee
+from hummingbot.core.web_assistant.connections.rest_connection import RESTConnection
+from hummingbot.core.web_assistant.rest_assistant import RESTAssistant
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+
+if TYPE_CHECKING:
+    from hummingbot.client.config.config_helpers import ClientConfigAdapter
+
+bpm_logger = None
+
+
+class HyperliquidExchange(ExchangePyBase):
+    web_utils = web_utils
+
+    SHORT_POLL_INTERVL = 5.0
+    LONG_POLL_INTERVAL = 12.0
+
+    def __init__(
+        self,
+        client_config_map: "ClientConfigAdapter",
+        hyperliquid_api_secret: str = None,
+        use_vault: bool = False,
+        hyperliquid_api_key: str = None,
+        trading_pairs: Optional[List[str]] = None,
+        trading_required: bool = True,
+        domain: str = CONSTANTS.DOMAIN,
+        throttler: Optional[AsyncThrottler] = None,
+    ):
+        self.hyperliquid_api_key = hyperliquid_api_key
+        self.hyperliquid_secret_key = hyperliquid_api_secret
+        self._use_vault = use_vault
+        self._trading_required = trading_required
+        self._trading_pairs = trading_pairs
+        self._domain = domain
+        self._position_mode = None
+        self._last_trade_history_timestamp = None
+        self.coin_to_asset: Dict[str, int] = {}
+        self._throttler = throttler
+        self.rest_assistant = RESTAssistant(
+            connection=RESTConnection(domain),
+            throttler=self._throttler,
+            auth=self.authenticator,
+        )
+        super().__init__(client_config_map)
+
+
+    @property
+    def name(self) -> str:
+        return self._domain
+    
+    @property
+    def authenticator(self) -> HyperliquidAuth:
+        return HyperliquidAuth(self.hyperliquid_api_key, self.hyperliquid_secret_key,
+                                        self._use_vault)
+    
+    @property
+    def rate_limits_rules(self) -> List[RateLimit]:
+        return CONSTANTS.RATE_LIMITS
+    
+    @property
+    def domain(self) -> str:
+        return self._domain
+    
+    @property
+    def client_order_id_max_length(self) -> int:
+        return CONSTANTS.MAX_ORDER_ID_LEN
+    
+    @property
+    def client_order_id_prefix(self) -> str:
+        return CONSTANTS.BROKER_ID
+
+    @property
+    def trading_rules_request_path(self) -> str:
+        return CONSTANTS.EXCHANGE_INFO_URL
+    
+    @property
+    def trading_pairs_request_path(self) -> str:
+        return CONSTANTS.EXCHANGE_INFO_URL
+    
+    @property
+    def check_network_request_path(self) -> str:
+        return CONSTANTS.PING_URL
+    
+    @property
+    def trading_pairs(self):
+        return self._trading_pairs
+    
+    @property
+    def is_cancel_request_in_exchange_synchronous(self) -> bool:
+        return True
+    
+    @property
+    def is_trading_required(self) -> bool:
+        return self._trading_required
+    
+    @property
+    def funding_fee_poll_interval(self) -> int:
+        return 120
+    
+    async def _make_network_check_request(self):
+        await self._api_post(path_url=self.check_network_request_path, data={"type": CONSTANTS.META_INFO})
+
+    def supported_order_types(self) -> List[OrderType]:
+        return [OrderType.LIMIT, OrderType.LIMIT_MAKER, OrderType.MARKET]
+    
+    def supported_position_modes(self):
+        return [PositionMode.ONEWAY]
+    
+    def get_buy_collateral_token(self, trading_pair: str) -> str:
+        trading_rule: TradingRule = self._trading_rules[trading_pair]
+        return trading_rule.buy_order_collateral_token
+
+    def get_sell_collateral_token(self, trading_pair: str) -> str:
+        trading_rule: TradingRule = self._trading_rules[trading_pair]
+        return trading_rule.sell_order_collateral_token
+    
+    def _is_request_exception_related_to_time_synchronizer(self, request_exception: Exception):
+        return False
+
+    def _create_web_assistants_factory(self) -> WebAssistantsFactory:
+        return web_utils.build_api_factory(
+            throttler=self._throttler,
+            auth=self._auth)
+
+    async def _make_trading_rules_request(self) -> Any:
+        exchange_info = await self._api_post(path_url=self.trading_rules_request_path,
+                                             data={"type": CONSTANTS.ASSET_CONTEXT_TYPE})
+        return exchange_info
+
+    async def _make_trading_pairs_request(self) -> Any:
+        exchange_info = await self._api_post(path_url=self.trading_pairs_request_path,
+                                             data={"type": CONSTANTS.ASSET_CONTEXT_TYPE})
+        return exchange_info
+
+    def _is_order_not_found_during_status_update_error(self, status_update_exception: Exception) -> bool:
+        return CONSTANTS.ORDER_NOT_EXIST_MESSAGE in str(status_update_exception)
+
+    def _is_order_not_found_during_cancelation_error(self, cancelation_exception: Exception) -> bool:
+        return CONSTANTS.UNKNOWN_ORDER_MESSAGE in str(cancelation_exception)
+    
+    async def _update_trading_rules(self):
+        exchange_info = await self._api_post(path_url=self.trading_rules_request_path,
+                                            data={"type": CONSTANTS.ASSET_CONTEXT_TYPE})
+        trading_rules_list = await self._format_trading_rules(exchange_info)
+        self._trading_rules.clear()
+        for trading_rule in trading_rules_list:
+            self._trading_rules[trading_rule.trading_pair] = trading_rule
+        self._initialize_trading_pair_symbols_from_exchange_info(exchange_info=exchange_info)
+
+    async def _initialize_trading_pair_symbol_map(self):
+        try:
+            exchange_info = await self._api_post(path_url=self.trading_pairs_request_path,
+                                                data={"type": CONSTANTS.ASSET_CONTEXT_TYPE})
+            
+            self._initialize_trading_pair_symbols_from_exchange_info(exchange_info=exchange_info)
+        except Exception:
+            self.logger().exception("There was an error requesting exchange info.")
+
+    def _create_order_book_data_source(self) -> OrderBookTrackerDataSource:
+        return HyperliquidAPIOrderBookDataSource(
+            trading_pairs=self._trading_pairs,
+            connector=self,
+            api_factory=self._web_assistants_factory,
+            domain=self.domain,
+        )
+
+    def _create_user_stream_data_source(self) -> UserStreamTrackerDataSource:
+        return HyperliquidUserStreamDataSource(
+            auth=self._auth,
+            trading_pairs=self._trading_pairs,
+            connector=self,
+            api_factory=self._web_assistants_factory,
+            domain=self.domain,
+        )
+
+    async def _update_order_status(self):
+        await self._update_orders()
+
+    async def _update_lost_orders_status(self):
+        await self._update_lost_orders()
+
+    def _get_fee(self,
+                 base_currency: str,
+                 quote_currency: str,
+                 order_type: OrderType,
+                 order_side: TradeType,
+                 position_action: PositionAction,
+                 amount: Decimal,
+                 price: Decimal = s_decimal_NaN,
+                 is_maker: Optional[bool] = None) -> TradeFeeBase:
+        is_maker = is_maker or False
+        fee = build_trade_fee(
+            self.name,
+            is_maker,
+            base_currency=base_currency,
+            quote_currency=quote_currency,
+            order_type=order_type,
+            order_side=order_side,
+            amount=amount,
+            price=price,
+        )
+        return fee
+    
+    async def _update_trading_fees(self):
+        """
+        Update fees information from the exchange
+        """
+        pass
+
+    async def _place_cancel(self, order_id: str, tracked_order: InFlightOrder):
+        ex_trading_pair = await self._connector.exchange_symbol_associated_to_pair(trading_pair=tracked_order.trading_pair)
+        coin = ex_trading_pair.split("-")[0]
+
+        api_params = {
+            "type": "cancel",
+            "cancels": {
+                "asset": self.coin_to_asset[coin],
+                "cloid": order_id
+            },
+        }
+        cancel_result = await self._api_post(
+            path_url=CONSTANTS.CANCEL_ORDER_URL,
+            data=api_params,
+            is_auth_required=True)
+
+        if cancel_result.get("status") == "err" or "error" in cancel_result["response"]["data"]["statuses"][0]:
+            self.logger().debug(f"The order {order_id} does not exist on Hyperliquid. "
+                                f"No cancelation needed.")
+            await self._order_tracker.process_order_not_found(order_id)
+            raise IOError(f'{cancel_result["response"]["data"]["statuses"][0]["error"]}')
+        if "success" in cancel_result["response"]["data"]["statuses"][0]:
+            return True
+        return False
+    
+    # === Orders placing ===
+    
+    def buy(self,
+            trading_pair: str,
+            amount: Decimal,
+            order_type=OrderType.LIMIT,
+            price: Decimal = s_decimal_NaN,
+            **kwargs) -> str:
+        """
+        Creates a promise to create a buy order using the parameters
+
+        :param trading_pair: the token pair to operate with
+        :param amount: the order amount
+        :param order_type: the type of order to create (MARKET, LIMIT, LIMIT_MAKER)
+        :param price: the order price
+
+        :return: the id assigned by the connector to the order (the client id)
+        """
+        order_id = get_new_client_order_id(
+            is_buy=True,
+            trading_pair=trading_pair,
+            hbot_order_id_prefix=self.client_order_id_prefix,
+            max_id_len=self.client_order_id_max_length
+        )
+        md5 = hashlib.md5()
+        md5.update(order_id.encode('utf-8'))
+        hex_order_id = f"0x{md5.hexdigest()}"
+        if order_type is OrderType.MARKET:
+            mid_price = self.get_mid_price(trading_pair)
+            slippage = CONSTANTS.MARKET_ORDER_SLIPPAGE
+            market_price = mid_price * Decimal(1 + slippage)
+            price = self.quantize_order_price(trading_pair, market_price)
+
+        safe_ensure_future(self._create_order(
+            trade_type=TradeType.BUY,
+            order_id=hex_order_id,
+            trading_pair=trading_pair,
+            amount=amount,
+            order_type=order_type,
+            price=price,
+            **kwargs))
+        return hex_order_id
+
+    def sell(self,
+             trading_pair: str,
+             amount: Decimal,
+             order_type: OrderType = OrderType.LIMIT,
+             price: Decimal = s_decimal_NaN,
+             **kwargs) -> str:
+        """
+        Creates a promise to create a sell order using the parameters.
+        :param trading_pair: the token pair to operate with
+        :param amount: the order amount
+        :param order_type: the type of order to create (MARKET, LIMIT, LIMIT_MAKER)
+        :param price: the order price
+        :return: the id assigned by the connector to the order (the client id)
+        """
+        order_id = get_new_client_order_id(
+            is_buy=False,
+            trading_pair=trading_pair,
+            hbot_order_id_prefix=self.client_order_id_prefix,
+            max_id_len=self.client_order_id_max_length
+        )
+        md5 = hashlib.md5()
+        md5.update(order_id.encode('utf-8'))
+        hex_order_id = f"0x{md5.hexdigest()}"
+        if order_type is OrderType.MARKET:
+            mid_price = self.get_mid_price(trading_pair)
+            slippage = CONSTANTS.MARKET_ORDER_SLIPPAGE
+            market_price = mid_price * Decimal(1 - slippage)
+            price = self.quantize_order_price(trading_pair, market_price)
+
+        safe_ensure_future(self._create_order(
+            trade_type=TradeType.SELL,
+            order_id=hex_order_id,
+            trading_pair=trading_pair,
+            amount=amount,
+            order_type=order_type,
+            price=price,
+            **kwargs))
+        return hex_order_id
+    
+    async def _place_order(self, order_id: str, trading_pair: str, amount: Decimal, trade_type: TradeType, 
+                       order_type: OrderType, price: Decimal, position_action: PositionAction = PositionAction.NIL, 
+                       **kwargs):
+        ex_trading_pair = await self._connector.exchange_symbol_associated_to_pair(trading_pair=trading_pair)
+        coin = ex_trading_pair.split("-")[0]
+
+        param_order_type = {"limit": {"tif": "Gtc"}}
+        if order_type is OrderType.LIMIT_MAKER:
+            param_order_type = {"limit": {"tif": "Alo"}}
+        if order_type is OrderType.MARKET:
+            param_order_type = {"limit": {"tif": "Ioc"}}
+
+        api_params = {
+            "type": "order",
+            "grouping": "na",
+            "orders": {
+                "asset": self.coin_to_asset[coin],
+                "isBuy": True if trade_type is TradeType.BUY else False,
+                "limitPx": float(price),
+                "sz": float(amount),
+                "reduceOnly": False,
+                "orderType": param_order_type,
+                "cloid": order_id,
+            }
+        }
+        order_result = await self._api_post(
+            path_url=CONSTANTS.CREATE_ORDER_URL,
+            data=api_params,
+            is_auth_required=True)
+        if order_result.get("status") == "err":
+            raise IOError(f"Error submitting order {order_id}: {order_result['response']}")
+        else:
+            o_order_result = order_result['response']["data"]["statuses"][0]
+        if "error" in o_order_result:
+            raise IOError(f"Error submitting order {order_id}: {o_order_result['error']}")
+        o_data = o_order_result.get("resting") or o_order_result.get("filled")
+        o_id = str(o_data["oid"])
+        return (o_id, self.current_timestamp)
+    
+    async def _update_trade_history(self):
+        orders = list(self._order_tracker.all_fillable_orders.values())
+        all_fillable_orders = self._order_tracker.all_fillable_orders_by_exchange_order_id
+        all_fills_response = []
+        if len(orders) > 0:
+            try:
+                all_fills_response = await self._api_post(
+                    path_url=CONSTANTS.ACCOUNT_TRADE_LIST_URL,
+                    data={
+                        "type": CONSTANTS.TRADES_TYPE,
+                        "user": self.hyperliquid_api_key,
+                    })
+            except asyncio.CancelledError:
+                raise
+            except Exception as request_error:
+                self.logger().warning(
+                    f"Failed to fetch trade updates. Error: {request_error}",
+                    exc_info=request_error,
+                )
+            for trade_fill in all_fills_response:
+                self._process_trade_rs_event_message(order_fill=trade_fill, all_fillable_order=all_fillable_orders)
+
+    def _process_trade_rs_event_message(self, order_fill: Dict[str, Any], all_fillable_order):
+        exchange_order_id = str(order_fill.get("oid"))
+        fillable_order = all_fillable_order.get(exchange_order_id)
+        if fillable_order is not None:
+            fee_asset = fillable_order.quote_asset
+
+            position_action = PositionAction.OPEN if order_fill["dir"].split(" ")[0] == "Open" else PositionAction.CLOSE
+            fee = TradeFeeBase.new_spot_fee(
+                fee_schema=self.trade_fee_schema(),
+                position_action=position_action,
+                percent_token=fee_asset,
+                flat_fees=[TokenAmount(amount=Decimal(order_fill["fee"]), token=fee_asset)]
+            )
+
+            trade_update = TradeUpdate(
+                trade_id=str(order_fill["tid"]),
+                client_order_id=fillable_order.client_order_id,
+                exchange_order_id=str(order_fill["oid"]),
+                trading_pair=fillable_order.trading_pair,
+                fee=fee,
+                fill_base_amount=Decimal(order_fill["sz"]),
+                fill_quote_amount=Decimal(order_fill["px"]) * Decimal(order_fill["sz"]),
+                fill_price=Decimal(order_fill["px"]),
+                fill_timestamp=order_fill["time"] * 1e-3,
+            )
+
+            self._order_tracker.process_trade_update(trade_update)
+
+    async def _all_trade_updates_for_order(self, order: InFlightOrder) -> List[TradeUpdate]:
+        # Use _update_trade_history instead
+        pass
+
+    async def _handle_update_error_for_active_order(self, order: InFlightOrder, error: Exception):
+        try:
+            raise error
+        except (asyncio.TimeoutError, KeyError):
+            self.logger().debug(
+                f"Tracked order {order.client_order_id} does not have an exchange id. "
+                f"Attempting fetch in next polling interval."
+            )
+            await self._order_tracker.process_order_not_found(order.client_order_id)
+        except asyncio.CancelledError:
+            raise
+        except Exception as request_error:
+            self.logger().warning(
+                f"Error fetching status update for the active order {order.client_order_id}: {request_error}.",
+            )
+            self.logger().debug(
+                f"Order {order.client_order_id} not found counter: {self._order_tracker._order_not_found_records.get(order.client_order_id, 0)}")
+            await self._order_tracker.process_order_not_found(order.client_order_id)
+
+    async def _request_order_status(self, tracked_order: InFlightOrder) -> OrderUpdate:
+        client_order_id = tracked_order.client_order_id
+        order_update = await self._api_post(
+            path_url=CONSTANTS.ORDER_URL,
+            data={
+                "type": CONSTANTS.ORDER_STATUS_TYPE,
+                "user": self.hyperliquid_api_key,
+                "oid": int(tracked_order.exchange_order_id) if tracked_order.exchange_order_id else client_order_id
+            })
+        current_state = order_update["order"]["status"]
+        _order_update: OrderUpdate = OrderUpdate(
+            trading_pair=tracked_order.trading_pair,
+            update_timestamp=order_update["order"]["order"]["timestamp"] * 1e-3,
+            new_state=CONSTANTS.ORDER_STATE[current_state],
+            client_order_id=order_update["order"]["order"]["cloid"] or client_order_id,
+            exchange_order_id=str(tracked_order.exchange_order_id),
+        )
+        return _order_update
+    
+    async def _iter_user_event_queue(self) -> AsyncIterable[Dict[str, any]]:
+        while True:
+            try:
+                yield await self._user_stream_tracker.user_stream.get()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                self.logger().network(
+                    "Unknown error. Retrying after 1 seconds.",
+                    exc_info=True,
+                    app_warning_msg="Could not fetch user events from Hyperliquid. Check API key and network connection.",
+                )
+                await self._sleep(1.0)
+
+    async def _user_stream_event_listener(self):
+        """
+        Listens to messages from _user_stream_tracker.user_stream queue.
+        Traders, Orders, and Balance updates from the WS.
+        """
+        user_channels = [
+            CONSTANTS.USER_ORDERS_ENDPOINT_NAME,
+            CONSTANTS.USEREVENT_ENDPOINT_NAME,
+        ]
+        async for event_message in self._iter_user_event_queue():
+            try:
+                if isinstance(event_message, dict):
+                    channel: str = event_message.get("channel", None)
+                    results = event_message.get("data", None)
+                elif event_message is asyncio.CancelledError:
+                    raise asyncio.CancelledError
+                else:
+                    raise Exception(event_message)
+                if channel not in user_channels:
+                    self.logger().error(
+                        f"Unexpected message in user stream: {event_message}.", exc_info=True)
+                    continue
+                if channel == CONSTANTS.USER_ORDERS_ENDPOINT_NAME:
+                    for order_msg in results:
+                        self._process_order_message(order_msg)
+                elif channel == CONSTANTS.USEREVENT_ENDPOINT_NAME:
+                    if "fills" in results:
+                        for trade_msg in results["fills"]:
+                            await self._process_trade_message(trade_msg)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                self.logger().error(
+                    "Unexpected error in user stream listener loop.", exc_info=True)
+                await self._sleep(5.0)
+
+    async def _process_trade_message(self, trade: Dict[str, Any], client_order_id: Optional[str] = None):
+        """
+        Updates in-flight order and trigger order filled event for trade message received. Triggers order completed
+        event if the total executed amount equals to the specified order amount.
+        Example Trade:
+        """
+        exchange_order_id = str(trade.get("oid", ""))
+        tracked_order = self._order_tracker.all_fillable_orders_by_exchange_order_id.get(exchange_order_id)
+
+        if tracked_order is None:
+            all_orders = self._order_tracker.all_fillable_orders
+            for k, v in all_orders.items():
+                await v.get_exchange_order_id()
+            _cli_tracked_orders = [o for o in all_orders.values() if exchange_order_id == o.exchange_order_id]
+            if not _cli_tracked_orders:
+                self.logger().debug(f"Ignoring trade message with id {client_order_id}: not in in_flight_orders.")
+                return
+            tracked_order = _cli_tracked_orders[0]
+        trading_pair_base_coin = tracked_order.base_asset
+        if trade["coin"] == trading_pair_base_coin:
+            position_action = PositionAction.OPEN if trade["dir"].split(" ")[0] == "Open" else PositionAction.CLOSE
+            fee_asset = tracked_order.quote_asset
+            fee = TradeFeeBase.new_spot_fee(
+                fee_schema=self.trade_fee_schema(),
+                position_action=position_action,
+                percent_token=fee_asset,
+                flat_fees=[TokenAmount(amount=Decimal(trade["fee"]), token=fee_asset)]
+            )
+            trade_update: TradeUpdate = TradeUpdate(
+                trade_id=str(trade["tid"]),
+                client_order_id=tracked_order.client_order_id,
+                exchange_order_id=str(trade["oid"]),
+                trading_pair=tracked_order.trading_pair,
+                fill_timestamp=trade["time"] * 1e-3,
+                fill_price=Decimal(trade["px"]),
+                fill_base_amount=Decimal(trade["sz"]),
+                fill_quote_amount=Decimal(trade["px"]) * Decimal(trade["sz"]),
+                fee=fee,
+            )
+            self._order_tracker.process_trade_update(trade_update)
+
+    def _process_order_message(self, order_msg: Dict[str, Any]):
+        """
+        Updates in-flight order and triggers cancelation or failure event if needed.
+
+        :param order_msg: The order response from either REST or web socket API (they are of the same format)
+
+        Example Order:
+        """
+        client_order_id = str(order_msg["order"].get("cloid", ""))
+        tracked_order = self._order_tracker.all_updatable_orders.get(client_order_id)
+        if not tracked_order:
+            self.logger().debug(f"Ignoring order message with id {client_order_id}: not in in_flight_orders.")
+            return
+        current_state = order_msg["status"]
+        order_update: OrderUpdate = OrderUpdate(
+            trading_pair=tracked_order.trading_pair,
+            update_timestamp=order_msg["statusTimestamp"] * 1e-3,
+            new_state=CONSTANTS.ORDER_STATE[current_state],
+            client_order_id=order_msg["order"]["cloid"],
+            exchange_order_id=str(order_msg["order"]["oid"]),
+        )
+        self._order_tracker.process_order_update(order_update=order_update)
+
+    async def _format_trading_rules(self, exchange_info_dict: List) -> List[TradingRule]:
+        """
+        Queries the necessary API endpoint and initialize the TradingRule object for each trading pair being traded.
+
+        Parameters
+        ----------
+        exchange_info_dict:
+            Trading rules dictionary response from the exchange
+        """
+        # rules: list = exchange_info_dict[0]
+        self.coin_to_asset = {asset_info["name"]: asset for (asset, asset_info) in enumerate(exchange_info_dict[0]["universe"])}
+
+        coin_infos: list = exchange_info_dict[0]["universe"]
+        token_infos: list = exchange_info_dict[0]["tokens"]
+        price_infos: list = exchange_info_dict[1]
+        return_val: list = []
+
+        for coin_info, price_info in zip(coin_infos, price_infos):
+            try:
+                base_token_index = coin_info["tokens"][0]
+                quote_token_index = coin_info["tokens"][1]
+
+                # base_token_name = token_infos[base_token_index]["name"]
+                quote_token_name = token_infos[quote_token_index]["name"]
+
+                trading_pair = f"@{base_token_index}-@{quote_token_index}"
+
+                step_size = Decimal(str(10 ** -token_infos[base_token_index].get("szDecimals")))
+                price_size = Decimal(str(10 ** -len(price_info.get("markPx").split('.')[1])))
+                collateral_token = quote_token_name
+
+                return_val.append(
+                    TradingRule(
+                        trading_pair=trading_pair,
+                        min_base_amount_increment=step_size,
+                        min_price_increment=price_size,
+                        buy_order_collateral_token=collateral_token,
+                        sell_order_collateral_token=collateral_token,
+                    )
+                )
+            except Exception:
+                self.logger().error(f"Error parsing the trading pair rule {coin_info}. Skipping.", exc_info=True)
+
+        return return_val
+
+    def _initialize_trading_pair_symbols_from_exchange_info(self, exchange_info: List):
+        mapping = bidict()
+        tokens = exchange_info[0]["tokens"]
+        universe = exchange_info[0]["universe"]
+
+        for coin_info in universe:
+            base_token_index = coin_info["tokens"][0]
+            quote_token_index = coin_info["tokens"][1]
+
+            base_token_name = tokens[base_token_index]["name"]
+            quote_token_name = tokens[quote_token_index]["name"]
+
+            trading_pair = f"@{base_token_index}-@{quote_token_index}"
+            ex_symbol = f"{base_token_name}_{base_token_index}-{quote_token_name}_{quote_token_index}"
+
+            mapping[trading_pair] = ex_symbol
+            self.logger().debug(f"Mapped {trading_pair} to {ex_symbol}")
+
+        self._set_trading_pair_symbol_map(mapping)
+    
+    async def _get_last_traded_price(self, trading_pair: str) -> float:
+        exchange_symbol = await self.exchange_symbol_associated_to_pair(trading_pair=trading_pair)
+        coin = f"@{exchange_symbol.split('_')[1].split('-')[0]}"
+        response = await self._api_post(path_url=CONSTANTS.TICKER_PRICE_CHANGE_URL,
+                                        data={"type": CONSTANTS.ASSET_CONTEXT_TYPE})
+        price = 0
+        for index, i in enumerate(response[0]['universe']):
+            if i['name'] == coin:
+                price = float(response[1][index]['markPx'])
+        return price
+    
+    async def _update_balances(self):
+        account_info = await self._api_post(
+            path_url=CONSTANTS.ACCOUNT_INFO_URL,
+            data={"type": CONSTANTS.USER_STATE_TYPE,
+                  "user": self.hyperliquid_api_key},
+        )
+
+        self._account_balances.clear()
+        self._account_available_balances.clear()
+
+        for token_info in account_info["balances"]:
+            coin_name = token_info["coin"]
+            total_balance = Decimal(token_info["total"])
+            hold_balance = Decimal(token_info["hold"])
+            
+            self._account_balances[coin_name] = total_balance
+            self._account_available_balances[coin_name] = total_balance - hold_balance
+
+    def get_order_price_quantum(self, trading_pair: str, price: Decimal) -> Decimal:
+        coin = f"@{trading_pair.split('-')[0].split('_')[1]}-@{trading_pair.split('-')[1].split('_')[1]}"
+        trading_rule = self._trading_rules[coin]
+        return trading_rule.min_price_increment

--- a/hummingbot/connector/exchange/hyperliquid/hyperliquid_order_book.py
+++ b/hummingbot/connector/exchange/hyperliquid/hyperliquid_order_book.py
@@ -1,0 +1,70 @@
+from typing import Dict, Optional
+
+from hummingbot.core.data_type.common import TradeType
+from hummingbot.core.data_type.order_book import OrderBook
+from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
+
+
+class HyperliquidOrderBook(OrderBook):
+
+    @classmethod
+    def snapshot_message_from_exchange(cls,
+                                       msg: Dict[str, any],
+                                       timestamp: float,
+                                       metadata: Optional[Dict] = None) -> OrderBookMessage:
+        if metadata:
+            msg.update(metadata)
+        return OrderBookMessage(OrderBookMessageType.SNAPSHOT, {
+            "trading_pair": msg["trading_pair"].replace("/", ""),
+            "update_id": msg["latest_update"],
+            "bids": msg["bids"],
+            "asks": msg["asks"]
+        }, timestamp=timestamp)
+
+    @classmethod
+    def diff_message_from_exchange(cls,
+                                   msg: Dict[str, any],
+                                   timestamp: Optional[float] = None,
+                                   metadata: Optional[Dict] = None) -> OrderBookMessage:
+        if metadata:
+            msg.update(metadata)
+        return OrderBookMessage(OrderBookMessageType.DIFF, {
+            "trading_pair": msg["trading_pair"].replace("/", ""),
+            "update_id": msg["update_id"],
+            "bids": msg["bids"],
+            "asks": msg["asks"]
+        }, timestamp=timestamp)
+
+    @classmethod
+    def snapshot_ws_message_from_exchange(cls,
+                                          msg: Dict[str, any],
+                                          timestamp: Optional[float] = None,
+                                          metadata: Optional[Dict] = None) -> OrderBookMessage:
+        if metadata:
+            msg.update(metadata)
+        return OrderBookMessage(OrderBookMessageType.SNAPSHOT, {
+            "trading_pair": msg["trading_pair"].replace("/", ""),
+            "update_id": msg["update_id"],
+            "bids": msg["bids"],
+            "asks": msg["asks"]
+        }, timestamp=timestamp)
+
+    @classmethod
+    def trade_message_from_exchange(cls, msg: Dict[str, any], metadata: Optional[Dict] = None):
+        if metadata:
+            msg.update(metadata)
+        ts = float(msg["trade"][2])
+        return OrderBookMessage(OrderBookMessageType.TRADE, {
+            "trading_pair": msg["pair"].replace("/", ""),
+            "trade_type": float(TradeType.SELL.value) if msg["trade"][3] == "s" else float(TradeType.BUY.value),
+            "trade_id": ts,
+            "update_id": ts,
+            "price": msg["trade"][0],
+            "amount": msg["trade"][1]
+        }, timestamp=ts)
+
+    @classmethod
+    def from_snapshot(cls, msg: OrderBookMessage) -> "OrderBook":
+        retval = HyperliquidOrderBook()
+        retval.apply_snapshot(msg.bids, msg.asks, msg.update_id)
+        return retval

--- a/hummingbot/connector/exchange/hyperliquid/hyperliquid_utils.py
+++ b/hummingbot/connector/exchange/hyperliquid/hyperliquid_utils.py
@@ -1,0 +1,124 @@
+from decimal import Decimal
+from typing import Optional
+
+from pydantic import Field, SecretStr
+from pydantic.class_validators import validator
+
+from hummingbot.client.config.config_data_types import BaseConnectorConfigMap, ClientFieldData
+from hummingbot.core.data_type.trade_fee import TradeFeeSchema
+
+# Maker rebates(-0.02%) are paid out continuously on each trade directly to the trading wallet.(https://hyperliquid.gitbook.io/hyperliquid-docs/trading/fees)
+DEFAULT_FEES = TradeFeeSchema(
+    maker_percent_fee_decimal=Decimal("0"),
+    taker_percent_fee_decimal=Decimal("0.00025"),
+    buy_percent_fee_deducted_from_returns=True
+)
+
+CENTRALIZED = True
+
+EXAMPLE_PAIR = "PURR-USD"
+
+BROKER_ID = "HBOT"
+
+
+def validate_bool(value: str) -> Optional[str]:
+    """
+    Permissively interpret a string as a boolean
+    """
+    valid_values = ('true', 'yes', 'y', 'false', 'no', 'n')
+    if value.lower() not in valid_values:
+        return f"Invalid value, please choose value from {valid_values}"
+
+
+class HyperliquidConfigMap(BaseConnectorConfigMap):
+    connector: str = Field(default="hyperliquid", client_data=None)
+    hyperliquid_api_secret: SecretStr = Field(
+        default=...,
+        client_data=ClientFieldData(
+            prompt=lambda cm: "Enter your Arbitrum wallet private key",
+            is_secure=True,
+            is_connect_key=True,
+            prompt_on_new=True,
+        )
+    )
+    use_vault: bool = Field(
+        default="no",
+        client_data=ClientFieldData(
+            prompt=lambda cm: "Do you want to use the vault address?(Yes/No)",
+            is_secure=False,
+            is_connect_key=True,
+            prompt_on_new=True,
+        ),
+    )
+    hyperliquid_api_key: SecretStr = Field(
+        default=...,
+        client_data=ClientFieldData(
+            prompt=lambda cm: "Enter your Arbitrum or vault address",
+            is_secure=True,
+            is_connect_key=True,
+            prompt_on_new=True,
+        )
+    )
+
+    @validator("use_vault", pre=True)
+    def validate_bool(cls, v: str):
+        """Used for client-friendly error output."""
+        if isinstance(v, str):
+            ret = validate_bool(v)
+            if ret is not None:
+                raise ValueError(ret)
+        return v
+
+
+KEYS = HyperliquidConfigMap.construct()
+
+OTHER_DOMAINS = ["hyperliquid_testnet"]
+OTHER_DOMAINS_PARAMETER = {"hyperliquid_testnet": "hyperliquid_testnet"}
+OTHER_DOMAINS_EXAMPLE_PAIR = {"hyperliquid_testnet": "PURR-USD"}
+OTHER_DOMAINS_DEFAULT_FEES = {"hyperliquid_testnet": [0, 0.025]}
+
+
+class HyperliquidTestnetConfigMap(BaseConnectorConfigMap):
+    connector: str = Field(default="hyperliquid_testnet", client_data=None)
+    hyperliquid_api_secret: SecretStr = Field(
+        default=...,
+        client_data=ClientFieldData(
+            prompt=lambda cm: "Enter your Arbitrum wallet private key",
+            is_secure=True,
+            is_connect_key=True,
+            prompt_on_new=True,
+        )
+    )
+    use_vault: bool = Field(
+        default="no",
+        client_data=ClientFieldData(
+            prompt=lambda cm: "Do you want to use the vault address?(Yes/No)",
+            is_secure=False,
+            is_connect_key=True,
+            prompt_on_new=True,
+        ),
+    )
+    hyperliquid_api_key: SecretStr = Field(
+        default=...,
+        client_data=ClientFieldData(
+            prompt=lambda cm: "Enter your Arbitrum or vault address",
+            is_secure=True,
+            is_connect_key=True,
+            prompt_on_new=True,
+        )
+    )
+
+    class Config:
+        title = "hyperliquid"
+
+    @validator("use_vault", pre=True)
+    def validate_bool(cls, v: str):
+        """Used for client-friendly error output."""
+        if isinstance(v, str):
+            ret = validate_bool(v)
+            if ret is not None:
+                raise ValueError(ret)
+        return v
+
+
+OTHER_DOMAINS_KEYS = {"hyperliquid_testnet": HyperliquidTestnetConfigMap.construct()}

--- a/hummingbot/connector/exchange/hyperliquid/hyperliquid_web_utils.py
+++ b/hummingbot/connector/exchange/hyperliquid/hyperliquid_web_utils.py
@@ -1,0 +1,155 @@
+import time
+from decimal import Decimal
+from typing import Any, Dict, Optional, Tuple
+
+import hummingbot.connector.exchange.hyperliquid.hyperliquid_constants as CONSTANTS
+from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from hummingbot.core.web_assistant.auth import AuthBase
+from hummingbot.core.web_assistant.connections.data_types import RESTRequest
+from hummingbot.core.web_assistant.rest_pre_processors import RESTPreProcessorBase
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+
+
+class HyperliquidSpotRESTPreProcessor(RESTPreProcessorBase):
+
+    async def pre_process(self, request: RESTRequest) -> RESTRequest:
+        if request.headers is None:
+            request.headers = {}
+        request.headers["Content-Type"] = (
+            "application/json"
+        )
+        return request
+    
+
+def private_rest_url(*args, **kwargs) -> str:
+    return rest_url(*args, **kwargs)
+
+
+def public_rest_url(*args, **kwargs) -> str:
+    return rest_url(*args, **kwargs)
+
+
+def rest_url(path_url: str, domain: str = "hyperliquid"):
+    base_url = CONSTANTS.BASE_URL if domain == "hyperliquid" else CONSTANTS.TESTNET_BASE_URL
+    return base_url + path_url
+
+
+def wss_url(domain: str = "hyperliquid"):
+    base_ws_url = CONSTANTS.WS_URL if domain == "hyperliquid" else CONSTANTS.TESTNET_WS_URL
+    return base_ws_url
+
+
+def build_api_factory(
+        throttler: Optional[AsyncThrottler] = None,
+        auth: Optional[AuthBase] = None) -> WebAssistantsFactory:
+    throttler = throttler or create_throttler()
+    api_factory = WebAssistantsFactory(
+        throttler=throttler,
+        rest_pre_processors=[HyperliquidSpotRESTPreProcessor()],
+        auth=auth)
+    return api_factory
+
+def build_api_factory_without_time_synchronizer_pre_processor(throttler: AsyncThrottler) -> WebAssistantsFactory:
+    api_factory = WebAssistantsFactory(
+        throttler=throttler,
+        rest_post_processors=[HyperliquidSpotRESTPreProcessor()])
+    return api_factory
+
+def create_throttler() -> AsyncThrottler:
+    return AsyncThrottler(CONSTANTS.RATE_LIMITS)
+
+async def get_current_server_time(
+        throttler,
+        domain
+) -> float:
+    return time.time()
+
+def is_exchange_information_valid(rule: Dict[str, Any]) -> bool:
+    """
+    Verifies if a trading pair is enabled to operate with based on its exchange information
+
+    :param exchange_info: the exchange information for a trading pair
+
+    :return: True if the trading pair is enabled, False otherwise
+    """
+    return True
+
+def order_type_to_tuple(order_type) -> Tuple[int, float]:
+    if "limit" in order_type:
+        tif = order_type["limit"]["tif"]
+        if tif == "Gtc":
+            return 2, 0
+        elif tif == "Alo":
+            return 1, 0
+        elif tif == "Ioc":
+            return 3, 0
+    elif "trigger" in order_type:
+        trigger = order_type["trigger"]
+        trigger_px = trigger["triggerPx"]
+        if trigger["isMarket"] and trigger["tpsl"] == "tp":
+            return 4, trigger_px
+        elif not trigger["isMarket"] and trigger["tpsl"] == "tp":
+            return 5, trigger_px
+        elif trigger["isMarket"] and trigger["tpsl"] == "sl":
+            return 6, trigger_px
+        elif not trigger["isMarket"] and trigger["tpsl"] == "sl":
+            return 7, trigger_px
+    raise ValueError("Invalid order type", order_type)
+
+def float_to_int_for_hashing(x: float) -> int:
+    return float_to_int(x, 8)
+
+
+def float_to_int(x: float, power: int) -> int:
+    with_decimals = x * 10 ** power
+    if abs(round(with_decimals) - with_decimals) >= 1e-3:
+        raise ValueError("float_to_int causes rounding", x)
+    return round(with_decimals)
+
+
+def str_to_bytes16(x: str) -> bytearray:
+    assert x.startswith("0x")
+    return bytearray.fromhex(x[2:])
+
+def order_grouping_to_number(grouping) -> int:
+    if grouping == "na":
+        return 0
+    elif grouping == "normalTpsl":
+        return 1
+    elif grouping == "positionTpsl":
+        return 2
+    
+def order_spec_to_order_wire(order_spec):
+    return {
+        "a": order_spec["asset"],
+        "b": order_spec["isBuy"],
+        "p": float_to_wire(order_spec["limitPx"]),
+        "s": float_to_wire(order_spec["sz"]),
+        "r": order_spec["reduceOnly"],
+        "t": order_type_to_wire(order_spec["orderType"]),
+        "c": order_spec["cloid"],
+    }
+
+
+def float_to_wire(x: float) -> str:
+    rounded = "{:.8f}".format(x)
+    if abs(float(rounded) - x) >= 1e-12:
+        raise ValueError("float_to_wire causes rounding", x)
+    if rounded == "-0":
+        rounded = "0"
+    normalized = Decimal(rounded).normalize()
+    return f"{normalized:f}"
+
+
+def order_type_to_wire(order_type):
+    if "limit" in order_type:
+        return {"limit": order_type["limit"]}
+    elif "trigger" in order_type:
+        return {
+            "trigger": {
+                "triggerPx": float_to_wire(order_type["trigger"]["triggerPx"]),
+                "tpsl": order_type["trigger"]["tpsl"],
+                "isMarket": order_type["trigger"]["isMarket"],
+            }
+        }
+    raise ValueError("Invalid order type", order_type)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Implementation of Hyperliquid Exchange Spot Connector

**Tests performed by the developer**:
Ongoing - Pure MM

**Tips for QA testing**:
Ongoing

**Fix Required**:
As the commit log notes, I'm struggling with the [c_get_price](https://github.com/CoinAlpha/hummingbot/blob/6ee8151a4d384d3770a6a7d02cdca4b1f57ee97d/hummingbot/connector/exchange_base.pyx#L153)
  
```
hummingbot.connector.exchange.hyperliquid.hyperliquid_exchange.HyperliquidExchange - WARNING - Ask orderbook for PURR_1-USDC_0 is empty.
```

The issue is how the Hyperliquid Spot API handles orders using a single token index instead of typical symbols like PURR-USDC.
(though it does accept PURR/USDC as a special case)

e.g. orders are placed using @ 1, @ 2, @ 3 for tokens PURR-USDC, TEST-USDC, JPL-USDC.
Additionally, Hyperliquid allows duplicate token names.

I’ve therefore mapped token indexes to token names in the [_initialize_trading_pair_symbols_from_exchange_info](https://github.com/lutwidse/hummingbot/blob/44ebe2a8f50979d4d2b7754a6e143a775715b4bd/hummingbot/connector/exchange/hyperliquid/hyperliquid_exchange.py#L651)
This follows the Hummingbot token format and also enables future support for pairs like @1-@1 and @1-@2, allowing us to handle individual token indices separately.

```
hummingbot.connector.exchange.hyperliquid.hyperliquid_exchange.HyperliquidExchange - DEBUG - Mapped @1-@0 to PURR_1-USDC_0
hummingbot.connector.exchange.hyperliquid.hyperliquid_exchange.HyperliquidExchange - DEBUG - Mapped @2-@0 to TEST_2-USDC_0
hummingbot.connector.exchange.hyperliquid.hyperliquid_exchange.HyperliquidExchange - DEBUG - Mapped @3-@0 to JPL _3-USDC_0
hummingbot.connector.exchange.hyperliquid.hyperliquid_exchange.HyperliquidExchange - DEBUG - Mapped @4-@0 to BREAD_4-USDC_0
hummingbot.connector.exchange.hyperliquid.hyperliquid_exchange.HyperliquidExchange - DEBUG - Mapped @6-@0 to KOGU_6-USDC_0
```

I’m looking for tips on implementing a secure solution for mapping a single token index as the trading_pairs.
Thank you.
