### PR TITLE
fix/Fix refreshing of listenkey for MEXC

### DIFF
--- a/hummingbot/connector/exchange/mexc/mexc_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/mexc/mexc_api_user_stream_data_source.py
@@ -95,7 +95,6 @@ class MexcAPIUserStreamDataSource(UserStreamTrackerDataSource):
                 url=web_utils.public_rest_url(path_url=CONSTANTS.MEXC_USER_STREAM_PATH_URL, domain=self._domain),
                 method=RESTMethod.POST,
                 throttler_limit_id=CONSTANTS.MEXC_USER_STREAM_PATH_URL,
-                headers=self._auth.header_for_authentication(),
                 is_auth_required=True
             )
         except asyncio.CancelledError:
@@ -114,7 +113,7 @@ class MexcAPIUserStreamDataSource(UserStreamTrackerDataSource):
                 method=RESTMethod.PUT,
                 return_err=True,
                 throttler_limit_id=CONSTANTS.MEXC_USER_STREAM_PATH_URL,
-                headers=self._auth.header_for_authentication()
+                is_auth_required=True
             )
 
             if "code" in data:


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Enable authentication on the rest request to refresh the listenkey, this was previously not done which let to the following error:

> Failed to refresh the listen key 6b3c6xxxx: {'code': 700004, 'msg': "Mandatory parameter 'signature' was not sent, was empty/null, or malformed."}


**Tests performed by the developer**:
The listenkey refreshes every 30 minutes, with this fix I've not seen any exceptions for the past 24 hours running the PMM strategy.


**Tips for QA testing**:


