### PR TITLE
(fix) pande The frame.append method is deprecated

### DIFF
--- a/hummingbot/strategy/pure_market_making/pure_market_making.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pyx
@@ -661,7 +661,8 @@ cdef class PureMarketMakingStrategy(StrategyBase):
         # append inventory skew stats.
         if self._inventory_skew_enabled:
             inventory_skew_df = map_df_to_str(self.inventory_skew_stats_data_frame())
-            assets_df = assets_df.append(inventory_skew_df)
+            assets_df = pd.concat(
+                [assets_df, inventory_skew_df], join="inner")
 
         first_col_length = max(*assets_df[0].apply(len))
         df_lines = assets_df.to_string(index=False, header=False,


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Warning errors flood the bot when inventory_skew_enabled is set to True

[conf_pure_mm_4.yml.zip](https://github.com/user-attachments/files/17482945/conf_pure_mm_4.yml.zip)

<img width="1320" alt="Screenshot 2024-08-11 at 21 37 15" src="https://github.com/user-attachments/assets/69bc063e-a519-4869-b15d-7d635325c76a">

/status_command.py:78: Futurewarning: The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.
st status = self.strategy.format status ()

**Tests performed by the developer**:
status && status --live


**Tips for QA testing**:


