### PR TITLE
(fix) adds gas variables to amm_arb strategy

### DIFF
--- a/hummingbot/strategy/amm_arb/amm_arb_config_map.py
+++ b/hummingbot/strategy/amm_arb/amm_arb_config_map.py
@@ -84,7 +84,7 @@ amm_arb_config_map = {
         on_validated=market_2_on_validated),
     "pool_id": ConfigVar(
         key="pool_id",
-        prompt="Specify poolId to interract with on the DEX connector >>> ",
+        prompt="Specify a pool to swap with on the AMM connector >>> ",
         prompt_on_new=False,
         type_str="str",
         default=""),
@@ -155,8 +155,22 @@ amm_arb_config_map = {
         type_str="bool"),
     "quote_conversion_rate": ConfigVar(
         key="quote_conversion_rate",
-        prompt="What is the fixed_rate used to convert quote assets? >>> ",
+        prompt="What is the fixed_rate used to convert quote assets across the pairs (e.g. USDT to USDC)? >>> ",
         default=Decimal("1"),
         validator=lambda v: validate_decimal(v),
+        prompt_on_new=False,
+        type_str="decimal"),
+    "gas_token": ConfigVar(
+        key="gas_token",
+        prompt="What is the symbol of the token used to pay gas? >>> ",
+        default="ETH",
+        prompt_on_new=False,
+        type_str="str"),
+    "gas_price": ConfigVar(
+        key="gas_price",
+        prompt="What is the gas price, expressed in the quote asset? >>> ",
+        default=Decimal("3500"),
+        validator=lambda v: validate_decimal(v),
+        prompt_on_new=False,
         type_str="decimal"),
 }

--- a/hummingbot/strategy/amm_arb/start.py
+++ b/hummingbot/strategy/amm_arb/start.py
@@ -80,11 +80,11 @@ def start(self):
         rate_source.add_rate(f"{quote_2}-{quote_1}", Decimal(str(quote_conversion_rate)))   # reverse rate is already handled in FixedRateSource find_rate method.
         rate_source.add_rate(f"{quote_1}-{quote_2}", Decimal(str(1 / quote_conversion_rate)))   # reverse rate is already handled in FixedRateSource find_rate method.
 
-    if gas_price:
-        rate_source.add_rate(f"{gas_token}-{quote_1}", Decimal(str(gas_price)))
-        rate_source.add_rate(f"{gas_token}-{quote_2}", Decimal(str(gas_price)))
-        rate_source.add_rate(f"{quote_1}-{gas_token}", Decimal(str(1 / gas_price)))
-        rate_source.add_rate(f"{quote_2}-{gas_token}", Decimal(str(1 / gas_price)))
+        if gas_price:
+            rate_source.add_rate(f"{gas_token}-{quote_1}", Decimal(str(gas_price)))
+            rate_source.add_rate(f"{gas_token}-{quote_2}", Decimal(str(gas_price)))
+            rate_source.add_rate(f"{quote_1}-{gas_token}", Decimal(str(1 / gas_price)))
+            rate_source.add_rate(f"{quote_2}-{gas_token}", Decimal(str(1 / gas_price)))
 
     self.strategy = AmmArbStrategy()
     self.strategy.init_params(market_info_1=market_info_1,

--- a/hummingbot/strategy/amm_arb/start.py
+++ b/hummingbot/strategy/amm_arb/start.py
@@ -29,6 +29,8 @@ def start(self):
     gateway_transaction_cancel_interval = amm_arb_config_map.get("gateway_transaction_cancel_interval").value
     rate_oracle_enabled = amm_arb_config_map.get("rate_oracle_enabled").value
     quote_conversion_rate = amm_arb_config_map.get("quote_conversion_rate").value
+    gas_token = amm_arb_config_map.get("gas_token").value
+    gas_price = amm_arb_config_map.get("gas_price").value
 
     self._initialize_markets([(connector_1, [market_1]), (connector_2, [market_2])])
     base_1, quote_1 = market_1.split("-")
@@ -77,6 +79,12 @@ def start(self):
         rate_source = FixedRateSource()
         rate_source.add_rate(f"{quote_2}-{quote_1}", Decimal(str(quote_conversion_rate)))   # reverse rate is already handled in FixedRateSource find_rate method.
         rate_source.add_rate(f"{quote_1}-{quote_2}", Decimal(str(1 / quote_conversion_rate)))   # reverse rate is already handled in FixedRateSource find_rate method.
+
+    if gas_price:
+        rate_source.add_rate(f"{gas_token}-{quote_1}", Decimal(str(gas_price)))
+        rate_source.add_rate(f"{gas_token}-{quote_2}", Decimal(str(gas_price)))
+        rate_source.add_rate(f"{quote_1}-{gas_token}", Decimal(str(1 / gas_price)))
+        rate_source.add_rate(f"{quote_2}-{gas_token}", Decimal(str(1 / gas_price)))
 
     self.strategy = AmmArbStrategy()
     self.strategy.init_params(market_info_1=market_info_1,

--- a/hummingbot/templates/conf_amm_arb_strategy_TEMPLATE.yml
+++ b/hummingbot/templates/conf_amm_arb_strategy_TEMPLATE.yml
@@ -41,9 +41,31 @@ debug_price_shim: false
 gateway_transaction_cancel_interval: 600
 
 # What rate source should be used for quote assets pair - between fixed_rate_source and rate_oracle_source?
+# When true: Uses an oracle (like CoinGecko) to get real-time conversion rates between quote assets
+# When false: Uses the fixed conversion rate specified in quote_conversion_rate
 rate_oracle_enabled: true
 
 # What is the fixed_rate used to convert quote assets?
+# Only used when rate_oracle_enabled is false
+# Example: If trading between USDT-XXX and USDC-XXX pairs, and quote_conversion_rate is 1,
+# then 1 USDT = 1 USDC for profit calculations
+# Set this value based on the expected conversion rate between your quote assets
 quote_conversion_rate: 1
 
+# Specify a pool to swap with on the AMM connector
+# This ID is appended to the trading pair name for AMM connectors to identify specific liquidity pools
+# For example, if trading WETH-USDC with pool_id "3", the full market would be "WETH-USDC_3"
+# Leave as null to use the default pool
 pool_id: null
+
+# What is the symbol of the token used to pay gas?
+# Specifies which token is used for transaction fees on the blockchain
+# Default is ETH for Ethereum-based networks, but could be different for other chains
+# This is used to calculate profitability by factoring in gas costs
+gas_token: ETH
+
+# What is the gas price, expressed in the quote asset?
+# Sets the conversion rate between the gas token and the quote asset
+# For example, if gas_price is 3500 and quote asset is USDC, then 1 ETH = 3500 USDC
+# This rate is used to convert gas fees to quote asset for profit calculations
+gas_price: 3500


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [X] Your code builds clean without any errors or warnings
- [X] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

- Adds `gas_token` and `gas_price`params to the `amm_arb` strategy
- This allows client to calculate transaction costs when user doesn't use the rate oracle


**Tests performed by the developer**:

- tested with the following configs:

```
connector_1: uniswap_ethereum_base
market_1: BAI-USDC
connector_2: mexc
market_2: BAI-USDT
order_amount: 3.0
rate_oracle_enabled: false

# What is the fixed_rate used to convert quote assets?
quote_conversion_rate: 1.0

# Specify a pool to swap with on the AMM connector
pool_id: ''

# What is the symbol of the token used to pay gas?
gas_token: ETH

# What is the gas price, expressed in the quote asset?
gas_price: 3500.0
```

- verified that error is thrown when `gas_token` is changed to `BNB`
