### PR TITLE
Fix MEXC market buy orders

### DIFF
--- a/hummingbot/connector/exchange/mexc/mexc_exchange.py
+++ b/hummingbot/connector/exchange/mexc/mexc_exchange.py
@@ -196,8 +196,9 @@ class MexcExchange(ExchangePyBase):
                         amount
                     ).result_price
                 del api_params['quantity']
+                quote_order_quantity = self.quantize_order_amount(trading_pair, price * amount)
                 api_params.update({
-                    "quoteOrderQty": f"{price * amount:f}",
+                    "quoteOrderQty": f"{quote_order_quantity}",
                 })
         if order_type == OrderType.LIMIT:
             api_params["timeInForce"] = CONSTANTS.TIME_IN_FORCE_GTC

--- a/test/hummingbot/connector/exchange/mexc/test_mexc_exchange.py
+++ b/test/hummingbot/connector/exchange/mexc/test_mexc_exchange.py
@@ -1112,7 +1112,7 @@ class MexcExchangeTests(AbstractExchangeConnectorTests.ExchangeConnectorTests):
         order_request = self._all_executed_requests(mock_api, url)[0]
         request_data = order_request.kwargs["data"]
         self.assertIn(order_id, self.exchange.in_flight_orders)
-        self.assertEqual("5.1000000", request_data["quoteOrderQty"])
+        self.assertEqual("5.100000", request_data["quoteOrderQty"])
         self.assertEqual("MARKET", request_data["type"])
         self.assertEqual("BUY", request_data["side"])
 


### PR DESCRIPTION
This is to resolve 'amount scale is invalid' errors when performing market buy orders.

**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
quantize the quote order amount for market buy orders


**Tests performed by the developer**:
I'm running a arbitrage bot with this change, before I had a log full of 
`Error executing request POST https://api.mexc.com/api/v3/order. HTTP status is 400. Error: {"msg":" amount scale is invalid","code":400}`

After this change it has been error free for 72 hours.


**Tips for QA testing**:


