### PR TITLE
fix/bybit-update-trade-fees

### DIFF
--- a/hummingbot/connector/exchange/bybit/bybit_exchange.py
+++ b/hummingbot/connector/exchange/bybit/bybit_exchange.py
@@ -306,8 +306,12 @@ class BybitExchange(ExchangePyBase):
         # await self._update_exchange_fee_rates()
         fee_rates = await self._get_exchange_fee_rates()
         for tpfee in fee_rates:
-            trading_pair = await self.trading_pair_associated_to_exchange_symbol(symbol=tpfee["symbol"])
-            self._trading_fees[trading_pair] = tpfee
+            try:
+                trading_pair = await self.trading_pair_associated_to_exchange_symbol(symbol=tpfee["symbol"])
+                self._trading_fees[trading_pair] = tpfee
+            except KeyError:
+                # Skip pairs that are not trade enabled ie. they are not present in the trading pair map
+                continue
 
     def _process_trade_event_message(self, trade_msg: Dict[str, Any]):
         """


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Quick fix for the ByBit connector trade fees error:

hummingbot.connector.exchange.bybit.bybit_exchange.BybitExchange - NETWORK - Unexpected error while fetching trading fees. 

Essentially the issue is that the resulting trading pair map only contains the trade-able pairs (which is correct) but the trading fees payload contains all pairs, not just the trade-able pairs. So when the method tries to map the rate pair from the trading pairs, there is no matching pair to map from.

eg CTANUSDT is not trade-able, so it is not in the mapped trading pairs, but it is present in the trade fee payload.

We continue on key error during trading fee to trading pair map

**Tests performed by the developer**:
All


**Tips for QA testing**:
Connect to bybit, start a PMM strategy, no funds required, the strategy should at least start without getting blocked by the previous fee rate pair error.

