### PR TITLE
(feat) update bitmart_perpetual ticker parsing

### DIFF
--- a/hummingbot/connector/derivative/bitmart_perpetual/bitmart_perpetual_api_order_book_data_source.py
+++ b/hummingbot/connector/derivative/bitmart_perpetual/bitmart_perpetual_api_order_book_data_source.py
@@ -237,8 +237,8 @@ class BitmartPerpetualAPIOrderBookDataSource(PerpetualAPIOrderBookDataSource):
         if trading_pair not in self._trading_pairs:
             return
 
-        self._last_mark_prices[trading_pair] = Decimal(data["last_price"])
-        self._last_index_prices[trading_pair] = Decimal(data["fair_price"])
+        self._last_mark_prices[trading_pair] = Decimal(data["mark_price"])
+        self._last_index_prices[trading_pair] = Decimal(data["index_price"])
 
     async def _request_complete_funding_info(self, trading_pair: str):
         ex_trading_pair = await self._connector.exchange_symbol_associated_to_pair(trading_pair=trading_pair)

--- a/test/hummingbot/connector/derivative/bitmart_perpetual/test_bitmart_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/bitmart_perpetual/test_bitmart_perpetual_api_order_book_data_source.py
@@ -278,7 +278,7 @@ class BitmartPerpetualAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTest
                 "volume_24": "117387.58",
                 "mark_price": "146.24",
                 "last_price": "146.24",
-                "index_price": "146.24",
+                "index_price": "146.28",
                 "range": "147.17",
                 "ask_price": "147.11",
                 "ask_vol": "1",
@@ -472,3 +472,11 @@ class BitmartPerpetualAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTest
         await self.data_source._parse_exchange_info_message(mock_msg)
         self.assertIsNone(self.data_source._last_mark_prices.get("NEWSYMBOL"))
         self.assertIsNone(self.data_source._last_index_prices.get("NEWSYMBOL"))
+
+    async def test_parse_exchange_info_message_success(self):
+        mock_msg = self._ticker_event()
+        await self.data_source._parse_exchange_info_message(mock_msg)
+        self.assertIn(self.trading_pair, self.data_source._last_mark_prices.keys())
+        self.assertEqual(Decimal("146.24"), self.data_source._last_mark_prices[self.trading_pair])
+        self.assertIn(self.trading_pair, self.data_source._last_index_prices.keys())
+        self.assertEqual(Decimal("146.28"), self.data_source._last_index_prices[self.trading_pair])

--- a/test/hummingbot/connector/derivative/bitmart_perpetual/test_bitmart_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/bitmart_perpetual/test_bitmart_perpetual_api_order_book_data_source.py
@@ -276,8 +276,9 @@ class BitmartPerpetualAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTest
             "data": {
                 "symbol": self.ex_trading_pair,
                 "volume_24": "117387.58",
-                "fair_price": "146.24",
+                "mark_price": "146.24",
                 "last_price": "146.24",
+                "index_price": "146.24",
                 "range": "147.17",
                 "ask_price": "147.11",
                 "ask_vol": "1",


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Update parsing logic for websocket messages according to recent api update:

[2025-02-11](https://developer-pro.bitmart.com/en/futuresv2/#change-log)
Websocket Stream
[Update] [Public] Ticker Channel
Support subscription by trading pair
Rename fair_price->mark_price
Add index_price


**Tests performed by the developer**:



**Tips for QA testing**:


