### PR TITLE
(fix) fix kucoin_perpetual trade stream

### DIFF
--- a/hummingbot/connector/derivative/kucoin_perpetual/kucoin_perpetual_api_order_book_data_source.py
+++ b/hummingbot/connector/derivative/kucoin_perpetual/kucoin_perpetual_api_order_book_data_source.py
@@ -62,7 +62,7 @@ class KucoinPerpetualAPIOrderBookDataSource(PerpetualAPIOrderBookDataSource):
             trades_payload = {
                 "id": web_utils.next_message_id(),
                 "type": "subscribe",
-                "topic": f"/contractMarket/ticker:{symbols}",
+                "topic": f"{CONSTANTS.WS_TRADES_TOPIC}:{symbols}",
                 "privateChannel": False,
                 "response": False,
             }
@@ -71,7 +71,7 @@ class KucoinPerpetualAPIOrderBookDataSource(PerpetualAPIOrderBookDataSource):
             order_book_payload = {
                 "id": web_utils.next_message_id(),
                 "type": "subscribe",
-                "topic": f"/contractMarket/level2:{symbols}",
+                "topic": f"{CONSTANTS.WS_ORDER_BOOK_EVENTS_TOPIC}:{symbols}",
                 "privateChannel": False,
                 "response": False,
             }
@@ -155,7 +155,7 @@ class KucoinPerpetualAPIOrderBookDataSource(PerpetualAPIOrderBookDataSource):
 
     async def _parse_trade_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
         trade_data: Dict[str, Any] = raw_message["data"]
-        timestamp: float = int(trade_data["time"]) * 1e-9
+        timestamp: float = int(trade_data["ts"]) * 1e-9
         trading_pair = await self._connector.trading_pair_associated_to_exchange_symbol(symbol=trade_data["symbol"])
         message_content = {
             "trade_id": str(trade_data["tradeId"]),

--- a/hummingbot/connector/derivative/kucoin_perpetual/kucoin_perpetual_constants.py
+++ b/hummingbot/connector/derivative/kucoin_perpetual/kucoin_perpetual_constants.py
@@ -67,7 +67,7 @@ PRIVATE_WS_DATA_PATH_URL = f"{REST_API_VERSION}/bullet-private"
 
 WS_PING_REQUEST = "ping"
 WS_ORDER_BOOK_EVENTS_TOPIC = "/contractMarket/level2"
-WS_TRADES_TOPIC = "/contractMarket/tradeOrders"
+WS_TRADES_TOPIC = "/contractMarket/execution"
 WS_INSTRUMENTS_INFO_TOPIC = "/contract/instrument"
 WS_TICKER_INFO_TOPIC = "/contractMarket/ticker"
 WS_WALLET_INFO_TOPIC = "/contractAccount/wallet"

--- a/test/hummingbot/connector/derivative/kucoin_perpetual/test_kucoin_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/kucoin_perpetual/test_kucoin_perpetual_api_order_book_data_source.py
@@ -209,7 +209,7 @@ class KucoinPerpetualAPIOrderBookDataSourceTests(IsolatedAsyncioWrapperTestCase)
         expected_trade_subscription = {
             "id": 1,
             "type": "subscribe",
-            "topic": f"/contractMarket/ticker:{self.trading_pair}",
+            "topic": f"{CONSTANTS.WS_TRADES_TOPIC}:{self.trading_pair}",
             "privateChannel": False,
             "response": False
         }
@@ -217,7 +217,7 @@ class KucoinPerpetualAPIOrderBookDataSourceTests(IsolatedAsyncioWrapperTestCase)
         expected_diff_subscription = {
             "id": 2,
             "type": "subscribe",
-            "topic": f"/contractMarket/level2:{self.trading_pair}",
+            "topic": f"{CONSTANTS.WS_ORDER_BOOK_EVENTS_TOPIC}:{self.trading_pair}",
             "privateChannel": False,
             "response": False
         }
@@ -367,7 +367,7 @@ class KucoinPerpetualAPIOrderBookDataSourceTests(IsolatedAsyncioWrapperTestCase)
     async def test_listen_for_order_book_diffs_logs_exception(self):
         incomplete_resp = {
             "type": "message",
-            "topic": f"/contractMarket/level2:{self.trading_pair}",
+            "topic": f"{CONSTANTS.WS_ORDER_BOOK_EVENTS_TOPIC}:{self.trading_pair}",
         }
 
         mock_queue = AsyncMock()
@@ -389,7 +389,7 @@ class KucoinPerpetualAPIOrderBookDataSourceTests(IsolatedAsyncioWrapperTestCase)
         mock_queue = AsyncMock()
         diff_event = {
             "subject": "level2",
-            "topic": f"/contractMarket/level2:{self.trading_pair}",
+            "topic": f"{CONSTANTS.WS_ORDER_BOOK_EVENTS_TOPIC}:{self.trading_pair}",
             "type": "message",
             "data": {
                 "sequence": 18,


### PR DESCRIPTION
**A description of the changes proposed in the pull request**:
Discussion started [here](https://discord.com/channels/530578568154054663/557343500908363786/1343588621760073818)

I realized that I don't receive any trade updates with `kucoin_perpetual`.

Then I found the error and fixed it, now it's working fine.

**Tips for QA testing**:
You can use `download_order_book_and_trades.py` script available in the basic repository to subscribe to the trade updates.
I compared trades received for 2 coins during several seconds with a web-site, 100% match.
