### PR TITLE
Fix/Error getting last traded prices coinbase rate source

### DIFF
--- a/hummingbot/client/config/client_config_map.py
+++ b/hummingbot/client/config/client_config_map.py
@@ -638,7 +638,7 @@ class CoinbaseAdvancedTradeRateSourceMode(ExchangeRateSourceModeBase):
         default=False,
         description="Use authentication for public endpoints",
         json_schema_extra = {
-            "prompt": lambda cm: "Would you like to use authentication for public endpoints? (Yes/No) (currently No is broken)",
+            "prompt": lambda cm: "Would you like to use authentication for public endpoints? (Yes/No) (only affects rate limiting)",
             "prompt_on_new": True,
             "is_connect_key": True,
         },

--- a/hummingbot/client/config/client_config_map.py
+++ b/hummingbot/client/config/client_config_map.py
@@ -639,7 +639,8 @@ class CoinbaseAdvancedTradeRateSourceMode(ExchangeRateSourceModeBase):
         description="Use authentication for public endpoints",
         json_schema_extra = {
             "prompt": lambda cm: "Would you like to use authentication for public endpoints? (Yes/No) (currently No is broken)",
-            "prompt_on_new": True
+            "prompt_on_new": True,
+            "is_connect_key": True,
         },
     )
 

--- a/hummingbot/client/config/client_config_map.py
+++ b/hummingbot/client/config/client_config_map.py
@@ -634,6 +634,17 @@ class DexalotRateSourceMode(ExchangeRateSourceModeBase):
 class CoinbaseAdvancedTradeRateSourceMode(ExchangeRateSourceModeBase):
     name: str = Field(default="coinbase_advanced_trade")
     model_config = ConfigDict(title="coinbase_advanced_trade")
+    use_auth_for_public_endpoints: bool = Field(
+        default=False,
+        description="Use authentication for public endpoints",
+        json_schema_extra = {
+            "prompt": lambda cm: "Would you like to use authentication for public endpoints? (Yes/No) (currently No is broken)",
+            "prompt_on_new": True
+        },
+    )
+
+    def build_rate_source(self) -> RateSourceBase:
+        return RATE_ORACLE_SOURCES[self.model_config["title"]](use_auth_for_public_endpoints=self.use_auth_for_public_endpoints)
 
 
 class HyperliquidRateSourceMode(ExchangeRateSourceModeBase):

--- a/hummingbot/connector/exchange/coinbase_advanced_trade/coinbase_advanced_trade_constants.py
+++ b/hummingbot/connector/exchange/coinbase_advanced_trade/coinbase_advanced_trade_constants.py
@@ -45,12 +45,16 @@ SIGNIN_ENDPOINTS = {
     CRYPTO_CURRENCIES_EP,
 }
 
+# Public API endpoints
+SERVER_TIME_EP = "/brokerage/time"
+ALL_PAIRS_EP = "/brokerage/market/products"  # https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_getpublicproducts
+PAIR_TICKER_24HR_EP = "/brokerage/market/products/{product_id}/ticker"
+PAIR_TICKER_24HR_RATE_LIMIT_ID = "ProductTicker24Hr"
+
 # Private API endpoints
-ALL_PAIRS_EP = "/brokerage/products"
-PAIR_TICKER_EP = "/brokerage/products/{product_id}"
-PAIR_TICKER_RATE_LIMIT_ID = "PairTicker"
-PAIR_TICKER_24HR_EP = "/brokerage/products/{product_id}/ticker"
-PAIR_TICKER_24HR_RATE_LIMIT_ID = "PairTicker24Hr"
+PRIVATE_PRODUCTS_EP = "/brokerage/products"  # https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_getproducts
+PRIVATE_PAIR_TICKER_24HR_EP = "/brokerage/products/{product_id}/ticker"
+PRIVATE_PAIR_TICKER_24HR_RATE_LIMIT_ID = "PrivatePairTicker24Hr"
 ORDER_EP = "/brokerage/orders"
 BATCH_CANCEL_EP = "/brokerage/orders/batch_cancel"
 GET_ORDER_STATUS_EP = "/brokerage/orders/historical/{order_id}"
@@ -69,9 +73,8 @@ CANDLES_EP_ID = "candles"
 SERVER_TIME_EP = "/brokerage/time"
 
 PRIVATE_REST_ENDPOINTS = {
-    ALL_PAIRS_EP,
-    PAIR_TICKER_RATE_LIMIT_ID,
-    PAIR_TICKER_24HR_RATE_LIMIT_ID,
+    PRIVATE_PRODUCTS_EP,
+    PRIVATE_PAIR_TICKER_24HR_RATE_LIMIT_ID,
     ORDER_EP,
     BATCH_CANCEL_EP,
     GET_ORDER_STATUS_RATE_LIMIT_ID,
@@ -86,6 +89,8 @@ PRIVATE_REST_ENDPOINTS = {
 PUBLIC_REST_ENDPOINTS = {
     CANDLES_EP_ID,
     SERVER_TIME_EP,
+    ALL_PAIRS_EP,
+    PAIR_TICKER_24HR_RATE_LIMIT_ID,
 }
 
 WS_HEARTBEAT_TIME_INTERVAL = 30
@@ -195,3 +200,17 @@ RATE_LIMITS = [
 RATE_LIMITS.extend(PRIVATE_REST_RATE_LIMITS)
 RATE_LIMITS.extend(PUBLIC_REST_RATE_LIMITS)
 RATE_LIMITS.extend(SIGNIN_RATE_LIMITS)
+
+
+def get_products_endpoint(use_auth_for_public_endpoints: bool) -> str:
+    if use_auth_for_public_endpoints:
+        return PRIVATE_PRODUCTS_EP
+    else:
+        return ALL_PAIRS_EP
+
+
+def get_ticker_endpoint(use_auth_for_public_endpoints: bool) -> Tuple[str, str]:
+    if use_auth_for_public_endpoints:
+        return (PRIVATE_PAIR_TICKER_24HR_EP, PRIVATE_PAIR_TICKER_24HR_RATE_LIMIT_ID)
+    else:
+        return (PAIR_TICKER_24HR_EP, PAIR_TICKER_24HR_RATE_LIMIT_ID)

--- a/hummingbot/connector/exchange/coinbase_advanced_trade/coinbase_advanced_trade_exchange.py
+++ b/hummingbot/connector/exchange/coinbase_advanced_trade/coinbase_advanced_trade_exchange.py
@@ -64,6 +64,7 @@ class CoinbaseAdvancedTradeExchange(ExchangePyBase):
                  client_config_map: "ClientConfigAdapter",
                  coinbase_advanced_trade_api_key: str,
                  coinbase_advanced_trade_api_secret: str,
+                 use_auth_for_public_endpoints: bool = True,
                  trading_pairs: List[str] | None = None,
                  trading_required: bool = True,
                  domain: str = constants.DEFAULT_DOMAIN,

--- a/hummingbot/connector/exchange/coinbase_advanced_trade/coinbase_advanced_trade_exchange.py
+++ b/hummingbot/connector/exchange/coinbase_advanced_trade/coinbase_advanced_trade_exchange.py
@@ -64,13 +64,14 @@ class CoinbaseAdvancedTradeExchange(ExchangePyBase):
                  client_config_map: "ClientConfigAdapter",
                  coinbase_advanced_trade_api_key: str,
                  coinbase_advanced_trade_api_secret: str,
-                 use_auth_for_public_endpoints: bool = True,
+                 use_auth_for_public_endpoints: bool = False,
                  trading_pairs: List[str] | None = None,
                  trading_required: bool = True,
                  domain: str = constants.DEFAULT_DOMAIN,
                  ):
         self._api_key = coinbase_advanced_trade_api_key
         self.secret_key = coinbase_advanced_trade_api_secret
+        self._use_auth_for_public_endpoints = use_auth_for_public_endpoints
         self._domain = domain
         self._trading_required = trading_required
         self._trading_pairs = trading_pairs
@@ -651,7 +652,7 @@ class CoinbaseAdvancedTradeExchange(ExchangePyBase):
     # as well as duplicating expensive API calls (call for all products)
     async def _update_trading_rules(self):
         def decimal_or_none(x: Any) -> Decimal | None:
-            return Decimal(x) if x is not None else None
+            return Decimal(x) if x else None
 
         self.trading_rules.clear()
         trading_pair_symbol_map: bidict[str, str] = bidict()
@@ -710,7 +711,7 @@ class CoinbaseAdvancedTradeExchange(ExchangePyBase):
         try:
             params: Dict[str, Any] = {}
             products: Dict[str, Any] = await self._api_get(
-                path_url=constants.ALL_PAIRS_EP,
+                path_url=constants.get_products_endpoint(self._use_auth_for_public_endpoints),
                 params=params,
                 is_auth_required=True)
             self._market_assets = [p for p in products.get("products") if all((p.get("product_type", None) == "SPOT",
@@ -791,11 +792,11 @@ class CoinbaseAdvancedTradeExchange(ExchangePyBase):
         params: Dict[str, Any] = {
             "limit": 1,
         }
-
+        path_url, limit_id = constants.get_ticker_endpoint(self._use_auth_for_public_endpoints)
         trade: Dict[str, Any] = await self._api_get(
-            path_url=constants.PAIR_TICKER_24HR_EP.format(product_id=product_id),
+            path_url=path_url.format(product_id=product_id),
             params=params,
-            limit_id=constants.PAIR_TICKER_24HR_RATE_LIMIT_ID,
+            limit_id=limit_id,
             is_auth_required=True
         )
         return float(trade.get("trades")[0]["price"])
@@ -805,7 +806,7 @@ class CoinbaseAdvancedTradeExchange(ExchangePyBase):
         Fetches the prices of all symbols in the exchange with a default quote of USD
         """
         products: List[Dict[str, str]] = await self._api_get(
-            path_url=constants.ALL_PAIRS_EP,
+            path_url=constants.get_products_endpoint(self._use_auth_for_public_endpoints),
             is_auth_required=True)
         for p in products:
             if all((

--- a/hummingbot/connector/exchange/coinbase_advanced_trade/coinbase_advanced_trade_utils.py
+++ b/hummingbot/connector/exchange/coinbase_advanced_trade/coinbase_advanced_trade_utils.py
@@ -38,7 +38,7 @@ class CoinbaseAdvancedTradeConfigMap(BaseConnectorConfigMap):
     use_auth_for_public_endpoints: bool = Field(
         default=False,
         json_schema_extra={
-            "prompt": "Would you like to use authentication for public endpoints? (Yes/No) (currently No is broken)",
+            "prompt": "Would you like to use authentication for public endpoints? (Yes/No) (only affects rate limiting)",
             "prompt_on_new": True,
             "is_connect_key": True
         }

--- a/hummingbot/connector/exchange/coinbase_advanced_trade/coinbase_advanced_trade_utils.py
+++ b/hummingbot/connector/exchange/coinbase_advanced_trade/coinbase_advanced_trade_utils.py
@@ -36,7 +36,7 @@ class CoinbaseAdvancedTradeRESTRequest(EndpointRESTRequest):
 class CoinbaseAdvancedTradeConfigMap(BaseConnectorConfigMap):
     connector: str = "coinbase_advanced_trade"
     use_auth_for_public_endpoints: bool = Field(
-        default=True,
+        default=False,
         json_schema_extra={
             "prompt": "Would you like to use authentication for public endpoints? (Yes/No) (currently No is broken)",
             "prompt_on_new": True,

--- a/hummingbot/connector/exchange/coinbase_advanced_trade/coinbase_advanced_trade_utils.py
+++ b/hummingbot/connector/exchange/coinbase_advanced_trade/coinbase_advanced_trade_utils.py
@@ -35,6 +35,7 @@ class CoinbaseAdvancedTradeRESTRequest(EndpointRESTRequest):
 
 class CoinbaseAdvancedTradeConfigMap(BaseConnectorConfigMap):
     connector: str = "coinbase_advanced_trade"
+    rate_endpoints_require_auth: bool = Field(default=True, const=True, client_data=None)
     coinbase_advanced_trade_api_key: SecretStr = Field(
         default=...,
         json_schema_extra={

--- a/hummingbot/connector/exchange/coinbase_advanced_trade/coinbase_advanced_trade_utils.py
+++ b/hummingbot/connector/exchange/coinbase_advanced_trade/coinbase_advanced_trade_utils.py
@@ -35,7 +35,14 @@ class CoinbaseAdvancedTradeRESTRequest(EndpointRESTRequest):
 
 class CoinbaseAdvancedTradeConfigMap(BaseConnectorConfigMap):
     connector: str = "coinbase_advanced_trade"
-    rate_endpoints_require_auth: bool = Field(default=True, const=True, client_data=None)
+    use_auth_for_public_endpoints: bool = Field(
+        default=True,
+        json_schema_extra={
+            "prompt": "Would you like to use authentication for public endpoints? (Yes/No) (currently No is broken)",
+            "prompt_on_new": True,
+            "is_connect_key": True
+        }
+    )
     coinbase_advanced_trade_api_key: SecretStr = Field(
         default=...,
         json_schema_extra={

--- a/hummingbot/core/rate_oracle/sources/coinbase_advanced_trade_rate_source.py
+++ b/hummingbot/core/rate_oracle/sources/coinbase_advanced_trade_rate_source.py
@@ -15,9 +15,10 @@ if TYPE_CHECKING:
 
 
 class CoinbaseAdvancedTradeRateSource(RateSourceBase):
-    def __init__(self):
+    def __init__(self, use_auth_for_public_endpoints: bool = False):
         super().__init__()
         self._coinbase_exchange: CoinbaseAdvancedTradeExchange | None = None  # delayed because of circular reference
+        self._use_auth_for_public_endpoints = use_auth_for_public_endpoints
 
     @property
     def name(self) -> str:
@@ -75,10 +76,16 @@ class CoinbaseAdvancedTradeRateSource(RateSourceBase):
         app = HummingbotApplication.main_application()
         client_config_map = app.client_config_map
         connector_config = AllConnectorSettings.get_connector_config_keys("coinbase_advanced_trade")
+        api_key = ""
+        api_secret = ""
+        if self._use_auth_for_public_endpoints:
+            api_key = getattr(connector_config, "coinbase_advanced_trade_api_key", SecretStr("")).get_secret_value()
+            api_secret = getattr(connector_config, "coinbase_advanced_trade_api_secret", SecretStr("")).get_secret_value()
+
         return CoinbaseAdvancedTradeExchange(
             client_config_map=client_config_map,
-            coinbase_advanced_trade_api_key=getattr(connector_config, "coinbase_advanced_trade_api_key", SecretStr("")).get_secret_value(),
-            coinbase_advanced_trade_api_secret=getattr(connector_config, "coinbase_advanced_trade_api_secret", SecretStr("")).get_secret_value(),
+            coinbase_advanced_trade_api_key=api_key,
+            coinbase_advanced_trade_api_secret=api_secret,
             trading_pairs=[],
             trading_required=False,
             domain=domain,

--- a/hummingbot/data_feed/market_data_provider.py
+++ b/hummingbot/data_feed/market_data_provider.py
@@ -197,7 +197,7 @@ class MarketDataProvider:
     @staticmethod
     def get_connector_config_map(connector_name: str):
         connector_config = AllConnectorSettings.get_connector_config_keys(connector_name)
-        if getattr(connector_config, "rate_endpoints_require_auth", False):
+        if getattr(connector_config, "use_auth_for_public_endpoints", False):
             api_keys = api_keys_from_connector_config_map(ClientConfigAdapter(connector_config))
         else:
             api_keys = {key: "" for key in connector_config.__fields__.keys() if key != "connector"}

--- a/hummingbot/data_feed/market_data_provider.py
+++ b/hummingbot/data_feed/market_data_provider.py
@@ -7,7 +7,11 @@ from typing import Dict, List, Optional, Tuple
 import pandas as pd
 
 from hummingbot.client.config.client_config_map import ClientConfigMap
-from hummingbot.client.config.config_helpers import ClientConfigAdapter, get_connector_class
+from hummingbot.client.config.config_helpers import (
+    ClientConfigAdapter,
+    api_keys_from_connector_config_map,
+    get_connector_class,
+)
 from hummingbot.client.settings import AllConnectorSettings
 from hummingbot.connector.connector_base import ConnectorBase
 from hummingbot.core.data_type.common import GroupedSetDict, LazyDict, PriceType, TradeType
@@ -180,17 +184,24 @@ class MarketDataProvider:
             raise ValueError(f"Connector {connector_name} not found")
 
         client_config_map = ClientConfigAdapter(ClientConfigMap())
-        connector_config = AllConnectorSettings.get_connector_config_keys(connector_name)
-        api_keys = {key: "" for key in connector_config.__fields__.keys() if key != "connector"}
         init_params = conn_setting.conn_init_parameters(
             trading_pairs=[],
             trading_required=False,
-            api_keys=api_keys,
+            api_keys=self.get_connector_config_map(connector_name),
             client_config_map=client_config_map,
         )
         connector_class = get_connector_class(connector_name)
         connector = connector_class(**init_params)
         return connector
+
+    @staticmethod
+    def get_connector_config_map(connector_name: str):
+        connector_config = AllConnectorSettings.get_connector_config_keys(connector_name)
+        if getattr(connector_config, "rate_endpoints_require_auth", False):
+            api_keys = api_keys_from_connector_config_map(ClientConfigAdapter(connector_config))
+        else:
+            api_keys = {key: "" for key in connector_config.__fields__.keys() if key != "connector"}
+        return api_keys
 
     def get_balance(self, connector_name: str, asset: str):
         connector = self.get_connector(connector_name)

--- a/hummingbot/strategy_v2/backtesting/backtesting_data_provider.py
+++ b/hummingbot/strategy_v2/backtesting/backtesting_data_provider.py
@@ -52,17 +52,12 @@ class BacktestingDataProvider(MarketDataProvider):
         init_params = conn_setting.conn_init_parameters(
             trading_pairs=[],
             trading_required=False,
-            api_keys=self.get_connector_config_map(connector_name),
+            api_keys=MarketDataProvider.get_connector_config_map(connector_name),
             client_config_map=client_config_map,
         )
         connector_class = get_connector_class(connector_name)
         connector = connector_class(**init_params)
         return connector
-
-    @staticmethod
-    def get_connector_config_map(connector_name: str):
-        connector_config = AllConnectorSettings.get_connector_config_keys(connector_name)
-        return {key: "" for key in connector_config.__fields__.keys() if key != "connector"}
 
     def get_trading_rules(self, connector_name: str, trading_pair: str):
         """

--- a/test/hummingbot/connector/test_utils.py
+++ b/test/hummingbot/connector/test_utils.py
@@ -102,8 +102,8 @@ class UtilsTest(unittest.TestCase):
                     print(el)
                     if el.attr == "connector":
                         self.assertEqual(el.value, connector_dir.name)
-                    elif el.attr == "rate_endpoints_require_auth":
-                        self.assertEqual(el.value, True)
+                    elif el.attr == "use_auth_for_public_endpoints":
+                        self.assertEqual(el.type_, bool)
                     elif el.client_field_data.is_secure:
                         self.assertEqual(el.type_, SecretStr)
 

--- a/test/hummingbot/connector/test_utils.py
+++ b/test/hummingbot/connector/test_utils.py
@@ -102,6 +102,8 @@ class UtilsTest(unittest.TestCase):
                     print(el)
                     if el.attr == "connector":
                         self.assertEqual(el.value, connector_dir.name)
+                    elif el.attr == "rate_endpoints_require_auth":
+                        self.assertEqual(el.value, True)
                     elif el.client_field_data.is_secure:
                         self.assertEqual(el.type_, SecretStr)
 


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
- Fixes usage of coinbase_advanced_trade as a rate or market data source. (https://github.com/hummingbot/hummingbot/issues/7498)
- Fixes Kraken APITier issue https://github.com/hummingbot/hummingbot/issues/7397 (
    - this change was actually already part of another PR but adding here as the changes in the other PR are quite significant https://github.com/hummingbot/hummingbot/pull/7465/files#diff-bcc410aebefc9d817e45c822e06189834a611ce0bfe421e24e2c96fbc01318ac

**Tests performed by the developer**:
1. Was able to start a kraken <- > coinbase arbitrage strategy 
2. `make test`

**Tips for QA testing**:
1. Set coinbase_advanced_trade as rate_oracle
2. Start a strategy which calls market_data_provider.initialize_rate_sources when 1 or more coinbase pairs are configured for the strategy.

