### PR TITLE
fix issue causing the rate oracle to forcibly default to BinanceRateS…

### DIFF
--- a/hummingbot/data_feed/market_data_provider.py
+++ b/hummingbot/data_feed/market_data_provider.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import time
 from decimal import Decimal
+from functools import cached_property
 from typing import Dict, List, Optional, Tuple
 
 import pandas as pd
@@ -9,6 +10,7 @@ import pandas as pd
 from hummingbot.client.config.client_config_map import ClientConfigMap
 from hummingbot.client.config.config_helpers import (
     ClientConfigAdapter,
+    MostRecentConfigLoadCache,
     api_keys_from_connector_config_map,
     get_connector_class,
 )
@@ -45,6 +47,14 @@ class MarketDataProvider:
         self._rate_sources = LazyDict[str, ConnectorBase](self.get_non_trading_connector)
         self._rates_required = GroupedSetDict[str, ConnectorPair]()
         self.conn_settings = AllConnectorSettings.get_connector_settings()
+
+    @cached_property
+    def client_config_map(self) -> ClientConfigAdapter:
+        config_map = MostRecentConfigLoadCache.get_client_config_map()
+        if config_map is None:
+            self.logger().warning("No client config map found in cache, creating default config map")
+            config_map = ClientConfigAdapter(ClientConfigMap())
+        return config_map
 
     def stop(self):
         for candle_feed in self.candles_feeds.values():
@@ -182,13 +192,11 @@ class MarketDataProvider:
         if conn_setting is None:
             self.logger().error(f"Connector {connector_name} not found")
             raise ValueError(f"Connector {connector_name} not found")
-
-        client_config_map = ClientConfigAdapter(ClientConfigMap())
         init_params = conn_setting.conn_init_parameters(
             trading_pairs=[],
             trading_required=False,
             api_keys=self.get_connector_config_map(connector_name),
-            client_config_map=client_config_map,
+            client_config_map=self.client_config_map,
         )
         connector_class = get_connector_class(connector_name)
         connector = connector_class(**init_params)

--- a/hummingbot/strategy_v2/backtesting/backtesting_data_provider.py
+++ b/hummingbot/strategy_v2/backtesting/backtesting_data_provider.py
@@ -4,8 +4,7 @@ from typing import Dict, Optional
 
 import pandas as pd
 
-from hummingbot.client.config.client_config_map import ClientConfigMap
-from hummingbot.client.config.config_helpers import ClientConfigAdapter, get_connector_class
+from hummingbot.client.config.config_helpers import get_connector_class
 from hummingbot.client.settings import AllConnectorSettings, ConnectorType
 from hummingbot.connector.connector_base import ConnectorBase
 from hummingbot.core.data_type.common import LazyDict, PriceType
@@ -48,12 +47,11 @@ class BacktestingDataProvider(MarketDataProvider):
             logger.error(f"Connector {connector_name} not found")
             raise ValueError(f"Connector {connector_name} not found")
 
-        client_config_map = ClientConfigAdapter(ClientConfigMap())
         init_params = conn_setting.conn_init_parameters(
             trading_pairs=[],
             trading_required=False,
             api_keys=MarketDataProvider.get_connector_config_map(connector_name),
-            client_config_map=client_config_map,
+            client_config_map=self.client_config_map,
         )
         connector_class = get_connector_class(connector_name)
         connector = connector_class(**init_params)

--- a/test/hummingbot/client/config/test_config_helpers.py
+++ b/test/hummingbot/client/config/test_config_helpers.py
@@ -14,6 +14,7 @@ from hummingbot.client.config.config_crypt import ETHKeyFileSecretManger
 from hummingbot.client.config.config_data_types import BaseClientModel, BaseConnectorConfigMap
 from hummingbot.client.config.config_helpers import (
     ClientConfigAdapter,
+    MostRecentConfigLoadCache,
     ReadOnlyClientConfigAdapter,
     get_connector_config_yml_path,
     get_strategy_config_map,
@@ -185,3 +186,26 @@ class ReadOnlyClientAdapterTest(unittest.TestCase):
 
         self.assertEqual("Cannot set an attribute on a read-only client adapter", str(context.exception))
         self.assertEqual(initial_instance_id, read_only_adapter.instance_id)
+
+
+class MostRecentConfigLoadCacheTest(unittest.TestCase):
+    def setUp(self) -> None:
+        # Reset the singleton instance before each test
+        MostRecentConfigLoadCache._instance = None
+
+    def test_singleton_behavior(self):
+        # Test that _get_instance returns the same instance
+        instance1 = MostRecentConfigLoadCache._get_instance()
+        instance2 = MostRecentConfigLoadCache._get_instance()
+        self.assertIs(instance1, instance2)
+
+    def test_initial_state(self):
+        # Test that the initial client_config_map is None
+        self.assertIsNone(MostRecentConfigLoadCache.get_client_config_map())
+
+    def test_set_and_get_client_config_map(self):
+        # Test setting and getting the client_config_map
+        config_map = ClientConfigAdapter(ClientConfigMap())
+        MostRecentConfigLoadCache.set_client_config_map(config_map)
+        retrieved_config_map = MostRecentConfigLoadCache.get_client_config_map()
+        self.assertIs(config_map, retrieved_config_map)

--- a/test/hummingbot/data_feed/test_market_data_provider.py
+++ b/test/hummingbot/data_feed/test_market_data_provider.py
@@ -21,6 +21,31 @@ class TestMarketDataProvider(IsolatedAsyncioWrapperTestCase):
         self.connectors = {"mock_connector": self.mock_connector}
         self.provider = MarketDataProvider(self.connectors)
 
+    @patch('hummingbot.client.config.config_helpers.MostRecentConfigLoadCache.get_client_config_map')
+    def test_client_config_map_from_cache(self, mock_get_client_config_map):
+        # Test when config map is found in cache
+        mock_config_map = MagicMock()
+        mock_get_client_config_map.return_value = mock_config_map
+
+        result = self.provider.client_config_map
+
+        mock_get_client_config_map.assert_called_once()
+        self.assertEqual(result, mock_config_map)
+
+    @patch('hummingbot.client.config.config_helpers.MostRecentConfigLoadCache.get_client_config_map')
+    @patch('hummingbot.data_feed.market_data_provider.ClientConfigAdapter')
+    def test_client_config_map_default(self, mock_client_config_adapter, mock_get_client_config_map):
+        # Test when config map is not found in cache
+        mock_get_client_config_map.return_value = None
+        mock_adapter = MagicMock()
+        mock_client_config_adapter.return_value = mock_adapter
+
+        result = self.provider.client_config_map
+
+        mock_get_client_config_map.assert_called_once()
+        mock_client_config_adapter.assert_called_once()
+        self.assertEqual(result, mock_adapter)
+
     def test_initialize_candles_feed(self):
         with patch('hummingbot.data_feed.candles_feed.candles_factory.CandlesFactory.get_candle', return_value=MagicMock()):
             config = CandlesConfig(connector="mock_connector", trading_pair="BTC-USDT", interval="1m", max_records=100)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

This PR fixes an issue where the rate oracle was forcibly defaulting to BinanceRateSource via rate_oracle_source_on_validated regardless of user configuration. The fix ensures that user-specified rate sources are properly respected, allowing for alternative rate sources to be used as configured. This is a significant problem for us residents as binance does not work as a rate source for them. 

**Tests performed by the developer**:

- Verified that coin_gecko can be properly configured to be rate_source and persists when using arbitrage_controller

**Tips for QA testing**:

- Configure different rate sources in the config and verify they're used correctly
- Check the logs to confirm the correct rate source is being initialized
- Test with rate_oracle_source set to different values to ensure the setting is respected