### PR TITLE
extend okx support for us users on app.okx. Also 1 performance tweak.

### DIFF
--- a/hummingbot/connector/exchange/okx/okx_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/okx/okx_api_order_book_data_source.py
@@ -65,7 +65,10 @@ class OkxAPIOrderBookDataSource(OrderBookTrackerDataSource):
 
         rest_assistant = await self._api_factory.get_rest_assistant()
         data = await rest_assistant.execute_request(
-            url=web_utils.public_rest_url(path_url=CONSTANTS.OKX_ORDER_BOOK_PATH),
+            url=web_utils.public_rest_url(
+                path_url=CONSTANTS.OKX_ORDER_BOOK_PATH,
+                domain=self._connector.domain
+            ),
             params=params,
             method=RESTMethod.GET,
             throttler_limit_id=CONSTANTS.OKX_ORDER_BOOK_PATH,
@@ -197,6 +200,6 @@ class OkxAPIOrderBookDataSource(OrderBookTrackerDataSource):
         ws: WSAssistant = await self._api_factory.get_ws_assistant()
         async with self._api_factory.throttler.execute_task(limit_id=CONSTANTS.WS_CONNECTION_LIMIT_ID):
             await ws.connect(
-                ws_url=CONSTANTS.OKX_WS_URI_PUBLIC,
+                ws_url=CONSTANTS.get_okx_ws_uri_public(sub_domain=self._connector.okx_registration_sub_domain),
                 message_timeout=CONSTANTS.SECONDS_TO_WAIT_TO_RECEIVE_MESSAGE)
         return ws

--- a/hummingbot/connector/exchange/okx/okx_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/okx/okx_api_user_stream_data_source.py
@@ -35,7 +35,7 @@ class OkxAPIUserStreamDataSource(UserStreamTrackerDataSource):
         ws: WSAssistant = await self._get_ws_assistant()
         async with self._api_factory.throttler.execute_task(limit_id=CONSTANTS.WS_CONNECTION_LIMIT_ID):
             await ws.connect(
-                ws_url=CONSTANTS.OKX_WS_URI_PRIVATE,
+                ws_url=CONSTANTS.get_okx_ws_uri_private(self._connector.okx_registration_sub_domain),
                 message_timeout=CONSTANTS.SECONDS_TO_WAIT_TO_RECEIVE_MESSAGE)
 
         payload = {

--- a/hummingbot/connector/exchange/okx/okx_constants.py
+++ b/hummingbot/connector/exchange/okx/okx_constants.py
@@ -8,14 +8,41 @@ CLIENT_ID_PREFIX = "93027a12dac34fBC"
 MAX_ID_LEN = 32
 SECONDS_TO_WAIT_TO_RECEIVE_MESSAGE = 30 * 0.8
 
-DEFAULT_DOMAIN = ""
+# URL mapping based on where account is registered:
+# sourced from https://app.okx.com/docs-v5/en/#overview-account-mode and https://my.okx.com/docs-v5/en/#overview-account-mode
 
-# URLs
+subdomain_to_api_subdomain = {
+    "www": "www",
+    "app": "us",
+    "my": "eea"
+}
 
-OKX_BASE_URL = "https://www.okx.com/"
 
-# Doesn't include base URL as the tail is required to generate the signature
+def get_okx_base_url(sub_domain: str) -> str:
+    """Returns OKX REST base URL based on API subdomain ("www", "us", "eea")"""
+    return f"https://{subdomain_to_api_subdomain[sub_domain]}.okx.com/"
 
+
+def get_ws_url(sub_domain: str) -> str:
+    """Returns OKX WebSocket base URL based on API subdomain ("www", "us", "eea")"""
+    if sub_domain == "www":
+        return "wss://ws.okx.com:8443"
+    else:
+        return f"wss://ws{subdomain_to_api_subdomain[sub_domain]}.okx.com:8443"
+
+
+DEFAULT_DOMAIN = get_okx_base_url("www")
+
+
+def get_okx_ws_uri_public(sub_domain):
+    return f"{get_ws_url(sub_domain)}/ws/v5/public"
+
+
+def get_okx_ws_uri_private(sub_domain):
+    return f"{get_ws_url(sub_domain)}/ws/v5/private"
+
+
+# REST API endpoints
 OKX_SERVER_TIME_PATH = '/api/v5/public/time'
 OKX_INSTRUMENTS_PATH = '/api/v5/public/instruments'
 OKX_TICKER_PATH = '/api/v5/market/ticker'
@@ -30,10 +57,7 @@ OKX_BATCH_ORDER_CANCEL_PATH = '/api/v5/trade/cancel-batch-orders'
 OKX_BALANCE_PATH = '/api/v5/account/balance'
 OKX_TRADE_FILLS_PATH = "/api/v5/trade/fills"
 
-# WS
-OKX_WS_URI_PUBLIC = "wss://ws.okx.com:8443/ws/v5/public"
-OKX_WS_URI_PRIVATE = "wss://ws.okx.com:8443/ws/v5/private"
-
+# WebSocket channels
 OKX_WS_ACCOUNT_CHANNEL = "account"
 OKX_WS_ORDERS_CHANNEL = "orders"
 OKX_WS_PUBLIC_TRADES_CHANNEL = "trades"
@@ -44,6 +68,7 @@ OKX_WS_CHANNELS = {
     OKX_WS_ORDERS_CHANNEL
 }
 
+# Rate limiting
 WS_CONNECTION_LIMIT_ID = "WSConnection"
 WS_REQUEST_LIMIT_ID = "WSRequest"
 WS_SUBSCRIPTION_LIMIT_ID = "WSSubscription"

--- a/hummingbot/connector/exchange/okx/okx_exchange.py
+++ b/hummingbot/connector/exchange/okx/okx_exchange.py
@@ -35,11 +35,16 @@ class OkxExchange(ExchangePyBase):
                  okx_secret_key: str,
                  okx_passphrase: str,
                  trading_pairs: Optional[List[str]] = None,
-                 trading_required: bool = True):
-
+                 trading_required: bool = True,
+                 okx_registration_sub_domain: str = "www"):
+        """
+        :param okx_registration_sub_domain: The subdomain to use - options are "www" (default), "app" (US users), or "my" (EEA users)
+                              See: https://github.com/ccxt/ccxt/issues/24601
+        """
         self.okx_api_key = okx_api_key
         self.okx_secret_key = okx_secret_key
         self.okx_passphrase = okx_passphrase
+        self.okx_registration_sub_domain = okx_registration_sub_domain or "www"
         self._trading_required = trading_required
         self._trading_pairs = trading_pairs
         super().__init__(client_config_map)
@@ -62,7 +67,7 @@ class OkxExchange(ExchangePyBase):
 
     @property
     def domain(self):
-        return ""
+        return CONSTANTS.get_okx_base_url(self.okx_registration_sub_domain)
 
     @property
     def client_order_id_max_length(self):
@@ -116,13 +121,15 @@ class OkxExchange(ExchangePyBase):
         # The default implementation was added when the functionality to detect not found orders was introduced in the
         # ExchangePyBase class. Also fix the unit test test_cancel_order_not_found_in_the_exchange when replacing the
         # dummy implementation
+        # _place_cancel already takes care of all expected exceptions.
         return False
 
     def _create_web_assistants_factory(self) -> WebAssistantsFactory:
         return web_utils.build_api_factory(
             throttler=self._throttler,
             time_synchronizer=self._time_synchronizer,
-            auth=self._auth)
+            auth=self._auth,
+            domain=self.domain)
 
     def _create_order_book_data_source(self) -> OrderBookTrackerDataSource:
         return OkxAPIOrderBookDataSource(
@@ -240,6 +247,8 @@ class OkxExchange(ExchangePyBase):
     async def get_last_traded_prices(self, trading_pairs: List[str] = None) -> Dict[str, float]:
         params = {"instType": "SPOT"}
 
+        if trading_pairs and len(trading_pairs) == 1:
+            return {trading_pairs[0]: await self._get_last_traded_price(trading_pairs[0])}
         resp_json = await self._api_get(
             path_url=CONSTANTS.OKX_TICKERS_PATH,
             params=params,

--- a/hummingbot/connector/exchange/okx/okx_utils.py
+++ b/hummingbot/connector/exchange/okx/okx_utils.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from typing import Any, Dict
+from typing import Any, Dict, Literal
 
 from pydantic.v1 import Field, SecretStr
 
@@ -41,6 +41,14 @@ class OKXConfigMap(BaseConnectorConfigMap):
         client_data=ClientFieldData(
             prompt=lambda cm: "Enter your OKX passphrase key",
             is_secure=True,
+            is_connect_key=True,
+            prompt_on_new=True,
+        ),
+    )
+    okx_registration_sub_domain: Literal["www", "app", "my"] = Field(
+        default="www",
+        client_data=ClientFieldData(
+            prompt=lambda cm: "Which OKX subdomain did you register the key at? (www/app/my) - Generally www for most users, app for US users, my for EEA users.",
             is_connect_key=True,
             prompt_on_new=True,
         ),


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
This PR extends OKX connector support for US and EEA users by adding proper domain handling based on where the account was registered. The changes include:

1. Added support for different OKX domains:
   - www.okx.com (default, international users)
   - app.okx.com (US users)
   - my.okx.com (EEA users)

2. Added a new configuration parameter `okx_registration_sub_domain` to specify which domain to use
3. Updated REST and WebSocket URL handling to use the correct domain based on user's registration
4. Added performance optimization for single trading pair price fetching

**Tests performed by the developer**:
- Verified REST API connectivity for all domains (www, app, my)
- Tested WebSocket connections for public and private channels
- Confirmed order book data retrieval works for app.okx.com
- Validated trading functionality with US-registered account
- Validated still able to get last_traded_price

**Tips for QA testing**:
1. Test with different `okx_registration_sub_domain` values:
   - "www" for international users
   - "app" for US users
   - "my" for EEA users
2. Verify both REST API and WebSocket connections work
3. Test order book data retrieval and trading functionality