### PR TITLE
Fix/Add Ed25519  and SECP256K1 raw private key to XRPL connector

### DIFF
--- a/hummingbot/connector/exchange/xrpl/xrpl_auth.py
+++ b/hummingbot/connector/exchange/xrpl/xrpl_auth.py
@@ -1,4 +1,5 @@
-# XRPL Import
+import ecdsa
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from xrpl.constants import CryptoAlgorithm
 from xrpl.wallet import Wallet
 
@@ -12,15 +13,45 @@ class XRPLAuth(AuthBase):
             if len(xrpl_secret_key) == 0:
                 self._wallet = Wallet.create()
             else:
-                self._wallet = Wallet.from_seed(xrpl_secret_key, algorithm=self.get_algorithm(key=xrpl_secret_key))
+                # Check if it's a raw private key (hex format)
+                if xrpl_secret_key.startswith("ED"):
+                    # Raw private key for Ed25519
+                    private_key = xrpl_secret_key
+                    # Convert private key to bytes
+                    private_key_bytes = bytes.fromhex(private_key[2:])  # Remove ED prefix
+                    # Derive public key using Ed25519
+                    private_key_obj = Ed25519PrivateKey.from_private_bytes(private_key_bytes)
+                    public_key_bytes = private_key_obj.public_key().public_bytes_raw()
+                    public_key = "ED" + public_key_bytes.hex()
+                    # Create wallet with derived keys
+                    self._wallet = Wallet(public_key=public_key, private_key=private_key)
+                elif xrpl_secret_key.startswith("00"):
+                    # Raw private key for SECP256K1
+                    private_key = xrpl_secret_key
+                    # Convert private key to bytes
+                    private_key_bytes = bytes.fromhex(private_key[2:])  # Remove 00 prefix
+                    # Create private key object and derive public key using SECP256K1
+                    private_key_obj = ecdsa.SigningKey.from_string(private_key_bytes, curve=ecdsa.SECP256k1)
+                    verifying_key = private_key_obj.get_verifying_key()
+                    if verifying_key is None:
+                        raise ValueError("Failed to derive public key from SECP256K1 private key")
+                    public_key_bytes = verifying_key.to_string()
+                    public_key = "00" + public_key_bytes.hex().upper()
+                    # Create wallet with derived keys
+                    self._wallet = Wallet(public_key=public_key, private_key=private_key)
+                elif xrpl_secret_key.startswith("s"):
+                    # Seed format
+                    self._wallet = Wallet.from_seed(xrpl_secret_key, algorithm=self.get_algorithm(key=xrpl_secret_key))
+                else:
+                    raise ValueError("Invalid XRPL secret key format. Must be either a seed (starting with 's'), or a raw private key (starting with 'ED' or '00')")
         except Exception as e:
             raise ValueError(f"Invalid XRPL secret key: {e}")
 
     async def rest_authenticate(self, request: RESTRequest) -> RESTRequest:
-        pass
+        return request
 
     async def ws_authenticate(self, request: WSRequest) -> WSRequest:
-        pass
+        return request
 
     def get_wallet(self) -> Wallet:
         return self._wallet
@@ -29,4 +60,9 @@ class XRPLAuth(AuthBase):
         return self._wallet.classic_address
 
     def get_algorithm(self, key: str) -> CryptoAlgorithm:
-        return CryptoAlgorithm.ED25519 if key.startswith("sEd") else CryptoAlgorithm.SECP256K1
+        if key.startswith("sEd"):
+            return CryptoAlgorithm.ED25519
+        elif key.startswith("s"):
+            return CryptoAlgorithm.SECP256K1
+        else:
+            raise ValueError("Invalid key format")

--- a/test/hummingbot/connector/exchange/xrpl/test_xrpl_auth.py
+++ b/test/hummingbot/connector/exchange/xrpl/test_xrpl_auth.py
@@ -9,10 +9,10 @@ from hummingbot.core.web_assistant.connections.data_types import RESTMethod, RES
 class TestXRPLAuth(IsolatedAsyncioTestCase):
     def setUp(self):
         # Test cases for different key formats
-        self.ed25519_seed = "asdasd"  # noqa: mock
-        self.secp256k1_seed = "sasdsad"  # noqa: mock
-        self.ed25519_private_key = "sadad"  # noqa: mock
-        self.secp256k1_private_key = "asdasd"  # noqa: mock
+        self.ed25519_seed = "sEdTvpec3RNNWwphd1WKZqt5Vs6GEFu"  # noqa: mock
+        self.secp256k1_seed = "snoPBrXtMeMyMHUVTgbuqAfg1SUTb"  # noqa: mock
+        self.ed25519_private_key = "ED705389D8FB3E6CAA22F6D87533F9C47E86ECE224C2307BFEEFB56D96A71441FA"  # noqa: mock
+        self.secp256k1_private_key = "001ACAAEDECE405B2A958212629E16F2EB46B153EEE94CDD350FDEFF52795525B7"  # noqa: mock
 
     def test_empty_secret_key(self):
         auth = XRPLAuth("")

--- a/test/hummingbot/connector/exchange/xrpl/test_xrpl_auth.py
+++ b/test/hummingbot/connector/exchange/xrpl/test_xrpl_auth.py
@@ -1,21 +1,68 @@
-import unittest
+from unittest.async_case import IsolatedAsyncioTestCase
 
 from xrpl.constants import CryptoAlgorithm
 
 from hummingbot.connector.exchange.xrpl.xrpl_auth import XRPLAuth
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod, RESTRequest, WSJSONRequest
 
 
-class TestXRPLAuth(unittest.TestCase):
+class TestXRPLAuth(IsolatedAsyncioTestCase):
     def setUp(self):
-        self.xrpl_secret_key = "sEdTvpec3RNNWwphd1WKZqt5Vs6GEFu"  # noqa: mock
-        self.xrpl_auth = XRPLAuth(self.xrpl_secret_key)
+        # Test cases for different key formats
+        self.ed25519_seed = "asdasd"  # noqa: mock
+        self.secp256k1_seed = "sasdsad"  # noqa: mock
+        self.ed25519_private_key = "sadad"  # noqa: mock
+        self.secp256k1_private_key = "asdasd"  # noqa: mock
 
-    def test_get_account(self):
-        account = self.xrpl_auth.get_account()
-        # Replace 'expected_account' with the expected account string
+    def test_empty_secret_key(self):
+        auth = XRPLAuth("")
+        self.assertIsNotNone(auth.get_wallet())
+        self.assertIsNotNone(auth.get_account())
+
+    def test_ed25519_seed(self):
+        auth = XRPLAuth(self.ed25519_seed)
         expected_account = "rfWRtDsi2M5bTxKtxpEmwpp81H8NAezwkw"  # noqa: mock
-        self.assertEqual(account, expected_account)
+        self.assertEqual(auth.get_account(), expected_account)
+        self.assertEqual(auth.get_algorithm(self.ed25519_seed), CryptoAlgorithm.ED25519)
 
-    def test_get_algorithm(self):
-        algorithm = self.xrpl_auth.get_algorithm(self.xrpl_secret_key)
-        self.assertEqual(algorithm, CryptoAlgorithm.ED25519)
+    def test_secp256k1_seed(self):
+        auth = XRPLAuth(self.secp256k1_seed)
+        expected_account = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"  # noqa: mock
+        self.assertEqual(auth.get_account(), expected_account)
+        self.assertEqual(auth.get_algorithm(self.secp256k1_seed), CryptoAlgorithm.SECP256K1)
+
+    def test_ed25519_private_key(self):
+        auth = XRPLAuth(self.ed25519_private_key)
+        expected_account = "rBWGigPacsJK2uBaGcJSZ3FJKxiRNipKcm"  # noqa: mock
+        self.assertEqual(auth.get_account(), expected_account)
+
+    def test_secp256k1_private_key(self):
+        auth = XRPLAuth(self.secp256k1_private_key)
+        expected_account = "rht63aedhW7g1cqbtDgMSLmGthyf4vZYrp"  # noqa: mock
+        self.assertEqual(auth.get_account(), expected_account)
+
+    def test_invalid_key_format(self):
+        with self.assertRaises(ValueError) as context:
+            XRPLAuth("invalid_key")
+        self.assertIn("Invalid XRPL secret key format", str(context.exception))
+
+    def test_get_wallet(self):
+        auth = XRPLAuth(self.ed25519_seed)
+        wallet = auth.get_wallet()
+        self.assertIsNotNone(wallet)
+        self.assertIsNotNone(wallet.public_key)
+        self.assertIsNotNone(wallet.private_key)
+
+    async def test_rest_authenticate(self):
+        auth = XRPLAuth(self.ed25519_seed)
+        request = RESTRequest(method=RESTMethod.GET, url="https://test.com")
+        result = await auth.rest_authenticate(request)
+        self.assertIsNotNone(result)
+        self.assertEqual(result, request)
+
+    async def test_ws_authenticate(self):
+        auth = XRPLAuth(self.ed25519_seed)
+        request = WSJSONRequest(payload={})
+        result = await auth.ws_authenticate(request)
+        self.assertIsNotNone(result)
+        self.assertEqual(result, request)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
- Added support for raw Ed25519 and SECP256K1 private key
- Should fix this issue: https://github.com/hummingbot/hummingbot/issues/7545


**Tests performed by the developer**:
- Added unit tests for raw Ed25519 and SECP256K1 private key


**Tips for QA testing**:
- Try to use raw private key string starting with "ED" (Ed25519 key) or "00" (SECP256K1 key) for testing

