### PR TITLE
add_or_update marketdict implementation

### DIFF
--- a/controllers/generic/arbitrage_controller.py
+++ b/controllers/generic/arbitrage_controller.py
@@ -25,9 +25,7 @@ class ArbitrageControllerConfig(ControllerConfigBase):
     quote_conversion_asset: str = "USDT"
 
     def update_markets(self, markets: MarketDict) -> MarketDict:
-        for connector_pair in [self.exchange_pair_1, self.exchange_pair_2]:
-            markets.add_or_update(connector_pair.connector_name, connector_pair.trading_pair)
-        return markets
+        return [markets.add_or_update(cp.connector_name, cp.trading_pair) for cp in [self.exchange_pair_1, self.exchange_pair_2]][-1]
 
 
 class ArbitrageController(ControllerBase):

--- a/controllers/generic/arbitrage_controller.py
+++ b/controllers/generic/arbitrage_controller.py
@@ -1,9 +1,10 @@
 from decimal import Decimal
-from typing import Dict, List, Set
+from typing import List
 
 import pandas as pd
 
 from hummingbot.client.ui.interface_utils import format_df_for_printout
+from hummingbot.core.data_type.common import MarketDict
 from hummingbot.data_feed.candles_feed.data_types import CandlesConfig
 from hummingbot.strategy_v2.controllers.controller_base import ControllerBase, ControllerConfigBase
 from hummingbot.strategy_v2.executors.arbitrage_executor.data_types import ArbitrageExecutorConfig
@@ -23,20 +24,9 @@ class ArbitrageControllerConfig(ControllerConfigBase):
     rate_connector: str = "binance"
     quote_conversion_asset: str = "USDT"
 
-    def update_markets(self, markets: Dict[str, Set[str]]) -> Dict[str, Set[str]]:
-        if self.exchange_pair_1.connector_name == self.exchange_pair_2.connector_name:
-            if self.exchange_pair_1.connector_name in markets:
-                markets[self.exchange_pair_1.connector_name].update({self.exchange_pair_1.trading_pair,
-                                                                     self.exchange_pair_2.trading_pair})
-            else:
-                markets[self.exchange_pair_1.connector_name] = {self.exchange_pair_1.trading_pair,
-                                                                self.exchange_pair_2.trading_pair}
-        else:
-            for connector_pair in [self.exchange_pair_1, self.exchange_pair_2]:
-                if connector_pair.connector_name in markets:
-                    markets[connector_pair.connector_name].add(connector_pair.trading_pair)
-                else:
-                    markets[connector_pair.connector_name] = {connector_pair.trading_pair}
+    def update_markets(self, markets: MarketDict) -> MarketDict:
+        for connector_pair in [self.exchange_pair_1, self.exchange_pair_2]:
+            markets.add_or_update(connector_pair.connector_name, connector_pair.trading_pair)
         return markets
 
 

--- a/controllers/generic/basic_order_example.py
+++ b/controllers/generic/basic_order_example.py
@@ -1,7 +1,6 @@
 from decimal import Decimal
-from typing import Dict, Set
 
-from hummingbot.core.data_type.common import PositionMode, PriceType, TradeType
+from hummingbot.core.data_type.common import MarketDict, PositionMode, PriceType, TradeType
 from hummingbot.strategy_v2.controllers import ControllerBase, ControllerConfigBase
 from hummingbot.strategy_v2.executors.order_executor.data_types import ExecutionStrategy, OrderExecutorConfig
 from hummingbot.strategy_v2.models.executor_actions import CreateExecutorAction, ExecutorAction
@@ -18,11 +17,8 @@ class BasicOrderExampleConfig(ControllerConfigBase):
     amount_quote: Decimal = Decimal("10")
     order_frequency: int = 10
 
-    def update_markets(self, markets: Dict[str, Set[str]]) -> Dict[str, Set[str]]:
-        if self.connector_name not in markets:
-            markets[self.connector_name] = set()
-        markets[self.connector_name].add(self.trading_pair)
-        return markets
+    def update_markets(self, markets: MarketDict) -> MarketDict:
+        return markets.add_or_update(self.connector_name, self.trading_pair)
 
 
 class BasicOrderExample(ControllerBase):

--- a/controllers/generic/basic_order_open_close_example.py
+++ b/controllers/generic/basic_order_open_close_example.py
@@ -1,7 +1,6 @@
 from decimal import Decimal
-from typing import Dict, Set
 
-from hummingbot.core.data_type.common import PositionAction, PositionMode, PriceType, TradeType
+from hummingbot.core.data_type.common import MarketDict, PositionAction, PositionMode, PriceType, TradeType
 from hummingbot.strategy_v2.controllers import ControllerBase, ControllerConfigBase
 from hummingbot.strategy_v2.executors.order_executor.data_types import ExecutionStrategy, OrderExecutorConfig
 from hummingbot.strategy_v2.models.executor_actions import CreateExecutorAction, ExecutorAction
@@ -20,11 +19,8 @@ class BasicOrderOpenCloseExampleConfig(ControllerConfigBase):
     close_partial_position: bool = False
     amount_quote: Decimal = Decimal("20")
 
-    def update_markets(self, markets: Dict[str, Set[str]]) -> Dict[str, Set[str]]:
-        if self.connector_name not in markets:
-            markets[self.connector_name] = set()
-        markets[self.connector_name].add(self.trading_pair)
-        return markets
+    def update_markets(self, markets: MarketDict) -> MarketDict:
+        return markets.add_or_update(self.connector_name, self.trading_pair)
 
 
 class BasicOrderOpenClose(ControllerBase):

--- a/controllers/generic/grid_strike.py
+++ b/controllers/generic/grid_strike.py
@@ -1,9 +1,9 @@
 from decimal import Decimal
-from typing import Dict, List, Optional, Set
+from typing import List, Optional
 
 from pydantic import Field
 
-from hummingbot.core.data_type.common import OrderType, PositionMode, PriceType, TradeType
+from hummingbot.core.data_type.common import MarketDict, OrderType, PositionMode, PriceType, TradeType
 from hummingbot.data_feed.candles_feed.data_types import CandlesConfig
 from hummingbot.strategy_v2.controllers import ControllerBase, ControllerConfigBase
 from hummingbot.strategy_v2.executors.data_types import ConnectorPair
@@ -52,11 +52,8 @@ class GridStrikeConfig(ControllerConfigBase):
         take_profit_order_type=OrderType.LIMIT_MAKER,
     )
 
-    def update_markets(self, markets: Dict[str, Set[str]]) -> Dict[str, Set[str]]:
-        if self.connector_name not in markets:
-            markets[self.connector_name] = set()
-        markets[self.connector_name].add(self.trading_pair)
-        return markets
+    def update_markets(self, markets: MarketDict) -> MarketDict:
+        return markets.add_or_update(self.connector_name, self.trading_pair)
 
 
 class GridStrike(ControllerBase):

--- a/controllers/generic/pmm.py
+++ b/controllers/generic/pmm.py
@@ -1,10 +1,10 @@
 from decimal import Decimal
-from typing import Dict, List, Optional, Set, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 from pydantic import Field, field_validator
 from pydantic_core.core_schema import ValidationInfo
 
-from hummingbot.core.data_type.common import OrderType, PositionMode, PriceType, TradeType
+from hummingbot.core.data_type.common import MarketDict, OrderType, PositionMode, PriceType, TradeType
 from hummingbot.core.data_type.trade_fee import TokenAmount
 from hummingbot.data_feed.candles_feed.data_types import CandlesConfig
 from hummingbot.strategy_v2.controllers.controller_base import ControllerBase, ControllerConfigBase
@@ -234,11 +234,8 @@ class PMMConfig(ControllerConfigBase):
         spreads = getattr(self, f'{trade_type.name.lower()}_spreads')
         return spreads, [amt_pct * self.total_amount_quote * self.portfolio_allocation for amt_pct in normalized_amounts_pct]
 
-    def update_markets(self, markets: Dict[str, Set[str]]) -> Dict[str, Set[str]]:
-        if self.connector_name not in markets:
-            markets[self.connector_name] = set()
-        markets[self.connector_name].add(self.trading_pair)
-        return markets
+    def update_markets(self, markets: MarketDict) -> MarketDict:
+        return markets.add_or_update(self.connector_name, self.trading_pair)
 
 
 class PMM(ControllerBase):

--- a/hummingbot/core/data_type/common.py
+++ b/hummingbot/core/data_type/common.py
@@ -1,6 +1,9 @@
+from collections import defaultdict
 from decimal import Decimal
 from enum import Enum
-from typing import NamedTuple
+from typing import Any, Callable, Dict, Generic, NamedTuple, Set, TypeVar
+
+from pydantic_core import core_schema
 
 
 class OrderType(Enum):
@@ -64,3 +67,50 @@ class LPType(Enum):
     ADD = 1
     REMOVE = 2
     COLLECT = 3
+
+
+_KT = TypeVar('_KT')
+_VT = TypeVar('_TV')
+
+
+class GroupedSetDict(Dict[_KT, Set[_VT]]):
+    def add_or_update(self, key: _KT, *args: _VT) -> None:
+        if key in self:
+            self[key].update(args)
+        else:
+            self[key] = set(args)
+        return self
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls,
+        _source_type: Any,
+        _handler: Any,
+    ) -> core_schema.CoreSchema:
+        return core_schema.no_info_after_validator_function(
+            cls,
+            core_schema.dict_schema(
+                core_schema.any_schema(),
+                core_schema.set_schema(core_schema.any_schema())
+            )
+        )
+
+
+MarketDict = GroupedSetDict[str, Set[str]]
+
+
+class LambdaDict(defaultdict[_KT, _VT], Generic[_KT, _VT]):
+    def __init__(self, default_value_factory: Callable[[_KT], _VT] = None):
+        super().__init__()
+        self.default_value_factory = default_value_factory
+
+    def __missing__(self, key: _KT) -> _VT:
+        if self.default_value_factory is None:
+            raise KeyError(f"Key {key} not found in {self} and no default value factory is set")
+        self[key] = self.default_value_factory(key)
+        return self[key]
+
+    def get_or_add(self, key: _KT, value_factory: Callable[[], _VT]) -> _VT:
+        if key not in self:
+            self[key] = value_factory()
+        return self[key]

--- a/hummingbot/data_feed/market_data_provider.py
+++ b/hummingbot/data_feed/market_data_provider.py
@@ -10,7 +10,7 @@ from hummingbot.client.config.client_config_map import ClientConfigMap
 from hummingbot.client.config.config_helpers import ClientConfigAdapter, get_connector_class
 from hummingbot.client.settings import AllConnectorSettings
 from hummingbot.connector.connector_base import ConnectorBase
-from hummingbot.core.data_type.common import GroupedSetDict, LambdaDict, PriceType, TradeType
+from hummingbot.core.data_type.common import GroupedSetDict, LazyDict, PriceType, TradeType
 from hummingbot.core.data_type.order_book_query_result import OrderBookQueryResult
 from hummingbot.core.gateway.gateway_http_client import GatewayHttpClient
 from hummingbot.core.rate_oracle.rate_oracle import RateOracle
@@ -38,7 +38,7 @@ class MarketDataProvider:
         self._rates_update_task = None
         self._rates_update_interval = rates_update_interval
         self._rates = {}
-        self._rate_sources = LambdaDict[str, ConnectorBase](self.get_non_trading_connector)
+        self._rate_sources = LazyDict[str, ConnectorBase](self.get_non_trading_connector)
         self._rates_required = GroupedSetDict[str, ConnectorPair]()
         self.conn_settings = AllConnectorSettings.get_connector_settings()
 

--- a/hummingbot/data_feed/market_data_provider.py
+++ b/hummingbot/data_feed/market_data_provider.py
@@ -10,7 +10,7 @@ from hummingbot.client.config.client_config_map import ClientConfigMap
 from hummingbot.client.config.config_helpers import ClientConfigAdapter, get_connector_class
 from hummingbot.client.settings import AllConnectorSettings
 from hummingbot.connector.connector_base import ConnectorBase
-from hummingbot.core.data_type.common import PriceType, TradeType
+from hummingbot.core.data_type.common import GroupedSetDict, LambdaDict, PriceType, TradeType
 from hummingbot.core.data_type.order_book_query_result import OrderBookQueryResult
 from hummingbot.core.gateway.gateway_http_client import GatewayHttpClient
 from hummingbot.core.rate_oracle.rate_oracle import RateOracle
@@ -38,8 +38,8 @@ class MarketDataProvider:
         self._rates_update_task = None
         self._rates_update_interval = rates_update_interval
         self._rates = {}
-        self._rate_sources = {}
-        self._rates_required = {}
+        self._rate_sources = LambdaDict[str, ConnectorBase](self.get_non_trading_connector)
+        self._rates_required = GroupedSetDict[str, ConnectorPair]()
         self.conn_settings = AllConnectorSettings.get_connector_settings()
 
     def stop(self):
@@ -66,17 +66,11 @@ class MarketDataProvider:
         :param connector_pair: ConnectorPair
         """
         for connector_pair in connector_pairs:
+            connector_name, _ = connector_pair
             if connector_pair.is_amm_connector():
-                if "gateway" not in self._rates_required:
-                    self._rates_required["gateway"] = []
-                self._rates_required["gateway"].append(connector_pair)
+                self._rates_required.add_or_update("gateway", connector_pair)
                 continue
-            if connector_pair.connector_name not in self._rates_required:
-                self._rates_required[connector_pair.connector_name] = []
-            self._rates_required[connector_pair.connector_name].append(connector_pair)
-            if connector_pair.connector_name not in self._rate_sources:
-                self._rate_sources[connector_pair.connector_name] = self.get_non_trading_connector(
-                    connector_pair.connector_name)
+            self._rates_required.add_or_update(connector_name, connector_pair)
         if not self._rates_update_task:
             self._rates_update_task = safe_ensure_future(self.update_rates_task())
 

--- a/hummingbot/strategy/strategy_v2_base.py
+++ b/hummingbot/strategy/strategy_v2_base.py
@@ -14,7 +14,7 @@ from hummingbot.client.config.config_data_types import BaseClientModel
 from hummingbot.client.ui.interface_utils import format_df_for_printout
 from hummingbot.connector.connector_base import ConnectorBase
 from hummingbot.connector.markets_recorder import MarketsRecorder
-from hummingbot.core.data_type.common import PositionMode
+from hummingbot.core.data_type.common import MarketDict, PositionMode
 from hummingbot.data_feed.candles_feed.data_types import CandlesConfig
 from hummingbot.data_feed.market_data_provider import MarketDataProvider
 from hummingbot.exceptions import InvalidController
@@ -39,7 +39,7 @@ class StrategyV2ConfigBase(BaseClientModel):
     """
     Base class for version 2 strategy configurations.
     """
-    markets: Dict[str, Set[str]] = Field(
+    markets: MarketDict = Field(
         default=...,
         json_schema_extra={
             "prompt": "Enter markets in format 'exchange1.tp1,tp2:exchange2.tp1,tp2':",
@@ -174,7 +174,7 @@ class StrategyV2Base(ScriptStrategyBase):
         Initialize the markets that the strategy is going to use. This method is called when the strategy is created in
         the start command. Can be overridden to implement custom behavior.
         """
-        markets = config.markets
+        markets = MarketDict(config.markets)
         controllers_configs = config.load_controller_configs()
         for controller_config in controllers_configs:
             markets = controller_config.update_markets(markets)

--- a/hummingbot/strategy_v2/backtesting/backtesting_data_provider.py
+++ b/hummingbot/strategy_v2/backtesting/backtesting_data_provider.py
@@ -1,6 +1,6 @@
 import logging
 from decimal import Decimal
-from typing import Dict
+from typing import Dict, Optional
 
 import pandas as pd
 
@@ -8,7 +8,7 @@ from hummingbot.client.config.client_config_map import ClientConfigMap
 from hummingbot.client.config.config_helpers import ClientConfigAdapter, get_connector_class
 from hummingbot.client.settings import AllConnectorSettings, ConnectorType
 from hummingbot.connector.connector_base import ConnectorBase
-from hummingbot.core.data_type.common import PriceType
+from hummingbot.core.data_type.common import LazyDict, PriceType
 from hummingbot.data_feed.candles_feed.candles_base import CandlesBase
 from hummingbot.data_feed.candles_feed.candles_factory import CandlesFactory
 from hummingbot.data_feed.candles_feed.data_types import CandlesConfig, HistoricalCandlesConfig
@@ -34,9 +34,13 @@ class BacktestingDataProvider(MarketDataProvider):
         self._time = None
         self.trading_rules = {}
         self.conn_settings = AllConnectorSettings.get_connector_settings()
-        self.connectors = {name: self.get_connector(name) for name, settings in self.conn_settings.items()
-                           if settings.type in self.CONNECTOR_TYPES and name not in self.EXCLUDED_CONNECTORS and
-                           "testnet" not in name}
+        self.connectors = LazyDict[str, Optional[ConnectorBase]](
+            lambda name: self.get_connector(name) if (
+                self.conn_settings[name].type in self.CONNECTOR_TYPES and
+                name not in self.EXCLUDED_CONNECTORS and
+                "testnet" not in name
+            ) else None
+        )
 
     def get_connector(self, connector_name: str):
         conn_setting = self.conn_settings.get(connector_name)

--- a/hummingbot/strategy_v2/controllers/controller_base.py
+++ b/hummingbot/strategy_v2/controllers/controller_base.py
@@ -2,11 +2,12 @@ import asyncio
 import importlib
 import inspect
 from decimal import Decimal
-from typing import TYPE_CHECKING, Callable, Dict, List, Set
+from typing import TYPE_CHECKING, Callable, List
 
 from pydantic import ConfigDict, Field, field_validator
 
 from hummingbot.client.config.config_data_types import BaseClientModel
+from hummingbot.core.data_type.common import MarketDict
 from hummingbot.core.data_type.trade_fee import TokenAmount
 from hummingbot.core.utils.async_utils import safe_ensure_future
 from hummingbot.data_feed.candles_feed.data_types import CandlesConfig
@@ -89,7 +90,7 @@ class ControllerConfigBase(BaseClientModel):
                 configs.append(config)
         return configs
 
-    def update_markets(self, markets: Dict[str, Set[str]]) -> Dict[str, Set[str]]:
+    def update_markets(self, markets: MarketDict) -> MarketDict:
         """
         Update the markets dict of the script from the config.
         """
@@ -115,6 +116,7 @@ class ControllerBase(RunnableBase):
     """
     Base class for controllers.
     """
+
     def __init__(self, config: ControllerConfigBase, market_data_provider: MarketDataProvider,
                  actions_queue: asyncio.Queue, update_interval: float = 1.0):
         super().__init__(update_interval=update_interval)

--- a/hummingbot/strategy_v2/controllers/directional_trading_controller_base.py
+++ b/hummingbot/strategy_v2/controllers/directional_trading_controller_base.py
@@ -1,11 +1,11 @@
 from decimal import Decimal
-from typing import Dict, List, Optional, Set
+from typing import List, Optional
 
 import pandas as pd
 from pydantic import Field, field_validator
 
 from hummingbot.client.ui.interface_utils import format_df_for_printout
-from hummingbot.core.data_type.common import OrderType, PositionMode, PriceType, TradeType
+from hummingbot.core.data_type.common import MarketDict, OrderType, PositionMode, PriceType, TradeType
 from hummingbot.strategy_v2.controllers.controller_base import ControllerBase, ControllerConfigBase
 from hummingbot.strategy_v2.executors.data_types import ConnectorPair
 from hummingbot.strategy_v2.executors.position_executor.data_types import (
@@ -146,17 +146,15 @@ class DirectionalTradingControllerConfigBase(ControllerConfigBase):
             time_limit_order_type=OrderType.MARKET  # Defaulting to MARKET as per requirement
         )
 
-    def update_markets(self, markets: Dict[str, Set[str]]) -> Dict[str, Set[str]]:
-        if self.connector_name not in markets:
-            markets[self.connector_name] = set()
-        markets[self.connector_name].add(self.trading_pair)
-        return markets
+    def update_markets(self, markets: MarketDict) -> MarketDict:
+        return markets.add_or_update(self.connector_name, self.trading_pair)
 
 
 class DirectionalTradingControllerBase(ControllerBase):
     """
     This class represents the base class for a Directional Strategy.
     """
+
     def __init__(self, config: DirectionalTradingControllerConfigBase, *args, **kwargs):
         super().__init__(config, *args, **kwargs)
         self.config = config

--- a/hummingbot/strategy_v2/controllers/market_making_controller_base.py
+++ b/hummingbot/strategy_v2/controllers/market_making_controller_base.py
@@ -1,10 +1,10 @@
 from decimal import Decimal
-from typing import Dict, List, Optional, Set, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 from pydantic import Field, field_validator
 from pydantic_core.core_schema import ValidationInfo
 
-from hummingbot.core.data_type.common import OrderType, PositionMode, PriceType, TradeType
+from hummingbot.core.data_type.common import MarketDict, OrderType, PositionMode, PriceType, TradeType
 from hummingbot.core.data_type.trade_fee import TokenAmount
 from hummingbot.strategy_v2.controllers.controller_base import ControllerBase, ControllerConfigBase
 from hummingbot.strategy_v2.executors.data_types import ConnectorPair
@@ -208,11 +208,8 @@ class MarketMakingControllerConfigBase(ControllerConfigBase):
         spreads = getattr(self, f'{trade_type.name.lower()}_spreads')
         return spreads, [amt_pct * self.total_amount_quote for amt_pct in normalized_amounts_pct]
 
-    def update_markets(self, markets: Dict[str, Set[str]]) -> Dict[str, Set[str]]:
-        if self.connector_name not in markets:
-            markets[self.connector_name] = set()
-        markets[self.connector_name].add(self.trading_pair)
-        return markets
+    def update_markets(self, markets: MarketDict) -> MarketDict:
+        return markets.add_or_update(self.connector_name, self.trading_pair)
 
 
 class MarketMakingControllerBase(ControllerBase):

--- a/hummingbot/strategy_v2/executors/data_types.py
+++ b/hummingbot/strategy_v2/executors/data_types.py
@@ -46,6 +46,13 @@ class ConnectorPair(BaseModel):
             AllConnectorSettings.get_gateway_amm_connector_names()
         )
 
+    class Config:
+        frozen = True  # This makes the model immutable and thus hashable
+
+    def __iter__(self):
+        yield self.connector_name
+        yield self.trading_pair
+
 
 class PositionSummary(BaseModel):
     connector_name: str

--- a/test/hummingbot/core/data_type/test_common.py
+++ b/test/hummingbot/core/data_type/test_common.py
@@ -1,7 +1,7 @@
 from typing import Set
 from unittest import TestCase
 
-from hummingbot.core.data_type.common import GroupedSetDict, LambdaDict
+from hummingbot.core.data_type.common import GroupedSetDict, LazyDict
 
 
 class GroupedSetDictTests(TestCase):
@@ -37,7 +37,7 @@ class GroupedSetDictTests(TestCase):
 
 class LambdaDictTests(TestCase):
     def setUp(self):
-        self.dict = LambdaDict[str, int]()
+        self.dict = LazyDict[str, int]()
 
     def test_get_or_add_new_key(self):
         call_count = 0
@@ -74,19 +74,23 @@ class LambdaDictTests(TestCase):
             nonlocal call_count
             call_count += 1
             return len(key)
-        self.dict = LambdaDict[str, int](default_value_factory=factory)
+        self.dict = LazyDict[str, int](default_value_factory=factory)
         self.assertEqual(self.dict["key1"], 4)
         self.assertEqual(call_count, 1)
         # Verify factory is not called again for existing key
         self.assertEqual(self.dict["key1"], 4)
+        self.assertEqual(self.dict.get("key1"), 4)
         self.assertEqual(call_count, 1)
         # Verify factory is called again for new key
         self.assertEqual(self.dict["longer_key"], 10)
+        self.assertEqual(self.dict.get("longer_key"), 10)
         self.assertEqual(call_count, 2)
 
     def test_missing_key_no_factory(self):
         with self.assertRaises(KeyError):
             _ = self.dict["nonexistent"]
+        with self.assertRaises(KeyError):
+            _ = self.dict.get("nonexistent")
 
 
 if __name__ == '__main__':

--- a/test/hummingbot/core/data_type/test_common.py
+++ b/test/hummingbot/core/data_type/test_common.py
@@ -1,0 +1,93 @@
+from typing import Set
+from unittest import TestCase
+
+from hummingbot.core.data_type.common import GroupedSetDict, LambdaDict
+
+
+class GroupedSetDictTests(TestCase):
+    def setUp(self):
+        self.dict = GroupedSetDict[str, str]()
+
+    def test_add_or_update_new_key(self):
+        self.dict.add_or_update("key1", "value1")
+        self.assertEqual(self.dict["key1"], {"value1"})
+
+    def test_add_or_update_existing_key(self):
+        self.dict.add_or_update("key1", "value1")
+        self.dict.add_or_update("key1", "value2")
+        self.assertEqual(self.dict["key1"], {"value1", "value2"})
+
+    def test_add_or_update_chaining(self):
+        (self.dict.add_or_update("key1", "value1")
+            .add_or_update("key1", "value2")
+            .add_or_update("key1", "value2")  # This should be a no-op
+            .add_or_update("key2", "value1"))
+        self.assertEqual(self.dict["key1"], {"value1", "value2"})
+        self.assertEqual(self.dict["key2"], {"value1"})
+
+    def test_add_or_update_multiple_values(self):
+        self.dict.add_or_update("key1", "value1", "value2", "value3")
+        self.assertEqual(self.dict["key1"], {"value1", "value2", "value3"})
+
+    def test_market_dict_type(self):
+        market_dict = GroupedSetDict[str, Set[str]]()
+        market_dict.add_or_update("exchange1", "BTC-USDT")
+        self.assertEqual(market_dict["exchange1"], {"BTC-USDT"})
+
+
+class LambdaDictTests(TestCase):
+    def setUp(self):
+        self.dict = LambdaDict[str, int]()
+
+    def test_get_or_add_new_key(self):
+        call_count = 0
+
+        def factory():
+            nonlocal call_count
+            call_count += 1
+            return 42
+        value = self.dict.get_or_add("key1", factory)
+
+        self.assertEqual(value, 42)
+        self.assertEqual(call_count, 1)
+        # Verify factory not called again on subsequent gets
+        self.assertEqual(self.dict.get_or_add("key1", factory), 42)
+        self.assertEqual(call_count, 1)
+
+        # Verify factory is called again for new key
+        self.assertEqual(self.dict.get_or_add("key2", factory), 42)
+        self.assertEqual(call_count, 2)
+
+    def test_get_or_add_existing_key(self):
+        self.dict["key1"] = 42
+
+        def factory():
+            return 100
+        value = self.dict.get_or_add("key1", factory)
+        self.assertEqual(value, 42)
+        self.assertEqual(self.dict["key1"], 42)
+
+    def test_default_value_factory(self):
+        call_count = 0
+
+        def factory(key: str) -> int:
+            nonlocal call_count
+            call_count += 1
+            return len(key)
+        self.dict = LambdaDict[str, int](default_value_factory=factory)
+        self.assertEqual(self.dict["key1"], 4)
+        self.assertEqual(call_count, 1)
+        # Verify factory is not called again for existing key
+        self.assertEqual(self.dict["key1"], 4)
+        self.assertEqual(call_count, 1)
+        # Verify factory is called again for new key
+        self.assertEqual(self.dict["longer_key"], 10)
+        self.assertEqual(call_count, 2)
+
+    def test_missing_key_no_factory(self):
+        with self.assertRaises(KeyError):
+            _ = self.dict["nonexistent"]
+
+
+if __name__ == '__main__':
+    TestCase.main()

--- a/test/hummingbot/data_feed/test_market_data_provider.py
+++ b/test/hummingbot/data_feed/test_market_data_provider.py
@@ -163,7 +163,7 @@ class TestMarketDataProvider(IsolatedAsyncioWrapperTestCase):
     @patch.object(MarketDataProvider, "update_rates_task", MagicMock())
     def test_initialize_rate_sources(self):
         self.provider.initialize_rate_sources([ConnectorPair(connector_name="binance", trading_pair="BTC-USDT")])
-        self.assertEqual(len(self.provider._rate_sources), 1)
+        self.assertEqual(len(self.provider._rates_required), 1)
         self.provider.stop()
 
     async def test_safe_get_last_traded_prices(self):

--- a/test/hummingbot/strategy_v2/controllers/test_directional_trading_controller_base.py
+++ b/test/hummingbot/strategy_v2/controllers/test_directional_trading_controller_base.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from hummingbot.core.data_type.common import OrderType, PositionMode, TradeType
+from hummingbot.core.data_type.common import MarketDict, OrderType, PositionMode, TradeType
 from hummingbot.data_feed.market_data_provider import MarketDataProvider
 from hummingbot.strategy_v2.controllers.directional_trading_controller_base import (
     DirectionalTradingControllerBase,
@@ -90,14 +90,14 @@ class TestDirectionalTradingControllerBase(IsolatedAsyncioWrapperTestCase):
         self.assertEqual(config.trailing_stop, None)
 
     def test_update_markets_new_connector(self):
-        markets = {}
+        markets = MarketDict()
         updated_markets = self.mock_controller_config.update_markets(markets)
 
         self.assertIn("binance_perpetual", updated_markets)
         self.assertIn("ETH-USDT", updated_markets["binance_perpetual"])
 
     def test_update_markets_existing_connector(self):
-        markets = {"binance_perpetual": {"BTC-USDT"}}
+        markets = MarketDict({"binance_perpetual": {"BTC-USDT"}})
         updated_markets = self.mock_controller_config.update_markets(markets)
 
         self.assertIn("binance_perpetual", updated_markets)

--- a/test/hummingbot/strategy_v2/controllers/test_market_making_controller_base.py
+++ b/test/hummingbot/strategy_v2/controllers/test_market_making_controller_base.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from hummingbot.core.data_type.common import OrderType, PositionMode, TradeType
+from hummingbot.core.data_type.common import MarketDict, OrderType, PositionMode, TradeType
 from hummingbot.core.data_type.trade_fee import TokenAmount
 from hummingbot.data_feed.market_data_provider import MarketDataProvider
 from hummingbot.strategy_v2.controllers.market_making_controller_base import (
@@ -97,14 +97,14 @@ class TestMarketMakingControllerBase(IsolatedAsyncioWrapperTestCase):
             MarketMakingControllerConfigBase.validate_position_mode("invalid_position_mode")
 
     def test_update_markets_new_connector(self):
-        markets = {}
+        markets = MarketDict()
         updated_markets = self.mock_controller_config.update_markets(markets)
 
         self.assertIn("binance_perpetual", updated_markets)
         self.assertIn("ETH-USDT", updated_markets["binance_perpetual"])
 
     def test_update_markets_existing_connector(self):
-        markets = {"binance_perpetual": {"BTC-USDT"}}
+        markets = MarketDict({"binance_perpetual": {"BTC-USDT"}})
         updated_markets = self.mock_controller_config.update_markets(markets)
 
         self.assertIn("binance_perpetual", updated_markets)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

key changes:

1. Adds `GroupedSetDict` and `MarketDict` data types to `common.py` to provide a convenient way to add values to the set mapped to by a dictionary. This primary usage for Hummingbot being the addition of trading pairs for a connector via add_or_update. 

2. Adds LambdaDict data type with a default_value_factory which is used when a key is not found and a get_or_add method. Ended up not using get_or_add in this PR but left it because it is needed if the lambda reference is not available during class initialization. 

3. Implements the logical locations to utilize add_or_update. Existing usages that don't use add_or_update still work. 

**Tests performed by the developer**:

- Ran affected test suite (had to modify 1 test.)
- Created unit tests for newtypes
- Verified that `GroupedSetDict` correctly handles adding and updating values
- Confirmed type checking works as expected with the new types
- Tested compatibility with Pydantic v2 schema generation
- Validated that existing code using these types and not using these types continues to work

**Tips for QA testing**:

- Test market-related operations that use `MarketDict`
- Verify that existing controllers that don't use MarketDict still work