### PR TITLE
Follow up to backtesting performance 7569 remove useless and possibly problematic usage of ensure_epoch_index

### DIFF
--- a/hummingbot/strategy_v2/backtesting/backtesting_data_provider.py
+++ b/hummingbot/strategy_v2/backtesting/backtesting_data_provider.py
@@ -130,8 +130,7 @@ class BacktestingDataProvider(MarketDataProvider):
         :return: Candles dataframe.
         """
         candles_df = self.candles_feeds.get(f"{connector_name}_{trading_pair}_{interval}")
-        candles_df = self.ensure_epoch_index(candles_df)
-        return candles_df.loc[self.start_time:self.end_time]
+        return candles_df[(candles_df["timestamp"] >= self.start_time) & (candles_df["timestamp"] <= self.end_time)]
 
     def get_price_by_type(self, connector_name: str, trading_pair: str, price_type: PriceType):
         """


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] Tests all pass
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Revert an unintended call to ensure_epoch_index. 


**Tests performed by the developer**:
This is the code I tested locally for https://github.com/hummingbot/hummingbot/pull/7569 . I am not sure what I did wrong when copying it over from my local branch where I had squashed all changes in 7569. I'm surprised that the pandas-ta issue wasn't present with this call to ensure_epoch_index.



**Tips for QA testing**:
Verify that pmm_dynamic backtesting works. 
