### PR TITLE
fix/ freeze cython version

### DIFF
--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - autopep8
   - conda-build>=3.26.0
   - coverage>=7.2.7
-  - cython
+  - cython==3.0.12
   - flake8>=6.0.0
   - diff-cover>=7.7.0
   - pip>=23.2.1


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] Tests all pass
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Cython version was updated today (5/9) to version 3.1.0 which breaks the install process when trying to compile. 

This is the problematic line - `return int(end_timestamp - start_timestamp) / 1e6` 
Seems newer Cython version does not allow implicit conversion from long long to double when assigning or returning values typed as long long.


Below is the full error returned when running the `./compile` command

```
[58/59] Cythonizing hummingbot/strategy/strategy_py_base.pyx
[59/59] Cythonizing hummingbot/strategy/twap/dummy.pyx

Error compiling Cython file:
------------------------------------------------------------
...
        if self.creation_timestamp > 0:
            start_timestamp = self.creation_timestamp
        elif len(self.client_order_id) > 16 and self.client_order_id[-16:].isnumeric():
            start_timestamp = int(self.client_order_id[-16:])
        if 0 < start_timestamp < end_timestamp:
            return int(end_timestamp - start_timestamp) / 1e6
                                                        ^
------------------------------------------------------------

hummingbot/core/data_type/limit_order.pyx:160:56: Cannot assign type 'double' to 'long long'
Traceback (most recent call last):
  File "/home/madcatz/miniconda3/envs/hummingbot/lib/python3.12/site-packages/Cython/Build/Dependencies.py", line 1297, in cythonize_one_helper
    return cythonize_one(*m)
           ^^^^^^^^^^^^^^^^^
  File "/home/madcatz/miniconda3/envs/hummingbot/lib/python3.12/site-packages/Cython/Build/Dependencies.py", line 1289, in cythonize_one
    raise CompileError(None, pyx_file)
Cython.Compiler.Errors.CompileError: hummingbot/core/data_type/limit_order.pyx
multiprocessing.pool.RemoteTraceback:
"""
Traceback (most recent call last):
  File "/home/madcatz/miniconda3/envs/hummingbot/lib/python3.12/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
                    ^^^^^^^^^^^^^^^^^^^
  File "/home/madcatz/miniconda3/envs/hummingbot/lib/python3.12/multiprocessing/pool.py", line 48, in mapstar
    return list(map(*args))
           ^^^^^^^^^^^^^^^^
  File "/home/madcatz/miniconda3/envs/hummingbot/lib/python3.12/site-packages/Cython/Build/Dependencies.py", line 1297, in cythonize_one_helper
    return cythonize_one(*m)
           ^^^^^^^^^^^^^^^^^
  File "/home/madcatz/miniconda3/envs/hummingbot/lib/python3.12/site-packages/Cython/Build/Dependencies.py", line 1289, in cythonize_one
    raise CompileError(None, pyx_file)
Cython.Compiler.Errors.CompileError: hummingbot/core/data_type/limit_order.pyx
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/madcatz/test/hummingbot/setup.py", line 141, in <module>
    main()
  File "/home/madcatz/test/hummingbot/setup.py", line 129, in main
    ext_modules=cythonize(cython_sources, compiler_directives=compiler_directives, **cython_kwargs),
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/madcatz/miniconda3/envs/hummingbot/lib/python3.12/site-packages/Cython/Build/Dependencies.py", line 1136, in cythonize
    result.get(99999)  # seconds
    ^^^^^^^^^^^^^^^^^
  File "/home/madcatz/miniconda3/envs/hummingbot/lib/python3.12/multiprocessing/pool.py", line 774, in get
    raise self._value
Cython.Compiler.Errors.CompileError: hummingbot/core/data_type/limit_order.pyx
```


**Tests performed by the developer**:



**Tips for QA testing**:

