### PR TITLE
Refactor and Provide a way to disable TLS 1.3 on connectionsFactory a…

### DIFF
--- a/hummingbot/core/web_assistant/connections/connections_factory.py
+++ b/hummingbot/core/web_assistant/connections/connections_factory.py
@@ -1,4 +1,5 @@
-from typing import TypeVar
+import ssl
+from typing import List, TypeVar
 
 import aiohttp
 
@@ -19,14 +20,33 @@ class ConnectionsFactory:
     a separate third-party library. In that case, a factory can be created that returns `RESTConnection`s using
     `aiohttp` and `WSConnection`s using `signalr_aio`.
     """
-    _instance: ConnectionsFactoryT | None = None
-    _ws_independent_session: aiohttp.ClientSession | None = None
-    _shared_client: aiohttp.ClientSession | None = None
+    _instance: ConnectionsFactoryT | None = None  # Singleton control
 
     def __new__(cls):
         if cls._instance is None:
             cls._instance = super().__new__(cls)
+            cls._instance._initialized = False
         return cls._instance
+
+    def __init__(self):
+        if not self._initialized:
+            self._ws_independent_session: aiohttp.ClientSession | None = None
+            self._shared_client: aiohttp.ClientSession | None = None
+            self._disable_tls_1_3: bool = False
+            self._clients_to_close: List[aiohttp.ClientSession] = []
+            self._initialized = True
+
+    def set_disable_tls_1_3(self, disable: bool) -> None:
+        """
+        Set the _disable_tls_1_3 flag. If a shared client exists, it will be added to the list of
+        clients to close and reset to None so that a new one with the updated settings will be created.
+
+        :param disable: Whether to disable TLS 1.3
+        """
+        self._disable_tls_1_3 = disable
+        if self._shared_client is not None:
+            self._clients_to_close.append(self._shared_client)
+            self._shared_client = None
 
     async def get_rest_connection(self) -> RESTConnection:
         """
@@ -48,7 +68,18 @@ class ConnectionsFactory:
         Lazily create a shared aiohttp.ClientSession if not already available.
         """
         if self._shared_client is None:
-            self._shared_client = aiohttp.ClientSession()
+            if self._disable_tls_1_3:
+                # Create SSL context with TLSv1.2 for better VPN compatibility
+                ssl_context = ssl.create_default_context()
+                ssl_context.options &= ~ssl.OP_NO_TLSv1_2  # Enable TLSv1.2
+                ssl_context.options |= ssl.OP_NO_TLSv1_3   # Disable TLSv1.3
+
+                # Create connector with SSL context
+                connector = aiohttp.TCPConnector(ssl=ssl_context)
+                self._shared_client = aiohttp.ClientSession(connector=connector)
+            else:
+                # Simple client session construction (original behavior)
+                self._shared_client = aiohttp.ClientSession()
         return self._shared_client
 
     async def close(self) -> None:
@@ -61,6 +92,11 @@ class ConnectionsFactory:
         if self._ws_independent_session is not None:
             await self._ws_independent_session.close()
             self._ws_independent_session = None
+
+        # Close any clients that were set aside for closing
+        for client in self._clients_to_close:
+            await client.close()
+        self._clients_to_close.clear()
 
     async def __aenter__(self) -> ConnectionsFactoryT:
         """

--- a/test/hummingbot/core/web_assistant/connections/test_connections_factory.py
+++ b/test/hummingbot/core/web_assistant/connections/test_connections_factory.py
@@ -12,14 +12,83 @@ class ConnectionsFactoryTest(IsolatedAsyncioWrapperTestCase):
 
     async def test_get_rest_connection(self):
         factory = ConnectionsFactory()
-
         rest_connection = await factory.get_rest_connection()
-
         self.assertIsInstance(rest_connection, RESTConnection)
 
     async def test_get_ws_connection(self):
         factory = ConnectionsFactory()
-
         rest_connection = await factory.get_ws_connection()
-
         self.assertIsInstance(rest_connection, WSConnection)
+
+    async def test_disable_tls_1_3_with_existing_client(self):
+        """Test that disabling TLS 1.3 with an existing client adds it to clients_to_close."""
+        factory = ConnectionsFactory()
+
+        # Create and verify initial client
+        await factory.get_rest_connection()
+        self.assertIsNotNone(factory._shared_client)
+        initial_client = factory._shared_client
+
+        # Disable TLS 1.3 and verify changes
+        factory.set_disable_tls_1_3(True)
+        self.assertTrue(factory._disable_tls_1_3)
+        self.assertIsNone(factory._shared_client)
+        self.assertEqual(len(factory._clients_to_close), 1)
+        self.assertEqual(factory._clients_to_close[0], initial_client)
+
+        await factory.close()
+
+    async def test_client_recreation_after_tls_setting_change(self):
+        """Test that a new client is created with different settings after TLS change."""
+        factory = ConnectionsFactory()
+
+        # Get initial client
+        await factory.get_rest_connection()
+        self.assertIsNotNone(factory._shared_client)
+        initial_client = factory._shared_client
+
+        # Change TLS setting and get new client
+        factory.set_disable_tls_1_3(True)
+        await factory.get_rest_connection()
+        self.assertIsNotNone(factory._shared_client)
+        new_client = factory._shared_client
+
+        # Verify clients are different
+        self.assertNotEqual(initial_client, new_client)
+
+        await factory.close()
+
+    async def test_clients_to_close_are_cleared_after_close(self):
+        """Test that clients_to_close list is cleared after closing."""
+        factory = ConnectionsFactory()
+
+        # Create initial client and change settings to add it to clients_to_close
+        await factory.get_rest_connection()
+        factory.set_disable_tls_1_3(True)
+        self.assertEqual(len(factory._clients_to_close), 1)
+
+        # Close all clients
+        await factory.close()
+        self.assertEqual(len(factory._clients_to_close), 0)
+
+    async def test_singleton_behavior_with_tls_settings(self):
+        """Test that TLS settings are shared across factory instances."""
+        factory1 = ConnectionsFactory()
+        factory2 = ConnectionsFactory()
+
+        # Change setting using class method
+        factory1.set_disable_tls_1_3(True)
+        self.assertTrue(factory1._disable_tls_1_3)
+
+        # Create client with second factory
+        await factory2.get_rest_connection()
+        self.assertIsNotNone(factory2._shared_client)
+        factory2.set_disable_tls_1_3(False)
+
+        # Verify that the fields are shared at instance level but not at class level
+        self.assertIs(factory1, factory2)
+        self.assertFalse(factory1._disable_tls_1_3)
+        self.assertIsNone(factory1._shared_client)
+        self.assertFalse(hasattr(ConnectionsFactory, '_shared_client'))
+
+        await factory1.close()


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings  
- [x] Tests all pass  
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")  

**A description of the changes proposed in the pull request**:  
This PR introduces the ability to disable TLS 1.3 in the `ConnectionsFactory` class to address compatibility issues with VPNs that may block TLS 1.3 connections. Key changes include:  
- Refactored to a proper singleton pattern to avoid class attribute shadowing by instance attributes
- Added a `set_disable_tls_1_3()` method to toggle TLS 1.3 support.  
- Modified `_get_shared_client()` to use TLSv1.2 when TLS 1.3 is disabled.  
- Ensured proper cleanup of client sessions when TLS settings change.  

**Tests performed by the developer**:  
- Added comprehensive unit tests for the new functionality.  
- Verified backward compatibility with existing connections.  
- Tested manually with openVPN setup that previously had issues with TLS 1.3.  

**Tips for QA testing**:  
- Verify that existing connections (without TLS 1.3 disabled) remain unaffected.  
- Check for any performance impact (or just verify it works) when TLS 1.3 is disabled.  