### PR TITLE
Feat/add delays to requests to prevent rate limits

### DIFF
--- a/hummingbot/connector/exchange/xrpl/xrpl_utils.py
+++ b/hummingbot/connector/exchange/xrpl/xrpl_utils.py
@@ -426,6 +426,15 @@ class XRPLConfigMap(BaseConnectorConfigMap):
         },
     )
 
+    lock_delay_seconds: int = Field(
+        default=10,
+        json_schema_extra={
+            "prompt": "Delay (in seconds) after acquiring XRPL lock to avoid rate limits",
+            "is_secure": False,
+            "prompt_on_new": True,
+        },
+    )
+
     custom_markets: Dict[str, XRPLMarket] = Field(
         default={
             "SOLO-XRP": XRPLMarket(

--- a/test/hummingbot/connector/exchange/xrpl/test_xrpl_amm.py
+++ b/test/hummingbot/connector/exchange/xrpl/test_xrpl_amm.py
@@ -54,6 +54,7 @@ class TestXRPLAMMFunctions(unittest.IsolatedAsyncioTestCase):
         self.connector.get_currencies_from_trading_pair = MagicMock(return_value=(self.xrp, self.usd))
         self.connector._submit_transaction = AsyncMock()
         self.connector._sleep = AsyncMock()
+        self.connector._lock_delay_seconds = 0
 
     @patch("xrpl.utils.xrp_to_drops")
     @patch("xrpl.utils.drops_to_xrp")

--- a/test/hummingbot/connector/exchange/xrpl/test_xrpl_amm.py
+++ b/test/hummingbot/connector/exchange/xrpl/test_xrpl_amm.py
@@ -153,8 +153,8 @@ class TestXRPLAMMFunctions(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(call_args[1].method, "amm_info")
 
         # Test error case - missing required parameters
-        with self.assertRaises(ValueError):
-            await self.connector.amm_get_pool_info()
+        result_without_params = await self.connector.amm_get_pool_info()
+        self.assertIsNone(result_without_params)
 
     async def test_amm_quote_add_liquidity(self):
         # Setup mock for amm_get_pool_info

--- a/test/hummingbot/connector/exchange/xrpl/test_xrpl_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/xrpl/test_xrpl_api_order_book_data_source.py
@@ -56,6 +56,8 @@ class XRPLAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):
         exchange_market_info = CONSTANTS.MARKETS
         self.connector._initialize_trading_pair_symbols_from_exchange_info(exchange_market_info)
 
+        self.connector._lock_delay_seconds = 0
+
         trading_rule = TradingRule(
             trading_pair=self.trading_pair,
             min_order_size=Decimal("1e-6"),

--- a/test/hummingbot/connector/exchange/xrpl/test_xrpl_api_user_stream_data_source.py
+++ b/test/hummingbot/connector/exchange/xrpl/test_xrpl_api_user_stream_data_source.py
@@ -62,6 +62,7 @@ class XRPLUserStreamDataSourceUnitTests(unittest.TestCase):
         )
 
         self.connector._trading_rules[self.trading_pair] = trading_rule
+        self.connector._lock_delay_seconds = 0
         self.data_source._xrpl_client = AsyncMock()
         self.data_source._xrpl_client.__aenter__.return_value = self.data_source._xrpl_client
         self.data_source._xrpl_client.__aexit__.return_value = None
@@ -92,10 +93,10 @@ class XRPLUserStreamDataSourceUnitTests(unittest.TestCase):
                 "DestinationTag": 500650668,
                 "Fee": "10",
                 "Sequence": 88946237,
-                "SigningPubKey": "ED9160E36E72C04E65A8F1FB0756B8C1183EDF6E1E1F23AB333352AA2E74261005", # noqa: mock
+                "SigningPubKey": "ED9160E36E72C04E65A8F1FB0756B8C1183EDF6E1E1F23AB333352AA2E74261005",  # noqa: mock
                 "TransactionType": "Payment",
-                "TxnSignature": "ED8BC137211720346E2D495541267385963AC2A3CE8BFAA9F35E72E299C6D3F6C7D03BDC90B007B2D9F164A27F4B62F516DDFCFCD5D2844E56D5A335BCCD8E0A", # noqa: mock
-                "hash": "B2A73146A25E1FFD2EA80268DF4C0DDF8B6D2DF8B45EB33B1CB96F356873F824", # noqa: mock
+                "TxnSignature": "ED8BC137211720346E2D495541267385963AC2A3CE8BFAA9F35E72E299C6D3F6C7D03BDC90B007B2D9F164A27F4B62F516DDFCFCD5D2844E56D5A335BCCD8E0A",  # noqa: mock
+                "hash": "B2A73146A25E1FFD2EA80268DF4C0DDF8B6D2DF8B45EB33B1CB96F356873F824",  # noqa: mock
                 "DeliverMax": "54",
                 "date": 772789130,
             },
@@ -104,32 +105,32 @@ class XRPLUserStreamDataSourceUnitTests(unittest.TestCase):
                     {
                         "ModifiedNode": {
                             "FinalFields": {
-                                "Account": "rJn2zAPdFA193sixJwuFixRkYDUtx3apQh", # noqa: mock
+                                "Account": "rJn2zAPdFA193sixJwuFixRkYDUtx3apQh",  # noqa: mock
                                 "Balance": "4518270821183",
                                 "Flags": 131072,
                                 "OwnerCount": 1,
                                 "Sequence": 115711,
                             },
                             "LedgerEntryType": "AccountRoot",
-                            "LedgerIndex": "C19B36F6B6F2EEC9F4E2AF875E533596503F4541DBA570F06B26904FDBBE9C52", # noqa: mock
+                            "LedgerIndex": "C19B36F6B6F2EEC9F4E2AF875E533596503F4541DBA570F06B26904FDBBE9C52",  # noqa: mock
                             "PreviousFields": {"Balance": "4518270821129"},
-                            "PreviousTxnID": "F1C1BAAF756567DB986114034755734E8325127741FF232A551BCF322929AF58", # noqa: mock
+                            "PreviousTxnID": "F1C1BAAF756567DB986114034755734E8325127741FF232A551BCF322929AF58",  # noqa: mock
                             "PreviousTxnLgrSeq": 88973728,
                         }
                     },
                     {
                         "ModifiedNode": {
                             "FinalFields": {
-                                "Account": "rE3xcPg7mRTUwS2XKarZgTDimBY8VdfZgh", # noqa: mock
+                                "Account": "rE3xcPg7mRTUwS2XKarZgTDimBY8VdfZgh",  # noqa: mock
                                 "Balance": "20284095",
                                 "Flags": 0,
                                 "OwnerCount": 0,
                                 "Sequence": 88946238,
                             },
                             "LedgerEntryType": "AccountRoot",
-                            "LedgerIndex": "FE4BF634F1E942248603DC4A3FE34A365218FDE7AF9DCA93850518E870E51D74", # noqa: mock
+                            "LedgerIndex": "FE4BF634F1E942248603DC4A3FE34A365218FDE7AF9DCA93850518E870E51D74",  # noqa: mock
                             "PreviousFields": {"Balance": "20284159", "Sequence": 88946237},
-                            "PreviousTxnID": "9A9D303AD39937976F4198EDB53E7C9AE4651F7FB116DFBBBF0B266E6E30EF3C", # noqa: mock
+                            "PreviousTxnID": "9A9D303AD39937976F4198EDB53E7C9AE4651F7FB116DFBBBF0B266E6E30EF3C",  # noqa: mock
                             "PreviousTxnLgrSeq": 88973727,
                         }
                     },
@@ -143,7 +144,7 @@ class XRPLUserStreamDataSourceUnitTests(unittest.TestCase):
             "status": "closed",
             "close_time_iso": "2024-06-27T07:38:50Z",
             "ledger_index": 88973728,
-            "ledger_hash": "90C78DEECE2DD7FD3271935BD6017668F500CCF0CF42C403F8B86A03F8A902AE", # noqa: mock
+            "ledger_hash": "90C78DEECE2DD7FD3271935BD6017668F500CCF0CF42C403F8B86A03F8A902AE",  # noqa: mock
             "engine_result_code": 0,
             "engine_result": "tesSUCCESS",
             "engine_result_message": "The transaction was applied. Only final in a validated ledger.",

--- a/test/hummingbot/connector/exchange/xrpl/test_xrpl_exchange.py
+++ b/test/hummingbot/connector/exchange/xrpl/test_xrpl_exchange.py
@@ -140,6 +140,8 @@ class XRPLExchangeUnitTests(IsolatedAsyncioTestCase):
         self.connector._xrpl_place_order_client.__aenter__.return_value = self.connector._xrpl_place_order_client
         self.connector._xrpl_place_order_client.__aexit__.return_value = None
 
+        self.connector._lock_delay_seconds = 0
+
     def tearDown(self) -> None:
         self.listening_task and self.listening_task.cancel()
         self.data_source.FULL_ORDER_BOOK_RESET_DELTA_SECONDS = self._original_full_order_book_reset_time


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] Tests all pass
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
- Add a default 10 seconds delay for general requests to XRPL to prevent rate limit


**Tests performed by the developer**:
- Run bot for 30 mins without any major rate limit issue, bot still operational with 4 order levels


**Tips for QA testing**:
- Try to run bot with default public nodes for as long as possible to see if we see blocking rate limit issues. There will be some minor rate limit errors but bot should resolve them by retrying logic
- This should be merged after https://github.com/hummingbot/hummingbot/pull/7635 got merged
