### PR TITLE
docs/added new visualization of the codebase for new contributors

### DIFF
--- a/.codeboarding/Configuration_Persistence.md
+++ b/.codeboarding/Configuration_Persistence.md
@@ -1,0 +1,167 @@
+```mermaid
+
+graph LR
+
+    Configuration_Management_Core["Configuration Management Core"]
+
+    Application_Settings_Connector_Registry["Application Settings & Connector Registry"]
+
+    Database_Connection_Migration["Database Connection & Migration"]
+
+    Operational_Data_Persistence_Data_Models_["Operational Data Persistence (Data Models)"]
+
+    Configuration_Management_Core -- "supports" --> Application_Settings_Connector_Registry
+
+    Configuration_Management_Core -- "retrieves parameters from" --> Database_Connection_Migration
+
+    Database_Connection_Migration -- "provides database sessions to" --> Operational_Data_Persistence_Data_Models_
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+This subsystem is critical for managing all aspects of application configuration, from initial setup and secure handling of sensitive data to the persistent storage and retrieval of operational trading data. It ensures that Hummingbot operates with correct parameters, maintains data integrity, and allows for historical analysis and recovery.
+
+
+
+### Configuration Management Core
+
+This component is the foundational layer for Hummingbot's configuration system. It defines the structure of configuration data using Pydantic models, handles the loading and saving of these configurations to and from YAML files, and provides mechanisms for data validation and secure encryption/decryption of sensitive information (e.g., API keys). It ensures that configuration data is consistently structured, validated, and securely managed throughout the application.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/config/config_helpers.py#L0-L0" target="_blank" rel="noopener noreferrer">`hummingbot/client/config/config_helpers.py` (0:0)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/config/config_data_types.py#L0-L0" target="_blank" rel="noopener noreferrer">`hummingbot/client/config/config_data_types.py` (0:0)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/config/config_validators.py#L0-L0" target="_blank" rel="noopener noreferrer">`hummingbot/client/config/config_validators.py` (0:0)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/config/config_crypt.py#L0-L0" target="_blank" rel="noopener noreferrer">`hummingbot/client/config/config_crypt.py` (0:0)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/config/security.py#L0-L0" target="_blank" rel="noopener noreferrer">`hummingbot/client/config/security.py` (0:0)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/config/config_var.py#L0-L0" target="_blank" rel="noopener noreferrer">`hummingbot/client/config/config_var.py` (0:0)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/config/config_methods.py#L0-L0" target="_blank" rel="noopener noreferrer">`hummingbot/client/config/config_methods.py` (0:0)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/config/conf_migration.py#L0-L0" target="_blank" rel="noopener noreferrer">`hummingbot/client/config/conf_migration.py` (0:0)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/config/trade_fee_schema_loader.py#L0-L0" target="_blank" rel="noopener noreferrer">`hummingbot/client/config/trade_fee_schema_loader.py` (0:0)</a>
+
+
+
+
+
+### Application Settings & Connector Registry
+
+This component serves as the central, high-level access point for all application-wide settings and dynamically manages configurations for various trading connectors. It provides a consolidated view and interface for other parts of the application to retrieve and interact with the currently loaded and active configurations, including the setup of simulated (paper trading) connector settings.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `hummingbot/client/settings/AllConnectorSettings.py` (0:0)
+
+- `hummingbot/client/settings/__init__.py` (0:0)
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/config/client_config_map.py#L0-L0" target="_blank" rel="noopener noreferrer">`hummingbot/client/config/client_config_map.py` (0:0)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/config/global_config_map.py#L0-L0" target="_blank" rel="noopener noreferrer">`hummingbot/client/config/global_config_map.py` (0:0)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/config/fee_overrides_config_map.py#L0-L0" target="_blank" rel="noopener noreferrer">`hummingbot/client/config/fee_overrides_config_map.py` (0:0)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/config/gateway_ssl_config_map.py#L0-L0" target="_blank" rel="noopener noreferrer">`hummingbot/client/config/gateway_ssl_config_map.py` (0:0)</a>
+
+
+
+
+
+### Database Connection & Migration
+
+This component is exclusively responsible for establishing and maintaining the connection to the SQLite database used by Hummingbot. It handles the initialization of the SQLAlchemy engine and metadata, and critically, it manages the database schema migration process to ensure compatibility and data integrity across different application versions.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/model/sql_connection_manager.py#L0-L0" target="_blank" rel="noopener noreferrer">`hummingbot/model/sql_connection_manager.py` (0:0)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/model/db_migration/migrator.py#L0-L0" target="_blank" rel="noopener noreferrer">`hummingbot/model/db_migration/migrator.py` (0:0)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/model/db_migration/base_transformation.py#L0-L0" target="_blank" rel="noopener noreferrer">`hummingbot/model/db_migration/base_transformation.py` (0:0)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/model/db_migration/transformations.py#L0-L0" target="_blank" rel="noopener noreferrer">`hummingbot/model/db_migration/transformations.py` (0:0)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/model/metadata.py#L0-L0" target="_blank" rel="noopener noreferrer">`hummingbot/model/metadata.py` (0:0)</a>
+
+
+
+
+
+### Operational Data Persistence (Data Models)
+
+This component defines the SQLAlchemy models that represent the various operational data points persisted to the SQLite database. These models facilitate the mapping of Python objects to database tables, enabling the storage and retrieval of critical information such as trade fills, order history, market states, and strategy-specific data. This data is essential for reporting, performance analysis, and strategy recovery.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/model/trade_fill.py#L0-L0" target="_blank" rel="noopener noreferrer">`hummingbot/model/trade_fill.py` (0:0)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/model/order.py#L0-L0" target="_blank" rel="noopener noreferrer">`hummingbot/model/order.py` (0:0)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/model/order_status.py#L0-L0" target="_blank" rel="noopener noreferrer">`hummingbot/model/order_status.py` (0:0)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/model/position.py#L0-L0" target="_blank" rel="noopener noreferrer">`hummingbot/model/position.py` (0:0)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/model/inventory_cost.py#L0-L0" target="_blank" rel="noopener noreferrer">`hummingbot/model/inventory_cost.py` (0:0)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/model/market_data.py#L0-L0" target="_blank" rel="noopener noreferrer">`hummingbot/model/market_data.py` (0:0)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/model/funding_payment.py#L0-L0" target="_blank" rel="noopener noreferrer">`hummingbot/model/funding_payment.py` (0:0)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/model/range_position_collected_fees.py#L0-L0" target="_blank" rel="noopener noreferrer">`hummingbot/model/range_position_collected_fees.py` (0:0)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/model/range_position_update.py#L0-L0" target="_blank" rel="noopener noreferrer">`hummingbot/model/range_position_update.py` (0:0)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/model/decimal_type_decorator.py#L0-L0" target="_blank" rel="noopener noreferrer">`hummingbot/model/decimal_type_decorator.py` (0:0)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/model/transaction_base.py#L0-L0" target="_blank" rel="noopener noreferrer">`hummingbot/model/transaction_base.py` (0:0)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/model/controllers.py#L0-L0" target="_blank" rel="noopener noreferrer">`hummingbot/model/controllers.py` (0:0)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/model/executors.py#L0-L0" target="_blank" rel="noopener noreferrer">`hummingbot/model/executors.py` (0:0)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Connectivity_Data_Services.md
+++ b/.codeboarding/Connectivity_Data_Services.md
@@ -1,0 +1,255 @@
+```mermaid
+
+graph LR
+
+    ExchangePyBase["ExchangePyBase"]
+
+    GatewayHttpClient["GatewayHttpClient"]
+
+    ClientOrderTracker["ClientOrderTracker"]
+
+    MarketDataProvider["MarketDataProvider"]
+
+    RateOracle["RateOracle"]
+
+    WebAssistantsFactory["WebAssistantsFactory"]
+
+    AuthBase["AuthBase"]
+
+    OrderBookTracker["OrderBookTracker"]
+
+    UserStreamTracker["UserStreamTracker"]
+
+    TimeSynchronizer["TimeSynchronizer"]
+
+    ExchangePyBase -- "uses" --> ClientOrderTracker
+
+    ExchangePyBase -- "uses" --> WebAssistantsFactory
+
+    GatewayHttpClient -- "uses" --> ClientOrderTracker
+
+    ExchangePyBase -- "sends updates to" --> ClientOrderTracker
+
+    GatewayHttpClient -- "sends updates to" --> ClientOrderTracker
+
+    ExchangePyBase -- "provides data to" --> MarketDataProvider
+
+    MarketDataProvider -- "utilizes" --> RateOracle
+
+    RateOracle -- "provides rates to" --> MarketDataProvider
+
+    WebAssistantsFactory -- "creates clients for" --> ExchangePyBase
+
+    WebAssistantsFactory -- "leverages" --> AuthBase
+
+    AuthBase -- "provides authentication to" --> WebAssistantsFactory
+
+    AuthBase -- "uses" --> TimeSynchronizer
+
+    OrderBookTracker -- "provides data to" --> ExchangePyBase
+
+    UserStreamTracker -- "provides data to" --> ExchangePyBase
+
+    TimeSynchronizer -- "provides time to" --> ExchangePyBase
+
+    TimeSynchronizer -- "assists" --> AuthBase
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+This subsystem is crucial for Hummingbot's ability to interact with various cryptocurrency exchanges, both centralized and decentralized. It handles the entire lifecycle of trading operations, from placing orders to receiving real-time market data and managing account balances.
+
+
+
+### ExchangePyBase
+
+This is the foundational abstract base class for all Python-based exchange connectors. It defines the common interface and core functionalities for interacting with cryptocurrency exchanges, including order placement, cancellation, balance updates, and trading rule management. It acts as the blueprint that all specific exchange implementations extend.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/connector/exchange_py_base.py#L39-L1096" target="_blank" rel="noopener noreferrer">`ExchangePyBase` (39:1096)</a>
+
+
+
+
+
+### GatewayHttpClient
+
+This component facilitates communication with the Hummingbot Gateway service, which acts as a bridge to decentralized exchanges (DEXs) and other blockchain-based protocols. It handles API requests, status checks, and configuration updates for all Gateway-connected operations, abstracting away blockchain complexities.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/core/gateway/gateway_http_client.py#L44-L781" target="_blank" rel="noopener noreferrer">`GatewayHttpClient` (44:781)</a>
+
+
+
+
+
+### ClientOrderTracker
+
+This is a central component responsible for managing the complete lifecycle of client orders. It tracks the status of orders from submission to completion, processes updates (e.g., partial fills, cancellations), and handles state restoration. It serves as a crucial hub for all order-related events.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/connector/client_order_tracker.py#L31-L444" target="_blank" rel="noopener noreferrer">`ClientOrderTracker` (31:444)</a>
+
+
+
+
+
+### MarketDataProvider
+
+This component provides a unified and abstracted interface for accessing various types of market data, including order books, trades, and candles, from different connectors. It simplifies data retrieval for trading strategies by abstracting away the specific API details of individual exchanges or data sources.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/data_feed/market_data_provider.py#L27-L382" target="_blank" rel="noopener noreferrer">`MarketDataProvider` (27:382)</a>
+
+
+
+
+
+### RateOracle
+
+The `RateOracle` is responsible for fetching and providing real-time exchange rate conversions between different cryptocurrency assets. It aggregates price data from various sources to calculate accurate and up-to-date conversion rates, which are essential for multi-asset strategies.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/core/rate_oracle/rate_oracle.py#L44-L216" target="_blank" rel="noopener noreferrer">`RateOracle` (44:216)</a>
+
+
+
+
+
+### WebAssistantsFactory
+
+This is a factory class responsible for creating and managing web communication clients, including both REST and WebSocket clients, for interacting with external exchange APIs. It centralizes the process of setting up authenticated and throttled web clients.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/core/web_assistant/web_assistants_factory.py#L13-L80" target="_blank" rel="noopener noreferrer">`WebAssistantsFactory` (13:80)</a>
+
+
+
+
+
+### AuthBase
+
+This is an abstract base class that defines the interface for authentication mechanisms used to sign requests to exchange APIs. Concrete implementations handle specific cryptographic signing algorithms and secure management of API credentials.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `AuthBase` (0:0)
+
+
+
+
+
+### OrderBookTracker
+
+This component is responsible for maintaining a real-time, consolidated, and accurate view of market order books. It continuously processes updates received from data sources, ensuring that strategies and other parts of the system always have access to the most current market depth information.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/core/data_type/order_book_tracker.py#L23-L344" target="_blank" rel="noopener noreferrer">`OrderBookTracker` (23:344)</a>
+
+
+
+
+
+### UserStreamTracker
+
+This component is responsible for maintaining a real-time, consolidated, and accurate view of user-specific data, such as account balances and open orders. It continuously processes updates from user data streams, ensuring that the bot has the most current information about its trading account.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/core/data_type/user_stream_tracker.py#L9-L39" target="_blank" rel="noopener noreferrer">`UserStreamTracker` (9:39)</a>
+
+
+
+
+
+### TimeSynchronizer
+
+This component is crucial for ensuring that the bot's internal system clock is accurately synchronized with the server time of external exchanges. This synchronization is vital for precise timestamping of orders and trades, and for fulfilling exchange API requirements that often involve time-based signatures.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/connector/time_synchronizer.py#L11-L95" target="_blank" rel="noopener noreferrer">`TimeSynchronizer` (11:95)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Hummingbot_Application_Core.md
+++ b/.codeboarding/Hummingbot_Application_Core.md
@@ -1,0 +1,261 @@
+```mermaid
+
+graph LR
+
+    Hummingbot_Application_Core["Hummingbot Application Core"]
+
+    CLI_User_Interface["CLI User Interface"]
+
+    Command_Processing["Command Processing"]
+
+    Configuration_Management["Configuration Management"]
+
+    Exchange_Connectors["Exchange Connectors"]
+
+    Trading_Strategies["Trading Strategies"]
+
+    SQL_Connection_Manager["SQL Connection Manager"]
+
+    Logging_System["Logging System"]
+
+    Core_Utilities_and_Data_Types["Core Utilities and Data Types"]
+
+    Rate_Oracle["Rate Oracle"]
+
+    Market_Data_Provider["Market Data Provider"]
+
+    Hummingbot_Application_Core -- "initializes and runs" --> CLI_User_Interface
+
+    Hummingbot_Application_Core -- "sends notifications to" --> CLI_User_Interface
+
+    Hummingbot_Application_Core -- "dispatches commands to" --> Command_Processing
+
+    Hummingbot_Application_Core -- "handles command shortcuts for" --> Command_Processing
+
+    Hummingbot_Application_Core -- "loads and saves" --> Configuration_Management
+
+    Hummingbot_Application_Core -- "retrieves strategy configurations from" --> Configuration_Management
+
+    Hummingbot_Application_Core -- "initializes and manages" --> Exchange_Connectors
+
+    Hummingbot_Application_Core -- "cancels outstanding orders on" --> Exchange_Connectors
+
+    Hummingbot_Application_Core -- "manages the lifecycle of" --> Trading_Strategies
+
+    Hummingbot_Application_Core -- "initializes and uses" --> SQL_Connection_Manager
+
+    Hummingbot_Application_Core -- "utilizes" --> Logging_System
+
+    Hummingbot_Application_Core -- "relies on" --> Core_Utilities_and_Data_Types
+
+    Hummingbot_Application_Core -- "orchestrates components that use" --> Rate_Oracle
+
+    Hummingbot_Application_Core -- "orchestrates components that use" --> Market_Data_Provider
+
+    click Hummingbot_Application_Core href "https://github.com/hummingbot/hummingbot/blob/main/.codeboarding//Hummingbot_Application_Core.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+Analysis of the Hummingbot Application Core component, its role, and its relationships with other key components within the Hummingbot client.
+
+
+
+### Hummingbot Application Core
+
+The Hummingbot Application Core is the central orchestrator of the Hummingbot client. It is responsible for initializing and managing all other core services, processing user commands, loading configurations, and overseeing the execution of trading strategies. It acts as the main event loop and the glue holding the entire application together.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/hummingbot_application.py#L1-L1" target="_blank" rel="noopener noreferrer">`hummingbot.client.hummingbot_application` (1:1)</a>
+
+- `HummingbotCLI` (1:1)
+
+- `HummingbotCLI:run` (1:1)
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/hummingbot_application.py#L177-L180" target="_blank" rel="noopener noreferrer">`HummingbotApplication:notify` (177:180)</a>
+
+- `HummingbotCLI:log` (1:1)
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/hummingbot_application.py#L212-L250" target="_blank" rel="noopener noreferrer">`HummingbotApplication:_handle_command` (212:250)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/hummingbot_application.py#L182-L210" target="_blank" rel="noopener noreferrer">`HummingbotApplication:_handle_shortcut` (182:210)</a>
+
+- `load_client_config_map_from_file` (1:1)
+
+- `load_ssl_config_map_from_file` (1:1)
+
+- `save_client_config` (1:1)
+
+- `get_strategy_config_map` (1:1)
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/hummingbot_application.py#L291-L331" target="_blank" rel="noopener noreferrer">`HummingbotApplication:_initialize_markets` (291:331)</a>
+
+- `ExchangeBase` (1:1)
+
+- `ExchangeBase:cancel_all` (1:1)
+
+- `strategy` (1:1)
+
+- `strategy_task` (1:1)
+
+- `SQLConnectionManager:get_trade_fills_instance` (1:1)
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/connector/markets_recorder.py#L53-L592" target="_blank" rel="noopener noreferrer">`MarketsRecorder` (53:592)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/hummingbot_application.py#L58-L62" target="_blank" rel="noopener noreferrer">`HummingbotApplication:logger` (58:62)</a>
+
+- `notifiers` (1:1)
+
+- `asyncio` (1:1)
+
+- `ClientConfigAdapter` (1:1)
+
+- `ExchangeBase` (1:1)
+
+- `StrategyBase` (1:1)
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/hummingbot_application.py#L1-L1" target="_blank" rel="noopener noreferrer">`HummingbotApplication:data_feed` (1:1)</a>
+
+
+
+
+
+### CLI User Interface
+
+
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### Command Processing
+
+
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### Configuration Management
+
+
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### Exchange Connectors
+
+
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### Trading Strategies
+
+
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### SQL Connection Manager
+
+
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### Logging System
+
+
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### Core Utilities and Data Types
+
+
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### Rate Oracle
+
+
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### Market Data Provider
+
+
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Strategy_Execution_Engine.md
+++ b/.codeboarding/Strategy_Execution_Engine.md
@@ -1,0 +1,267 @@
+```mermaid
+
+graph LR
+
+    ScriptStrategyBase["ScriptStrategyBase"]
+
+    StrategyV2Base["StrategyV2Base"]
+
+    ControllerBase["ControllerBase"]
+
+    ExecutorBase["ExecutorBase"]
+
+    ExecutorOrchestrator["ExecutorOrchestrator"]
+
+    MarketDataProvider["MarketDataProvider"]
+
+    BacktestingEngineBase["BacktestingEngineBase"]
+
+    BacktestingDataProvider["BacktestingDataProvider"]
+
+    PositionExecutor["PositionExecutor"]
+
+    ConnectorBase["ConnectorBase"]
+
+    StrategyV2Base -- "extends" --> ScriptStrategyBase
+
+    ExecutorBase -- "relies on" --> ScriptStrategyBase
+
+    StrategyV2Base -- "relies on" --> MarketDataProvider
+
+    StrategyV2Base -- "uses" --> ControllerBase
+
+    StrategyV2Base -- "uses" --> ExecutorOrchestrator
+
+    ControllerBase -- "receives data from" --> MarketDataProvider
+
+    ControllerBase -- "sends actions to" --> ExecutorOrchestrator
+
+    ExecutorBase -- "interacts with" --> ScriptStrategyBase
+
+    ExecutorOrchestrator -- "manages" --> ExecutorBase
+
+    ExecutorOrchestrator -- "receives actions from" --> ControllerBase
+
+    ExecutorOrchestrator -- "interacts with" --> StrategyV2Base
+
+    MarketDataProvider -- "provides data to" --> StrategyV2Base
+
+    MarketDataProvider -- "provides data to" --> ControllerBase
+
+    MarketDataProvider -- "relies on" --> ConnectorBase
+
+    BacktestingEngineBase -- "relies on" --> BacktestingDataProvider
+
+    BacktestingEngineBase -- "interacts with" --> ControllerBase
+
+    BacktestingDataProvider -- "extends" --> MarketDataProvider
+
+    BacktestingDataProvider -- "provides data to" --> BacktestingEngineBase
+
+    PositionExecutor -- "extends" --> ExecutorBase
+
+    PositionExecutor -- "interacts with" --> ConnectorBase
+
+    ScriptStrategyBase -- "interacts with" --> ConnectorBase
+
+    ExecutorBase -- "interacts with" --> ConnectorBase
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The Strategy Execution Engine is the core of Hummingbot's automated trading capabilities, responsible for defining, executing, and backtesting trading strategies. It has evolved to support both legacy monolithic strategies and a more modular V2 framework.
+
+
+
+### ScriptStrategyBase
+
+The foundational abstract class for all trading strategies in Hummingbot. It provides essential functionalities for interacting with exchanges, including placing and canceling orders, retrieving market information, and managing account balances. It serves as the base for both traditional and modular V2 strategies.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/strategy/script_strategy_base.py#L27-L255" target="_blank" rel="noopener noreferrer">`ScriptStrategyBase` (27:255)</a>
+
+
+
+
+
+### StrategyV2Base
+
+The core abstract class for the modular V2 strategy framework. It extends `ScriptStrategyBase` and orchestrates the overall lifecycle of V2 strategies. Its responsibilities include managing market data provision, initializing and updating strategy controllers, and coordinating the actions of executors through the `ExecutorOrchestrator`.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/strategy/strategy_v2_base.py#L161-L499" target="_blank" rel="noopener noreferrer">`StrategyV2Base` (161:499)</a>
+
+
+
+
+
+### ControllerBase
+
+An abstract base class for V2 strategy controllers. Controllers encapsulate the high-level trading logic, analyze market conditions using data from the `MarketDataProvider`, and propose trading actions (e.g., creating or stopping executors) to the `ExecutorOrchestrator` to achieve strategy goals.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/strategy_v2/controllers/controller_base.py#L128-L207" target="_blank" rel="noopener noreferrer">`ControllerBase` (128:207)</a>
+
+
+
+
+
+### ExecutorBase
+
+An abstract base class for V2 strategy executors. Executors represent atomic trading operations, handling the low-level details of order placement, tracking, and reporting by interacting with the underlying connectors via `ScriptStrategyBase`. Concrete executors (like `PositionExecutor`) implement specific trading patterns.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/strategy_v2/executors/executor_base.py#L28-L416" target="_blank" rel="noopener noreferrer">`ExecutorBase` (28:416)</a>
+
+
+
+
+
+### ExecutorOrchestrator
+
+A central component within the V2 strategy framework responsible for managing the lifecycle and execution of various `ExecutorBase` instances. It receives proposed actions from `ControllerBase` instances, creates and monitors executors, and aggregates their status and performance. It also handles the persistence of executor and position data.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/strategy_v2/executors/executor_orchestrator.py#L133-L608" target="_blank" rel="noopener noreferrer">`ExecutorOrchestrator` (133:608)</a>
+
+
+
+
+
+### MarketDataProvider
+
+Responsible for providing real-time and historical market data (e.g., candles, order book snapshots, prices) to strategies and controllers. It abstracts the complexities of data acquisition from various `ConnectorBase` instances, ensuring a consistent data interface for the trading logic.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/data_feed/market_data_provider.py#L27-L382" target="_blank" rel="noopener noreferrer">`MarketDataProvider` (27:382)</a>
+
+
+
+
+
+### BacktestingEngineBase
+
+Provides the core framework for backtesting V2 strategies. It simulates market conditions and processes strategy logic over historical data, evaluating the performance of executors in a simulated environment without live market interaction.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/strategy_v2/backtesting/backtesting_engine_base.py#L31-L330" target="_blank" rel="noopener noreferrer">`BacktestingEngineBase` (31:330)</a>
+
+
+
+
+
+### BacktestingDataProvider
+
+A specialized data provider for the backtesting engine. It extends `MarketDataProvider` and is responsible for loading and serving historical market data, mimicking real-time data feeds for simulation purposes. It ensures that backtests operate on consistent and accurate historical data.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/strategy_v2/backtesting/backtesting_data_provider.py#L21-L185" target="_blank" rel="noopener noreferrer">`BacktestingDataProvider` (21:185)</a>
+
+
+
+
+
+### PositionExecutor
+
+A concrete implementation of `ExecutorBase` designed to manage and execute a single trading position. It handles the entire lifecycle of opening and closing a position, including advanced features like stop-loss, take-profit, and trailing stop functionalities, by interacting directly with the configured connector.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/strategy_v2/executors/position_executor/position_executor.py#L25-L802" target="_blank" rel="noopener noreferrer">`PositionExecutor` (25:802)</a>
+
+
+
+
+
+### ConnectorBase
+
+Represents the abstract interface for interacting with various cryptocurrency exchanges and decentralized protocols. It provides essential methods for placing orders, fetching market data (order books, prices, balances), and managing account information. It is a critical dependency for `MarketDataProvider` and `ScriptStrategyBase` (and thus `ExecutorBase`), enabling actual trading operations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `ConnectorBase` (0:0)
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/System_Utilities_Monitoring.md
+++ b/.codeboarding/System_Utilities_Monitoring.md
@@ -1,0 +1,179 @@
+```mermaid
+
+graph LR
+
+    Logging_System["Logging System"]
+
+    Notification_System["Notification System"]
+
+    MQTT_Gateway["MQTT Gateway"]
+
+    API_Throttling["API Throttling"]
+
+    Asynchronous_Utilities["Asynchronous Utilities"]
+
+    General_Core_Utilities["General Core Utilities"]
+
+    Logging_System -- "Logs notification events" --> Notification_System
+
+    Notification_System -- "Logs its own operations" --> Logging_System
+
+    Logging_System -- "Logs MQTT events" --> MQTT_Gateway
+
+    MQTT_Gateway -- "Forwards logs via MQTT" --> Logging_System
+
+    Logging_System -- "Logs throttling warnings" --> API_Throttling
+
+    Logging_System -- "Logs async operation errors" --> Asynchronous_Utilities
+
+    Logging_System -- "Logs utility-specific events" --> General_Core_Utilities
+
+    Notification_System -- "Dispatches notifications via MQTT" --> MQTT_Gateway
+
+    MQTT_Gateway -- "Can receive commands for notifications" --> Notification_System
+
+    Asynchronous_Utilities -- "Supports async notification dispatch" --> Notification_System
+
+    Asynchronous_Utilities -- "Manages async MQTT operations" --> MQTT_Gateway
+
+    Asynchronous_Utilities -- "Implements async rate limiting" --> API_Throttling
+
+    Asynchronous_Utilities -- "Supports async utility functions" --> General_Core_Utilities
+
+    General_Core_Utilities -- "Uses logging for internal events" --> Logging_System
+
+    General_Core_Utilities -- "Utilizes async helpers for operations" --> Asynchronous_Utilities
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The System Utilities & Monitoring subsystem provides essential cross-cutting functionalities for the application's operation, debugging, and external monitoring. It encompasses a centralized logging system, flexible notification dispatch, robust asynchronous programming helpers, API rate limiting mechanisms, and other common utilities crucial for the stable and observable operation of Hummingbot.
+
+
+
+### Logging System
+
+Provides a centralized and flexible logging infrastructure for the entire Hummingbot application. It handles the capture, formatting, and output of various log messages, including standard operational logs, network-specific events, and critical application warnings. This system is vital for debugging, auditing, and monitoring the bot's behavior.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/logger/logger.py#L1-L1" target="_blank" rel="noopener noreferrer">`hummingbot.logger.logger` (1:1)</a>
+
+
+
+
+
+### Notification System
+
+Manages and dispatches various types of notifications to the user (e.g., CLI) or integrated external systems (e.g., MQTT). It provides a flexible and extensible way to communicate important events, alerts, and status updates beyond standard logging.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/notifier/notifier_base.py#L1-L1" target="_blank" rel="noopener noreferrer">`hummingbot.notifier.notifier_base` (1:1)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/hummingbot_application.py#L1-L1" target="_blank" rel="noopener noreferrer">`hummingbot.client.hummingbot_application` (1:1)</a>
+
+
+
+
+
+### MQTT Gateway
+
+Establishes and manages the MQTT (Message Queuing Telemetry Transport) interface, enabling remote control, external monitoring, and real-time event forwarding for the Hummingbot application. It orchestrates various MQTT-related sub-components to broadcast logs, notifications, status updates, and market events, and to receive commands.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/remote_iface/mqtt.py#L1-L1" target="_blank" rel="noopener noreferrer">`hummingbot.remote_iface.mqtt` (1:1)</a>
+
+
+
+
+
+### API Throttling
+
+Implements mechanisms to manage and enforce rate limits for API requests made to external exchanges and services. This component is crucial for preventing excessive API calls that could lead to temporary bans, request rejections, or other service disruptions, thereby ensuring stable and compliant operation.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/core/api_throttler/async_throttler.py#L1-L1" target="_blank" rel="noopener noreferrer">`hummingbot.core.api_throttler.async_throttler` (1:1)</a>
+
+
+
+
+
+### Asynchronous Utilities
+
+Provides a set of core utility functions and classes designed to facilitate asynchronous programming patterns throughout the application. This includes safe scheduling of coroutines, retry mechanisms for transient failures, and other helpers essential for managing concurrent operations in an event-driven environment.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/core/utils/async_utils.py#L1-L1" target="_blank" rel="noopener noreferrer">`hummingbot.core.utils.async_utils` (1:1)</a>
+
+
+
+
+
+### General Core Utilities
+
+A collection of diverse utility modules providing common, reusable functionalities that are not specific to a single domain but are broadly applicable across the application. This includes helpers for managing SSL certificates for secure connections, generating unique tracking nonces for requests, and implementing emergency stop mechanisms.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/core/utils/ssl_cert.py#L1-L1" target="_blank" rel="noopener noreferrer">`hummingbot.core.utils.ssl_cert` (1:1)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/core/utils/tracking_nonce.py#L1-L1" target="_blank" rel="noopener noreferrer">`hummingbot.core.utils.tracking_nonce` (1:1)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/core/utils/kill_switch.py#L1-L1" target="_blank" rel="noopener noreferrer">`hummingbot.core.utils.kill_switch` (1:1)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/User_Interface_CLI_.md
+++ b/.codeboarding/User_Interface_CLI_.md
@@ -1,0 +1,243 @@
+```mermaid
+
+graph LR
+
+    HummingbotCLI["HummingbotCLI"]
+
+    Parser["Parser"]
+
+    Completer["Completer"]
+
+    Layout["Layout"]
+
+    Custom_Widgets["Custom Widgets"]
+
+    Interface_Utilities["Interface Utilities"]
+
+    Style["Style"]
+
+    Keybindings["Keybindings"]
+
+    Stdout_Redirection["Stdout Redirection"]
+
+    Scroll_Handlers["Scroll Handlers"]
+
+    HummingbotCLI -- "Uses" --> Parser
+
+    HummingbotCLI -- "Uses" --> Completer
+
+    HummingbotCLI -- "Manages" --> Layout
+
+    HummingbotCLI -- "Uses" --> Interface_Utilities
+
+    HummingbotCLI -- "Configures" --> Stdout_Redirection
+
+    HummingbotCLI -- "Processes" --> Keybindings
+
+    HummingbotCLI -- "Applies" --> Style
+
+    Layout -- "Contains" --> Custom_Widgets
+
+    Custom_Widgets -- "Adopts" --> Style
+
+    Keybindings -- "Controls" --> Scroll_Handlers
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+Overview of the User Interface (CLI) subsystem in Hummingbot
+
+
+
+### HummingbotCLI
+
+The central orchestrator of the CLI. It initializes the user interface, manages input and output loops, dispatches user commands, and integrates all other UI components. It's the main loop that keeps the CLI running and responsive.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/ui/hummingbot_cli.py#L1-L1" target="_blank" rel="noopener noreferrer">`hummingbot/client/ui/hummingbot_cli.py` (1:1)</a>
+
+
+
+
+
+### Parser
+
+Responsible for interpreting and validating user commands entered into the CLI. It translates raw text input into structured commands that the application's command handlers can process, ensuring that user input is correctly understood.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/ui/parser.py#L1-L1" target="_blank" rel="noopener noreferrer">`hummingbot/client/ui/parser.py` (1:1)</a>
+
+
+
+
+
+### Completer
+
+Enhances user experience by providing intelligent auto-completion suggestions for commands, parameters, and configuration values as the user types. This significantly reduces typing effort and potential errors.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/ui/completer.py#L1-L1" target="_blank" rel="noopener noreferrer">`hummingbot/client/ui/completer.py` (1:1)</a>
+
+
+
+
+
+### Layout
+
+Defines the visual structure and arrangement of different display areas within the CLI, such as the input prompt, log panel, and status panel. It ensures an organized and readable presentation of information.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/ui/layout.py#L1-L1" target="_blank" rel="noopener noreferrer">`hummingbot/client/ui/layout.py` (1:1)</a>
+
+
+
+
+
+### Custom Widgets
+
+Provides reusable, specialized graphical elements for the CLI, such as tables, progress bars, or formatted text areas. These are used to present complex information effectively within the text-based interface.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/ui/custom_widgets.py#L1-L1" target="_blank" rel="noopener noreferrer">`hummingbot/client/ui/custom_widgets.py` (1:1)</a>
+
+
+
+
+
+### Interface Utilities
+
+A collection of helper functions for common UI tasks, such as formatting output, displaying messages, and handling user prompts. It ensures consistent presentation and interaction across the CLI.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/ui/interface_utils.py#L1-L1" target="_blank" rel="noopener noreferrer">`hummingbot/client/ui/interface_utils.py` (1:1)</a>
+
+
+
+
+
+### Style
+
+Manages the visual theme of the CLI, including color schemes, text styles, and other aesthetic properties. It ensures a consistent and user-friendly appearance.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/ui/style.py#L1-L1" target="_blank" rel="noopener noreferrer">`hummingbot/client/ui/style.py` (1:1)</a>
+
+
+
+
+
+### Keybindings
+
+Defines and manages keyboard shortcuts for various actions within the CLI, enabling efficient navigation and interaction without relying solely on command input.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/ui/keybindings.py#L1-L1" target="_blank" rel="noopener noreferrer">`hummingbot/client/ui/keybindings.py` (1:1)</a>
+
+
+
+
+
+### Stdout Redirection
+
+A mechanism to capture and redirect standard output (e.g., print statements, logging messages) to specific panels or areas within the CLI's graphical layout, ensuring all relevant information is displayed correctly within the structured UI.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/ui/stdout_redirection.py#L1-L1" target="_blank" rel="noopener noreferrer">`hummingbot/client/ui/stdout_redirection.py` (1:1)</a>
+
+
+
+
+
+### Scroll Handlers
+
+Manages the scrolling behavior within different panels of the CLI, allowing users to view extensive logs or data outputs that exceed the visible screen area.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/ui/scroll_handlers.py#L1-L1" target="_blank" rel="noopener noreferrer">`hummingbot/client/ui/scroll_handlers.py` (1:1)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,213 @@
+```mermaid
+
+graph LR
+
+    Hummingbot_Application_Core["Hummingbot Application Core"]
+
+    User_Interface_CLI_["User Interface (CLI)"]
+
+    Configuration_Persistence["Configuration & Persistence"]
+
+    Connectivity_Data_Services["Connectivity & Data Services"]
+
+    Strategy_Execution_Engine["Strategy Execution Engine"]
+
+    System_Utilities_Monitoring["System Utilities & Monitoring"]
+
+    Hummingbot_Application_Core -- "Orchestrates UI, Receives commands from UI" --> User_Interface_CLI_
+
+    Hummingbot_Application_Core -- "Manages configurations, Loads/Saves configurations" --> Configuration_Persistence
+
+    Hummingbot_Application_Core -- "Manages connectors, Receives market data/order updates" --> Connectivity_Data_Services
+
+    Hummingbot_Application_Core -- "Manages strategies, Receives strategy reports" --> Strategy_Execution_Engine
+
+    Hummingbot_Application_Core -- "Manages logging/monitoring, Sends logs/notifications" --> System_Utilities_Monitoring
+
+    User_Interface_CLI_ -- "Sends commands, Receives status updates" --> Hummingbot_Application_Core
+
+    User_Interface_CLI_ -- "Receives notifications, Displays logs" --> System_Utilities_Monitoring
+
+    Configuration_Persistence -- "Provides configurations, Persists application state" --> Hummingbot_Application_Core
+
+    Configuration_Persistence -- "Provides connector configs, Persists trade data" --> Connectivity_Data_Services
+
+    Configuration_Persistence -- "Provides strategy configs, Persists strategy state" --> Strategy_Execution_Engine
+
+    Connectivity_Data_Services -- "Provides market data, Receives management commands" --> Hummingbot_Application_Core
+
+    Connectivity_Data_Services -- "Provides market data, Executes orders" --> Strategy_Execution_Engine
+
+    Connectivity_Data_Services -- "Receives configs, Persists operational data" --> Configuration_Persistence
+
+    Strategy_Execution_Engine -- "Reports status, Receives execution commands" --> Hummingbot_Application_Core
+
+    Strategy_Execution_Engine -- "Requests market data, Places/Cancels orders" --> Connectivity_Data_Services
+
+    Strategy_Execution_Engine -- "Loads strategy configs, Saves strategy state" --> Configuration_Persistence
+
+    System_Utilities_Monitoring -- "Receives logs, Provides system health" --> Hummingbot_Application_Core
+
+    System_Utilities_Monitoring -- "Sends notifications, Displays logs" --> User_Interface_CLI_
+
+    click Hummingbot_Application_Core href "https://github.com/hummingbot/hummingbot/blob/main/.codeboarding//Hummingbot_Application_Core.md" "Details"
+
+    click User_Interface_CLI_ href "https://github.com/hummingbot/hummingbot/blob/main/.codeboarding//User_Interface_CLI_.md" "Details"
+
+    click Configuration_Persistence href "https://github.com/hummingbot/hummingbot/blob/main/.codeboarding//Configuration_Persistence.md" "Details"
+
+    click Connectivity_Data_Services href "https://github.com/hummingbot/hummingbot/blob/main/.codeboarding//Connectivity_Data_Services.md" "Details"
+
+    click Strategy_Execution_Engine href "https://github.com/hummingbot/hummingbot/blob/main/.codeboarding//Strategy_Execution_Engine.md" "Details"
+
+    click System_Utilities_Monitoring href "https://github.com/hummingbot/hummingbot/blob/main/.codeboarding//System_Utilities_Monitoring.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The architecture of Hummingbot can be effectively understood through six fundamental components, each with distinct responsibilities and clear interactions. These components are chosen for their critical roles in the application's lifecycle, from initialization and user interaction to core trading logic and external connectivity.
+
+
+
+### Hummingbot Application Core
+
+The central orchestrator of the Hummingbot client. It initializes and manages all other core services, processes user commands, loads configurations, and oversees the execution of trading strategies. It acts as the main loop and the glue holding the entire application together.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/hummingbot_application.py#L50-L349" target="_blank" rel="noopener noreferrer">`hummingbot.client.hummingbot_application.HummingbotApplication` (50:349)</a>
+
+
+
+
+
+### User Interface (CLI)
+
+Provides the interactive command-line interface through which users control Hummingbot, configure strategies, and view real-time status, logs, and performance metrics. It's the primary human-machine interface.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/ui/hummingbot_cli.py#L51-L276" target="_blank" rel="noopener noreferrer">`hummingbot.client.ui.hummingbot_cli.HummingbotCLI` (51:276)</a>
+
+
+
+
+
+### Configuration & Persistence
+
+Manages the loading, saving, validation, and secure handling of all application and strategy configurations. This includes sensitive data such as API keys. It also handles the persistence of operational data (e.g., trade fills, order history, strategy states) to the SQLite database, enabling reporting and recovery.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/client/config/config_helpers.py#L1-L1" target="_blank" rel="noopener noreferrer">`hummingbot.client.config.config_helpers` (1:1)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/model/sql_connection_manager.py#L24-L131" target="_blank" rel="noopener noreferrer">`hummingbot.model.sql_connection_manager.SQLConnectionManager` (24:131)</a>
+
+
+
+
+
+### Connectivity & Data Services
+
+Abstracts interactions with various external cryptocurrency exchanges (centralized and decentralized via the Hummingbot Gateway service). This component is responsible for handling order placement, cancellation, balance updates, and streaming raw market data (order books, trades, candles). It also includes the Rate Oracle for real-time asset conversion rates and the Order Tracker for managing the lifecycle of in-flight orders.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/connector/exchange_py_base.py#L39-L1096" target="_blank" rel="noopener noreferrer">`hummingbot.connector.exchange_py_base.ExchangePyBase` (39:1096)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/connector/derivative/binance_perpetual/binance_perpetual_derivative.py#L1-L1" target="_blank" rel="noopener noreferrer">`hummingbot.connector.derivative.binance_perpetual.binance_perpetual_derivative` (1:1)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/core/gateway/gateway_http_client.py#L44-L781" target="_blank" rel="noopener noreferrer">`hummingbot.core.gateway.gateway_http_client.GatewayHttpClient` (44:781)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/connector/client_order_tracker.py#L31-L444" target="_blank" rel="noopener noreferrer">`hummingbot.connector.client_order_tracker.ClientOrderTracker` (31:444)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/data_feed/market_data_provider.py#L27-L382" target="_blank" rel="noopener noreferrer">`hummingbot.data_feed.market_data_provider.MarketDataProvider` (27:382)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/core/rate_oracle/rate_oracle.py#L44-L216" target="_blank" rel="noopener noreferrer">`hummingbot.core.rate_oracle.rate_oracle.RateOracle` (44:216)</a>
+
+
+
+
+
+### Strategy Execution Engine
+
+The core component for defining, executing, and backtesting automated trading strategies. It encompasses both the legacy monolithic strategies and the newer, more modular V2 strategies (composed of Controllers and Executors). It defines the core logic for how the bot makes trading decisions based on market data and manages order placement through the Connectivity & Data Services.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/strategy/script_strategy_base.py#L27-L255" target="_blank" rel="noopener noreferrer">`hummingbot.strategy.script_strategy_base.ScriptStrategyBase` (27:255)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/strategy/strategy_v2_base.py#L161-L499" target="_blank" rel="noopener noreferrer">`hummingbot.strategy.strategy_v2_base.StrategyV2Base` (161:499)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/strategy_v2/backtesting/backtesting_engine_base.py#L1-L1" target="_blank" rel="noopener noreferrer">`hummingbot.strategy_v2.backtesting.backtesting_engine_base` (1:1)</a>
+
+
+
+
+
+### System Utilities & Monitoring
+
+Provides cross-cutting functionalities essential for the application's operation, debugging, and external monitoring. This includes a centralized logging system, notification dispatch (e.g., to CLI, MQTT), asynchronous programming helpers, API rate limiting mechanisms, and other common utilities used across the application.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/logger/logger.py#L30-L105" target="_blank" rel="noopener noreferrer">`hummingbot.logger.logger.HummingbotLogger` (30:105)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/remote_iface/mqtt.py#L574-L870" target="_blank" rel="noopener noreferrer">`hummingbot.remote_iface.mqtt.MQTTGateway` (574:870)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/core/utils/async_utils.py#L1-L1" target="_blank" rel="noopener noreferrer">`hummingbot.core.utils.async_utils` (1:1)</a>
+
+- <a href="https://github.com/hummingbot/hummingbot/blob/master/hummingbot/core/api_throttler/async_throttler.py#L1-L1" target="_blank" rel="noopener noreferrer">`hummingbot.core.api_throttler.async_throttler` (1:1)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

The first two are not relevent but I checked them.

- [x] Your code builds clean without any errors or warnings
- [x] Tests all pass
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

This PR contains high-level diagrams for the hummingbot's codebase. You can see how they render in Github here:
https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/hummingbot/on_boarding.md

Our goal is to help new team members (in this case I suppose it is anyone on github) get up to speed with the codebase more quickly. We believe that having a high-level overview from the start is crucial, and diagrams are one of the most effective ways to convey this. By visualizing the codebase, new contributors can gain context more easily and focus on the specific components relevant to their work - we believe that especially if you are working with good willed contirbutors online they will want to start from a single component (module) of the codebase.

I’d love to hear about your current process for onboarding people to the codebase—do you think these diagrams could be integrated into it?

Any feedback is more than welcome! We've just released a free GitHub Action that can automatically update the diagrams and this way keep them always up-to-date.

Full disclosure: we're trying to turn this into a startup, but we're still in a very early stage and figuring out what will actually be useful for people.

I would usually start by opening a discussion, but they are not enabled for this repository so I opened a PR instead!


**Tests performed by the developer**:



**Tips for QA testing**:

