### PR TITLE
feat: Add triple barrier conditions to DEMA SuperTrend ADX strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,4 @@ coverage.xml
 **/.claude/settings.local.json
 .taskmaster
 .cursor
+.claude

--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,5 @@ coverage.xml
 .env
 
 **/.claude/settings.local.json
+.taskmaster
+.cursor

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,88 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+Hummingbot is an open-source Python-based framework for building and deploying algorithmic trading bots. The framework supports trading on 140+ exchanges (both CEX and DEX) and includes both traditional strategies and a new Strategy V2 architecture with Controllers and Executors.
+
+## Development Commands
+
+### Environment Setup
+- `./install` - Install dependencies using Anaconda
+- `./compile` - Compile Cython extensions
+- `./clean` - Clean up compiled files and build artifacts
+
+### Running
+- `./start` - Start Hummingbot with options: `-p <password>`, `-f <file>`, `-c <config>`
+- `make run-v2` - Run Strategy V2 with controllers
+
+### Testing
+- `make test` - Run pytest with coverage
+- Pre-commit hooks are installed automatically with `./install`
+
+## Tips to always keep in mind
+The architecture already has robust and well implemented code for the following -
+
+Managing Exchange Connections
+Interacting With Exchanges
+Fetching Candles,Orderbooks and all other kinds of Api Data from Exchanges
+Order Lifecycle management
+Position Management and tracking
+Event Tracking for all important events throughtout trading, like order fills, cancellations, funding payments,
+Use existing framework to achieve all of this. We only make changes to the actual trading strategies etc we want to write
+When working on executors controllers or connectors always look at existing ones to find the standard ways to do it
+
+## Web3 Blockchain Integration
+- Already offers robust web3 trading through Gateway connector
+- Gateway is a complementing rest api based codebase that helps interact with various web3 blockchains and has endpoints for connected web3 account and dex related operations
+
+## Strategy V2 Architecture
+
+### Controllers (`hummingbot/strategy_v2/controllers/`)
+- **Purpose**: High-level strategy logic and decision making
+- **Base Class**: `ControllerBase` extends `RunnableBase`
+- **Configuration**: Uses Pydantic models extending `ControllerConfigBase`
+
+### Executors (`hummingbot/strategy_v2/executors/`)
+- **Purpose**: Execute specific trading actions (orders, positions)
+- **Base Class**: `ExecutorBase` extends `RunnableBase`
+- **Orchestration**: `ExecutorOrchestrator` manages multiple executors
+
+### Connectors
+- **Purpose**: Interface with exchanges and blockchains for trading operations
+- **Base Classes**:
+  - `ConnectorBase` - Root base for all connectors
+  - `ExchangeBase` - Foundation for exchange connectors
+  - `ExchangePyBase` - Python CEX implementation (most common)
+  - `PerpetualDerivativePyBase` - Perpetual/futures exchanges
+  - `GatewayBase` - Blockchain/DEX connectors via Gateway
+
+### Order Management
+Core classes for order lifecycle management:
+- `InFlightOrder` - Main order tracking throughout lifecycle
+- `ClientOrderTracker` - Core order management for connectors
+- `OrderCandidate` - Pre-order validation and sizing
+- `OrderUpdate/TradeUpdate` - Order state and fill updates
+- `LimitOrder/MarketOrder` - Order data structures
+
+### Strategy Base Classes
+**Strategy V2 Architecture:**
+- `RunnableBase` - Core base for all smart components
+- `ControllerBase` - High-level strategy logic and decisions
+- `ExecutorBase` - Specific trading action execution
+- `MarketMakingControllerBase` - Market making strategies
+- `DirectionalTradingControllerBase` - Directional trading strategies
+- `StrategyV2Base` - Main strategy orchestrator
+
+**Legacy Architecture:**
+- `ScriptStrategyBase` - Simple script-based strategies
+- `DirectionalStrategyBase` - Legacy directional strategies
+
+## Reference Lookup when working with scripts, controllers or executors
+
+position_executor.py : for order placement/management and position management
+dca_executor.py : for managing multiple orders and positions
+market_making_controller_base.py : for market making related controllers
+directional_trading_controller_base.py: for directional trading related controllers
+dman_maker_v2.py : for managing multiple maker limit orders etc

--- a/controllers/generic/arbitrage_controller.py
+++ b/controllers/generic/arbitrage_controller.py
@@ -32,7 +32,7 @@ class ArbitrageControllerConfig(ControllerConfigBase):
 
 class ArbitrageController(ControllerBase):
     gas_token_by_network = {
-        "ethereum": "BERA",
+        "ethereum": "ETH",
         "solana": "SOL",
         "binance-smart-chain": "BNB",
         "polygon": "POL",

--- a/controllers/generic/funding_rate_arbitrage_controller.py
+++ b/controllers/generic/funding_rate_arbitrage_controller.py
@@ -1,0 +1,699 @@
+from decimal import Decimal
+from typing import Dict, List, Optional, Set, Tuple
+
+from pydantic import Field, field_validator
+
+from hummingbot.core.data_type.common import MarketDict, OrderType, PriceType, TradeType
+from hummingbot.strategy_v2.controllers.controller_base import ControllerBase, ControllerConfigBase
+from hummingbot.strategy_v2.executors.data_types import ConnectorPair
+from hummingbot.strategy_v2.executors.funding_arbitrage_executor.data_types import FundingArbitrageExecutorConfig
+from hummingbot.strategy_v2.models.base import RunnableStatus
+from hummingbot.strategy_v2.models.executor_actions import CreateExecutorAction, ExecutorAction
+
+
+class FundingRateArbitrageControllerConfig(ControllerConfigBase):
+    """
+    Configuration for the Funding Rate Arbitrage Controller.
+
+    This controller monitors funding rates across multiple exchanges and tokens,
+    identifies profitable arbitrage opportunities, and creates executors to
+    capture funding rate differentials.
+    """
+    controller_type: str = "funding_rate_arbitrage"
+
+    # Exchange and token configuration
+    exchanges: Set[str] = Field(
+        default="hyperliquid_perpetual,binance_perpetual",
+        json_schema_extra={
+            "prompt": "Enter the perpetual exchanges separated by commas (e.g., hyperliquid_perpetual,binance_perpetual): ",
+            "prompt_on_new": True,
+            "is_updatable": True
+        }
+    )
+
+    token: str = Field(
+        default="WIF",
+        json_schema_extra={
+            "prompt": "Enter the token to monitor (e.g., WIF): ",
+            "prompt_on_new": True,
+            "is_updatable": True
+        }
+    )
+
+    # Position sizing
+    position_size_quote: Decimal = Field(
+        default=Decimal("100"),
+        gt=0,
+        json_schema_extra={
+            "prompt": "Enter the position size in quote asset (e.g., 100 will open $100 long and $100 short): ",
+            "prompt_on_new": True,
+            "is_updatable": True
+        }
+    )
+
+    # Funding rate normalization and profitability calculation
+    funding_profitability_interval_hours: int = Field(
+        default=24,
+        ge=1,
+        json_schema_extra={
+            "prompt": "Enter the time interval in hours to calculate funding profitability (e.g., 24 for daily): ",
+            "prompt_on_new": True,
+            "is_updatable": True
+        }
+    )
+
+    # Profitability thresholds
+    min_funding_rate_profitability: Decimal = Field(
+        default=Decimal("0.001"),
+        gt=0,
+        json_schema_extra={
+            "prompt": "Enter the minimum funding rate profitability to enter a position (e.g., 0.001 for 0.1%): ",
+            "prompt_on_new": True,
+            "is_updatable": True
+        }
+    )
+
+    profitability_to_take_profit: Decimal = Field(
+        default=Decimal("0.01"),
+        gt=0,
+        json_schema_extra={
+            "prompt": "Enter the profitability threshold to take profit (including PnL and funding received, e.g., 0.01 for 1%): ",
+            "prompt_on_new": True,
+            "is_updatable": True
+        }
+    )
+
+    funding_rate_diff_stop_loss: Decimal = Field(
+        default=Decimal("-0.001"),
+        json_schema_extra={
+            "prompt": "Enter the funding rate difference to stop the position (e.g., -0.001 for -0.1%): ",
+            "prompt_on_new": True,
+            "is_updatable": True
+        }
+    )
+
+    # Risk management
+    max_active_positions: int = Field(
+        default=3,
+        ge=1,
+        json_schema_extra={
+            "prompt": "Enter the maximum number of active arbitrage positions (e.g., 3): ",
+            "prompt_on_new": True,
+            "is_updatable": True
+        }
+    )
+
+    leverage: int = Field(
+        default=20,
+        ge=1,
+        json_schema_extra={
+            "prompt": "Enter the leverage to use for trading (e.g., 20 for 20x leverage): ",
+            "prompt_on_new": True,
+            "is_updatable": True
+        }
+    )
+
+    # Risk management (add after existing risk management fields)
+    stop_loss_pct: Optional[Decimal] = Field(
+        default=Decimal("0.02"),
+        ge=0,
+        json_schema_extra={
+            "prompt": "Enter the stop loss threshold as percentage (e.g., 0.02 for 2%): ",
+            "prompt_on_new": True,
+            "is_updatable": True
+        }
+    )
+
+    max_position_duration_seconds: Optional[int] = Field(
+        default=24 * 60 * 60,  # 24 hours
+        gt=0,
+        json_schema_extra={
+            "prompt": "Enter maximum position duration in seconds (e.g., 86400 for 24 hours): ",
+            "prompt_on_new": True,
+            "is_updatable": True
+        }
+    )
+
+    asymmetric_fill_timeout_seconds: int = Field(
+        default=300,  # 5 minutes
+        ge=1,
+        json_schema_extra={
+            "prompt": "Enter timeout in seconds before closing positions if only one side is filled (e.g., 600 for 10 minutes): ",
+            "prompt_on_new": True,
+            "is_updatable": True
+        }
+    )
+
+    order_renewal_threshold_pct: Decimal = Field(
+        default=Decimal("0.005"),  # 0.5%
+        ge=0,
+        json_schema_extra={
+            "prompt": "Enter price movement threshold to trigger order renewal (e.g., 0.005 for 0.5%): ",
+            "prompt_on_new": True,
+            "is_updatable": True
+        }
+    )
+
+    entry_limit_order_spread_bps: int = Field(
+        default=2,
+        ge=0,
+        json_schema_extra={
+            "prompt": "Enter spread in basis points for entry limit orders (e.g., 2 for 0.02%): ",
+            "prompt_on_new": True,
+            "is_updatable": True
+        }
+    )
+
+    @field_validator("exchanges", mode="before")
+    @classmethod
+    def validate_sets(cls, v):
+        """Convert comma-separated strings to sets."""
+        if isinstance(v, str):
+            return set(item.strip() for item in v.split(",") if item.strip())
+        return v
+
+    @field_validator("exchanges")
+    @classmethod
+    def validate_exchanges(cls, v):
+        """Validate that exchanges are perpetual futures exchanges."""
+        perpetual_exchanges = {
+            "binance_perpetual", "hyperliquid_perpetual", "bybit_perpetual",
+            "dydx_perpetual", "coinbase_perpetual", "okx_perpetual"
+        }
+        invalid_exchanges = v - perpetual_exchanges
+        if invalid_exchanges:
+            raise ValueError(f"Invalid perpetual exchanges: {invalid_exchanges}. "
+                             f"Valid options: {perpetual_exchanges}")
+        return v
+
+    @field_validator("token")
+    @classmethod
+    def validate_token(cls, v):
+        """Validate token format."""
+        if not v.isalnum() or len(v) > 10:
+            raise ValueError(f"Invalid token format: {v}. "
+                             f"Token should be alphanumeric and <= 10 characters.")
+        return v
+
+    @property
+    def funding_payment_interval_map(self) -> Dict[str, int]:
+        """
+        Map of exchange to funding payment intervals in seconds.
+        Similar to the existing v2 script approach.
+        """
+        return {
+            "binance_perpetual": 60 * 60 * 8,  # 8 hours
+            "hyperliquid_perpetual": 60 * 60 * 1,  # 1 hour
+            "bybit_perpetual": 60 * 60 * 8,  # 8 hours
+            "dydx_perpetual": 60 * 60 * 8,  # 8 hours
+            "coinbase_perpetual": 60 * 60 * 8,  # 8 hours
+            "okx_perpetual": 60 * 60 * 8,  # 8 hours
+        }
+
+    @property
+    def funding_profitability_interval_seconds(self) -> int:
+        """
+        Convert funding profitability interval from hours to seconds.
+        Used for calculating expected profitability over the specified time period.
+        """
+        return self.funding_profitability_interval_hours * 60 * 60
+
+    def get_normalized_funding_rate_per_second(self, funding_rate: Decimal, exchange: str) -> Decimal:
+        """
+        Convert funding rate to per-second rate for comparison across exchanges.
+        Similar to the existing v2 script's get_normalized_funding_rate_in_seconds method.
+
+        Args:
+            funding_rate: The raw funding rate from the exchange
+            exchange: The exchange name
+
+        Returns:
+            Normalized funding rate per second
+        """
+        interval_seconds = self.funding_payment_interval_map.get(exchange, 60 * 60 * 8)
+        return funding_rate / Decimal(interval_seconds)
+
+    def calculate_funding_profitability(self, rate_per_second_1: Decimal, rate_per_second_2: Decimal) -> Decimal:
+        """
+        Calculate the expected profitability from funding rate differential over the configured interval.
+        Similar to the existing v2 script's profitability calculation.
+
+        Args:
+            rate_per_second_1: Normalized funding rate per second for exchange 1
+            rate_per_second_2: Normalized funding rate per second for exchange 2
+
+        Returns:
+            Expected profitability over the configured interval
+        """
+        funding_rate_diff = abs(rate_per_second_1 - rate_per_second_2)
+        return funding_rate_diff * Decimal(self.funding_profitability_interval_seconds)
+
+    def update_markets(self, markets: MarketDict) -> MarketDict:
+        """Update the markets dict with required trading pairs."""
+        quote_asset_map = {
+            "hyperliquid_perpetual": "USD",
+            "binance_perpetual": "USDT",
+            "bybit_perpetual": "USDT",
+            "dydx_perpetual": "USD",
+            "coinbase_perpetual": "USD",
+            "okx_perpetual": "USDT"
+        }
+
+        for exchange in self.exchanges:
+            quote_asset = quote_asset_map.get(exchange, "USDT")
+            trading_pair = f"{self.token}-{quote_asset}"
+            markets = markets.add_or_update(exchange, trading_pair)
+
+        return markets
+
+
+class FundingRateArbitrageController(ControllerBase):
+    """
+    A controller that monitors funding rates across exchanges for a single token
+    and creates executors to capture arbitrage opportunities.
+
+    Following proper V2 patterns where:
+    - Controller only creates executors when opportunities arise
+    - Executors are self-sufficient and manage their own lifecycle
+    - Controller focuses on a single token for simplicity
+    """
+
+    def __init__(self, config: FundingRateArbitrageControllerConfig, *args, **kwargs):
+        super().__init__(config, *args, **kwargs)
+        self.config = config
+
+        # Data storage for funding rates and normalization
+        self.funding_rates_data: Dict[str, object] = {}  # exchange -> FundingInfo
+        self.normalized_rates_data: Dict[str, Decimal] = {}  # exchange -> normalized_rate
+
+        # Track active executors count (but don't manage them)
+        self._active_executors_count = 0
+
+    async def update_processed_data(self):
+        """
+        Update processed data by fetching and normalizing funding rates.
+        This is called by the framework before determine_executor_actions.
+        """
+        self._fetch_funding_rates()
+        self._normalize_funding_rates()
+
+    def determine_executor_actions(self) -> List[ExecutorAction]:
+        """
+        Determine if any executor actions should be taken.
+        Only creates new executors when opportunities exist and capacity allows.
+        """
+        actions = []
+
+        self.logger().info(f"Determining executor actions for {self.config.token}")
+
+        # Update active executor count from framework
+        self._active_executors_count = len([
+            executor for executor in self.executors_info
+            if executor.status == RunnableStatus.RUNNING
+        ])
+
+        self.logger().info(f"Active executors: {self._active_executors_count}/{self.config.max_active_positions}")
+
+        # Only create new executors if under max capacity
+        if self._active_executors_count < self.config.max_active_positions:
+            opportunity = self._find_best_opportunity()
+            if opportunity:
+                self.logger().info(f"Best opportunity found: {opportunity}")
+                executor_config = self._create_arbitrage_executor(opportunity)
+                if executor_config:
+                    action = CreateExecutorAction(
+                        controller_id=self.config.id,
+                        executor_config=executor_config
+                    )
+                    actions.append(action)
+                    self.logger().info(f"Created arbitrage executor action for {self.config.token}: "
+                                       f"{opportunity['long_exchange']} (long) vs {opportunity['short_exchange']} (short), "
+                                       f"differential: {opportunity['funding_rate_differential']:.6f}")
+                else:
+                    self.logger().warning(f"Failed to create executor config for opportunity: {opportunity}")
+            else:
+                self.logger().info("No profitable opportunities found")
+        else:
+            self.logger().info(f"At maximum capacity ({self._active_executors_count}/{self.config.max_active_positions})")
+
+        return actions
+
+    def _fetch_funding_rates(self):
+        """Fetch funding rate information for the token across all exchanges."""
+        self.funding_rates_data = {}
+
+        for exchange in self.config.exchanges:
+            try:
+                trading_pair = self._get_trading_pair_for_exchange(exchange)
+                funding_info = self.market_data_provider.get_funding_info(exchange, trading_pair)
+
+                if funding_info:
+                    self.funding_rates_data[exchange] = funding_info
+                else:
+                    self.logger().warning(f"No funding info available for {exchange}:{trading_pair}")
+
+            except Exception as e:
+                self.logger().error(f"Error fetching funding rates for {exchange}: {e}")
+
+    def _normalize_funding_rates(self):
+        """Normalize funding rates using config parameters for comparison."""
+        self.normalized_rates_data = {}
+
+        # Only process exchanges that actually have funding data
+        for exchange, funding_info in self.funding_rates_data.items():
+            try:
+                # Use config method to get normalized rate per second
+                rate_per_second = self.config.get_normalized_funding_rate_per_second(
+                    funding_info.rate, exchange
+                )
+                self.normalized_rates_data[exchange] = rate_per_second
+
+            except Exception as e:
+                self.logger().error(f"Error normalizing funding rate for {exchange}: {e}")
+
+    def _find_best_opportunity(self) -> Optional[Dict]:
+        """
+        Find the best arbitrage opportunity for the token.
+        Returns the opportunity with highest profitability above the minimum threshold.
+        """
+        if len(self.normalized_rates_data) < 2:
+            return None
+
+        best_opportunity = None
+        highest_net_profitability = Decimal("0")
+
+        exchanges = list(self.normalized_rates_data.keys())
+
+        # Evaluate all exchange pairs
+        for i, long_exchange in enumerate(exchanges):
+            for short_exchange in exchanges[i + 1:]:
+                opportunity = self._evaluate_exchange_pair(long_exchange, short_exchange)
+                if opportunity and opportunity["net_profitability"] > highest_net_profitability:
+                    highest_net_profitability = opportunity["net_profitability"]
+                    best_opportunity = opportunity
+
+                # Also check the reverse direction
+                opportunity = self._evaluate_exchange_pair(short_exchange, long_exchange)
+                if opportunity and opportunity["net_profitability"] > highest_net_profitability:
+                    highest_net_profitability = opportunity["net_profitability"]
+                    best_opportunity = opportunity
+
+        return best_opportunity
+
+    def _evaluate_exchange_pair(self, exchange_1: str, exchange_2: str) -> Optional[Dict]:
+        """Evaluate if an exchange pair provides a profitable opportunity."""
+        try:
+            rate_per_second_1 = self.normalized_rates_data[exchange_1]
+            rate_per_second_2 = self.normalized_rates_data[exchange_2]
+
+            # Calculate expected profitability using config method
+            expected_funding_profitability = self.config.calculate_funding_profitability(
+                rate_per_second_1, rate_per_second_2
+            )
+
+            # Determine direction (we want to short higher rate, long lower rate)
+            if rate_per_second_1 < rate_per_second_2:
+                long_exchange = exchange_1
+                short_exchange = exchange_2
+                funding_rate_differential = rate_per_second_2 - rate_per_second_1
+            else:
+                long_exchange = exchange_2
+                short_exchange = exchange_1
+                funding_rate_differential = rate_per_second_1 - rate_per_second_2
+
+            # If no meaningful differential, skip
+            if funding_rate_differential <= 0:
+                return None
+
+            # Calculate estimated trading fees
+            long_entry_fee, short_entry_fee, long_exit_fee, short_exit_fee, total_fees = self._calculate_estimated_trading_fees(long_exchange, short_exchange)
+
+            # Net profitability calculation (like XEMM executor)
+            net_profitability = expected_funding_profitability - total_fees
+
+            if net_profitability >= self.config.min_funding_rate_profitability:
+                return {
+                    "long_exchange": long_exchange,
+                    "short_exchange": short_exchange,
+                    "funding_rate_differential": funding_rate_differential,
+                    "expected_funding_pnl": expected_funding_profitability,
+                    "estimated_fees": total_fees,
+                    "fee_breakdown": {
+                        "long_entry_fee": long_entry_fee,
+                        "short_entry_fee": short_entry_fee,
+                        "long_exit_fee": long_exit_fee,
+                        "short_exit_fee": short_exit_fee,
+                        "total_fees": total_fees
+                    },
+                    "net_profitability": net_profitability
+                }
+
+        except Exception as e:
+            self.logger().error(f"Error evaluating exchange pair {exchange_1}-{exchange_2}: {e}")
+
+        return None
+
+    def _calculate_estimated_trading_fees(self, long_exchange: str, short_exchange: str) -> Tuple[Decimal, Decimal, Decimal, Decimal, Decimal]:
+        """
+        Calculate estimated trading fees for entering and exiting positions.
+        Uses connector APIs when available, similar to XEMM executor approach.
+        Differentiates between maker and taker
+        """
+        try:
+            long_trading_pair = self._get_trading_pair_for_exchange(long_exchange)
+            short_trading_pair = self._get_trading_pair_for_exchange(short_exchange)
+
+            # Entry: Use limit makers when possible for better pricing
+            entry_order_type = OrderType.LIMIT_MAKER
+            # Exit: Can use more aggressive pricing for faster execution
+            exit_order_type = OrderType.MARKET
+
+            # Calculate entry fees (long position on long_exchange, short position on short_exchange)
+            long_entry_fee = self._get_connector_trading_fee(
+                long_exchange, long_trading_pair, entry_order_type, TradeType.BUY, is_entry=True
+            )
+            short_entry_fee = self._get_connector_trading_fee(
+                short_exchange, short_trading_pair, entry_order_type, TradeType.SELL, is_entry=True
+            )
+
+            # Calculate exit fees (close long position, close short position)
+            long_exit_fee = self._get_connector_trading_fee(
+                long_exchange, long_trading_pair, exit_order_type, TradeType.SELL, is_entry=False
+            )
+            short_exit_fee = self._get_connector_trading_fee(
+                short_exchange, short_trading_pair, exit_order_type, TradeType.BUY, is_entry=False
+            )
+            total_fees = long_entry_fee + short_entry_fee + long_exit_fee + short_exit_fee
+            return long_entry_fee, short_entry_fee, long_exit_fee, short_exit_fee, total_fees
+
+        except Exception as e:
+            self.logger().error(f"Error calculating trading fees: {e}")
+            return Decimal("0.0004"), Decimal("0.0004"), Decimal("0.0004"), Decimal("0.0004"), Decimal("0.0016")  # 4 trades total
+
+    def _get_connector_trading_fee(self, exchange: str, trading_pair: str, order_type: OrderType,
+                                   trade_type: TradeType, is_entry: bool) -> Decimal:
+        """
+        Get trading fee using the V2 standard pattern.
+        Controllers use market data provider for fee calculation when available.
+        """
+        try:
+            # Try to get fee info from market data provider's connectors
+            if hasattr(self.market_data_provider, 'connectors') and exchange in self.market_data_provider.connectors:
+                connector = self.market_data_provider.connectors[exchange]
+
+                # Get current price for fee calculation
+                current_price = self.market_data_provider.get_price_by_type(
+                    exchange, trading_pair, PriceType.MidPrice
+                )
+
+                if current_price and current_price > 0:
+                    # Calculate order amount based on position size
+                    order_amount = self.config.position_size_quote / current_price
+                    base_asset, quote_asset = trading_pair.split("-")
+
+                    # Use connector's get_fee method
+                    fee_info = connector.get_fee(
+                        base_currency=base_asset,
+                        quote_currency=quote_asset,
+                        order_type=order_type,
+                        order_side=trade_type,
+                        amount=order_amount,
+                        price=current_price,
+                        is_maker=(order_type == OrderType.LIMIT_MAKER)
+                    )
+
+                    # Return the percentage fee
+                    return fee_info.percent
+
+        except Exception as e:
+            self.logger().debug(f"Could not get connector fee for {exchange}, using estimate: {e}")
+
+        # Fallback to hardcoded estimates when connector is not available
+        return self._get_estimated_exchange_fee(exchange, order_type)
+
+    def _get_estimated_exchange_fee(self, exchange: str, order_type: OrderType) -> Decimal:
+        """Get estimated fee for an exchange, differentiating maker vs taker."""
+        if order_type == OrderType.LIMIT_MAKER:
+            # Maker fees (limit orders)
+            maker_fee_estimates = {
+                "binance_perpetual": Decimal("0.0002"),
+                "hyperliquid_perpetual": Decimal("0.0000"),  # No maker fees
+                "dydx_perpetual": Decimal("0.0003"),
+                "bybit_perpetual": Decimal("0.0002"),
+                "gate_io_perpetual": Decimal("0.0002"),
+                "kucoin_perpetual": Decimal("0.0002"),
+                "okx_perpetual": Decimal("0.0002")
+            }
+            return maker_fee_estimates.get(exchange, Decimal("0.0002"))
+        else:
+            # Taker fees (market orders)
+            taker_fee_estimates = {
+                "binance_perpetual": Decimal("0.0004"),
+                "hyperliquid_perpetual": Decimal("0.0002"),
+                "dydx_perpetual": Decimal("0.0005"),
+                "bybit_perpetual": Decimal("0.0006"),
+                "gate_io_perpetual": Decimal("0.0004"),
+                "kucoin_perpetual": Decimal("0.0006"),
+                "okx_perpetual": Decimal("0.0005")
+            }
+            return taker_fee_estimates.get(exchange, Decimal("0.0005"))
+
+    def _create_arbitrage_executor(self, opportunity: Dict) -> Optional[FundingArbitrageExecutorConfig]:
+        """Create a FundingArbitrageExecutorConfig from an opportunity."""
+        try:
+            long_trading_pair = self._get_trading_pair_for_exchange(opportunity["long_exchange"])
+            short_trading_pair = self._get_trading_pair_for_exchange(opportunity["short_exchange"])
+
+            executor_config = FundingArbitrageExecutorConfig(
+                timestamp=self.market_data_provider.time(),
+                long_market=ConnectorPair(
+                    connector_name=opportunity["long_exchange"],
+                    trading_pair=long_trading_pair
+                ),
+                short_market=ConnectorPair(
+                    connector_name=opportunity["short_exchange"],
+                    trading_pair=short_trading_pair
+                ),
+                position_size_quote=self.config.position_size_quote,
+                leverage=self.config.leverage,
+                entry_limit_order_spread_bps=self.config.entry_limit_order_spread_bps,
+                take_profit_pct=self.config.profitability_to_take_profit,
+                stop_loss_pct=self.config.stop_loss_pct,
+                min_funding_rate_differential=self.config.funding_rate_diff_stop_loss,
+                max_position_duration_seconds=self.config.max_position_duration_seconds,
+                asymmetric_fill_timeout_seconds=self.config.asymmetric_fill_timeout_seconds,
+                order_renewal_threshold_pct=self.config.order_renewal_threshold_pct,
+            )
+            return executor_config
+
+        except Exception as e:
+            self.logger().error(f"Error creating executor config: {e}")
+            self.logger().error(f"Error type: {type(e)}")
+            import traceback
+            self.logger().error(f"Full traceback: {traceback.format_exc()}")
+            return None
+
+    def _get_trading_pair_for_exchange(self, exchange: str) -> str:
+        """Get the trading pair for a given exchange."""
+        quote_asset_map = {
+            "hyperliquid_perpetual": "USD",
+            "binance_perpetual": "USDT",
+            "bybit_perpetual": "USDT",
+            "dydx_perpetual": "USD",
+            "coinbase_perpetual": "USD",
+            "okx_perpetual": "USDT"
+        }
+        quote_asset = quote_asset_map.get(exchange, "USDT")
+        return f"{self.config.token}-{quote_asset}"
+
+    def _get_order_type_info(self) -> Dict[str, str]:
+        """Get formatted order type information for display."""
+        return {
+            "entry_type": "MAKER (Limit)",
+            "exit_type": "TAKER (Market)",
+            "description": ""
+        }
+
+    def to_format_status(self) -> List[str]:
+        """
+        Format the status of the controller for display with compact vertical layout.
+        """
+        status_lines = []
+
+        # Header line with all key info
+        status_lines.append(f"=== Funding Rate Arbitrage: {self.config.token} | Size: ${self.config.position_size_quote} | Min: {self.config.min_funding_rate_profitability:.3%} | Active: {self._active_executors_count}/{self.config.max_active_positions} ===")
+
+        # Display current funding rates in compact format
+        if self.normalized_rates_data:
+            # One line per exchange with horizontal layout
+            rate_display = []
+            for exchange, rate in self.normalized_rates_data.items():
+                daily_rate = rate * 86400 * 100  # Convert per-second to per-day percentage
+                exchange_short = exchange.replace("_perpetual", "").upper()
+                rate_display.append(f"{exchange_short}: {daily_rate:+.3f}%/d")
+
+            status_lines.append(f"📈 Funding Rates: {' | '.join(rate_display)}")
+
+            # Display best opportunity in compact format
+            opportunity = self._find_best_opportunity()
+            if opportunity:
+                long_ex = opportunity['long_exchange'].replace('_perpetual', '').upper()
+                short_ex = opportunity['short_exchange'].replace('_perpetual', '').upper()
+                daily_diff = opportunity['funding_rate_differential'] * 86400 * 100
+                expected_pnl = opportunity['expected_funding_pnl']
+                total_fees = opportunity.get('estimated_fees', Decimal('0'))
+                net_pnl = opportunity['net_profitability']
+
+                # Status indicator
+                if self._active_executors_count >= self.config.max_active_positions:
+                    status_icon = "⏸️"
+                elif net_pnl >= self.config.min_funding_rate_profitability:
+                    status_icon = "✅"
+                else:
+                    status_icon = "❌"
+
+                status_lines.append(f"🎯 Best Opportunity: {status_icon} Long {long_ex} / Short {short_ex} | Diff: {daily_diff:+.3f}%/d | Expected: {expected_pnl:.3%} | Fees: {total_fees:.3%} | Net: {net_pnl:.3%}")
+            else:
+                status_lines.append("🔍 No profitable opportunities available")
+        else:
+            status_lines.append("⚠️  Waiting for funding rate data...")
+
+        # Compact executor status table
+        if self.executors_info:
+            running_executors = [e for e in self.executors_info if e.status == RunnableStatus.RUNNING]
+            if running_executors:
+                status_lines.append("🔧 Active Executors:")
+                # Table header
+                status_lines.append(f"{'ID':<8} {'Type':<20} {'PnL':<10} {'Age':<8} {'Status':<12}")
+                status_lines.append("-" * 65)
+
+                for executor_info in running_executors:
+                    try:
+                        executor_id = executor_info.id[:8]
+                        executor_type = executor_info.type[:20] if hasattr(executor_info, 'type') else "Unknown"
+
+                        # PnL info
+                        pnl_str = "N/A"
+                        if hasattr(executor_info, 'net_pnl_quote') and executor_info.net_pnl_quote is not None:
+                            pnl_str = f"${executor_info.net_pnl_quote:.2f}"
+                        elif hasattr(executor_info, 'custom_info') and executor_info.custom_info:
+                            custom_info = executor_info.custom_info
+                            if 'total_pnl_quote' in custom_info:
+                                pnl_str = f"${custom_info['total_pnl_quote']:.2f}"
+
+                        # Age info
+                        age_str = "N/A"
+                        if hasattr(executor_info, 'custom_info') and executor_info.custom_info:
+                            custom_info = executor_info.custom_info
+                            if 'position_age_seconds' in custom_info:
+                                age_hours = int(custom_info['position_age_seconds'] // 3600)
+                                age_minutes = int((custom_info['position_age_seconds'] % 3600) // 60)
+                                age_str = f"{age_hours}h{age_minutes}m"
+
+                        status_str = executor_info.status.name
+                        status_lines.append(f"{executor_id:<8} {executor_type:<20} {pnl_str:<10} {age_str:<8} {status_str:<12}")
+
+                    except Exception:
+                        status_lines.append(f"{executor_info.id[:8]:<8} {'ERROR':<20} {'N/A':<10} {'N/A':<8} {'ERROR':<12}")
+
+        return status_lines

--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_constants.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_constants.py
@@ -43,6 +43,7 @@ POSITION_IDX_HEDGE_SELL = 2
 ORDER_TYPE_MAP = {
     OrderType.LIMIT: "Limit",
     OrderType.MARKET: "Market",
+    OrderType.LIMIT_MAKER: "Limit",
 }
 
 POSITION_MODE_API_ONEWAY = 0
@@ -165,3 +166,10 @@ RET_CODE_API_KEY_INVALID = 10003
 RET_CODE_INVALID_TIME = 10002
 RET_CODE_API_KEY_EXPIRED = 33004
 RET_CODE_POSITION_ZERO = 130125
+
+TIME_IN_FORCE_OPTIONS = {
+    "GTC": "GTC",     # Good Till Cancelled
+    "IOC": "IOC",     # Immediate or Cancel
+    "FOK": "FOK",     # Fill or Kill
+    "PostOnly": "PostOnly"  # Maker-only orders
+}

--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_derivative.py
@@ -146,7 +146,7 @@ class BybitPerpetualDerivative(PerpetualDerivativePyBase):
         """
         :return a list of OrderType supported by this connector
         """
-        return [OrderType.LIMIT, OrderType.MARKET]
+        return [OrderType.LIMIT, OrderType.MARKET, OrderType.LIMIT_MAKER]
 
     def supported_position_modes(self) -> List[PositionMode]:
         if all(bybit_utils.is_linear_perpetual(tp) for tp in self._trading_pairs):
@@ -237,6 +237,8 @@ class BybitPerpetualDerivative(PerpetualDerivativePyBase):
             "positionIdx": position_idx,
             "orderType": CONSTANTS.ORDER_TYPE_MAP[order_type],
         }
+        if order_type == OrderType.LIMIT_MAKER:
+            data["timeInForce"] = CONSTANTS.TIME_IN_FORCE_OPTIONS["PostOnly"]
         if order_type.is_limit_type():
             data["price"] = str(price)
 
@@ -282,7 +284,7 @@ class BybitPerpetualDerivative(PerpetualDerivativePyBase):
                  price: Decimal = s_decimal_NaN,
                  is_maker: Optional[bool] = None,
                  position_action: PositionAction = None) -> TradeFeeBase:
-        is_maker = is_maker or False
+        is_maker = is_maker or (order_type == OrderType.LIMIT_MAKER)
         fee = build_trade_fee(
             self.name,
             is_maker,

--- a/hummingbot/strategy_v2/executors/arbitrage_executor/arbitrage_executor.py
+++ b/hummingbot/strategy_v2/executors/arbitrage_executor/arbitrage_executor.py
@@ -267,11 +267,12 @@ class ArbitrageExecutor(ExecutorBase):
 
         _, buy_quote_asset = split_hb_trading_pair(self.buying_market.trading_pair)
         _, sell_quote_asset = split_hb_trading_pair(self.selling_market.trading_pair)
-        interchange_map = self.config.interchange_tokens_for_price_fetch
-        if buy_quote_asset in interchange_map:
-            buy_quote_asset = interchange_map[buy_quote_asset]
-        if sell_quote_asset in interchange_map:
-            sell_quote_asset = interchange_map[sell_quote_asset]
+        interchange_map = getattr(self.config, 'interchange_tokens_for_price_fetch', {})
+        if interchange_map:
+            if buy_quote_asset in interchange_map:
+                buy_quote_asset = interchange_map[buy_quote_asset]
+            if sell_quote_asset in interchange_map:
+                sell_quote_asset = interchange_map[sell_quote_asset]
 
         # Define the conversion trading pair (e.g., SOL/USDT or USDT/SOL)
         self.quote_conversion_pair = f"{sell_quote_asset}-{buy_quote_asset}"

--- a/hummingbot/strategy_v2/executors/arbitrage_executor/data_types.py
+++ b/hummingbot/strategy_v2/executors/arbitrage_executor/data_types.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from typing import Literal, Optional
+from typing import Dict, Literal, Optional
 
 from hummingbot.strategy_v2.executors.data_types import ConnectorPair, ExecutorConfigBase
 
@@ -10,4 +10,6 @@ class ArbitrageExecutorConfig(ExecutorConfigBase):
     selling_market: ConnectorPair
     order_amount: Decimal
     min_profitability: Decimal
+    slippage: Optional[Decimal] = None
     gas_conversion_price: Optional[Decimal] = None
+    interchange_tokens_for_price_fetch: Dict[str, str] = {}

--- a/hummingbot/strategy_v2/executors/data_types.py
+++ b/hummingbot/strategy_v2/executors/data_types.py
@@ -14,7 +14,7 @@ from hummingbot.core.data_type.common import TradeType
 class ExecutorConfigBase(BaseModel):
     id: str = None  # Make ID optional
     type: Literal["position_executor", "dca_executor", "grid_executor", "order_executor",
-                  "xemm_executor", "arbitrage_executor", "twap_executor"]
+                  "xemm_executor", "arbitrage_executor", "twap_executor", "funding_arbitrage_executor"]
     timestamp: Optional[float] = None
     controller_id: str = "main"
 

--- a/hummingbot/strategy_v2/executors/executor_orchestrator.py
+++ b/hummingbot/strategy_v2/executors/executor_orchestrator.py
@@ -15,6 +15,9 @@ if TYPE_CHECKING:
 from hummingbot.strategy_v2.executors.arbitrage_executor.arbitrage_executor import ArbitrageExecutor
 from hummingbot.strategy_v2.executors.data_types import PositionSummary
 from hummingbot.strategy_v2.executors.dca_executor.dca_executor import DCAExecutor
+from hummingbot.strategy_v2.executors.funding_arbitrage_executor.funding_arbitrage_executor import (
+    FundingArbitrageExecutor,
+)
 from hummingbot.strategy_v2.executors.grid_executor.grid_executor import GridExecutor
 from hummingbot.strategy_v2.executors.order_executor.order_executor import OrderExecutor
 from hummingbot.strategy_v2.executors.position_executor.position_executor import PositionExecutor
@@ -144,6 +147,7 @@ class ExecutorOrchestrator:
         "twap_executor": TWAPExecutor,
         "xemm_executor": XEMMExecutor,
         "order_executor": OrderExecutor,
+        "funding_arbitrage_executor": FundingArbitrageExecutor,
     }
 
     @classmethod
@@ -387,6 +391,7 @@ class ExecutorOrchestrator:
 
         executor.start()
         self.active_executors[controller_id].append(executor)
+
         # MarketsRecorder.get_instance().store_or_update_executor(executor)
         self.logger().debug(f"Created {type(executor).__name__} for controller {controller_id}")
 

--- a/hummingbot/strategy_v2/executors/funding_arbitrage_executor/__init__.py
+++ b/hummingbot/strategy_v2/executors/funding_arbitrage_executor/__init__.py
@@ -1,0 +1,2 @@
+# Empty init file to avoid circular imports
+# Import statements should be done directly from the specific modules

--- a/hummingbot/strategy_v2/executors/funding_arbitrage_executor/data_types.py
+++ b/hummingbot/strategy_v2/executors/funding_arbitrage_executor/data_types.py
@@ -1,0 +1,154 @@
+from decimal import Decimal
+from typing import Literal, Optional
+
+from pydantic import Field, field_validator
+
+from hummingbot.strategy_v2.executors.data_types import ConnectorPair, ExecutorConfigBase
+
+
+class FundingArbitrageExecutorConfig(ExecutorConfigBase):
+    """
+    Configuration for the Funding Arbitrage Executor.
+
+    This executor manages a pair of opposing positions (long and short) on two
+    different exchanges to capture funding rate differentials while using
+    limit order management for optimal execution.
+    """
+    type: Literal["funding_arbitrage_executor"] = "funding_arbitrage_executor"
+
+    # Market configuration
+    long_market: ConnectorPair = Field(
+        ...,
+        description="The market where the long position will be opened"
+    )
+
+    short_market: ConnectorPair = Field(
+        ...,
+        description="The market where the short position will be opened"
+    )
+
+    # Position sizing
+    position_size_quote: Decimal = Field(
+        ...,
+        gt=0,
+        description="The position size in quote asset for each leg of the arbitrage"
+    )
+
+    leverage: int = Field(
+        default=20,
+        ge=1,
+        description="Leverage to use for both positions"
+    )
+
+    # Risk management parameters
+    take_profit_pct: Optional[Decimal] = Field(
+        default=Decimal("0.01"),
+        ge=0,
+        description="Take profit threshold as percentage of position size (e.g., 0.01 for 1%)"
+    )
+
+    stop_loss_pct: Optional[Decimal] = Field(
+        default=Decimal("0.02"),
+        ge=0,
+        description="Stop loss threshold as percentage of position size (e.g., 0.02 for 2%)"
+    )
+
+    max_position_duration_seconds: Optional[int] = Field(
+        default=24 * 60 * 60,  # 24 hours
+        gt=0,
+        description="Maximum duration to hold the position in seconds"
+    )
+
+    # Order management parameters
+    entry_limit_order_spread_bps: int = Field(
+        default=2,
+        ge=0,
+        description="Spread in basis points from best bid/ask for entry limit orders"
+    )
+
+    # Asymmetric fill handling
+    asymmetric_fill_timeout_seconds: int = Field(
+        default=300,  # 5 minutes
+        ge=1,
+        description="Timeout in seconds before closing positions if only one side is filled"
+    )
+
+    # Order renewal parameters
+    order_renewal_threshold_pct: Decimal = Field(
+        default=Decimal("0.005"),  # 0.5%
+        ge=0,
+        description="Price movement threshold to trigger order renewal (e.g., 0.005 for 0.5%)"
+    )
+
+    # Funding arbitrage specific
+    min_funding_rate_differential: Decimal = Field(
+        default=Decimal("0.001"),
+        gt=-0.005,
+        description="Minimum funding rate differential required to maintain the position"
+    )
+
+    @field_validator("take_profit_pct", "stop_loss_pct", "order_renewal_threshold_pct", mode="before")
+    @classmethod
+    def validate_percentages(cls, v):
+        """Ensure percentage values are reasonable."""
+        if v is not None:
+            # Convert to Decimal if it's a string or other numeric type
+            try:
+                decimal_v = Decimal(str(v)) if not isinstance(v, Decimal) else v
+                if decimal_v > 1:
+                    raise ValueError("Percentage values should be decimals (e.g., 0.01 for 1%), not whole numbers")
+                return decimal_v
+            except (ValueError, TypeError) as e:
+                raise ValueError(f"Invalid percentage value: {v}. Must be a valid number.") from e
+        return v
+
+    @field_validator("entry_limit_order_spread_bps")
+    @classmethod
+    def validate_spread_bps(cls, v):
+        """Validate spread basis points."""
+        if v > 1000:  # 10%
+            raise ValueError("Spread basis points should be reasonable (max 1000 bps = 10%)")
+        return v
+
+    @field_validator("leverage")
+    @classmethod
+    def validate_leverage(cls, v):
+        """Validate leverage value."""
+        if v > 100:
+            raise ValueError("Leverage should be reasonable (max 100x)")
+        return v
+
+    def validate_markets(self) -> bool:
+        """
+        Validate that the long and short markets are compatible for arbitrage.
+        They should have the same base asset but can have different quote assets.
+        """
+        long_base = self.long_market.trading_pair.split("-")[0]
+        short_base = self.short_market.trading_pair.split("-")[0]
+
+        if long_base != short_base:
+            raise ValueError(f"Base assets must match: {long_base} != {short_base}")
+
+        if self.long_market.connector_name == self.short_market.connector_name:
+            raise ValueError("Long and short markets must be on different exchanges")
+
+        return True
+
+    @property
+    def base_asset(self) -> str:
+        """Get the base asset from the trading pair."""
+        return self.long_market.trading_pair.split("-")[0]
+
+    @property
+    def long_quote_asset(self) -> str:
+        """Get the quote asset for the long market."""
+        return self.long_market.trading_pair.split("-")[1]
+
+    @property
+    def short_quote_asset(self) -> str:
+        """Get the quote asset for the short market."""
+        return self.short_market.trading_pair.split("-")[1]
+
+    def __post_init__(self):
+        """Validate configuration after initialization."""
+        self.validate_markets()

--- a/hummingbot/strategy_v2/executors/funding_arbitrage_executor/funding_arbitrage_executor.py
+++ b/hummingbot/strategy_v2/executors/funding_arbitrage_executor/funding_arbitrage_executor.py
@@ -1186,4 +1186,4 @@ class FundingArbitrageExecutor(ExecutorBase):
         :return: The cumulative fees in quote asset.
         """
         orders = [self._long_order, self._short_order, self._long_close_order, self._short_close_order]
-        return sum([order.cum_fees_quote for order in orders if order])
+        return sum([order.cum_fees_quote for order in orders if order and order.cum_fees_quote])

--- a/hummingbot/strategy_v2/executors/funding_arbitrage_executor/funding_arbitrage_executor.py
+++ b/hummingbot/strategy_v2/executors/funding_arbitrage_executor/funding_arbitrage_executor.py
@@ -1,0 +1,1189 @@
+import asyncio
+import logging
+from decimal import Decimal
+from typing import List, Optional, Union
+
+from hummingbot.core.data_type.common import OrderType, PositionAction, TradeType
+from hummingbot.core.data_type.order_candidate import PerpetualOrderCandidate
+from hummingbot.core.event.events import (
+    BuyOrderCompletedEvent,
+    BuyOrderCreatedEvent,
+    FundingPaymentCompletedEvent,
+    MarketOrderFailureEvent,
+    OrderCancelledEvent,
+    OrderFilledEvent,
+    SellOrderCompletedEvent,
+    SellOrderCreatedEvent,
+)
+from hummingbot.logger import HummingbotLogger
+from hummingbot.strategy.script_strategy_base import ScriptStrategyBase
+from hummingbot.strategy_v2.executors.executor_base import ExecutorBase
+from hummingbot.strategy_v2.executors.funding_arbitrage_executor.data_types import FundingArbitrageExecutorConfig
+from hummingbot.strategy_v2.models.base import RunnableStatus
+from hummingbot.strategy_v2.models.executors import CloseType, TrackedOrder
+
+
+class FundingArbitrageExecutor(ExecutorBase):
+    """
+    FundingArbitrageExecutor manages a pair of opposing positions (long and short)
+    on two different exchanges to capture funding rate differentials.
+
+    This executor:
+    - Opens synchronized positions on two exchanges (long on one, short on another)
+    - Tracks funding payments from both positions
+    - Monitors combined PnL (trade PnL + funding PnL)
+    - Closes positions based on risk controls (TP/SL/duration)
+    """
+
+    _logger = None
+
+    @classmethod
+    def logger(cls) -> HummingbotLogger:
+        if cls._logger is None:
+            cls._logger = logging.getLogger(__name__)
+        return cls._logger
+
+    def __init__(self,
+                 strategy: ScriptStrategyBase,
+                 config: FundingArbitrageExecutorConfig,
+                 update_interval: float = 1.0,
+                 max_retries: int = 10):
+        """
+        Initialize the FundingArbitrageExecutor.
+
+        :param strategy: The strategy to be used by the executor
+        :param config: Configuration for the funding arbitrage executor
+        :param update_interval: How often to run the control loop (seconds)
+        :param max_retries: Maximum number of retries for failed operations
+        """
+        super().__init__(
+            strategy=strategy,
+            connectors=[config.long_market.connector_name, config.short_market.connector_name],
+            config=config,
+            update_interval=update_interval
+        )
+
+        self.config: FundingArbitrageExecutorConfig = config
+        self._max_retries = max_retries
+        self._current_retries = 0
+
+        # Order tracking - simplified approach following PositionExecutor pattern
+        self._long_order: TrackedOrder = TrackedOrder()
+        self._short_order: TrackedOrder = TrackedOrder()
+        self._long_close_order: Optional[TrackedOrder] = None
+        self._short_close_order: Optional[TrackedOrder] = None
+
+        # Failed orders tracking
+        self._failed_orders: List[TrackedOrder] = []
+
+        # PnL tracking
+        self._trade_pnl_quote = Decimal("0")
+        self._realized_pnl_quote = Decimal("0")
+        self._funding_payments: list = []
+        self._cumulative_funding_pnl = Decimal("0")
+
+        # Timing controls for cooldown
+        self._last_order_time: Optional[float] = None
+        self._order_cooldown_seconds = 2.0
+
+        # Asymmetric fill tracking and timeout
+        self._asymmetric_fill_start_time: Optional[float] = None
+        self._asymmetric_fill_timeout_seconds = config.asymmetric_fill_timeout_seconds
+
+        # Position tracking
+        self._start_timestamp = strategy.current_timestamp
+
+        # Leverage setup tracking
+        self._leverage_setup_complete = False
+        self._leverage_setup_attempts = 0
+        self._max_leverage_setup_attempts = 3
+
+        # Cancellation tracking to prevent duplicate requests
+        self._pending_cancellations = set()  # Track order IDs pending cancellation
+
+    @property
+    def long_order(self) -> TrackedOrder:
+        """The long position order"""
+        return self._long_order
+
+    @property
+    def short_order(self) -> TrackedOrder:
+        """The short position order"""
+        return self._short_order
+
+    @property
+    def trade_pnl_quote(self) -> Decimal:
+        """Current trade PnL in quote currency"""
+        return self._trade_pnl_quote
+
+    @property
+    def funding_pnl_quote(self) -> Decimal:
+        """Cumulative funding PnL in quote currency"""
+        return self._cumulative_funding_pnl
+
+    @property
+    def realized_pnl_quote(self) -> Decimal:
+        """Realized PnL in quote currency from completed orders"""
+        return self._realized_pnl_quote
+
+    @property
+    def total_pnl_quote(self) -> Decimal:
+        """Total PnL (trade + realized + funding) in quote currency"""
+        return self.trade_pnl_quote + self.realized_pnl_quote + self.funding_pnl_quote
+
+    @property
+    def position_age_seconds(self) -> float:
+        """Age of the position in seconds"""
+        if not self.is_position_active:
+            return 0.0
+
+        # Get creation timestamps from orders (with fallback)
+        long_timestamp = (self._long_order.creation_timestamp
+                          if self._long_order.creation_timestamp else self._strategy.current_timestamp)
+        short_timestamp = (self._short_order.creation_timestamp
+                           if self._short_order.creation_timestamp else self._strategy.current_timestamp)
+
+        return self._strategy.current_timestamp - min(long_timestamp, short_timestamp)
+
+    @property
+    def is_position_active(self) -> bool:
+        """Check if both legs of the arbitrage position are active"""
+        return (self._long_order.is_filled and
+                self._short_order.is_filled)
+
+    @property
+    def entry_orders_partially_filled(self) -> bool:
+        """Check if entry orders have asymmetric fills (one side filled, other not)"""
+        # Simple check: one side filled, other not filled
+        return ((self._long_order.is_filled and not self._short_order.is_filled) or
+                (self._short_order.is_filled and not self._long_order.is_filled))
+
+    @property
+    def all_close_orders_completed(self) -> bool:
+        """Check if all close orders have been completed"""
+        long_closed = (self._long_close_order is None or
+                       (self._long_close_order.order and bool(self._long_close_order.order.is_filled)))
+        short_closed = (self._short_close_order is None or
+                        (self._short_close_order.order and bool(self._short_close_order.order.is_filled)))
+        return bool(long_closed and short_closed)
+
+    def get_net_pnl_quote(self) -> Decimal:
+        """
+        Returns the net profit or loss in quote currency.
+        Includes trade PnL, realized PnL, and funding payments minus trading fees.
+        """
+        return self.total_pnl_quote - self.get_cum_fees_quote()
+
+    def get_net_pnl_pct(self) -> Decimal:
+        """
+        Returns the net profit or loss as a percentage.
+        Based on the position size in quote currency.
+        """
+        if self.config.position_size_quote > 0:
+            return self.total_pnl_quote / self.config.position_size_quote
+        return Decimal("0")
+
+    async def validate_sufficient_balance(self) -> bool:
+        """
+        Validate that both connectors have sufficient balance for the planned positions.
+        Uses OrderCandidate pattern for accurate validation and stores adjusted amounts.
+        """
+        try:
+            # Get current prices for amount calculations
+            long_price = self.get_price(
+                self.config.long_market.connector_name,
+                self.config.long_market.trading_pair
+            )
+            short_price = self.get_price(
+                self.config.short_market.connector_name,
+                self.config.short_market.trading_pair
+            )
+
+            if not long_price or not short_price:
+                self.logger().warning("Unable to get current prices for balance validation")
+                return False
+
+            # Calculate base amounts needed
+            long_base_amount = self.config.position_size_quote / long_price
+            short_base_amount = self.config.position_size_quote / short_price
+
+            # Get trading rules for minimum size validation
+            long_trading_rules = self.get_trading_rules(
+                self.config.long_market.connector_name,
+                self.config.long_market.trading_pair
+            )
+            short_trading_rules = self.get_trading_rules(
+                self.config.short_market.connector_name,
+                self.config.short_market.trading_pair
+            )
+
+            # Validate minimum sizes before creating order candidates
+            long_notional = long_base_amount * long_price
+            short_notional = short_base_amount * short_price
+
+            if long_base_amount < long_trading_rules.min_order_size:
+                self.logger().error(f"Long base amount {long_base_amount} below minimum {long_trading_rules.min_order_size}")
+                return False
+
+            if long_notional < long_trading_rules.min_notional_size:
+                self.logger().error(f"Long notional {long_notional} below minimum {long_trading_rules.min_notional_size}")
+                return False
+
+            if short_base_amount < short_trading_rules.min_order_size:
+                self.logger().error(f"Short base amount {short_base_amount} below minimum {short_trading_rules.min_order_size}")
+                return False
+
+            if short_notional < short_trading_rules.min_notional_size:
+                self.logger().error(f"Short notional {short_notional} below minimum {short_trading_rules.min_notional_size}")
+                return False
+
+            # Create OrderCandidates for validation - using limit orders
+            long_order_candidate = PerpetualOrderCandidate(
+                trading_pair=self.config.long_market.trading_pair,
+                is_maker=True,
+                order_type=OrderType.LIMIT_MAKER,
+                order_side=TradeType.BUY,
+                amount=long_base_amount,
+                price=long_price,
+                leverage=self.config.leverage,
+            )
+
+            short_order_candidate = PerpetualOrderCandidate(
+                trading_pair=self.config.short_market.trading_pair,
+                is_maker=True,
+                order_type=OrderType.LIMIT_MAKER,
+                order_side=TradeType.SELL,
+                amount=short_base_amount,
+                price=short_price,
+                leverage=self.config.leverage,
+            )
+
+            # Validate balances using adjust_order_candidates
+            long_adjusted = self.adjust_order_candidates(
+                self.config.long_market.connector_name,
+                [long_order_candidate]
+            )
+            short_adjusted = self.adjust_order_candidates(
+                self.config.short_market.connector_name,
+                [short_order_candidate]
+            )
+
+            if not long_adjusted or long_adjusted[0].amount == Decimal("0"):
+                self.logger().error(f"Insufficient balance on {self.config.long_market.connector_name} "
+                                    f"for long position of {long_base_amount}")
+                return False
+
+            if not short_adjusted or short_adjusted[0].amount == Decimal("0"):
+                self.logger().error(f"Insufficient balance on {self.config.short_market.connector_name} "
+                                    f"for short position of {short_base_amount}")
+                return False
+
+            # Store adjusted amounts for use in actual order placement
+            self._validated_long_amount = long_adjusted[0].amount
+            self._validated_short_amount = short_adjusted[0].amount
+            self._validated_long_price = long_adjusted[0].price
+            self._validated_short_price = short_adjusted[0].price
+
+            self.logger().info(f"Balance validation successful - Adjusted amounts: Long={self._validated_long_amount}, Short={self._validated_short_amount}")
+            return True
+
+        except Exception as e:
+            self.logger().error(f"Error during balance validation: {e}")
+            return False
+
+    async def control_task(self):
+        """Control task that manages the executor lifecycle using simplified approach"""
+        if self.status == RunnableStatus.RUNNING:
+            # Setup leverage first if not done
+            if not self._leverage_setup_complete:
+                await self._setup_leverage()
+            else:
+                self.control_open_orders()
+                self.control_barriers()
+        elif self.status == RunnableStatus.SHUTTING_DOWN:
+            await self._control_shutdown_process()
+        self.evaluate_max_retries()
+
+    def control_open_orders(self):
+        """Control the placement and management of open orders"""
+        # Control each order independently
+        self.control_long_order()
+        self.control_short_order()
+
+        # Monitor existing orders and renew if needed
+        self._monitor_existing_orders()
+
+    def control_long_order(self):
+        """Control the long order independently"""
+        current_time = self._strategy.current_timestamp
+        cooldown_remaining = 0
+        if self._last_order_time:
+            cooldown_remaining = max(0, self._order_cooldown_seconds - (current_time - self._last_order_time))
+
+        if not self._long_order.order_id:
+            self.logger().debug(f"Long order missing - cooldown remaining: {cooldown_remaining:.1f}s")
+            # Check if we should place a new long order
+            if self._can_place_orders():
+                # Check for asymmetric fill requiring aggressive hedge
+                if self._short_order.is_filled and not self._long_order.order_id:
+                    self.logger().info("Asymmetric fill detected: short filled, placing aggressive long hedge")
+                    self._place_aggressive_long_hedge()
+                else:
+                    # Normal case: place both orders (if this is the first control call)
+                    if not self._short_order.order_id:
+                        self.logger().info("Placing initial order pair")
+                        self.place_open_orders()
+                    else:
+                        self.logger().debug("Short order exists, waiting for individual long placement logic")
+            else:
+                self.logger().debug(f"Cannot place orders yet - cooldown: {cooldown_remaining:.1f}s")
+        else:
+            # Monitor existing long order
+            long_status = "filled" if self._long_order.is_filled else ("open" if self._long_order.order and self._long_order.order.is_open else "unknown")
+            self.logger().debug(f"Long order {self._long_order.order_id} status: {long_status}")
+            self._monitor_long_order()
+
+    def control_short_order(self):
+        """Control the short order independently"""
+        current_time = self._strategy.current_timestamp
+        cooldown_remaining = 0
+        if self._last_order_time:
+            cooldown_remaining = max(0, self._order_cooldown_seconds - (current_time - self._last_order_time))
+
+        if not self._short_order.order_id:
+            self.logger().debug(f"Short order missing - cooldown remaining: {cooldown_remaining:.1f}s")
+            # Check if we should place a new short order
+            if self._can_place_orders():
+                # Check for asymmetric fill requiring aggressive hedge
+                if self._long_order.is_filled and not self._short_order.order_id:
+                    self.logger().info("Asymmetric fill detected: long filled, placing aggressive short hedge")
+                    self._place_aggressive_short_hedge()
+                else:
+                    # Normal case handled in control_long_order to avoid duplication
+                    self.logger().debug("Normal case handled in control_long_order")
+            else:
+                self.logger().debug(f"Cannot place orders yet - cooldown: {cooldown_remaining:.1f}s")
+        else:
+            # Monitor existing short order
+            short_status = "filled" if self._short_order.is_filled else ("open" if self._short_order.order and self._short_order.order.is_open else "unknown")
+            self.logger().debug(f"Short order {self._short_order.order_id} status: {short_status}")
+            self._monitor_short_order()
+
+    def control_barriers(self):
+        """Control risk management barriers (take profit, stop loss, time limit)"""
+        if self.is_position_active:
+            self._update_trade_pnl()
+            self._check_exit_conditions()
+
+    def _can_place_orders(self) -> bool:
+        """Check if orders can be placed (cooldown and validation)"""
+        current_time = self._strategy.current_timestamp
+
+        # Check cooldown
+        if (self._last_order_time and
+                current_time - self._last_order_time < self._order_cooldown_seconds):
+            return False
+
+        return True
+
+    def place_open_orders(self):
+        """Place normal limit orders for both long and short positions (non-asymmetric case)"""
+        try:
+            # Get current prices for limit order placement
+            long_price_raw = self.get_price(
+                self.config.long_market.connector_name,
+                self.config.long_market.trading_pair
+            )
+            short_price_raw = self.get_price(
+                self.config.short_market.connector_name,
+                self.config.short_market.trading_pair
+            )
+
+            if not long_price_raw or not short_price_raw:
+                self.logger().warning("Unable to get current prices for order placement")
+                return
+
+            # Quantize prices to 5 decimal precision like Hyperliquid connector
+            long_price = Decimal(round(float(f"{long_price_raw:.5g}"), 5))
+            short_price = Decimal(round(float(f"{short_price_raw:.5g}"), 5))
+
+            self.logger().info(f"Placing normal orders - Long price: {long_price_raw} -> {long_price}, Short price: {short_price_raw} -> {short_price}")
+
+            # Use validated amounts if available, otherwise calculate from config
+            if hasattr(self, '_validated_long_amount') and hasattr(self, '_validated_short_amount'):
+                long_amount = self._validated_long_amount
+                short_amount = self._validated_short_amount
+                self.logger().info(f"Using validated amounts - Long: {long_amount}, Short: {short_amount}")
+            else:
+                # Fallback to calculated amounts using quantized prices
+                long_amount = self.config.position_size_quote / long_price
+                short_amount = self.config.position_size_quote / short_price
+                self.logger().info(f"Calculated amounts - Long: {long_amount}, Short: {short_amount}")
+
+            # Normal case: place both orders with conservative spread on quantized prices
+            spread_bps = self.config.entry_limit_order_spread_bps
+            spread_pct = Decimal(str(spread_bps)) / Decimal("10000")
+
+            # Apply spread to quantized prices
+            long_limit_price = long_price * (Decimal("1") - spread_pct)  # Buy below market
+            short_limit_price = short_price * (Decimal("1") + spread_pct)  # Sell above market
+
+            self.logger().info(f"Order prices with {spread_bps} bps spread - Long: {long_limit_price}, Short: {short_limit_price}")
+
+            # Place long order (buy) only if not already present
+            if not self._long_order.order_id:
+                long_order_id = self.place_order(
+                    connector_name=self.config.long_market.connector_name,
+                    trading_pair=self.config.long_market.trading_pair,
+                    order_type=OrderType.LIMIT_MAKER,
+                    side=TradeType.BUY,
+                    amount=long_amount,
+                    price=long_limit_price,
+                    position_action=PositionAction.OPEN
+                )
+
+                if long_order_id:
+                    self._long_order.order_id = long_order_id
+                    self.logger().info(f"Long limit order placed: {long_order_id} at {long_limit_price}")
+                else:
+                    self.logger().error("Failed to place long order - order_id is None")
+            else:
+                self.logger().debug(f"Long order already exists: {self._long_order.order_id}")
+
+            # Place short order (sell) only if not already present
+            if not self._short_order.order_id:
+                short_order_id = self.place_order(
+                    connector_name=self.config.short_market.connector_name,
+                    trading_pair=self.config.short_market.trading_pair,
+                    order_type=OrderType.LIMIT_MAKER,
+                    side=TradeType.SELL,
+                    amount=short_amount,
+                    price=short_limit_price,
+                    position_action=PositionAction.OPEN
+                )
+
+                if short_order_id:
+                    self._short_order.order_id = short_order_id
+                    self.logger().info(f"Short limit order placed: {short_order_id} at {short_limit_price}")
+                else:
+                    self.logger().error("Failed to place short order - order_id is None")
+            else:
+                self.logger().debug(f"Short order already exists: {self._short_order.order_id}")
+
+            self._last_order_time = self._strategy.current_timestamp
+
+        except Exception as e:
+            self.logger().error(f"Error placing open orders: {e}")
+            self._current_retries += 1
+
+    def _monitor_existing_orders(self):
+        """Monitor existing orders and renew if market has moved significantly"""
+        try:
+            renewal_threshold = self.config.order_renewal_threshold_pct
+
+            # Check long order
+            if (self._long_order.order_id and
+                self._long_order.order and
+                    self._long_order.order.is_open):
+
+                current_price = self.get_price(
+                    self.config.long_market.connector_name,
+                    self.config.long_market.trading_pair
+                )
+
+                if current_price:
+                    price_diff_pct = abs(current_price - self._long_order.order.price) / current_price
+                    if price_diff_pct > renewal_threshold:
+                        self._renew_long_order()
+
+            # Check short order
+            if (self._short_order.order_id and
+                self._short_order.order and
+                    self._short_order.order.is_open):
+
+                current_price = self.get_price(
+                    self.config.short_market.connector_name,
+                    self.config.short_market.trading_pair
+                )
+
+                if current_price:
+                    price_diff_pct = abs(current_price - self._short_order.order.price) / current_price
+                    if price_diff_pct > renewal_threshold:
+                        self._renew_short_order()
+
+        except Exception as e:
+            self.logger().error(f"Error monitoring existing orders: {e}")
+
+    def _renew_long_order(self):
+        """Cancel and replace long order with updated price"""
+        if self._can_place_orders():
+            self.cancel_long_order()
+            # New order will be placed in next control loop iteration
+
+    def _renew_short_order(self):
+        """Cancel and replace short order with updated price"""
+        if self._can_place_orders():
+            self.cancel_short_order()
+            # New order will be placed in next control loop iteration
+
+    def _monitor_long_order(self):
+        """Monitor the long order for renewal needs"""
+        if (self._long_order.order_id and
+            self._long_order.order and
+                self._long_order.order.is_open):
+
+            current_price = self.get_price(
+                self.config.long_market.connector_name,
+                self.config.long_market.trading_pair
+            )
+
+            if current_price:
+                renewal_threshold = self.config.order_renewal_threshold_pct
+                price_diff_pct = abs(current_price - self._long_order.order.price) / current_price
+                if price_diff_pct > renewal_threshold:
+                    self.logger().info(f"Long order price difference {price_diff_pct:.4%} exceeds threshold {renewal_threshold:.4%}, renewing")
+                    self._renew_long_order()
+
+    def _monitor_short_order(self):
+        """Monitor the short order for renewal needs"""
+        if (self._short_order.order_id and
+            self._short_order.order and
+                self._short_order.order.is_open):
+
+            current_price = self.get_price(
+                self.config.short_market.connector_name,
+                self.config.short_market.trading_pair
+            )
+
+            if current_price:
+                renewal_threshold = self.config.order_renewal_threshold_pct
+                price_diff_pct = abs(current_price - self._short_order.order.price) / current_price
+                if price_diff_pct > renewal_threshold:
+                    self.logger().info(f"Short order price difference {price_diff_pct:.4%} exceeds threshold {renewal_threshold:.4%}, renewing")
+                    self._renew_short_order()
+
+    def _place_aggressive_long_hedge(self):
+        """Place aggressive long hedge order for asymmetric fill recovery"""
+        try:
+            long_price_raw = self.get_price(
+                self.config.long_market.connector_name,
+                self.config.long_market.trading_pair
+            )
+
+            if not long_price_raw:
+                self.logger().warning("Unable to get long price for aggressive hedge")
+                return
+
+            # Quantize price to 5 decimal precision
+            long_price = Decimal(round(float(f"{long_price_raw:.5g}"), 5))
+
+            # Use validated amount if available
+            if hasattr(self, '_validated_long_amount'):
+                long_amount = self._validated_long_amount
+            else:
+                long_amount = self.config.position_size_quote / long_price
+
+            # Use aggressive 1 bps spread for quick fill on quantized price
+            aggressive_spread_pct = Decimal("0.0001")  # 1 bps = 0.01%
+            long_limit_price = long_price * (Decimal("1") - aggressive_spread_pct)  # Buy below market
+
+            long_order_id = self.place_order(
+                connector_name=self.config.long_market.connector_name,
+                trading_pair=self.config.long_market.trading_pair,
+                order_type=OrderType.LIMIT_MAKER,
+                side=TradeType.BUY,
+                amount=long_amount,
+                price=long_limit_price,
+                position_action=PositionAction.OPEN
+            )
+
+            if long_order_id:
+                self._long_order.order_id = long_order_id
+                self.logger().info(f"Aggressive long hedge placed: {long_order_id} at {long_limit_price}")
+                self._last_order_time = self._strategy.current_timestamp
+
+        except Exception as e:
+            self.logger().error(f"Error placing aggressive long hedge: {e}")
+            self._current_retries += 1
+
+    def _place_aggressive_short_hedge(self):
+        """Place aggressive short hedge order for asymmetric fill recovery"""
+        try:
+            short_price_raw = self.get_price(
+                self.config.short_market.connector_name,
+                self.config.short_market.trading_pair
+            )
+
+            if not short_price_raw:
+                self.logger().warning("Unable to get short price for aggressive hedge")
+                return
+
+            # Quantize price to 5 decimal precision
+            short_price = Decimal(round(float(f"{short_price_raw:.5g}"), 5))
+
+            # Use validated amount if available
+            if hasattr(self, '_validated_short_amount'):
+                short_amount = self._validated_short_amount
+            else:
+                short_amount = self.config.position_size_quote / short_price
+
+            # Use aggressive 1 bps spread for quick fill on quantized price
+            aggressive_spread_pct = Decimal("0.0001")  # 1 bps = 0.01%
+            short_limit_price = short_price * (Decimal("1") + aggressive_spread_pct)  # Sell above market
+
+            short_order_id = self.place_order(
+                connector_name=self.config.short_market.connector_name,
+                trading_pair=self.config.short_market.trading_pair,
+                order_type=OrderType.LIMIT_MAKER,
+                side=TradeType.SELL,
+                amount=short_amount,
+                price=short_limit_price,
+                position_action=PositionAction.OPEN
+            )
+
+            if short_order_id:
+                self._short_order.order_id = short_order_id
+                self.logger().info(f"Aggressive short hedge placed: {short_order_id} at {short_limit_price}")
+                self._last_order_time = self._strategy.current_timestamp
+
+        except Exception as e:
+            self.logger().error(f"Error placing aggressive short hedge: {e}")
+            self._current_retries += 1
+
+    def cancel_long_order(self):
+        """Cancel the long order"""
+        if self._long_order.order_id:
+            order = self.get_in_flight_order(
+                self.config.long_market.connector_name,
+                self._long_order.order_id
+            )
+            if order and order.is_open:
+                self._strategy.cancel(
+                    connector_name=self.config.long_market.connector_name,
+                    trading_pair=self.config.long_market.trading_pair,
+                    order_id=self._long_order.order_id
+                )
+                self.logger().info(f"Cancelling long order {self._long_order.order_id}")
+                # NOTE: Order state will be cleared in process_order_canceled_event() when exchange confirms cancellation
+
+    def cancel_short_order(self):
+        """Cancel the short order"""
+        if self._short_order.order_id:
+            order = self.get_in_flight_order(
+                self.config.short_market.connector_name,
+                self._short_order.order_id
+            )
+            if order and order.is_open:
+                self._strategy.cancel(
+                    connector_name=self.config.short_market.connector_name,
+                    trading_pair=self.config.short_market.trading_pair,
+                    order_id=self._short_order.order_id
+                )
+                self.logger().info(f"Cancelling short order {self._short_order.order_id}")
+                # NOTE: Order state will be cleared in process_order_canceled_event() when exchange confirms cancellation
+
+    def cancel_all_open_orders(self):
+        """Cancel all open orders"""
+        self.cancel_long_order()
+        self.cancel_short_order()
+
+    def _check_exit_conditions(self):
+        """Check various exit conditions for the position"""
+        # Check if we have any position to monitor (full or asymmetric)
+        if not self.is_position_active and not self.entry_orders_partially_filled:
+            return
+
+        # Update PnL for any filled positions
+        if self.is_position_active or self.entry_orders_partially_filled:
+            self._update_trade_pnl()
+
+        # Check asymmetric fill timeout
+        if self.entry_orders_partially_filled:
+            self._check_asymmetric_fill_timeout()
+
+        # Take profit check (applies to both full and asymmetric positions)
+        if self.config.take_profit_pct:
+            total_pnl_pct = self.total_pnl_quote / self.config.position_size_quote
+            self.logger().debug(f"Take profit check: PnL={self.total_pnl_quote:.6f}, Position Size={self.config.position_size_quote:.6f}, PnL%={total_pnl_pct:.4%}, Threshold={self.config.take_profit_pct:.4%}")
+            if total_pnl_pct >= self.config.take_profit_pct:
+                self.logger().info(f"Take profit triggered: {total_pnl_pct:.4%} >= {self.config.take_profit_pct:.4%}")
+                self.logger().info(f"PnL breakdown - Trade: {self.trade_pnl_quote:.6f}, Realized: {self.realized_pnl_quote:.6f}, Funding: {self.funding_pnl_quote:.6f}, Fees: {self.get_cum_fees_quote():.6f}, Net: {self.get_net_pnl_quote():.6f}")
+                self.close_type = CloseType.TAKE_PROFIT
+                self.place_close_orders()
+
+        # Stop loss check (applies to both full and asymmetric positions)
+        if self.config.stop_loss_pct:
+            total_pnl_pct = self.total_pnl_quote / self.config.position_size_quote
+            self.logger().debug(f"Stop loss check: PnL={self.total_pnl_quote:.6f}, Position Size={self.config.position_size_quote:.6f}, PnL%={total_pnl_pct:.4%}, Threshold={-self.config.stop_loss_pct:.4%}")
+            if total_pnl_pct <= -self.config.stop_loss_pct:
+                self.logger().info(f"Stop loss triggered: {total_pnl_pct:.4%} <= {-self.config.stop_loss_pct:.4%}")
+                self.logger().info(f"PnL breakdown - Trade: {self.trade_pnl_quote:.6f}, Realized: {self.realized_pnl_quote:.6f}, Funding: {self.funding_pnl_quote:.6f}, Fees: {self.get_cum_fees_quote():.6f}, Net: {self.get_net_pnl_quote():.6f}")
+                self.close_type = CloseType.STOP_LOSS
+                self.place_close_orders()
+
+        # Time limit check (applies to both full and asymmetric positions)
+        if self.config.max_position_duration_seconds:
+            if self.position_age_seconds >= self.config.max_position_duration_seconds:
+                self.logger().info(f"Position duration limit reached: {self.position_age_seconds}s")
+                self.close_type = CloseType.TIME_LIMIT
+                self.place_close_orders()
+
+        # Funding rate deterioration check (only applies to full positions)
+        if self.is_position_active:
+            self._check_funding_rate_deterioration()
+
+    def _check_funding_rate_deterioration(self):
+        """Monitor funding rate deterioration and close position if needed"""
+        try:
+            # Get current funding rates
+            long_funding_info = self.connectors[self.config.long_market.connector_name].get_funding_info(
+                self.config.long_market.trading_pair
+            )
+            short_funding_info = self.connectors[self.config.short_market.connector_name].get_funding_info(
+                self.config.short_market.trading_pair
+            )
+
+            if not long_funding_info or not short_funding_info:
+                return
+
+            # Calculate current differential (short - long for profitable arbitrage)
+            current_differential = short_funding_info.rate - long_funding_info.rate
+
+            # Check for deterioration below configured threshold
+            if current_differential < self.config.min_funding_rate_differential:
+                self.logger().info(f"Funding rate differential deteriorated to {current_differential:.6f}, "
+                                   f"below threshold {self.config.min_funding_rate_differential:.6f}")
+                self.close_type = CloseType.STOP_LOSS
+                self.place_close_orders()
+
+        except Exception as e:
+            self.logger().error(f"Error monitoring funding rate deterioration: {e}")
+
+    def _check_asymmetric_fill_timeout(self):
+        """Check and handle asymmetric fill timeout"""
+        current_time = self._strategy.current_timestamp
+
+        # Start tracking asymmetric fill time if not already started
+        if self._asymmetric_fill_start_time is None:
+            self._asymmetric_fill_start_time = current_time
+            self.logger().info("Asymmetric fill detected - starting timeout timer")
+            return
+
+        # Check if timeout has been reached
+        time_elapsed = current_time - self._asymmetric_fill_start_time
+        if time_elapsed >= self._asymmetric_fill_timeout_seconds:
+            self.logger().warning(f"Asymmetric fill timeout reached after {time_elapsed:.1f}s - closing positions gracefully")
+            self.close_type = CloseType.TIME_LIMIT
+            self.place_close_orders()
+
+    def place_close_orders(self):
+        """Place market orders to close both positions"""
+        self.cancel_all_open_orders()
+
+        try:
+            # Close long position (sell)
+            if self._long_order.is_filled:
+                long_close_order_id = self.place_order(
+                    connector_name=self.config.long_market.connector_name,
+                    trading_pair=self.config.long_market.trading_pair,
+                    order_type=OrderType.MARKET,
+                    side=TradeType.SELL,
+                    amount=self._long_order.executed_amount_base,
+                    price=Decimal("NaN"),
+                    position_action=PositionAction.CLOSE
+                )
+
+                if long_close_order_id:
+                    self._long_close_order = TrackedOrder(order_id=long_close_order_id)
+                    self.logger().info(f"Long close order placed: {long_close_order_id}")
+
+            # Close short position (buy)
+            if self._short_order.is_filled:
+                short_close_order_id = self.place_order(
+                    connector_name=self.config.short_market.connector_name,
+                    trading_pair=self.config.short_market.trading_pair,
+                    order_type=OrderType.MARKET,
+                    side=TradeType.BUY,
+                    amount=self._short_order.executed_amount_base,
+                    price=Decimal("NaN"),
+                    position_action=PositionAction.CLOSE
+                )
+
+                if short_close_order_id:
+                    self._short_close_order = TrackedOrder(order_id=short_close_order_id)
+                    self.logger().info(f"Short close order placed: {short_close_order_id}")
+
+            self._status = RunnableStatus.SHUTTING_DOWN
+            self.close_timestamp = self._strategy.current_timestamp
+
+        except Exception as e:
+            self.logger().error(f"Error placing close orders: {e}")
+            self._current_retries += 1
+
+    def _update_trade_pnl(self):
+        """Update the current trade PnL based on positions (full or asymmetric)"""
+        try:
+            # Initialize PnL components
+            long_pnl = Decimal("0")
+            short_pnl = Decimal("0")
+
+            # Calculate long position unrealized PnL
+            if self._long_order.is_filled:
+                current_long_price = self.get_price(
+                    self.config.long_market.connector_name,
+                    self.config.long_market.trading_pair
+                )
+                if current_long_price and self._long_order.average_executed_price:
+                    # Long PnL = (current_price - entry_price) * amount
+                    long_pnl = (current_long_price - self._long_order.average_executed_price) * self._long_order.executed_amount_base
+                    self.logger().debug(f"Long PnL: ({current_long_price} - {self._long_order.average_executed_price}) * {self._long_order.executed_amount_base} = {long_pnl}")
+
+            # Calculate short position unrealized PnL
+            if self._short_order.is_filled:
+                current_short_price = self.get_price(
+                    self.config.short_market.connector_name,
+                    self.config.short_market.trading_pair
+                )
+                if current_short_price and self._short_order.average_executed_price:
+                    # Short PnL = (entry_price - current_price) * amount
+                    short_pnl = (self._short_order.average_executed_price - current_short_price) * self._short_order.executed_amount_base
+                    self.logger().debug(f"Short PnL: ({self._short_order.average_executed_price} - {current_short_price}) * {self._short_order.executed_amount_base} = {short_pnl}")
+
+            # Total unrealized PnL
+            self._trade_pnl_quote = long_pnl + short_pnl
+            self.logger().debug(f"Total unrealized PnL: {long_pnl} + {short_pnl} = {self._trade_pnl_quote}")
+
+        except Exception as e:
+            self.logger().error(f"Error updating trade PnL: {e}")
+            self._trade_pnl_quote = Decimal("0")
+
+    async def _setup_leverage(self):
+        """Setup leverage on both exchanges before placing orders"""
+        try:
+            self._leverage_setup_attempts += 1
+
+            # Check if both connectors are perpetual
+            long_connector = self.connectors.get(self.config.long_market.connector_name)
+            short_connector = self.connectors.get(self.config.short_market.connector_name)
+
+            if not long_connector or not short_connector:
+                self.logger().error("One or both connectors not available for leverage setup")
+                return
+
+            # Check if connectors support leverage (are perpetual)
+            long_is_perpetual = hasattr(long_connector, 'set_leverage')
+            short_is_perpetual = hasattr(short_connector, 'set_leverage')
+
+            if not long_is_perpetual or not short_is_perpetual:
+                self.logger().warning("One or both connectors do not support leverage - skipping leverage setup")
+                self._leverage_setup_complete = True
+                return
+
+            # Set leverage on long market
+            current_long_leverage = long_connector.get_leverage(self.config.long_market.trading_pair)
+            if current_long_leverage != self.config.leverage:
+                self.logger().info(f"Setting leverage on {self.config.long_market.connector_name} from {current_long_leverage} to {self.config.leverage}")
+                long_connector.set_leverage(self.config.long_market.trading_pair, self.config.leverage)
+
+            # Set leverage on short market
+            current_short_leverage = short_connector.get_leverage(self.config.short_market.trading_pair)
+            if current_short_leverage != self.config.leverage:
+                self.logger().info(f"Setting leverage on {self.config.short_market.connector_name} from {current_short_leverage} to {self.config.leverage}")
+                short_connector.set_leverage(self.config.short_market.trading_pair, self.config.leverage)
+
+            # Wait a moment for leverage to be applied
+            await asyncio.sleep(2.0)
+
+            # Verify leverage was set correctly
+            final_long_leverage = long_connector.get_leverage(self.config.long_market.trading_pair)
+            final_short_leverage = short_connector.get_leverage(self.config.short_market.trading_pair)
+
+            if final_long_leverage == self.config.leverage and final_short_leverage == self.config.leverage:
+                self.logger().info(f"Leverage setup complete: Long={final_long_leverage}x, Short={final_short_leverage}x")
+                self._leverage_setup_complete = True
+            else:
+                self.logger().warning(f"Leverage verification failed: Long={final_long_leverage}x (expected {self.config.leverage}x), Short={final_short_leverage}x (expected {self.config.leverage}x)")
+
+                # Retry if we haven't exceeded max attempts
+                if self._leverage_setup_attempts >= self._max_leverage_setup_attempts:
+                    self.logger().error(f"Failed to setup leverage after {self._max_leverage_setup_attempts} attempts - proceeding anyway")
+                    self._leverage_setup_complete = True
+
+        except Exception as e:
+            self.logger().error(f"Error setting up leverage: {e}")
+            if self._leverage_setup_attempts >= self._max_leverage_setup_attempts:
+                self.logger().error("Max leverage setup attempts reached - proceeding without leverage verification")
+                self._leverage_setup_complete = True
+
+    def _validate_leverage_before_orders(self) -> bool:
+        """Validate that leverage is correctly set before placing orders"""
+        try:
+            if not self._leverage_setup_complete:
+                self.logger().warning("Leverage setup not complete - skipping order placement")
+                return False
+
+            # Check current leverage on both exchanges
+            long_connector = self.connectors.get(self.config.long_market.connector_name)
+            short_connector = self.connectors.get(self.config.short_market.connector_name)
+
+            if not long_connector or not short_connector:
+                return False
+
+            # Skip validation if connectors don't support leverage
+            if not hasattr(long_connector, 'get_leverage') or not hasattr(short_connector, 'get_leverage'):
+                return True
+
+            long_leverage = long_connector.get_leverage(self.config.long_market.trading_pair)
+            short_leverage = short_connector.get_leverage(self.config.short_market.trading_pair)
+
+            if long_leverage != self.config.leverage or short_leverage != self.config.leverage:
+                self.logger().warning(f"Leverage mismatch detected: Long={long_leverage}x, Short={short_leverage}x, Expected={self.config.leverage}x")
+                self._leverage_setup_complete = False  # Trigger re-setup
+                return False
+
+            return True
+
+        except Exception as e:
+            self.logger().error(f"Error validating leverage: {e}")
+            return False
+
+    def evaluate_max_retries(self):
+        """
+        This method is responsible for evaluating the maximum number of retries to place an order and stop the executor
+        if the maximum number of retries is reached.
+
+        :return: None
+        """
+        if self._current_retries > self._max_retries:
+            self.close_type = CloseType.FAILED
+            self.stop()
+
+    async def _control_shutdown_process(self):
+        """Control the shutdown process"""
+        if not self.all_close_orders_completed:
+            self.close_type = CloseType.FAILED
+            self.stop()
+
+    def close_execution_by(self, close_type):
+        """Close execution with specified close type"""
+        self.close_type = close_type
+
+    def early_stop(self, keep_position: bool = False):
+        """Stop the executor early"""
+        if keep_position:
+            self.logger().info("Early stop requested with position preservation")
+            self.stop()
+        else:
+            self.logger().info("Early stop requested, closing positions")
+            self.close_type = CloseType.EARLY_STOP
+
+    def update_tracked_orders_with_order_id(self, order_id: str):
+        """
+        Update the tracked orders with the information from the InFlightOrder, using
+        the order_id as a reference.
+
+        :param order_id: The order_id to be used as a reference.
+        :return: None
+        """
+        # Get InFlightOrder for long market
+        if self._long_order and self._long_order.order_id == order_id:
+            in_flight_order = self.get_in_flight_order(self.config.long_market.connector_name, order_id)
+            if in_flight_order:
+                self._long_order.order = in_flight_order
+
+        # Get InFlightOrder for short market
+        elif self._short_order and self._short_order.order_id == order_id:
+            in_flight_order = self.get_in_flight_order(self.config.short_market.connector_name, order_id)
+            if in_flight_order:
+                self._short_order.order = in_flight_order
+
+        # Get InFlightOrder for long close order
+        elif self._long_close_order and self._long_close_order.order_id == order_id:
+            in_flight_order = self.get_in_flight_order(self.config.long_market.connector_name, order_id)
+            if in_flight_order:
+                self._long_close_order.order = in_flight_order
+
+        # Get InFlightOrder for short close order
+        elif self._short_close_order and self._short_close_order.order_id == order_id:
+            in_flight_order = self.get_in_flight_order(self.config.short_market.connector_name, order_id)
+            if in_flight_order:
+                self._short_close_order.order = in_flight_order
+
+    def process_order_created_event(self, _event_tag, _market, event: Union[BuyOrderCreatedEvent, SellOrderCreatedEvent]):
+        """
+        Process order created events. Updates TrackedOrder with the InFlightOrder information
+        using the order_id as a reference.
+        """
+        self.update_tracked_orders_with_order_id(event.order_id)
+
+    def process_order_filled_event(self, _event_tag, _market, event: OrderFilledEvent):
+        """
+        Process order filled events. Updates TrackedOrder with the InFlightOrder information
+        and handles PnL tracking for fills.
+        """
+        order_id = event.order_id
+
+        self.logger().info(f"Order fill confirmed: {order_id} - Amount: {event.amount}, Price: {event.price}")
+
+        # Update tracked order with latest information
+        self.update_tracked_orders_with_order_id(order_id)
+
+        # Log fill details and check for asymmetric state
+        if order_id == self._long_order.order_id:
+            self.logger().info(f"Long order filled: {order_id}")
+            self._update_realized_pnl_from_fill(event, TradeType.BUY)
+            # Check for asymmetric fill
+            if not self._short_order.is_filled:
+                self.logger().debug("ASYMMETRIC FILL: Long filled but short not filled yet")
+        elif order_id == self._short_order.order_id:
+            self.logger().info(f"Short order filled: {order_id}")
+            self._update_realized_pnl_from_fill(event, TradeType.SELL)
+            # Check for asymmetric fill
+            if not self._long_order.is_filled:
+                self.logger().debug("ASYMMETRIC FILL: Short filled but long not filled yet")
+        elif self._long_close_order and order_id == self._long_close_order.order_id:
+            self.logger().info(f"Long close order filled: {order_id}")
+            self._update_realized_pnl_from_fill(event, TradeType.SELL)
+        elif self._short_close_order and order_id == self._short_close_order.order_id:
+            self.logger().info(f"Short close order filled: {order_id}")
+            self._update_realized_pnl_from_fill(event, TradeType.BUY)
+        else:
+            self.logger().warning(f"Received fill for unknown order: {order_id}")
+
+        # Reset asymmetric fill timer if both orders are now filled
+        if self.is_position_active and self._asymmetric_fill_start_time is not None:
+            self.logger().info("Both positions now filled - resetting asymmetric fill timer")
+            self._asymmetric_fill_start_time = None
+
+    def _update_realized_pnl_from_fill(self, event: OrderFilledEvent, trade_type: TradeType):
+        """Update realized PnL and fees from order fill events"""
+        try:
+            fill_amount = event.amount
+            fill_price = event.price
+
+            # For entry orders: No realized PnL yet (position just opened)
+            # For exit orders: Calculate actual realized PnL = (exit_price - entry_price) * amount
+
+            # Check if this is a close order (exit)
+            if self._long_close_order and event.order_id == self._long_close_order.order_id:
+                # Calculate realized PnL for long close: (exit_price - entry_price) * amount
+                if self._long_order.average_executed_price:
+                    realized_pnl = (fill_price - self._long_order.average_executed_price) * fill_amount
+                    self._realized_pnl_quote += realized_pnl
+                    self.logger().debug(f"Long close realized PnL: ({fill_price} - {self._long_order.average_executed_price}) * {fill_amount} = {realized_pnl}")
+            elif self._short_close_order and event.order_id == self._short_close_order.order_id:
+                # Calculate realized PnL for short close: (entry_price - exit_price) * amount
+                if self._short_order.average_executed_price:
+                    realized_pnl = (self._short_order.average_executed_price - fill_price) * fill_amount
+                    self._realized_pnl_quote += realized_pnl
+                    self.logger().debug(f"Short close realized PnL: ({self._short_order.average_executed_price} - {fill_price}) * {fill_amount} = {realized_pnl}")
+
+        except Exception as e:
+            self.logger().error(f"Error updating realized PnL and fees from fill: {e}")
+
+    def process_order_completed_event(self, _event_tag, _market, event: Union[BuyOrderCompletedEvent, SellOrderCompletedEvent]):
+        """
+        Process order completed events. Updates TrackedOrder with the InFlightOrder information
+        and handles final PnL calculations.
+        """
+        order_id = event.order_id
+
+        # Update tracked order with latest information
+        self.update_tracked_orders_with_order_id(order_id)
+
+        # Note: Realized PnL is now calculated in _update_realized_pnl_from_fill during order fills
+        # No additional processing needed for completed orders
+
+    def process_order_failed_event(self, _event_tag, _market, event: MarketOrderFailureEvent):
+        """Process order failure events"""
+        order_id = event.order_id
+        self.logger().error(f"Order failed: {order_id} - {event.order_type}")
+
+        # Clear failed order state
+        if order_id == self._long_order.order_id:
+            self._failed_orders.append(self._long_order)
+            self._long_order = TrackedOrder()
+            self.logger().error(f"Long order failed {order_id}")
+        elif order_id == self._short_order.order_id:
+            self._failed_orders.append(self._short_order)
+            self._short_order = TrackedOrder()
+            self.logger().error(f"Short order failed {order_id}")
+        elif self._long_close_order and order_id == self._long_close_order.order_id:
+            self._failed_orders.append(self._long_close_order)
+            self._long_close_order = None
+            self.logger().error(f"Long close order failed {order_id}")
+        elif self._short_close_order and order_id == self._short_close_order.order_id:
+            self._failed_orders.append(self._short_close_order)
+            self._short_close_order = None
+            self.logger().error(f"Short close order failed {order_id}")
+
+        # Increment retry counter for failed orders
+        self._current_retries += 1
+
+        # Mark executor as failed if max retries exceeded
+        if self._current_retries > self._max_retries:
+            self.logger().error(f"Max retries exceeded for executor {self.config.id}. Stopping executor.")
+            self.close_type = CloseType.FAILED
+            self.stop()
+
+    def process_order_canceled_event(self, _event_tag, _market, event: OrderCancelledEvent):
+        """
+        Process order canceled events. Handles cleanup for canceled orders.
+        """
+        order_id = event.order_id
+
+        self.logger().info(f"Order cancellation confirmed by exchange: {order_id}")
+
+        # Remove from pending cancellations
+        self._pending_cancellations.discard(order_id)
+
+        # Clean up canceled order state
+        if self._long_order and order_id == self._long_order.order_id:
+            self._failed_orders.append(self._long_order)
+            self._long_order = TrackedOrder()
+            self.logger().info(f"Long order canceled and state cleared: {order_id}")
+            # Log asymmetric state
+            if self._short_order.is_filled:
+                self.logger().debug("ASYMMETRIC STATE: Long order canceled but short order is filled")
+        elif self._short_order and order_id == self._short_order.order_id:
+            self._failed_orders.append(self._short_order)
+            self._short_order = TrackedOrder()
+            self.logger().info(f"Short order canceled and state cleared: {order_id}")
+            # Log asymmetric state
+            if self._long_order.is_filled:
+                self.logger().debug("ASYMMETRIC STATE: Short order canceled but long order is filled")
+        elif self._long_close_order and order_id == self._long_close_order.order_id:
+            self._failed_orders.append(self._long_close_order)
+            self._long_close_order = None
+            self.logger().info(f"Long close order canceled and state cleared: {order_id}")
+        elif self._short_close_order and order_id == self._short_close_order.order_id:
+            self._failed_orders.append(self._short_close_order)
+            self._short_close_order = None
+            self.logger().info(f"Short close order canceled and state cleared: {order_id}")
+        else:
+            self.logger().warning(f"Received cancellation for unknown order: {order_id}")
+
+    def did_complete_funding_payment(self, funding_event: FundingPaymentCompletedEvent):
+        """
+        Handle funding payment events.
+        This method should be called by the strategy when funding payments are received.
+        """
+        # Check if this funding payment is for one of our positions
+        if (funding_event.market == self.config.long_market.connector_name and
+            funding_event.trading_pair == self.config.long_market.trading_pair) or \
+           (funding_event.market == self.config.short_market.connector_name and
+                funding_event.trading_pair == self.config.short_market.trading_pair):
+
+            self._funding_payments.append(funding_event)
+            self._cumulative_funding_pnl += funding_event.amount
+
+            self.logger().info(f"Funding payment received: {funding_event.amount} "
+                               f"on {funding_event.market} for {funding_event.trading_pair}")
+
+    def get_cum_fees_quote(self) -> Decimal:
+        """
+        Calculate the cumulative fees in quote asset
+        :return: The cumulative fees in quote asset.
+        """
+        orders = [self._long_order, self._short_order, self._long_close_order, self._short_close_order]
+        return sum([order.cum_fees_quote for order in orders if order])

--- a/hummingbot/strategy_v2/models/executors.py
+++ b/hummingbot/strategy_v2/models/executors.py
@@ -122,12 +122,3 @@ class TrackedOrder:
             return self.order.is_filled
         else:
             return False
-
-    @property
-    def position_age_seconds(self) -> float:
-        """Age of the position in seconds"""
-        if not self.is_position_active:
-            return 0.0
-        return self._strategy.current_timestamp - min(
-            self._long_order.creation_timestamp, self._short_order.creation_timestamp
-        )

--- a/hummingbot/strategy_v2/models/executors.py
+++ b/hummingbot/strategy_v2/models/executors.py
@@ -122,3 +122,12 @@ class TrackedOrder:
             return self.order.is_filled
         else:
             return False
+
+    @property
+    def position_age_seconds(self) -> float:
+        """Age of the position in seconds"""
+        if not self.is_position_active:
+            return 0.0
+        return self._strategy.current_timestamp - min(
+            self._long_order.creation_timestamp, self._short_order.creation_timestamp
+        )

--- a/hummingbot/strategy_v2/models/executors_info.py
+++ b/hummingbot/strategy_v2/models/executors_info.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from hummingbot.core.data_type.common import TradeType
 from hummingbot.strategy_v2.executors.arbitrage_executor.data_types import ArbitrageExecutorConfig
 from hummingbot.strategy_v2.executors.dca_executor.data_types import DCAExecutorConfig
+from hummingbot.strategy_v2.executors.funding_arbitrage_executor.data_types import FundingArbitrageExecutorConfig
 from hummingbot.strategy_v2.executors.grid_executor.data_types import GridExecutorConfig
 from hummingbot.strategy_v2.executors.order_executor.data_types import OrderExecutorConfig
 from hummingbot.strategy_v2.executors.position_executor.data_types import PositionExecutorConfig
@@ -14,7 +15,7 @@ from hummingbot.strategy_v2.executors.xemm_executor.data_types import XEMMExecut
 from hummingbot.strategy_v2.models.base import RunnableStatus
 from hummingbot.strategy_v2.models.executors import CloseType
 
-AnyExecutorConfig = Union[PositionExecutorConfig, DCAExecutorConfig, GridExecutorConfig, XEMMExecutorConfig, ArbitrageExecutorConfig, OrderExecutorConfig, TWAPExecutorConfig]
+AnyExecutorConfig = Union[PositionExecutorConfig, DCAExecutorConfig, GridExecutorConfig, XEMMExecutorConfig, ArbitrageExecutorConfig, OrderExecutorConfig, TWAPExecutorConfig, FundingArbitrageExecutorConfig]
 
 
 class ExecutorInfo(BaseModel):

--- a/scripts/Dema_ST_ADX.py
+++ b/scripts/Dema_ST_ADX.py
@@ -361,13 +361,11 @@ class DEMASTADXTokenStrategy(StrategyV2Base):
                             current_supertrend_direction == 1 and
                             prev_supertrend_direction == -1)
 
-        prev_dema = self.prev_dema[trading_pair]
-        prev_candle_close = candles["close"].iloc[-2]
-        prev_prev_candle_close = candles["close"].iloc[-3]
-        long_condition_3 = (prev_candle_close >= prev_dema and
-                            prev_prev_candle_close < prev_dema and
-                            adx_above_threshold and
-                            current_supertrend_direction == 1)
+        # NOTE: not gonna use this, the price acts as a barrier not a support
+        # long_condition_3 = (prev_candle_close >= prev_dema and
+        #                     prev_prev_candle_close < prev_dema and
+        #                     adx_above_threshold and
+        #                     current_supertrend_direction == 1)
 
         long_condition_startup = (is_startup_check and
                                   self.config.enable_startup_entry and
@@ -393,13 +391,11 @@ class DEMASTADXTokenStrategy(StrategyV2Base):
                              current_supertrend_direction == -1 and
                              prev_supertrend_direction == 1)
 
-        prev_dema = self.prev_dema[trading_pair]
-        prev_candle_close = candles["close"].iloc[-2]
-        prev_prev_candle_close = candles["close"].iloc[-3]
-        short_condition_3 = (prev_candle_close <= prev_dema and
-                             prev_prev_candle_close >= prev_dema and
-                             adx_above_threshold and
-                             current_supertrend_direction == -1)
+        # NOTE: not gonna use this, the price acts as a barrier not a support
+        # short_condition_3 = (prev_candle_close <= prev_dema and
+        #                      prev_prev_candle_close >= prev_dema and
+        #                      adx_above_threshold and
+        #                      current_supertrend_direction == -1)
 
         short_condition_startup = (is_startup_check and
                                    self.config.enable_startup_entry and
@@ -410,9 +406,9 @@ class DEMASTADXTokenStrategy(StrategyV2Base):
         # self.logger().info(f"Short Condition 2: {short_condition_2}")
         # self.logger().info(f"Short Condition Startup: {short_condition_startup}")
         # Determine signal
-        if long_condition_1 or long_condition_2 or long_condition_3 or long_condition_startup:
+        if long_condition_1 or long_condition_2 or long_condition_startup:
             signal = 1
-        elif short_condition_1 or short_condition_2 or short_condition_3 or short_condition_startup:
+        elif short_condition_1 or short_condition_2 or short_condition_startup:
             signal = -1
         else:
             signal = 0

--- a/scripts/Dema_ST_ADX.py
+++ b/scripts/Dema_ST_ADX.py
@@ -1,0 +1,505 @@
+import os
+from decimal import Decimal
+from typing import Dict, List, Optional
+
+from pydantic import Field, field_validator
+
+from hummingbot.connector.connector_base import ConnectorBase
+from hummingbot.core.clock import Clock
+from hummingbot.core.data_type.common import MarketDict, PositionMode, PriceType, TradeType
+from hummingbot.data_feed.candles_feed.candles_factory import CandlesConfig
+from hummingbot.strategy.strategy_v2_base import StrategyV2Base, StrategyV2ConfigBase
+from hummingbot.strategy_v2.executors.position_executor.data_types import PositionExecutorConfig, TripleBarrierConfig
+from hummingbot.strategy_v2.models.executor_actions import CreateExecutorAction, StopExecutorAction
+
+
+class DEMASTADXTokenConfig(StrategyV2ConfigBase):
+    script_file_name: str = os.path.basename(__file__)
+    # markets: Dict[str, List[str]] = {}
+    markets: MarketDict = MarketDict()
+    candles_config: List[CandlesConfig] = []
+    controllers_config: List[str] = []
+    exchange: str = Field(default="hyperliquid_perpetual")
+    trading_pairs: List[str] = Field(default=["ETH-USD"])
+    candles_exchange: str = Field(default="binance_perpetual")
+    candles_pairs: List[str] = Field(default=["ETH-USDT"])
+    candles_interval: str = Field(default="5m")
+    candles_length: int = Field(default=15, gt=0)
+
+    # DEMA Configuration
+    dema_length: int = Field(default=200, gt=0)
+
+    # SuperTrend Configuration
+    supertrend_length: int = Field(default=12, gt=0)
+    supertrend_multiplier: float = Field(default=3.0, gt=0)
+
+    # Order Configuration
+    order_amount_quote: Decimal = Field(default=Decimal("30"), gt=0)
+    leverage: int = Field(default=10, gt=0)
+    position_mode: PositionMode = Field(default=PositionMode.ONEWAY)
+
+    # Triple Barrier Configuration
+    # stop_loss: Decimal = Field(default=Decimal("0.03"), gt=0)
+    # take_profit: Decimal = Field(default=Decimal("0.02"), gt=0)
+    # time_limit: int = Field(default=60 * 45, gt=0)
+
+    # Executor Timeout Configuration
+    executor_timeout: int = Field(default=30, gt=0)
+
+    # Startup Entry Configuration
+    enable_startup_entry: bool = Field(default=False)
+
+    # ADX Configuration
+    adx_length: int = Field(default=14, gt=0)
+    adx_threshold_choppy: float = Field(default=20.0, gt=0)
+    adx_threshold_trending: float = Field(default=25.0, gt=0)
+    adx_threshold_extreme: float = Field(default=45.0, gt=0)
+    adx_slope_period: int = Field(default=5, gt=0)  # For trend acceleration/deceleration
+
+    # Position sizing based on ADX
+    enable_adx_position_sizing: bool = Field(default=True)
+    position_size_weak_trend: Decimal = Field(default=Decimal("0.5"), gt=0)  # 50% size when ADX 20-25
+    position_size_strong_trend: Decimal = Field(default=Decimal("1.0"), gt=0)  # 100% size when ADX > 25
+    position_size_extreme_trend: Decimal = Field(default=Decimal("0.7"), gt=0)  # 70% size when ADX > 45
+
+    @field_validator('position_mode', mode="before")
+    @classmethod
+    def validate_position_mode(cls, v: str) -> PositionMode:
+        if v.upper() in PositionMode.__members__:
+            return PositionMode[v.upper()]
+        raise ValueError(f"Invalid position mode: {v}. Valid options are: {', '.join(PositionMode.__members__)}")
+
+    @field_validator('trading_pairs', mode="before")
+    @classmethod
+    def validate_trading_pairs(cls, v) -> List[str]:
+        if isinstance(v, str):
+            return [pair.strip() for pair in v.split(',')]
+        return v
+
+    @field_validator('candles_pairs', mode="before")
+    @classmethod
+    def validate_candles_pairs(cls, v) -> List[str]:
+        if isinstance(v, str):
+            return [pair.strip() for pair in v.split(',')]
+        return v
+
+
+class DEMASTADXTokenStrategy(StrategyV2Base):
+    """
+    This strategy uses DEMA and SuperTrend indicators to generate trading signals.
+    Supports multiple trading pairs with candles from different exchanges.
+    """
+
+    account_config_set = False
+
+    @classmethod
+    def init_markets(cls, config: DEMASTADXTokenConfig):
+        cls.markets = {config.exchange: set(config.trading_pairs)}
+
+    def __init__(self, connectors: Dict[str, ConnectorBase], config: DEMASTADXTokenConfig):
+        self.max_records = max(config.dema_length, config.supertrend_length, config.candles_length) + 20
+        if len(config.candles_config) == 0:
+            for candles_pair in config.candles_pairs:
+                config.candles_config.append(CandlesConfig(
+                    connector=config.candles_exchange,
+                    trading_pair=candles_pair,
+                    interval=config.candles_interval,
+                    max_records=self.max_records
+                ))
+        super().__init__(connectors, config)
+        self.config = config
+        # Store indicators per trading pair
+        self.current_dema = {}
+        self.current_supertrend_direction = {}
+        self.prev_supertrend_direction = {}
+        self.current_price = {}
+        self.prev_price = {}
+        self.prev_dema = {}
+        self.current_signal = {}
+        self.is_startup = {}
+        # ADX tracking
+        self.current_adx = {}
+        self.prev_adx = {}
+        self.current_plus_di = {}
+        self.current_minus_di = {}
+        self.adx_slope = {}
+        self.market_condition = {}  # "CHOPPY", "WEAK_TREND", "STRONG_TREND", "EXTREME_TREND"
+        self.prev_market_condition = {}
+
+    def start(self, clock: Clock, timestamp: float) -> None:  # clock is required by base class
+        """
+        Start the strategy.
+        :param clock: Clock to use.
+        :param timestamp: Current time.
+        """
+        self._last_timestamp = timestamp
+        self.apply_initial_setting()
+        # Initialize startup flag for each trading pair
+        for candles_pair in self.config.candles_pairs:
+            self.is_startup[candles_pair] = True
+
+    def create_actions_proposal(self) -> List[CreateExecutorAction]:
+        create_actions = []
+
+        # Check signals for each trading pair
+        for i, trading_pair in enumerate(self.config.trading_pairs):
+            if i >= len(self.config.candles_pairs):
+                raise ValueError(f"Index {i} out of range for candles_pairs. trading_pairs: {self.config.trading_pairs}, candles_pairs: {self.config.candles_pairs}")
+            candles_pair = self.config.candles_pairs[i]
+            signal = self.get_signal(self.config.candles_exchange, candles_pair)
+            active_longs, active_shorts = self.get_active_executors_by_side(self.config.exchange, trading_pair)
+
+            if signal is not None and signal != 0:  # Only process non-zero signals
+                mid_price = self.market_data_provider.get_price_by_type(self.config.exchange,
+                                                                        trading_pair,
+                                                                        PriceType.MidPrice)
+
+                # Dynamic position sizing based on ADX
+                base_amount = self.config.order_amount_quote
+                if self.config.enable_adx_position_sizing:
+                    market_condition = self.market_condition.get(candles_pair, "CHOPPY")
+                    if market_condition == "WEAK_TREND":
+                        base_amount *= self.config.position_size_weak_trend
+                    elif market_condition == "STRONG_TREND":
+                        base_amount *= self.config.position_size_strong_trend
+                    elif market_condition == "EXTREME_TREND":
+                        base_amount *= self.config.position_size_extreme_trend
+                        # Log warning about extreme trend
+                        self.logger().warning(f"{trading_pair}: ADX > {self.config.adx_threshold_extreme}, reducing size to {self.config.position_size_extreme_trend}")
+
+                if signal == 1 and len(active_longs) == 0:
+                    create_actions.append(CreateExecutorAction(
+                        executor_config=PositionExecutorConfig(
+                            timestamp=self.current_timestamp,
+                            connector_name=self.config.exchange,
+                            trading_pair=trading_pair,
+                            side=TradeType.BUY,
+                            entry_price=mid_price,
+                            amount=base_amount / mid_price,
+                            triple_barrier_config=TripleBarrierConfig(),  # Default config with all barriers disabled
+                            leverage=self.config.leverage
+                        )))
+                elif signal == -1 and len(active_shorts) == 0:
+                    create_actions.append(CreateExecutorAction(
+                        executor_config=PositionExecutorConfig(
+                            timestamp=self.current_timestamp,
+                            connector_name=self.config.exchange,
+                            trading_pair=trading_pair,
+                            side=TradeType.SELL,
+                            entry_price=mid_price,
+                            amount=base_amount / mid_price,
+                            triple_barrier_config=TripleBarrierConfig(),  # Default config with all barriers disabled
+                            leverage=self.config.leverage
+                        )))
+        return create_actions
+
+    def stop_actions_proposal(self) -> List[StopExecutorAction]:
+        stop_actions = []
+
+        # Check signals for each trading pair
+        for i, trading_pair in enumerate(self.config.trading_pairs):
+            if i >= len(self.config.candles_pairs):
+                raise ValueError(f"Index {i} out of range for candles_pairs. trading_pairs: {self.config.trading_pairs}, candles_pairs: {self.config.candles_pairs}")
+            candles_pair = self.config.candles_pairs[i]
+
+            # Get current SuperTrend direction for stop logic
+            current_supertrend_direction = self.current_supertrend_direction.get(candles_pair)
+            active_longs, active_shorts = self.get_active_executors_by_side(self.config.exchange, trading_pair)
+
+            if current_supertrend_direction is not None:
+                # Stop positions when SuperTrend reverses
+                if current_supertrend_direction == -1 and len(active_longs) > 0:
+                    stop_actions.extend([StopExecutorAction(
+                        controller_id=e.controller_id or "main",
+                        executor_id=e.id
+                    ) for e in active_longs])
+                elif current_supertrend_direction == 1 and len(active_shorts) > 0:
+                    stop_actions.extend([StopExecutorAction(
+                        controller_id=e.controller_id or "main",
+                        executor_id=e.id
+                    ) for e in active_shorts])
+
+            # NEW: ADX-based stops
+            adx_value = self.current_adx.get(candles_pair, 0)
+            adx_slope = self.adx_slope.get(candles_pair, 0)
+
+            # Stop if market becomes choppy
+            if adx_value < self.config.adx_threshold_choppy:
+                all_positions = active_longs + active_shorts
+                for executor in all_positions:
+                    # Only close profitable positions in choppy markets
+                    if executor.net_pnl_pct > 0.002:  # 0.2% profit threshold
+                        stop_actions.append(StopExecutorAction(
+                            controller_id=executor.controller_id or "main",
+                            executor_id=executor.id
+                        ))
+                        self.logger().info(f"Closing {trading_pair} position due to choppy market (ADX={adx_value:.1f})")
+
+            # Stop on trend exhaustion (high ADX + negative slope)
+            elif adx_value > self.config.adx_threshold_extreme and adx_slope < -1:
+                all_positions = active_longs + active_shorts
+                for executor in all_positions:
+                    if executor.net_pnl_pct > 0:  # Any profit
+                        stop_actions.append(StopExecutorAction(
+                            controller_id=executor.controller_id or "main",
+                            executor_id=executor.id
+                        ))
+                        self.logger().info(f"Closing {trading_pair} position due to trend exhaustion (ADX={adx_value:.1f}, slope={adx_slope:.2f})")
+
+            # Check for timeout on unfilled executors
+            all_active_executors = active_longs + active_shorts
+            for executor in all_active_executors:
+                executor_age = self.current_timestamp - executor.timestamp
+                # Stop executors that are active but not trading (unfilled) and have exceeded timeout
+                if executor.is_active and not executor.is_trading and executor_age > self.config.executor_timeout:
+                    stop_actions.append(StopExecutorAction(
+                        controller_id=executor.controller_id or "main",
+                        executor_id=executor.id
+                    ))
+
+        return stop_actions
+
+    def get_active_executors_by_side(self, connector_name: str, trading_pair: str):
+        active_executors_by_trading_pair = self.filter_executors(
+            executors=self.get_all_executors(),
+            filter_func=lambda e: e.connector_name == connector_name and e.trading_pair == trading_pair and e.is_active
+        )
+        active_longs = [e for e in active_executors_by_trading_pair if e.side == TradeType.BUY]
+        active_shorts = [e for e in active_executors_by_trading_pair if e.side == TradeType.SELL]
+        return active_longs, active_shorts
+
+    def get_signal(self, connector_name: str, trading_pair: str) -> Optional[float]:
+        candles = self.market_data_provider.get_candles_df(connector_name,
+                                                           trading_pair,
+                                                           self.config.candles_interval,
+                                                           self.max_records)
+
+        if candles is None or candles.empty:
+            return None
+
+        # Calculate indicators
+        candles.ta.dema(length=self.config.dema_length, append=True)
+        candles.ta.supertrend(length=self.config.supertrend_length, multiplier=self.config.supertrend_multiplier, append=True)
+
+        # Calculate ADX with directional indicators
+        candles.ta.adx(length=self.config.adx_length, append=True)
+
+        # Store previous ADX value before updating
+        if trading_pair in self.current_adx:
+            self.prev_adx[trading_pair] = self.current_adx[trading_pair]
+        else:
+            # Initialize prev_adx on first run
+            if len(candles) > 1:
+                self.prev_adx[trading_pair] = candles[f"ADX_{self.config.adx_length}"].iloc[-2]
+            else:
+                self.prev_adx[trading_pair] = candles[f"ADX_{self.config.adx_length}"].iloc[-1]
+
+        # Get ADX values
+        self.current_adx[trading_pair] = candles[f"ADX_{self.config.adx_length}"].iloc[-1]
+        self.current_plus_di[trading_pair] = candles[f"DMP_{self.config.adx_length}"].iloc[-1]
+        self.current_minus_di[trading_pair] = candles[f"DMN_{self.config.adx_length}"].iloc[-1]
+
+        # Calculate ADX slope for trend acceleration/deceleration
+        if len(candles) > self.config.adx_slope_period:
+            current_adx = self.current_adx[trading_pair]
+            past_adx = candles[f"ADX_{self.config.adx_length}"].iloc[-self.config.adx_slope_period - 1]
+            self.adx_slope[trading_pair] = (current_adx - past_adx) / self.config.adx_slope_period
+        else:
+            self.adx_slope[trading_pair] = 0
+
+        # Store previous market condition before updating
+        if trading_pair in self.market_condition:
+            self.prev_market_condition[trading_pair] = self.market_condition[trading_pair]
+        else:
+            self.prev_market_condition[trading_pair] = "CHOPPY"  # Default to choppy
+
+        # Determine market condition
+        adx_value = self.current_adx[trading_pair]
+        if adx_value < self.config.adx_threshold_choppy:
+            self.market_condition[trading_pair] = "CHOPPY"
+        elif adx_value < self.config.adx_threshold_trending:
+            self.market_condition[trading_pair] = "WEAK_TREND"
+        elif adx_value < self.config.adx_threshold_extreme:
+            self.market_condition[trading_pair] = "STRONG_TREND"
+        else:
+            self.market_condition[trading_pair] = "EXTREME_TREND"
+
+        # Get current values
+        self.current_price[trading_pair] = candles["close"].iloc[-1]
+        self.current_dema[trading_pair] = candles[f"DEMA_{self.config.dema_length}"].iloc[-1]
+        self.current_supertrend_direction[trading_pair] = candles[f"SUPERTd_{self.config.supertrend_length}_{self.config.supertrend_multiplier}"].iloc[-1]
+
+        # Get previous values for trend change detection
+        if len(candles) > 1:
+            self.prev_supertrend_direction[trading_pair] = candles[f"SUPERTd_{self.config.supertrend_length}_{self.config.supertrend_multiplier}"].iloc[-2]
+            self.prev_price[trading_pair] = candles["close"].iloc[-2]
+            self.prev_dema[trading_pair] = candles[f"DEMA_{self.config.dema_length}"].iloc[-2]
+        else:
+            self.prev_supertrend_direction[trading_pair] = self.current_supertrend_direction[trading_pair]
+            self.prev_price[trading_pair] = self.current_price[trading_pair]
+            self.prev_dema[trading_pair] = self.current_dema[trading_pair]
+
+        # Generate long and short conditions
+        current_price = self.current_price[trading_pair]
+        current_dema = self.current_dema[trading_pair]
+        current_supertrend_direction = self.current_supertrend_direction[trading_pair]
+        prev_supertrend_direction = self.prev_supertrend_direction[trading_pair]
+
+        # self.logger().info(f"Current Price: {current_price}, Current DEMA: {current_dema}, Current SuperTrend Direction: {current_supertrend_direction}, Previous SuperTrend Direction: {prev_supertrend_direction}")
+
+        # Check if this is the first signal check after startup
+        is_startup_check = self.is_startup.get(trading_pair, False)
+
+        # Get ADX values for conditions
+        current_adx_val = self.current_adx[trading_pair]
+        prev_adx_val = self.prev_adx.get(trading_pair, 0)
+        adx_crossed_threshold = prev_adx_val < self.config.adx_threshold_choppy <= current_adx_val
+        adx_above_threshold = current_adx_val >= self.config.adx_threshold_choppy
+
+        # Long Entry Conditions:
+        # 1. ADX crosses threshold with established bullish trend: ST already positive + Price > DEMA + ADX crosses above threshold
+        # 2. ADX already established and ST flips: ADX above threshold + ST turns positive + Price > DEMA
+        # 3. STARTUP: Price above DEMA AND SuperTrend is green (no flip required)
+        long_condition_1 = (current_supertrend_direction == 1 and
+                            current_price > current_dema and
+                            adx_crossed_threshold)
+
+        long_condition_2 = (adx_above_threshold and
+                            current_price > current_dema and
+                            current_supertrend_direction == 1 and
+                            prev_supertrend_direction == -1)
+
+        long_condition_startup = (is_startup_check and
+                                  self.config.enable_startup_entry and
+                                  current_price > current_dema and
+                                  current_supertrend_direction == 1)
+        # self.logger().info(f"Long Condition 1: {long_condition_1}")
+        # self.logger().info(f"Long Condition 2: {long_condition_2}")
+        # self.logger().info(f"Long Condition Startup: {long_condition_startup}")
+        # Short Entry Conditions:
+        # 1. ADX crosses threshold with established bearish trend: ST already negative + Price < DEMA + ADX crosses above threshold
+        # 2. ADX already established and ST flips: ADX above threshold + ST turns negative + Price < DEMA
+        # 3. STARTUP: Price below DEMA AND SuperTrend is red (no flip required)
+        short_condition_1 = (current_supertrend_direction == -1 and
+                             current_price < current_dema and
+                             adx_crossed_threshold)
+
+        short_condition_2 = (adx_above_threshold and
+                             current_price < current_dema and
+                             current_supertrend_direction == -1 and
+                             prev_supertrend_direction == 1)
+
+        short_condition_startup = (is_startup_check and
+                                   self.config.enable_startup_entry and
+                                   current_price < current_dema and
+                                   current_supertrend_direction == -1)
+        # self.logger().info(f"Short Condition 1: {short_condition_1}")
+        # self.logger().info(f"Short Condition 2: {short_condition_2}")
+        # self.logger().info(f"Short Condition Startup: {short_condition_startup}")
+        # Determine signal
+        if long_condition_1 or long_condition_2 or long_condition_startup:
+            signal = 1
+        elif short_condition_1 or short_condition_2 or short_condition_startup:
+            signal = -1
+        else:
+            signal = 0
+
+        # Additional filter: Ensure directional agreement
+        if signal == 1 and self.current_plus_di[trading_pair] <= self.current_minus_di[trading_pair]:
+            signal = 0  # Cancel long if -DI is stronger
+        elif signal == -1 and self.current_minus_di[trading_pair] <= self.current_plus_di[trading_pair]:
+            signal = 0  # Cancel short if +DI is stronger
+
+        # Reset startup flag after first signal check
+        if is_startup_check:
+            self.is_startup[trading_pair] = False
+
+        self.current_signal[trading_pair] = signal
+        return signal
+
+    def apply_initial_setting(self):
+        if not self.account_config_set:
+            for connector_name, connector in self.connectors.items():
+                if self.is_perpetual(connector_name):
+                    connector.set_position_mode(self.config.position_mode)
+                    for trading_pair in self.config.trading_pairs:
+                        connector.set_leverage(trading_pair, self.config.leverage)
+            self.account_config_set = True
+
+    def format_status(self) -> str:
+        if not self.ready_to_trade:
+            return "Market connectors are not ready."
+        lines = []
+
+        balance_df = self.get_balance_df()
+        lines.extend(["", "  Balances:"] + ["    " + line for line in balance_df.to_string(index=False).split("\n")])
+
+        # Create compact trading pairs overview
+        lines.extend(["", "  Trading Pairs Overview:"])
+
+        # Header for the grid
+        header = f"{'Pair':<12} {'Price':<8} {'DEMA':<8} {'ST Dir':<6} {'ADX':<5} {'Condition':<10} {'Signal':<7} {'Long':<4} {'Short':<5}"
+        lines.append(f"    {header}")
+        lines.append(f"    {'-' * len(header)}")
+
+        # Display each trading pair in compact format
+        for i, candles_pair in enumerate(self.config.candles_pairs):
+            # Get indicator values for this pair
+            price = self.current_price.get(candles_pair, 0)
+            dema = self.current_dema.get(candles_pair, 0)
+            st_dir = self.current_supertrend_direction.get(candles_pair, 0)
+            signal = self.current_signal.get(candles_pair, 0)
+
+            # Format signal and direction display
+            signal_text = "LONG" if signal == 1 else "SHORT" if signal == -1 else "NONE"
+            st_text = "UP" if st_dir == 1 else "DOWN" if st_dir == -1 else "NONE"
+
+            # Get ADX values
+            adx = self.current_adx.get(candles_pair, 0)
+            condition = self.market_condition.get(candles_pair, "UNKNOWN")
+
+            # Get active positions for this pair
+            if i < len(self.config.trading_pairs):
+                actual_trading_pair = self.config.trading_pairs[i]
+                active_longs, active_shorts = self.get_active_executors_by_side(self.config.exchange, actual_trading_pair)
+            else:
+                active_longs, active_shorts = [], []
+
+            # Format the row
+            pair_display = candles_pair.replace('-', '/') if len(candles_pair) > 12 else candles_pair
+            row = f"{pair_display:<12} {price:>7.3f} {dema:>7.3f} {st_text:>6} {adx:>4.1f} {condition:<10} {signal_text:>7} {len(active_longs):>4} {len(active_shorts):>5}"
+            lines.append(f"    {row}")
+
+        # Add configuration info
+        lines.extend([
+            "",
+            f"  Config: DEMA({self.config.dema_length}) | SuperTrend({self.config.supertrend_length}, {self.config.supertrend_multiplier})"
+        ])
+
+        try:
+            orders_df = self.active_orders_df()
+            lines.extend(["", "  Active Orders:"] + ["    " + line for line in orders_df.to_string(index=False).split("\n")])
+        except ValueError:
+            lines.extend(["", "  No active maker orders."])
+
+        # Active Position Executors
+        active_executors = self.filter_executors(
+            executors=self.get_all_executors(),
+            filter_func=lambda e: e.is_active
+        )
+
+        if active_executors:
+            lines.extend(["", "  Active Position Executors:"])
+            for executor_info in active_executors:
+                lines.extend([
+                    f"    ID: {executor_info.id} | Type: {executor_info.type} | Status: {executor_info.status.value}",
+                    f"    Pair: {executor_info.trading_pair} | Exchange: {executor_info.connector_name} | Side: {executor_info.side}",
+                    f"    Net PnL: {executor_info.net_pnl_quote:.6f} ({executor_info.net_pnl_pct * 100:.2f}%)",
+                    f"    Filled Amount: {executor_info.filled_amount_quote:.4f} | Fees: {executor_info.cum_fees_quote:.6f}",
+                    f"    Active: {executor_info.is_active} | Trading: {executor_info.is_trading}",
+                    "    ---"
+                ])
+        else:
+            lines.extend(["", "  No active position executors."])
+
+        return "\n".join(lines)

--- a/scripts/v2_dema_supertrend_multi_token.py
+++ b/scripts/v2_dema_supertrend_multi_token.py
@@ -1,0 +1,386 @@
+import os
+from decimal import Decimal
+from typing import Dict, List, Optional
+
+from pydantic import Field, field_validator
+
+from hummingbot.connector.connector_base import ConnectorBase
+from hummingbot.core.clock import Clock
+from hummingbot.core.data_type.common import MarketDict, PositionMode, PriceType, TradeType
+from hummingbot.data_feed.candles_feed.candles_factory import CandlesConfig
+from hummingbot.strategy.strategy_v2_base import StrategyV2Base, StrategyV2ConfigBase
+from hummingbot.strategy_v2.executors.position_executor.data_types import PositionExecutorConfig, TripleBarrierConfig
+from hummingbot.strategy_v2.models.executor_actions import CreateExecutorAction, StopExecutorAction
+
+
+class DemaSuperTrendMultiTokenConfig(StrategyV2ConfigBase):
+    script_file_name: str = os.path.basename(__file__)
+    # markets: Dict[str, List[str]] = {}
+    markets: MarketDict = MarketDict()
+    candles_config: List[CandlesConfig] = []
+    controllers_config: List[str] = []
+    exchange: str = Field(default="hyperliquid_perpetual")
+    trading_pairs: List[str] = Field(default=["ETH-USD"])
+    candles_exchange: str = Field(default="binance_perpetual")
+    candles_pairs: List[str] = Field(default=["ETH-USDT"])
+    candles_interval: str = Field(default="5m")
+    candles_length: int = Field(default=15, gt=0)
+
+    # DEMA Configuration
+    dema_length: int = Field(default=200, gt=0)
+
+    # SuperTrend Configuration
+    supertrend_length: int = Field(default=12, gt=0)
+    supertrend_multiplier: float = Field(default=3.0, gt=0)
+
+    # Order Configuration
+    order_amount_quote: Decimal = Field(default=Decimal("30"), gt=0)
+    leverage: int = Field(default=10, gt=0)
+    position_mode: PositionMode = Field(default=PositionMode.ONEWAY)
+
+    # Triple Barrier Configuration
+    # stop_loss: Decimal = Field(default=Decimal("0.03"), gt=0)
+    # take_profit: Decimal = Field(default=Decimal("0.02"), gt=0)
+    # time_limit: int = Field(default=60 * 45, gt=0)
+
+    # Executor Timeout Configuration
+    executor_timeout: int = Field(default=30, gt=0)
+
+    # Startup Entry Configuration
+    enable_startup_entry: bool = Field(default=False)
+
+    @field_validator('position_mode', mode="before")
+    @classmethod
+    def validate_position_mode(cls, v: str) -> PositionMode:
+        if v.upper() in PositionMode.__members__:
+            return PositionMode[v.upper()]
+        raise ValueError(f"Invalid position mode: {v}. Valid options are: {', '.join(PositionMode.__members__)}")
+
+    @field_validator('trading_pairs', mode="before")
+    @classmethod
+    def validate_trading_pairs(cls, v) -> List[str]:
+        if isinstance(v, str):
+            return [pair.strip() for pair in v.split(',')]
+        return v
+
+    @field_validator('candles_pairs', mode="before")
+    @classmethod
+    def validate_candles_pairs(cls, v) -> List[str]:
+        if isinstance(v, str):
+            return [pair.strip() for pair in v.split(',')]
+        return v
+
+
+class DemaSuperTrendMultiTokenStrategy(StrategyV2Base):
+    """
+    This strategy uses DEMA and SuperTrend indicators to generate trading signals.
+    Supports multiple trading pairs with candles from different exchanges.
+    """
+
+    account_config_set = False
+
+    @classmethod
+    def init_markets(cls, config: DemaSuperTrendMultiTokenConfig):
+        cls.markets = {config.exchange: set(config.trading_pairs)}
+
+    def __init__(self, connectors: Dict[str, ConnectorBase], config: DemaSuperTrendMultiTokenConfig):
+        self.max_records = max(config.dema_length, config.supertrend_length, config.candles_length) + 20
+        if len(config.candles_config) == 0:
+            for candles_pair in config.candles_pairs:
+                config.candles_config.append(CandlesConfig(
+                    connector=config.candles_exchange,
+                    trading_pair=candles_pair,
+                    interval=config.candles_interval,
+                    max_records=self.max_records
+                ))
+        super().__init__(connectors, config)
+        self.config = config
+        # Store indicators per trading pair
+        self.current_dema = {}
+        self.current_supertrend_direction = {}
+        self.prev_supertrend_direction = {}
+        self.current_price = {}
+        self.prev_price = {}
+        self.prev_dema = {}
+        self.current_signal = {}
+        self.is_startup = {}
+
+    def start(self, clock: Clock, timestamp: float) -> None:
+        """
+        Start the strategy.
+        :param clock: Clock to use.
+        :param timestamp: Current time.
+        """
+        self._last_timestamp = timestamp
+        self.apply_initial_setting()
+        # Initialize startup flag for each trading pair
+        for candles_pair in self.config.candles_pairs:
+            self.is_startup[candles_pair] = True
+
+    def create_actions_proposal(self) -> List[CreateExecutorAction]:
+        create_actions = []
+
+        # Check signals for each trading pair
+        for i, trading_pair in enumerate(self.config.trading_pairs):
+            if i >= len(self.config.candles_pairs):
+                raise ValueError(f"Index {i} out of range for candles_pairs. trading_pairs: {self.config.trading_pairs}, candles_pairs: {self.config.candles_pairs}")
+            candles_pair = self.config.candles_pairs[i]
+            signal = self.get_signal(self.config.candles_exchange, candles_pair)
+            active_longs, active_shorts = self.get_active_executors_by_side(self.config.exchange, trading_pair)
+
+            if signal is not None:
+                mid_price = self.market_data_provider.get_price_by_type(self.config.exchange,
+                                                                        trading_pair,
+                                                                        PriceType.MidPrice)
+                if signal == 1 and len(active_longs) == 0:
+                    create_actions.append(CreateExecutorAction(
+                        executor_config=PositionExecutorConfig(
+                            timestamp=self.current_timestamp,
+                            connector_name=self.config.exchange,
+                            trading_pair=trading_pair,
+                            side=TradeType.BUY,
+                            entry_price=mid_price,
+                            amount=self.config.order_amount_quote / mid_price,
+                            triple_barrier_config=TripleBarrierConfig(),  # Default config with all barriers disabled
+                            leverage=self.config.leverage
+                        )))
+                elif signal == -1 and len(active_shorts) == 0:
+                    create_actions.append(CreateExecutorAction(
+                        executor_config=PositionExecutorConfig(
+                            timestamp=self.current_timestamp,
+                            connector_name=self.config.exchange,
+                            trading_pair=trading_pair,
+                            side=TradeType.SELL,
+                            entry_price=mid_price,
+                            amount=self.config.order_amount_quote / mid_price,
+                            triple_barrier_config=TripleBarrierConfig(),  # Default config with all barriers disabled
+                            leverage=self.config.leverage
+                        )))
+        return create_actions
+
+    def stop_actions_proposal(self) -> List[StopExecutorAction]:
+        stop_actions = []
+
+        # Check signals for each trading pair
+        for i, trading_pair in enumerate(self.config.trading_pairs):
+            if i >= len(self.config.candles_pairs):
+                raise ValueError(f"Index {i} out of range for candles_pairs. trading_pairs: {self.config.trading_pairs}, candles_pairs: {self.config.candles_pairs}")
+            candles_pair = self.config.candles_pairs[i]
+
+            # Get current SuperTrend direction for stop logic
+            current_supertrend_direction = self.current_supertrend_direction.get(candles_pair)
+            active_longs, active_shorts = self.get_active_executors_by_side(self.config.exchange, trading_pair)
+
+            if current_supertrend_direction is not None:
+                # Stop positions when SuperTrend reverses
+                if current_supertrend_direction == -1 and len(active_longs) > 0:
+                    stop_actions.extend([StopExecutorAction(
+                        controller_id=e.controller_id or "main",
+                        executor_id=e.id
+                    ) for e in active_longs])
+                elif current_supertrend_direction == 1 and len(active_shorts) > 0:
+                    stop_actions.extend([StopExecutorAction(
+                        controller_id=e.controller_id or "main",
+                        executor_id=e.id
+                    ) for e in active_shorts])
+
+            # Check for timeout on unfilled executors
+            all_active_executors = active_longs + active_shorts
+            for executor in all_active_executors:
+                executor_age = self.current_timestamp - executor.timestamp
+                # Stop executors that are active but not trading (unfilled) and have exceeded timeout
+                if executor.is_active and not executor.is_trading and executor_age > self.config.executor_timeout:
+                    stop_actions.append(StopExecutorAction(
+                        controller_id=executor.controller_id or "main",
+                        executor_id=executor.id
+                    ))
+
+        return stop_actions
+
+    def get_active_executors_by_side(self, connector_name: str, trading_pair: str):
+        active_executors_by_trading_pair = self.filter_executors(
+            executors=self.get_all_executors(),
+            filter_func=lambda e: e.connector_name == connector_name and e.trading_pair == trading_pair and e.is_active
+        )
+        active_longs = [e for e in active_executors_by_trading_pair if e.side == TradeType.BUY]
+        active_shorts = [e for e in active_executors_by_trading_pair if e.side == TradeType.SELL]
+        return active_longs, active_shorts
+
+    def get_signal(self, connector_name: str, trading_pair: str) -> Optional[float]:
+        candles = self.market_data_provider.get_candles_df(connector_name,
+                                                           trading_pair,
+                                                           self.config.candles_interval,
+                                                           self.max_records)
+
+        if candles is None or candles.empty:
+            return None
+
+        # Calculate indicators
+        candles.ta.dema(length=self.config.dema_length, append=True)
+        candles.ta.supertrend(length=self.config.supertrend_length, multiplier=self.config.supertrend_multiplier, append=True)
+
+        # Get current values
+        self.current_price[trading_pair] = candles["close"].iloc[-1]
+        self.current_dema[trading_pair] = candles[f"DEMA_{self.config.dema_length}"].iloc[-1]
+        self.current_supertrend_direction[trading_pair] = candles[f"SUPERTd_{self.config.supertrend_length}_{self.config.supertrend_multiplier}"].iloc[-1]
+
+        # Get previous values for trend change detection
+        if len(candles) > 1:
+            self.prev_supertrend_direction[trading_pair] = candles[f"SUPERTd_{self.config.supertrend_length}_{self.config.supertrend_multiplier}"].iloc[-2]
+            self.prev_price[trading_pair] = candles["close"].iloc[-2]
+            self.prev_dema[trading_pair] = candles[f"DEMA_{self.config.dema_length}"].iloc[-2]
+        else:
+            self.prev_supertrend_direction[trading_pair] = self.current_supertrend_direction[trading_pair]
+            self.prev_price[trading_pair] = self.current_price[trading_pair]
+            self.prev_dema[trading_pair] = self.current_dema[trading_pair]
+
+        # Generate long and short conditions
+        current_price = self.current_price[trading_pair]
+        current_dema = self.current_dema[trading_pair]
+        current_supertrend_direction = self.current_supertrend_direction[trading_pair]
+        prev_supertrend_direction = self.prev_supertrend_direction[trading_pair]
+        prev_price = self.prev_price[trading_pair]
+        prev_dema = self.prev_dema[trading_pair]
+
+        # self.logger().info(f"Current Price: {current_price}, Current DEMA: {current_dema}, Current SuperTrend Direction: {current_supertrend_direction}, Previous SuperTrend Direction: {prev_supertrend_direction}")
+
+        # Check if this is the first signal check after startup
+        is_startup_check = self.is_startup.get(trading_pair, False)
+
+        # Long Entry Conditions:
+        # 1. Price above DEMA AND SuperTrend turns green (from previous candle)
+        # 2. SuperTrend already green AND price crosses above DEMA
+        # 3. STARTUP: Price above DEMA AND SuperTrend is green (no flip required)
+        long_condition_1 = (current_price > current_dema and
+                            current_supertrend_direction == 1 and
+                            prev_supertrend_direction == -1)
+
+        long_condition_2 = (current_supertrend_direction == 1 and
+                            current_price > current_dema and
+                            prev_price <= prev_dema)
+
+        long_condition_startup = (is_startup_check and
+                                  self.config.enable_startup_entry and
+                                  current_price > current_dema and
+                                  current_supertrend_direction == 1)
+        # self.logger().info(f"Long Condition 1: {long_condition_1}")
+        # self.logger().info(f"Long Condition 2: {long_condition_2}")
+        # self.logger().info(f"Long Condition Startup: {long_condition_startup}")
+        # Short Entry Conditions:
+        # 1. Price below DEMA AND SuperTrend turns red (from previous candle)
+        # 2. SuperTrend already red AND price crosses below DEMA
+        # 3. STARTUP: Price below DEMA AND SuperTrend is red (no flip required)
+        short_condition_1 = (current_price < current_dema and
+                             current_supertrend_direction == -1 and
+                             prev_supertrend_direction == 1)
+
+        short_condition_2 = (current_supertrend_direction == -1 and
+                             current_price < current_dema and
+                             prev_price >= prev_dema)
+
+        short_condition_startup = (is_startup_check and
+                                   self.config.enable_startup_entry and
+                                   current_price < current_dema and
+                                   current_supertrend_direction == -1)
+        # self.logger().info(f"Short Condition 1: {short_condition_1}")
+        # self.logger().info(f"Short Condition 2: {short_condition_2}")
+        # self.logger().info(f"Short Condition Startup: {short_condition_startup}")
+        # Determine signal
+        if long_condition_1 or long_condition_2 or long_condition_startup:
+            signal = 1
+        elif short_condition_1 or short_condition_2 or short_condition_startup:
+            signal = -1
+        else:
+            signal = 0
+
+        # Reset startup flag after first signal check
+        if is_startup_check:
+            self.is_startup[trading_pair] = False
+
+        self.current_signal[trading_pair] = signal
+        return signal
+
+    def apply_initial_setting(self):
+        if not self.account_config_set:
+            for connector_name, connector in self.connectors.items():
+                if self.is_perpetual(connector_name):
+                    connector.set_position_mode(self.config.position_mode)
+                    for trading_pair in self.config.trading_pairs:
+                        connector.set_leverage(trading_pair, self.config.leverage)
+            self.account_config_set = True
+
+    def format_status(self) -> str:
+        if not self.ready_to_trade:
+            return "Market connectors are not ready."
+        lines = []
+
+        balance_df = self.get_balance_df()
+        lines.extend(["", "  Balances:"] + ["    " + line for line in balance_df.to_string(index=False).split("\n")])
+
+        # Create compact trading pairs overview
+        lines.extend(["", "  Trading Pairs Overview:"])
+
+        # Header for the grid
+        header = f"{'Pair':<12} {'Price':<8} {'DEMA':<8} {'ST Dir':<6} {'Prev ST':<7} {'Signal':<7} {'Long':<4} {'Short':<5}"
+        lines.append(f"    {header}")
+        lines.append(f"    {'-' * len(header)}")
+
+        # Display each trading pair in compact format
+        for i, candles_pair in enumerate(self.config.candles_pairs):
+            # Get indicator values for this pair
+            price = self.current_price.get(candles_pair, 0)
+            dema = self.current_dema.get(candles_pair, 0)
+            st_dir = self.current_supertrend_direction.get(candles_pair, 0)
+            prev_st_dir = self.prev_supertrend_direction.get(candles_pair, 0)
+            signal = self.current_signal.get(candles_pair, 0)
+
+            # Format signal and direction display
+            signal_text = "LONG" if signal == 1 else "SHORT" if signal == -1 else "NONE"
+            st_text = "UP" if st_dir == 1 else "DOWN" if st_dir == -1 else "NONE"
+            prev_st_text = "UP" if prev_st_dir == 1 else "DOWN" if prev_st_dir == -1 else "NONE"
+
+            # Get active positions for this pair
+            if i < len(self.config.trading_pairs):
+                actual_trading_pair = self.config.trading_pairs[i]
+                active_longs, active_shorts = self.get_active_executors_by_side(self.config.exchange, actual_trading_pair)
+            else:
+                active_longs, active_shorts = [], []
+
+            # Format the row
+            pair_display = candles_pair.replace('-', '/') if len(candles_pair) > 12 else candles_pair
+            row = f"{pair_display:<12} {price:>7.3f} {dema:>7.3f} {st_text:>6} {prev_st_text:>7} {signal_text:>7} {len(active_longs):>4} {len(active_shorts):>5}"
+            lines.append(f"    {row}")
+
+        # Add configuration info
+        lines.extend([
+            "",
+            f"  Config: DEMA({self.config.dema_length}) | SuperTrend({self.config.supertrend_length}, {self.config.supertrend_multiplier})"
+        ])
+
+        try:
+            orders_df = self.active_orders_df()
+            lines.extend(["", "  Active Orders:"] + ["    " + line for line in orders_df.to_string(index=False).split("\n")])
+        except ValueError:
+            lines.extend(["", "  No active maker orders."])
+
+        # Active Position Executors
+        active_executors = self.filter_executors(
+            executors=self.get_all_executors(),
+            filter_func=lambda e: e.is_active
+        )
+
+        if active_executors:
+            lines.extend(["", "  Active Position Executors:"])
+            for executor_info in active_executors:
+                lines.extend([
+                    f"    ID: {executor_info.id} | Type: {executor_info.type} | Status: {executor_info.status.value}",
+                    f"    Pair: {executor_info.trading_pair} | Exchange: {executor_info.connector_name} | Side: {executor_info.side}",
+                    f"    Net PnL: {executor_info.net_pnl_quote:.6f} ({executor_info.net_pnl_pct * 100:.2f}%)",
+                    f"    Filled Amount: {executor_info.filled_amount_quote:.4f} | Fees: {executor_info.cum_fees_quote:.6f}",
+                    f"    Active: {executor_info.is_active} | Trading: {executor_info.is_trading}",
+                    "    ---"
+                ])
+        else:
+            lines.extend(["", "  No active position executors."])
+
+        return "\n".join(lines)

--- a/scripts/v2_macd_bb_rsi_reversion.py
+++ b/scripts/v2_macd_bb_rsi_reversion.py
@@ -207,8 +207,9 @@ class MACDBBRSIStrategy(StrategyV2Base):
             for connector_name, connector in self.connectors.items():
                 if self.is_perpetual(connector_name):
                     connector.set_position_mode(self.config.position_mode)
-                    for trading_pair in self.market_data_provider.get_trading_pairs(connector_name):
-                        connector.set_leverage(trading_pair, self.config.leverage)
+        if self.is_perpetual(connector_name):
+            connector.set_position_mode(self.config.position_mode)
+            connector.set_leverage(self.config.trading_pair, self.config.leverage)
             self.account_config_set = True
 
     def format_status(self) -> str:

--- a/scripts/v2_macd_bb_rsi_reversion.py
+++ b/scripts/v2_macd_bb_rsi_reversion.py
@@ -1,0 +1,259 @@
+import os
+from decimal import Decimal
+from typing import Dict, List, Optional
+
+import pandas_ta as ta  # noqa: F401
+from pydantic import Field, field_validator
+
+from hummingbot.connector.connector_base import ConnectorBase
+from hummingbot.core.clock import Clock
+from hummingbot.core.data_type.common import OrderType, PositionMode, PriceType, TradeType
+from hummingbot.data_feed.candles_feed.candles_factory import CandlesConfig
+from hummingbot.strategy.strategy_v2_base import StrategyV2Base, StrategyV2ConfigBase
+from hummingbot.strategy_v2.executors.position_executor.data_types import PositionExecutorConfig, TripleBarrierConfig
+from hummingbot.strategy_v2.models.executor_actions import CreateExecutorAction, StopExecutorAction
+
+
+class MACDBBRSIConfig(StrategyV2ConfigBase):
+    script_file_name: str = os.path.basename(__file__)
+    markets: Dict[str, List[str]] = {}
+    candles_config: List[CandlesConfig] = []
+    controllers_config: List[str] = []
+    exchange: str = Field(default="hyperliquid_perpetual")
+    trading_pair: str = Field(default="ETH-USD")
+    candles_exchange: str = Field(default="binance_perpetual")
+    candles_pair: str = Field(default="ETH-USDT")
+    candles_interval: str = Field(default="5m")
+    candles_length: int = Field(default=60, gt=0)
+
+    # RSI Configuration
+    rsi_low: float = Field(default=20, gt=0)
+    rsi_high: float = Field(default=80, gt=0)
+    rsi_length: int = Field(default=14, gt=0)
+
+    # MACD Configuration
+    macd_fast: int = Field(default=6, gt=0)
+    macd_slow: int = Field(default=13, gt=0)
+    macd_signal: int = Field(default=4, gt=0)
+
+    # Bollinger Bands Configuration
+    bb_length: int = Field(default=100, gt=0)
+    bb_std: float = Field(default=2.5, gt=0)
+
+    # Bollinger Bands Threshold Configuration
+    bb_long_threshold: float = Field(default=0.0)
+    bb_short_threshold: float = Field(default=1.0)
+
+    # Order Configuration
+    order_amount_quote: Decimal = Field(default=30, gt=0)
+    leverage: int = Field(default=10, gt=0)
+    position_mode: PositionMode = Field(default="ONEWAY")
+
+    # Triple Barrier Configuration
+    stop_loss: Decimal = Field(default=Decimal("0.03"), gt=0)
+    take_profit: Decimal = Field(default=Decimal("0.01"), gt=0)
+    time_limit: int = Field(default=60 * 15, gt=0)
+
+    @property
+    def triple_barrier_config(self) -> TripleBarrierConfig:
+        return TripleBarrierConfig(
+            stop_loss=self.stop_loss,
+            take_profit=self.take_profit,
+            time_limit=self.time_limit,
+            open_order_type=OrderType.MARKET,
+            take_profit_order_type=OrderType.LIMIT,
+            stop_loss_order_type=OrderType.MARKET,
+            time_limit_order_type=OrderType.MARKET
+        )
+
+    @field_validator('position_mode', mode="before")
+    @classmethod
+    def validate_position_mode(cls, v: str) -> PositionMode:
+        if v.upper() in PositionMode.__members__:
+            return PositionMode[v.upper()]
+        raise ValueError(f"Invalid position mode: {v}. Valid options are: {', '.join(PositionMode.__members__)}")
+
+
+class MACDBBRSIStrategy(StrategyV2Base):
+    """
+    This strategy uses a combination of RSI, MACD, and Bollinger Bands to generate trading signals.
+    It combines multiple technical indicators for more robust signal generation.
+    """
+
+    account_config_set = False
+
+    @classmethod
+    def init_markets(cls, config: MACDBBRSIConfig):
+        cls.markets = {config.exchange: {config.trading_pair}}
+
+    def __init__(self, connectors: Dict[str, ConnectorBase], config: MACDBBRSIConfig):
+        self.max_records = max(config.macd_slow, config.macd_fast, config.macd_signal, config.bb_length, config.candles_length) + 20
+        if len(config.candles_config) == 0:
+            config.candles_config.append(CandlesConfig(
+                connector=config.candles_exchange,
+                trading_pair=config.candles_pair,
+                interval=config.candles_interval,
+                max_records=self.max_records
+            ))
+        super().__init__(connectors, config)
+        self.config = config
+        self.current_rsi = None
+        self.current_macd = None
+        self.current_macd_histogram = None
+        self.current_bbp = None
+        self.current_signal = None
+
+    def start(self, clock: Clock, timestamp: float) -> None:
+        """
+        Start the strategy.
+        :param clock: Clock to use.
+        :param timestamp: Current time.
+        """
+        self._last_timestamp = timestamp
+        self.apply_initial_setting()
+
+    def create_actions_proposal(self) -> List[CreateExecutorAction]:
+        create_actions = []
+        signal = self.get_signal(self.config.candles_exchange, self.config.candles_pair)
+        active_longs, active_shorts = self.get_active_executors_by_side(self.config.exchange,
+                                                                        self.config.trading_pair)
+        if signal is not None:
+            mid_price = self.market_data_provider.get_price_by_type(self.config.exchange,
+                                                                    self.config.trading_pair,
+                                                                    PriceType.MidPrice)
+            if signal == 1 and len(active_longs) == 0:
+                create_actions.append(CreateExecutorAction(
+                    executor_config=PositionExecutorConfig(
+                        timestamp=self.current_timestamp,
+                        connector_name=self.config.exchange,
+                        trading_pair=self.config.trading_pair,
+                        side=TradeType.BUY,
+                        entry_price=mid_price,
+                        amount=self.config.order_amount_quote / mid_price,
+                        triple_barrier_config=self.config.triple_barrier_config,
+                        leverage=self.config.leverage
+                    )))
+            elif signal == -1 and len(active_shorts) == 0:
+                create_actions.append(CreateExecutorAction(
+                    executor_config=PositionExecutorConfig(
+                        timestamp=self.current_timestamp,
+                        connector_name=self.config.exchange,
+                        trading_pair=self.config.trading_pair,
+                        side=TradeType.SELL,
+                        entry_price=mid_price,
+                        amount=self.config.order_amount_quote / mid_price,
+                        triple_barrier_config=self.config.triple_barrier_config,
+                        leverage=self.config.leverage
+                    )))
+        return create_actions
+
+    def stop_actions_proposal(self) -> List[StopExecutorAction]:
+        stop_actions = []
+        signal = self.get_signal(self.config.candles_exchange, self.config.candles_pair)
+        active_longs, active_shorts = self.get_active_executors_by_side(self.config.exchange,
+                                                                        self.config.trading_pair)
+        if signal is not None:
+            if signal == -1 and len(active_longs) > 0:
+                stop_actions.extend([StopExecutorAction(executor_id=e.id) for e in active_longs])
+            elif signal == 1 and len(active_shorts) > 0:
+                stop_actions.extend([StopExecutorAction(executor_id=e.id) for e in active_shorts])
+        return stop_actions
+
+    def get_active_executors_by_side(self, connector_name: str, trading_pair: str):
+        active_executors_by_connector_pair = self.filter_executors(
+            executors=self.get_all_executors(),
+            filter_func=lambda e: e.connector_name == connector_name and e.trading_pair == trading_pair and e.is_active
+        )
+        active_longs = [e for e in active_executors_by_connector_pair if e.side == TradeType.BUY]
+        active_shorts = [e for e in active_executors_by_connector_pair if e.side == TradeType.SELL]
+        return active_longs, active_shorts
+
+    def get_signal(self, connector_name: str, trading_pair: str) -> Optional[float]:
+        candles = self.market_data_provider.get_candles_df(connector_name,
+                                                           trading_pair,
+                                                           self.config.candles_interval,
+                                                           self.max_records)
+
+        # Calculate indicators
+        candles.ta.rsi(length=self.config.rsi_length, append=True)
+        candles.ta.bbands(length=self.config.bb_length, std=self.config.bb_std, append=True)
+        candles.ta.macd(fast=self.config.macd_fast, slow=self.config.macd_slow, signal=self.config.macd_signal, append=True)
+
+        # Get current indicator values
+        self.current_rsi = candles.iloc[-1][f"RSI_{self.config.rsi_length}"]
+        self.current_bbp = candles.iloc[-1][f"BBP_{self.config.bb_length}_{self.config.bb_std}"]
+        self.current_macd = candles.iloc[-1][f"MACD_{self.config.macd_fast}_{self.config.macd_slow}_{self.config.macd_signal}"]
+        self.current_macd_histogram = candles.iloc[-1][f"MACDh_{self.config.macd_fast}_{self.config.macd_slow}_{self.config.macd_signal}"]
+
+        # Define combined signal conditions
+        rsi_condition = candles[f"RSI_{self.config.rsi_length}"]
+        bbp_condition = candles[f"BBP_{self.config.bb_length}_{self.config.bb_std}"]
+        macd_condition = candles[f"MACD_{self.config.macd_fast}_{self.config.macd_slow}_{self.config.macd_signal}"]
+        macdh_condition = candles[f"MACDh_{self.config.macd_fast}_{self.config.macd_slow}_{self.config.macd_signal}"]
+
+        # Generate combined signals
+        long_condition = (rsi_condition < self.config.rsi_low) & (bbp_condition < self.config.bb_long_threshold) & (macdh_condition > 0) & (macd_condition < 0)
+        short_condition = (rsi_condition > self.config.rsi_high) & (bbp_condition > self.config.bb_short_threshold) & (macdh_condition < 0) & (macd_condition > 0)
+
+        candles["signal"] = 0
+        candles.loc[long_condition, "signal"] = 1
+        candles.loc[short_condition, "signal"] = -1
+
+        self.current_signal = candles.iloc[-1]["signal"] if not candles.empty else None
+        return self.current_signal
+
+    def apply_initial_setting(self):
+        if not self.account_config_set:
+            for connector_name, connector in self.connectors.items():
+                if self.is_perpetual(connector_name):
+                    connector.set_position_mode(self.config.position_mode)
+                    for trading_pair in self.market_data_provider.get_trading_pairs(connector_name):
+                        connector.set_leverage(trading_pair, self.config.leverage)
+            self.account_config_set = True
+
+    def format_status(self) -> str:
+        if not self.ready_to_trade:
+            return "Market connectors are not ready."
+        lines = []
+
+        balance_df = self.get_balance_df()
+        lines.extend(["", "  Balances:"] + ["    " + line for line in balance_df.to_string(index=False).split("\n")])
+
+        # Create RSI progress bar
+        if self.current_rsi is not None:
+            bar_length = 50
+            rsi_position = int((self.current_rsi / 100) * bar_length)
+            progress_bar = ["─"] * bar_length
+
+            # Add threshold markers
+            low_threshold_pos = int((self.config.rsi_low / 100) * bar_length)
+            high_threshold_pos = int((self.config.rsi_high / 100) * bar_length)
+            progress_bar[low_threshold_pos] = "L"
+            progress_bar[high_threshold_pos] = "H"
+
+            # Add current position marker
+            if 0 <= rsi_position < bar_length:
+                progress_bar[rsi_position] = "●"
+
+            progress_bar = "".join(progress_bar)
+            lines.extend([
+                "",
+                f"  RSI: {self.current_rsi:.2f}  (Long ≤ {self.config.rsi_low}, Short ≥ {self.config.rsi_high})",
+                f"  0 {progress_bar} 100",
+            ])
+
+        # Display MACD and BB values
+        if self.current_macd is not None:
+            lines.extend([
+                "",
+                f"  MACD: {self.current_macd:.4f}  |  MACD Histogram: {self.current_macd_histogram:.4f}",
+                f"  BBP: {self.current_bbp:.4f}  (Long ≤ {self.config.bb_long_threshold}, Short ≥ {self.config.bb_short_threshold})",
+            ])
+
+        try:
+            orders_df = self.active_orders_df()
+            lines.extend(["", "  Active Orders:"] + ["    " + line for line in orders_df.to_string(index=False).split("\n")])
+        except ValueError:
+            lines.extend(["", "  No active maker orders."])
+
+        return "\n".join(lines)

--- a/scripts/v2_macd_bb_rsi_reversion_multi_token.py
+++ b/scripts/v2_macd_bb_rsi_reversion_multi_token.py
@@ -254,33 +254,15 @@ class MACDBBRSIStrategy(StrategyV2Base):
         header = f"{'Pair':<12} {'RSI':<7} {'MACD':<9} {'MACDH':<9} {'BBP':<7} {'Signal':<7} {'Long':<4} {'Short':<5}"
         lines.append(f"    {header}")
         lines.append(f"    {'-' * len(header)}")
-
         # Display each trading pair in compact format
         for i, trading_pair in enumerate(self.config.candles_pairs):
-            # Get indicator values for this pair - fix the fallback logic
-            rsi_val = self.current_rsi.get(trading_pair)
-            if rsi_val is None:
-                rsi_val = -1
-
-            macd_val = self.current_macd.get(trading_pair)
-            if macd_val is None:
-                macd_val = -1
-
-            macdh_val = self.current_macd_histogram.get(trading_pair)
-            if macdh_val is None:
-                macdh_val = -1
-
-            bbp_val = self.current_bbp.get(trading_pair)
-            if bbp_val is None:
-                bbp_val = -1
-
             signal = self.current_signal.get(trading_pair)
-            if signal is None:
-                signal = -1
-
+            macd_val = self.current_macd.get(trading_pair)
+            macdh_val = self.current_macd_histogram.get(trading_pair)
+            bbp_val = self.current_bbp.get(trading_pair)
             # Format signal display
             signal_text = "LONG" if signal == 1 else "SHORT" if signal == -1 else "NONE"
-
+            rsi_val = self.current_rsi.get(trading_pair)
             # Get active positions for this pair - need to map back to trading pair
             actual_trading_pair = self.config.trading_pairs[i] if i < len(self.config.trading_pairs) else trading_pair
             active_longs, active_shorts = self.get_active_executors_by_side(self.config.exchange, actual_trading_pair)

--- a/scripts/v2_macd_bb_rsi_reversion_multi_token.py
+++ b/scripts/v2_macd_bb_rsi_reversion_multi_token.py
@@ -1,0 +1,325 @@
+import os
+from decimal import Decimal
+from typing import Dict, List, Optional
+
+import pandas_ta as ta  # noqa: F401
+from pydantic import Field, field_validator
+
+from hummingbot.connector.connector_base import ConnectorBase
+from hummingbot.core.clock import Clock
+from hummingbot.core.data_type.common import OrderType, PositionMode, PriceType, TradeType
+from hummingbot.data_feed.candles_feed.candles_factory import CandlesConfig
+from hummingbot.strategy.strategy_v2_base import StrategyV2Base, StrategyV2ConfigBase
+from hummingbot.strategy_v2.executors.position_executor.data_types import PositionExecutorConfig, TripleBarrierConfig
+from hummingbot.strategy_v2.models.executor_actions import CreateExecutorAction, StopExecutorAction
+
+
+class MACDBBRSIConfig(StrategyV2ConfigBase):
+    script_file_name: str = os.path.basename(__file__)
+    markets: Dict[str, List[str]] = {}
+    candles_config: List[CandlesConfig] = []
+    controllers_config: List[str] = []
+    exchange: str = Field(default="hyperliquid_perpetual")
+    trading_pairs: List[str] = Field(default=["ETH-USD"])
+    candles_exchange: str = Field(default="binance_perpetual")
+    candles_pairs: List[str] = Field(default=["ETH-USDT"])
+    candles_interval: str = Field(default="5m")
+    candles_length: int = Field(default=60, gt=0)
+
+    # RSI Configuration
+    rsi_low: float = Field(default=20, gt=0)
+    rsi_high: float = Field(default=80, gt=0)
+    rsi_length: int = Field(default=14, gt=0)
+
+    # MACD Configuration
+    macd_fast: int = Field(default=6, gt=0)
+    macd_slow: int = Field(default=13, gt=0)
+    macd_signal: int = Field(default=4, gt=0)
+
+    # Bollinger Bands Configuration
+    bb_length: int = Field(default=20, gt=0)
+    bb_std: float = Field(default=2.2, gt=0)
+
+    # Bollinger Bands Threshold Configuration
+    bb_long_threshold: float = Field(default=0.0)
+    bb_short_threshold: float = Field(default=1.0)
+
+    # Order Configuration
+    order_amount_quote: Decimal = Field(default=30, gt=0)
+    leverage: int = Field(default=10, gt=0)
+    position_mode: PositionMode = Field(default="ONEWAY")
+
+    # Triple Barrier Configuration
+    stop_loss: Decimal = Field(default=Decimal("0.03"), gt=0)
+    take_profit: Decimal = Field(default=Decimal("0.01"), gt=0)
+    time_limit: int = Field(default=60 * 15, gt=0)
+
+    @property
+    def triple_barrier_config(self) -> TripleBarrierConfig:
+        return TripleBarrierConfig(
+            stop_loss=self.stop_loss,
+            take_profit=self.take_profit,
+            time_limit=self.time_limit,
+            open_order_type=OrderType.MARKET,
+            take_profit_order_type=OrderType.LIMIT,
+            stop_loss_order_type=OrderType.MARKET,
+            time_limit_order_type=OrderType.MARKET
+        )
+
+    @field_validator('position_mode', mode="before")
+    @classmethod
+    def validate_position_mode(cls, v: str) -> PositionMode:
+        if v.upper() in PositionMode.__members__:
+            return PositionMode[v.upper()]
+        raise ValueError(f"Invalid position mode: {v}. Valid options are: {', '.join(PositionMode.__members__)}")
+
+    @field_validator('trading_pairs', mode="before")
+    @classmethod
+    def validate_trading_pairs(cls, v) -> List[str]:
+        if isinstance(v, str):
+            return [pair.strip() for pair in v.split(',')]
+        return v
+
+    @field_validator('candles_pairs', mode="before")
+    @classmethod
+    def validate_candles_pairs(cls, v) -> List[str]:
+        if isinstance(v, str):
+            return [pair.strip() for pair in v.split(',')]
+        return v
+
+
+class MACDBBRSIStrategy(StrategyV2Base):
+    """
+    This strategy uses a combination of RSI, MACD, and Bollinger Bands to generate trading signals.
+    It combines multiple technical indicators for more robust signal generation.
+    """
+
+    account_config_set = False
+
+    @classmethod
+    def init_markets(cls, config: MACDBBRSIConfig):
+        cls.markets = {config.exchange: set(config.trading_pairs)}
+
+    def __init__(self, connectors: Dict[str, ConnectorBase], config: MACDBBRSIConfig):
+        self.max_records = max(config.macd_slow, config.macd_fast, config.macd_signal, config.bb_length, config.candles_length) + 20
+        if len(config.candles_config) == 0:
+            for candles_pair in config.candles_pairs:
+                config.candles_config.append(CandlesConfig(
+                    connector=config.candles_exchange,
+                    trading_pair=candles_pair,
+                    interval=config.candles_interval,
+                    max_records=self.max_records
+                ))
+        super().__init__(connectors, config)
+        self.config = config
+        # Store indicators per trading pair
+        self.current_rsi = {}
+        self.current_macd = {}
+        self.current_macd_histogram = {}
+        self.current_bbp = {}
+        self.current_signal = {}
+
+    def start(self, clock: Clock, timestamp: float) -> None:
+        """
+        Start the strategy.
+        :param clock: Clock to use.
+        :param timestamp: Current time.
+        """
+        self._last_timestamp = timestamp
+        self.apply_initial_setting()
+
+    def create_actions_proposal(self) -> List[CreateExecutorAction]:
+        create_actions = []
+
+        # Check signals for each trading pair
+        for i, trading_pair in enumerate(self.config.trading_pairs):
+            if i >= len(self.config.candles_pairs):
+                raise ValueError(f"Index {i} out of range for candles_pairs. trading_pairs: {self.config.trading_pairs}, candles_pairs: {self.config.candles_pairs}")
+            candles_pair = self.config.candles_pairs[i]
+            signal = self.get_signal(self.config.candles_exchange, candles_pair)
+            active_longs, active_shorts = self.get_active_executors_by_side(self.config.exchange, trading_pair)
+
+            if signal is not None:
+                mid_price = self.market_data_provider.get_price_by_type(self.config.exchange,
+                                                                        trading_pair,
+                                                                        PriceType.MidPrice)
+                if signal == 1 and len(active_longs) == 0:
+                    create_actions.append(CreateExecutorAction(
+                        executor_config=PositionExecutorConfig(
+                            timestamp=self.current_timestamp,
+                            connector_name=self.config.exchange,
+                            trading_pair=trading_pair,
+                            side=TradeType.BUY,
+                            entry_price=mid_price,
+                            amount=self.config.order_amount_quote / mid_price,
+                            triple_barrier_config=self.config.triple_barrier_config,
+                            leverage=self.config.leverage
+                        )))
+                elif signal == -1 and len(active_shorts) == 0:
+                    create_actions.append(CreateExecutorAction(
+                        executor_config=PositionExecutorConfig(
+                            timestamp=self.current_timestamp,
+                            connector_name=self.config.exchange,
+                            trading_pair=trading_pair,
+                            side=TradeType.SELL,
+                            entry_price=mid_price,
+                            amount=self.config.order_amount_quote / mid_price,
+                            triple_barrier_config=self.config.triple_barrier_config,
+                            leverage=self.config.leverage
+                        )))
+        return create_actions
+
+    def stop_actions_proposal(self) -> List[StopExecutorAction]:
+        stop_actions = []
+
+        # Check signals for each trading pair
+        for i, trading_pair in enumerate(self.config.trading_pairs):
+            if i >= len(self.config.candles_pairs):
+                raise ValueError(f"Index {i} out of range for candles_pairs. trading_pairs: {self.config.trading_pairs}, candles_pairs: {self.config.candles_pairs}")
+            candles_pair = self.config.candles_pairs[i]
+            signal = self.get_signal(self.config.candles_exchange, candles_pair)
+            active_longs, active_shorts = self.get_active_executors_by_side(self.config.exchange, trading_pair)
+
+            if signal is not None:
+                if signal == -1 and len(active_longs) > 0:
+                    stop_actions.extend([StopExecutorAction(executor_id=e.id) for e in active_longs])
+                elif signal == 1 and len(active_shorts) > 0:
+                    stop_actions.extend([StopExecutorAction(executor_id=e.id) for e in active_shorts])
+        return stop_actions
+
+    def get_active_executors_by_side(self, connector_name: str, trading_pair: str):
+        active_executors_by_trading_pair = self.filter_executors(
+            executors=self.get_all_executors(),
+            filter_func=lambda e: e.connector_name == connector_name and e.trading_pair == trading_pair and e.is_active
+        )
+        active_longs = [e for e in active_executors_by_trading_pair if e.side == TradeType.BUY]
+        active_shorts = [e for e in active_executors_by_trading_pair if e.side == TradeType.SELL]
+        return active_longs, active_shorts
+
+    def get_signal(self, connector_name: str, trading_pair: str) -> Optional[float]:
+        candles = self.market_data_provider.get_candles_df(connector_name,
+                                                           trading_pair,
+                                                           self.config.candles_interval,
+                                                           self.max_records)
+
+        # Calculate indicators
+        candles.ta.rsi(length=self.config.rsi_length, append=True)
+        candles.ta.bbands(length=self.config.bb_length, std=self.config.bb_std, append=True)
+        candles.ta.macd(fast=self.config.macd_fast, slow=self.config.macd_slow, signal=self.config.macd_signal, append=True)
+
+        # Get current indicator values and store per trading pair
+        self.current_rsi[trading_pair] = candles.iloc[-1][f"RSI_{self.config.rsi_length}"]
+        self.current_bbp[trading_pair] = candles.iloc[-1][f"BBP_{self.config.bb_length}_{self.config.bb_std}"]
+        self.current_macd[trading_pair] = candles.iloc[-1][f"MACD_{self.config.macd_fast}_{self.config.macd_slow}_{self.config.macd_signal}"]
+        self.current_macd_histogram[trading_pair] = candles.iloc[-1][f"MACDh_{self.config.macd_fast}_{self.config.macd_slow}_{self.config.macd_signal}"]
+        # Define combined signal conditions
+        rsi_condition = candles[f"RSI_{self.config.rsi_length}"]
+        bbp_condition = candles[f"BBP_{self.config.bb_length}_{self.config.bb_std}"]
+        macd_condition = candles[f"MACD_{self.config.macd_fast}_{self.config.macd_slow}_{self.config.macd_signal}"]
+        macdh_condition = candles[f"MACDh_{self.config.macd_fast}_{self.config.macd_slow}_{self.config.macd_signal}"]
+
+        # Generate combined signals
+        long_condition = (rsi_condition < self.config.rsi_low) & (bbp_condition < self.config.bb_long_threshold) & (macdh_condition > 0) & (macd_condition < 0)
+        short_condition = (rsi_condition > self.config.rsi_high) & (bbp_condition > self.config.bb_short_threshold) & (macdh_condition < 0) & (macd_condition > 0)
+
+        candles["signal"] = 0
+        candles.loc[long_condition, "signal"] = 1
+        candles.loc[short_condition, "signal"] = -1
+
+        signal_value = candles.iloc[-1]["signal"] if not candles.empty else None
+        self.current_signal[trading_pair] = signal_value
+        return signal_value
+
+    def apply_initial_setting(self):
+        if not self.account_config_set:
+            for connector_name, connector in self.connectors.items():
+                if self.is_perpetual(connector_name):
+                    connector.set_position_mode(self.config.position_mode)
+                    for trading_pair in self.config.trading_pairs:
+                        connector.set_leverage(trading_pair, self.config.leverage)
+            self.account_config_set = True
+
+    def format_status(self) -> str:
+        if not self.ready_to_trade:
+            return "Market connectors are not ready."
+        lines = []
+
+        balance_df = self.get_balance_df()
+        lines.extend(["", "  Balances:"] + ["    " + line for line in balance_df.to_string(index=False).split("\n")])
+
+        # Create compact trading pairs overview
+        lines.extend(["", "  Trading Pairs Overview:"])
+
+        # Header for the grid
+        header = f"{'Pair':<12} {'RSI':<7} {'MACD':<9} {'MACDH':<9} {'BBP':<7} {'Signal':<7} {'Long':<4} {'Short':<5}"
+        lines.append(f"    {header}")
+        lines.append(f"    {'-' * len(header)}")
+
+        # Display each trading pair in compact format
+        for i, trading_pair in enumerate(self.config.candles_pairs):
+            # Get indicator values for this pair - fix the fallback logic
+            rsi_val = self.current_rsi.get(trading_pair)
+            if rsi_val is None:
+                rsi_val = -1
+
+            macd_val = self.current_macd.get(trading_pair)
+            if macd_val is None:
+                macd_val = -1
+
+            macdh_val = self.current_macd_histogram.get(trading_pair)
+            if macdh_val is None:
+                macdh_val = -1
+
+            bbp_val = self.current_bbp.get(trading_pair)
+            if bbp_val is None:
+                bbp_val = -1
+
+            signal = self.current_signal.get(trading_pair)
+            if signal is None:
+                signal = -1
+
+            # Format signal display
+            signal_text = "LONG" if signal == 1 else "SHORT" if signal == -1 else "NONE"
+
+            # Get active positions for this pair - need to map back to trading pair
+            actual_trading_pair = self.config.trading_pairs[i] if i < len(self.config.trading_pairs) else trading_pair
+            active_longs, active_shorts = self.get_active_executors_by_side(self.config.exchange, actual_trading_pair)
+
+            # Format the row with better spacing and alignment
+            pair_display = trading_pair.replace('-', '/') if len(trading_pair) > 12 else trading_pair
+            row = f"{pair_display:<12} {rsi_val:>6.1f} {macd_val:>8.4f} {macdh_val:>8.4f} {bbp_val:>6.3f} {signal_text:>9} {len(active_longs):>4} {len(active_shorts):>4}"
+            lines.append(f"    {row}")
+
+        # Add threshold info in compact format
+        lines.extend([
+            "",
+            f"  Thresholds: RSI({self.config.rsi_low}-{self.config.rsi_high}) | BB({self.config.bb_long_threshold:.3f}-{self.config.bb_short_threshold:.3f})"
+        ])
+
+        try:
+            orders_df = self.active_orders_df()
+            lines.extend(["", "  Active Orders:"] + ["    " + line for line in orders_df.to_string(index=False).split("\n")])
+        except ValueError:
+            lines.extend(["", "  No active maker orders."])
+
+        # Active Position Executors
+        active_executors = self.filter_executors(
+            executors=self.get_all_executors(),
+            filter_func=lambda e: e.is_active
+        )
+
+        if active_executors:
+            lines.extend(["", "  Active Position Executors:"])
+            executors_df = self.executors_info_to_df(active_executors)
+            if not executors_df.empty:
+                executors_df["age"] = self.current_timestamp - executors_df["timestamp"]
+                executor_columns = ["type", "connector_name", "trading_pair", "side", "status",
+                                    "net_pnl_pct", "net_pnl_quote", "filled_amount_quote", "age"]
+                available_columns = [col for col in executor_columns if col in executors_df.columns]
+                from hummingbot.client.ui.interface_utils import format_df_for_printout
+                lines.extend(["    " + line for line in format_df_for_printout(executors_df[available_columns],
+                                                                               table_format="psql", index=False).split("\n")])
+        else:
+            lines.extend(["", "  No active position executors."])
+
+        return "\n".join(lines)

--- a/scripts/v2_macd_bb_rsi_reversion_multitimeframe.py
+++ b/scripts/v2_macd_bb_rsi_reversion_multitimeframe.py
@@ -1,0 +1,259 @@
+import os
+from decimal import Decimal
+from typing import Dict, List, Optional
+
+import pandas_ta as ta  # noqa: F401
+from pydantic import Field, field_validator
+
+from hummingbot.connector.connector_base import ConnectorBase
+from hummingbot.core.clock import Clock
+from hummingbot.core.data_type.common import OrderType, PositionMode, PriceType, TradeType
+from hummingbot.data_feed.candles_feed.candles_factory import CandlesConfig
+from hummingbot.strategy.strategy_v2_base import StrategyV2Base, StrategyV2ConfigBase
+from hummingbot.strategy_v2.executors.position_executor.data_types import PositionExecutorConfig, TripleBarrierConfig
+from hummingbot.strategy_v2.models.executor_actions import CreateExecutorAction, StopExecutorAction
+
+
+class MACDBBRSIConfig(StrategyV2ConfigBase):
+    script_file_name: str = os.path.basename(__file__)
+    markets: Dict[str, List[str]] = {}
+    candles_config: List[CandlesConfig] = []
+    controllers_config: List[str] = []
+    exchange: str = Field(default="hyperliquid_perpetual")
+    trading_pair: str = Field(default="ETH-USD")
+    candles_exchange: str = Field(default="binance_perpetual")
+    candles_pair: str = Field(default="ETH-USDT")
+    candles_interval: str = Field(default="5m")
+    candles_length: int = Field(default=60, gt=0)
+
+    # RSI Configuration
+    rsi_low: float = Field(default=20, gt=0)
+    rsi_high: float = Field(default=80, gt=0)
+    rsi_length: int = Field(default=14, gt=0)
+
+    # MACD Configuration
+    macd_fast: int = Field(default=6, gt=0)
+    macd_slow: int = Field(default=13, gt=0)
+    macd_signal: int = Field(default=4, gt=0)
+
+    # Bollinger Bands Configuration
+    bb_length: int = Field(default=100, gt=0)
+    bb_std: float = Field(default=2.5, gt=0)
+
+    # Bollinger Bands Threshold Configuration
+    bb_long_threshold: float = Field(default=0.0)
+    bb_short_threshold: float = Field(default=1.0)
+
+    # Order Configuration
+    order_amount_quote: Decimal = Field(default=30, gt=0)
+    leverage: int = Field(default=10, gt=0)
+    position_mode: PositionMode = Field(default="ONEWAY")
+
+    # Triple Barrier Configuration
+    stop_loss: Decimal = Field(default=Decimal("0.03"), gt=0)
+    take_profit: Decimal = Field(default=Decimal("0.01"), gt=0)
+    time_limit: int = Field(default=60 * 15, gt=0)
+
+    @property
+    def triple_barrier_config(self) -> TripleBarrierConfig:
+        return TripleBarrierConfig(
+            stop_loss=self.stop_loss,
+            take_profit=self.take_profit,
+            time_limit=self.time_limit,
+            open_order_type=OrderType.MARKET,
+            take_profit_order_type=OrderType.LIMIT,
+            stop_loss_order_type=OrderType.MARKET,
+            time_limit_order_type=OrderType.MARKET
+        )
+
+    @field_validator('position_mode', mode="before")
+    @classmethod
+    def validate_position_mode(cls, v: str) -> PositionMode:
+        if v.upper() in PositionMode.__members__:
+            return PositionMode[v.upper()]
+        raise ValueError(f"Invalid position mode: {v}. Valid options are: {', '.join(PositionMode.__members__)}")
+
+
+class MACDBBRSIStrategy(StrategyV2Base):
+    """
+    This strategy uses a combination of RSI, MACD, and Bollinger Bands to generate trading signals.
+    It combines multiple technical indicators for more robust signal generation.
+    """
+
+    account_config_set = False
+
+    @classmethod
+    def init_markets(cls, config: MACDBBRSIConfig):
+        cls.markets = {config.exchange: {config.trading_pair}}
+
+    def __init__(self, connectors: Dict[str, ConnectorBase], config: MACDBBRSIConfig):
+        self.max_records = max(config.macd_slow, config.macd_fast, config.macd_signal, config.bb_length, config.candles_length) + 20
+        if len(config.candles_config) == 0:
+            config.candles_config.append(CandlesConfig(
+                connector=config.candles_exchange,
+                trading_pair=config.candles_pair,
+                interval=config.candles_interval,
+                max_records=self.max_records
+            ))
+        super().__init__(connectors, config)
+        self.config = config
+        self.current_rsi = None
+        self.current_macd = None
+        self.current_macd_histogram = None
+        self.current_bbp = None
+        self.current_signal = None
+
+    def start(self, clock: Clock, timestamp: float) -> None:
+        """
+        Start the strategy.
+        :param clock: Clock to use.
+        :param timestamp: Current time.
+        """
+        self._last_timestamp = timestamp
+        self.apply_initial_setting()
+
+    def create_actions_proposal(self) -> List[CreateExecutorAction]:
+        create_actions = []
+        signal = self.get_signal(self.config.candles_exchange, self.config.candles_pair)
+        active_longs, active_shorts = self.get_active_executors_by_side(self.config.exchange,
+                                                                        self.config.trading_pair)
+        if signal is not None:
+            mid_price = self.market_data_provider.get_price_by_type(self.config.exchange,
+                                                                    self.config.trading_pair,
+                                                                    PriceType.MidPrice)
+            if signal == 1 and len(active_longs) == 0:
+                create_actions.append(CreateExecutorAction(
+                    executor_config=PositionExecutorConfig(
+                        timestamp=self.current_timestamp,
+                        connector_name=self.config.exchange,
+                        trading_pair=self.config.trading_pair,
+                        side=TradeType.BUY,
+                        entry_price=mid_price,
+                        amount=self.config.order_amount_quote / mid_price,
+                        triple_barrier_config=self.config.triple_barrier_config,
+                        leverage=self.config.leverage
+                    )))
+            elif signal == -1 and len(active_shorts) == 0:
+                create_actions.append(CreateExecutorAction(
+                    executor_config=PositionExecutorConfig(
+                        timestamp=self.current_timestamp,
+                        connector_name=self.config.exchange,
+                        trading_pair=self.config.trading_pair,
+                        side=TradeType.SELL,
+                        entry_price=mid_price,
+                        amount=self.config.order_amount_quote / mid_price,
+                        triple_barrier_config=self.config.triple_barrier_config,
+                        leverage=self.config.leverage
+                    )))
+        return create_actions
+
+    def stop_actions_proposal(self) -> List[StopExecutorAction]:
+        stop_actions = []
+        signal = self.get_signal(self.config.candles_exchange, self.config.candles_pair)
+        active_longs, active_shorts = self.get_active_executors_by_side(self.config.exchange,
+                                                                        self.config.trading_pair)
+        if signal is not None:
+            if signal == -1 and len(active_longs) > 0:
+                stop_actions.extend([StopExecutorAction(executor_id=e.id) for e in active_longs])
+            elif signal == 1 and len(active_shorts) > 0:
+                stop_actions.extend([StopExecutorAction(executor_id=e.id) for e in active_shorts])
+        return stop_actions
+
+    def get_active_executors_by_side(self, connector_name: str, trading_pair: str):
+        active_executors_by_connector_pair = self.filter_executors(
+            executors=self.get_all_executors(),
+            filter_func=lambda e: e.connector_name == connector_name and e.trading_pair == trading_pair and e.is_active
+        )
+        active_longs = [e for e in active_executors_by_connector_pair if e.side == TradeType.BUY]
+        active_shorts = [e for e in active_executors_by_connector_pair if e.side == TradeType.SELL]
+        return active_longs, active_shorts
+
+    def get_signal(self, connector_name: str, trading_pair: str) -> Optional[float]:
+        candles = self.market_data_provider.get_candles_df(connector_name,
+                                                           trading_pair,
+                                                           self.config.candles_interval,
+                                                           self.max_records)
+
+        # Calculate indicators
+        candles.ta.rsi(length=self.config.rsi_length, append=True)
+        candles.ta.bbands(length=self.config.bb_length, std=self.config.bb_std, append=True)
+        candles.ta.macd(fast=self.config.macd_fast, slow=self.config.macd_slow, signal=self.config.macd_signal, append=True)
+
+        # Get current indicator values
+        self.current_rsi = candles.iloc[-1][f"RSI_{self.config.rsi_length}"]
+        self.current_bbp = candles.iloc[-1][f"BBP_{self.config.bb_length}_{self.config.bb_std}"]
+        self.current_macd = candles.iloc[-1][f"MACD_{self.config.macd_fast}_{self.config.macd_slow}_{self.config.macd_signal}"]
+        self.current_macd_histogram = candles.iloc[-1][f"MACDh_{self.config.macd_fast}_{self.config.macd_slow}_{self.config.macd_signal}"]
+
+        # Define combined signal conditions
+        rsi_condition = candles[f"RSI_{self.config.rsi_length}"]
+        bbp_condition = candles[f"BBP_{self.config.bb_length}_{self.config.bb_std}"]
+        macd_condition = candles[f"MACD_{self.config.macd_fast}_{self.config.macd_slow}_{self.config.macd_signal}"]
+        macdh_condition = candles[f"MACDh_{self.config.macd_fast}_{self.config.macd_slow}_{self.config.macd_signal}"]
+
+        # Generate combined signals
+        long_condition = (rsi_condition < self.config.rsi_low) & (bbp_condition < self.config.bb_long_threshold) & (macdh_condition > 0) & (macd_condition < 0)
+        short_condition = (rsi_condition > self.config.rsi_high) & (bbp_condition > self.config.bb_short_threshold) & (macdh_condition < 0) & (macd_condition > 0)
+
+        candles["signal"] = 0
+        candles.loc[long_condition, "signal"] = 1
+        candles.loc[short_condition, "signal"] = -1
+
+        self.current_signal = candles.iloc[-1]["signal"] if not candles.empty else None
+        return self.current_signal
+
+    def apply_initial_setting(self):
+        if not self.account_config_set:
+            for connector_name, connector in self.connectors.items():
+                if self.is_perpetual(connector_name):
+                    connector.set_position_mode(self.config.position_mode)
+                    for trading_pair in self.market_data_provider.get_trading_pairs(connector_name):
+                        connector.set_leverage(trading_pair, self.config.leverage)
+            self.account_config_set = True
+
+    def format_status(self) -> str:
+        if not self.ready_to_trade:
+            return "Market connectors are not ready."
+        lines = []
+
+        balance_df = self.get_balance_df()
+        lines.extend(["", "  Balances:"] + ["    " + line for line in balance_df.to_string(index=False).split("\n")])
+
+        # Create RSI progress bar
+        if self.current_rsi is not None:
+            bar_length = 50
+            rsi_position = int((self.current_rsi / 100) * bar_length)
+            progress_bar = ["─"] * bar_length
+
+            # Add threshold markers
+            low_threshold_pos = int((self.config.rsi_low / 100) * bar_length)
+            high_threshold_pos = int((self.config.rsi_high / 100) * bar_length)
+            progress_bar[low_threshold_pos] = "L"
+            progress_bar[high_threshold_pos] = "H"
+
+            # Add current position marker
+            if 0 <= rsi_position < bar_length:
+                progress_bar[rsi_position] = "●"
+
+            progress_bar = "".join(progress_bar)
+            lines.extend([
+                "",
+                f"  RSI: {self.current_rsi:.2f}  (Long ≤ {self.config.rsi_low}, Short ≥ {self.config.rsi_high})",
+                f"  0 {progress_bar} 100",
+            ])
+
+        # Display MACD and BB values
+        if self.current_macd is not None:
+            lines.extend([
+                "",
+                f"  MACD: {self.current_macd:.4f}  |  MACD Histogram: {self.current_macd_histogram:.4f}",
+                f"  BBP: {self.current_bbp:.4f}  (Long ≤ {self.config.bb_long_threshold}, Short ≥ {self.config.bb_short_threshold})",
+            ])
+
+        try:
+            orders_df = self.active_orders_df()
+            lines.extend(["", "  Active Orders:"] + ["    " + line for line in orders_df.to_string(index=False).split("\n")])
+        except ValueError:
+            lines.extend(["", "  No active maker orders."])
+
+        return "\n".join(lines)


### PR DESCRIPTION
## Summary
- Add new long condition 3: ST green, ADX above threshold, price below DEMA
- Add new short condition 3: ST red, ADX above threshold, price above DEMA  
- Implement triple barrier configuration for condition 3 with DEMA as take profit
- Add configurable stop_loss_pct parameter for triple barrier stop loss
- Remove startup entry conditions to simplify strategy logic

## Changes Made
- **New Long Condition 3**: SuperTrend green + ADX above threshold + price below DEMA (mean reversion entry)
- **New Short Condition 3**: SuperTrend red + ADX above threshold + price above DEMA (mean reversion entry)
- **Triple Barrier Implementation**: Condition 3 uses DEMA as take profit target with configurable stop loss
- **Signal Source Tracking**: Track which condition (1, 2, or 3) triggered the signal
- **Configuration**: Added `stop_loss_pct` parameter (default 2%) for triple barrier stop loss
- **Cleanup**: Removed startup entry conditions to streamline strategy logic

## Technical Details
- Conditions 1 & 2 continue using default barrier config (no automatic barriers)
- Condition 3 implements mean reversion strategy expecting price to return to DEMA
- Take profit and stop loss percentages are adjusted for leverage
- Signal generation now returns both signal and signal source for proper barrier configuration

## Test plan
- [ ] Test condition 3 long entries when price is below DEMA with ST green and ADX above threshold
- [ ] Test condition 3 short entries when price is above DEMA with ST red and ADX above threshold
- [ ] Verify triple barrier configuration correctly sets TP at DEMA price
- [ ] Verify stop loss uses configurable percentage from entry price
- [ ] Confirm existing conditions 1 & 2 continue to work as before
- [ ] Test leverage adjustment for TP/SL percentages