### PR TITLE
Max Possible Arbitrage Amount

### DIFF
--- a/hummingbot/strategy/spot_perpetual_arbitrage/arb_proposal.py
+++ b/hummingbot/strategy/spot_perpetual_arbitrage/arb_proposal.py
@@ -1,5 +1,6 @@
+from functools import lru_cache
 from decimal import Decimal
-
+from typing import List
 from hummingbot.strategy.market_trading_pair_tuple import MarketTradingPairTuple
 
 s_decimal_nan = Decimal("NaN")
@@ -13,23 +14,25 @@ class ArbProposalSide:
     def __init__(self,
                  market_info: MarketTradingPairTuple,
                  is_buy: bool,
-                 order_price: Decimal
+                 order_levels: List[List[Decimal, Decimal]]
                  ):
         """
         :param market_info: The market where to submit the order
         :param is_buy: True if buy order
-        :param order_price: The price required for order submission, this could differ from the quote price
+        :param order_levels: A list of tuples, each tuple contains (order_price, order_amount)
         """
         self.market_info: MarketTradingPairTuple = market_info
         self.is_buy: bool = is_buy
-        self.order_price: Decimal = order_price
+        self.order_levels: List[List[Decimal, Decimal]] = order_levels
 
-    def __repr__(self):
-        side = "Buy" if self.is_buy else "Sell"
-        base, quote = self.market_info.trading_pair.split("-")
-        return f"{self.market_info.market.display_name.capitalize()}: {side} {base}" \
-               f" at {self.order_price} {quote}."
-
+    @lru_cache()
+    def get_order_price(self, order_amount: Decimal) -> Decimal:
+        cum_amount = Decimal("0")
+        for price, amount in self.order_levels:
+            cum_amount += amount
+            if cum_amount >= order_amount:
+                return price
+        raise ValueError(f"Order amount {order_amount} exceeds available levels.")
 
 class ArbProposal:
     """
@@ -38,29 +41,67 @@ class ArbProposal:
     def __init__(self,
                  spot_side: ArbProposalSide,
                  perp_side: ArbProposalSide,
-                 order_amount: Decimal):
+                 max_possible_arbitrage_amount: Decimal):
         """
         Creates ArbProposal
         :param spot_side: An ArbProposalSide on spot market
         :param perp_side: An ArbProposalSide on perpetual market
-        :param order_amount: An order amount for both spot and perpetual market
+        :param max_possible_arbitrage_amount: The maximum amount of base asset to arbitrage
         """
         if spot_side.is_buy == perp_side.is_buy:
             raise Exception("Spot and perpetual arb proposal cannot be on the same side.")
         self.spot_side: ArbProposalSide = spot_side
         self.perp_side: ArbProposalSide = perp_side
-        self.order_amount: Decimal = order_amount
+        self.max_possible_arbitrage_amount: Decimal = max_possible_arbitrage_amount
 
-    def profit_pct(self) -> Decimal:
+    def profit_pct(self, order_amount: Decimal) -> Decimal:
         """
         Calculates and returns arbitrage profit (in percentage value).
         """
-        buy_price = self.spot_side.order_price if self.spot_side.is_buy else self.perp_side.order_price
-        sell_price = self.spot_side.order_price if not self.spot_side.is_buy else self.perp_side.order_price
+        buy_price = self.spot_side.get_order_price(order_amount) if self.spot_side.is_buy else self.perp_side.get_order_price(order_amount)
+        sell_price = self.spot_side.get_order_price(order_amount) if not self.spot_side.is_buy else self.perp_side.get_order_price(order_amount)
         if sell_price and buy_price:
             return (sell_price - buy_price) / buy_price
         return s_decimal_0
 
-    def __repr__(self):
-        return f"Spot: {self.spot_side}\nPerpetual: {self.perp_side}\nOrder amount: {self.order_amount}\n" \
-               f"Profit: {self.profit_pct():.2%}"
+    def  get_max_profit_order_amount(self) -> Decimal:
+        """
+        Calculates and returns the order amount that maximises profit.
+        It does this by checking the profit at each discrete liquidity level across both order books.
+        """
+        buy_side = self.spot_side if self.spot_side.is_buy else self.perp_side
+        sell_side = self.perp_side if self.spot_side.is_buy else self.spot_side
+
+        all_cumulative_amounts: List[Decimal] = []
+        cumulative_amount = s_decimal_0
+        for _, amount in buy_side.order_levels:
+            cumulative_amount += amount
+            if cumulative_amount > self.max_possible_arbitrage_amount:
+                break
+            all_cumulative_amounts.append(cumulative_amount)
+
+        cumulative_amount = s_decimal_0
+        for _, amount in sell_side.order_levels:
+            cumulative_amount += amount
+            if cumulative_amount > self.max_possible_arbitrage_amount:
+                break
+            all_cumulative_amounts.append(cumulative_amount)
+
+        # get a unique, sorted list of all discrete amounts to check for profitability.
+        # can be linear, but this is easier to understand.
+        amounts_to_check: List[Decimal] = sorted(list(set(all_cumulative_amounts)))
+
+        max_profit: Decimal = s_decimal_0
+        best_amount: Decimal = s_decimal_0
+
+        for amount in amounts_to_check:
+            buy_price = buy_side.get_order_price(amount)
+            sell_price = sell_side.get_order_price(amount)
+            profit = (sell_price - buy_price) / buy_price * amount
+            if profit <= max_profit:
+                # maxima exists, exit if decreasing profit
+                break
+            max_profit = profit
+            best_amount = amount
+
+        return min(best_amount, self.max_possible_arbitrage_amount)

--- a/hummingbot/strategy/spot_perpetual_arbitrage/spot_perpetual_arbitrage_config_map.py
+++ b/hummingbot/strategy/spot_perpetual_arbitrage/spot_perpetual_arbitrage_config_map.py
@@ -47,10 +47,10 @@ def perpetual_market_prompt() -> str:
            % (connector, f" (e.g. {example})" if example else "")
 
 
-def order_amount_prompt() -> str:
+def max_possible_arbitrage_amount_prompt() -> str:
     trading_pair = spot_perpetual_arbitrage_config_map["spot_market"].value
     base_asset, quote_asset = trading_pair.split("-")
-    return f"What is the amount of {base_asset} per order? >>> "
+    return f"What is the maximum amount of {base_asset} per order? >>> "
 
 
 spot_perpetual_arbitrage_config_map = {
@@ -82,9 +82,9 @@ spot_perpetual_arbitrage_config_map = {
         prompt_on_new=True,
         validator=perpetual_market_validator,
         on_validated=perpetual_market_on_validated),
-    "order_amount": ConfigVar(
-        key="order_amount",
-        prompt=order_amount_prompt,
+    "max_possible_arbitrage_amount": ConfigVar(
+        key="max_possible_arbitrage_amount",
+        prompt=max_possible_arbitrage_amount_prompt,
         type_str="decimal",
         prompt_on_new=True),
     "perpetual_leverage": ConfigVar(

--- a/hummingbot/strategy/spot_perpetual_arbitrage/start.py
+++ b/hummingbot/strategy/spot_perpetual_arbitrage/start.py
@@ -12,7 +12,7 @@ def start(self):
     spot_market = spot_perpetual_arbitrage_config_map.get("spot_market").value
     perpetual_connector = spot_perpetual_arbitrage_config_map.get("perpetual_connector").value.lower()
     perpetual_market = spot_perpetual_arbitrage_config_map.get("perpetual_market").value
-    order_amount = spot_perpetual_arbitrage_config_map.get("order_amount").value
+    max_possible_arbitrage_amount = spot_perpetual_arbitrage_config_map.get("max_possible_arbitrage_amount").value
     perpetual_leverage = spot_perpetual_arbitrage_config_map.get("perpetual_leverage").value
     min_opening_arbitrage_pct = spot_perpetual_arbitrage_config_map.get("min_opening_arbitrage_pct").value / Decimal("100")
     min_closing_arbitrage_pct = spot_perpetual_arbitrage_config_map.get("min_closing_arbitrage_pct").value / Decimal("100")
@@ -31,7 +31,7 @@ def start(self):
     self.strategy = SpotPerpetualArbitrageStrategy()
     self.strategy.init_params(spot_market_info,
                               perpetual_market_info,
-                              order_amount,
+                              max_possible_arbitrage_amount,
                               perpetual_leverage,
                               min_opening_arbitrage_pct,
                               min_closing_arbitrage_pct,

--- a/test/hummingbot/strategy/spot_perpetual_arbitrage/test_spot_perpetual_arbitrage_start.py
+++ b/test/hummingbot/strategy/spot_perpetual_arbitrage/test_spot_perpetual_arbitrage_start.py
@@ -29,7 +29,7 @@ class SpotPerpetualArbitrageStartTest(unittest.TestCase):
         strategy_cmap.get("perpetual_connector").value = "kucoin"
         strategy_cmap.get("perpetual_market").value = "BTC-USDT"
 
-        strategy_cmap.get("order_amount").value = Decimal("1")
+        strategy_cmap.get("max_possible_arbitrage_amount").value = Decimal("1")
         strategy_cmap.get("perpetual_leverage").value = Decimal("2")
         strategy_cmap.get("min_opening_arbitrage_pct").value = Decimal("10")
         strategy_cmap.get("min_closing_arbitrage_pct").value = Decimal("1")
@@ -51,7 +51,7 @@ class SpotPerpetualArbitrageStartTest(unittest.TestCase):
 
     def test_strategy_creation(self):
         strategy_start.start(self)
-        self.assertEqual(self.strategy._order_amount, Decimal("1"))
+        self.assertEqual(self.strategy._max_possible_arbitrage_amount, Decimal("1"))
         self.assertEqual(self.strategy._perp_leverage, Decimal("2"))
         self.assertEqual(self.strategy._min_opening_arbitrage_pct, Decimal("0.1"))
         self.assertEqual(self.strategy._min_closing_arbitrage_pct, Decimal("0.01"))


### PR DESCRIPTION
# 1. Review

### The strategy's core workflow: How does it detect, validate and execute arbitrage opportunities?

| Phase | Description |
| :--- | :--- |
| **Detection** | The process begins in the `main()` method, which calls `create_base_proposals()`. This function fetches the current order book prices from both the spot and perpetual exchanges for the configured `order_amount`. There is a specific connector for each of the spot/perpetual exchange that will be set up before the strategy is constructed.<br><br>It then constructs two potential arbitrage scenarios:<br>1. Proposal 1: Buy on the spot market and sell on the perpetual market.<br>2. Proposal 2: Sell on the spot market and buy on the perpetual market. |
| **Validation** | The proposals go through several validation checks.<br>1. **Profitability Filter**: If a position is already `Opened`, it will only consider the proposal that closes the position (e.g., if it's short on perpetuals, it only looks for a proposal to buy perpetuals). The potential profit must exceed the `min_closing_arbitrage_pct`. If the state is `Closed`, it evaluates both proposals and requires the profit to exceed the `min_opening_arbitrage_pct`.<br>2. **Slippage Buffer**: It adjusts the order prices using the configured slippage buffers (`_spot_market_slippage_buffer`, `_perp_market_slippage_buffer`) to account for potential price movements during execution.<br>3. **Budget Check**: The `check_budget_constraint()` method performs a final check to ensure there are sufficient funds on both exchanges to execute both legs of the trade. If either side lacks the required balance, no proposal will be executed. |
| **Execution** | If a proposal passes all validation checks, `execute_arb_proposal()` is called. If both proposals pass, `spot_buy_perp_sell` is selected. This function places both the spot and perpetual orders concurrently. This is a "fire-and-forget" action; it does not wait for the orders to be filled. Immediately after submitting the orders, it transitions the strategy's state to an intermediate phase (`Opening` or `Closing`). |

### The strategy's structural lifecycle: How is the logic modularised and triggered within the Hummingbot engine?

| Component | Description |
| :--- | :--- |
| **Initialisation & Start** | The Strategy is an instance of `StrategyPyBase`, it is configurable and runnable by the main HummingBot engine and application. Once the strategy begins, the `start()` method is called, connectors start running in the background and all leverage and position mode is configured. |
| **On Tick** | The strategy's heartbeat is the `tick()` method, which the engine calls every second. On each tick, it checks if the previous `main` task has completed and, if so, schedules a new execution of `main()`. This ensures arbitrage checks are run continuously but not concurrently. |
| **Main Method** | The `main()` method is responsible for the detection, validation and firing of executions. It will only proceed if the state of the strategy is either `Opened` or `Closed`. |
| **State-Driven Logic** | `Closed` > `Opening` > `Opened` > `Closing` > `Closed`<br>1. **`Closed`**: The default state. The strategy actively searches for arbitrage opportunities to open a new position.<br>2. **`Opening`**: An intermediate state entered immediately after the opening orders are placed. In this state, the main loop is bypassed, and the bot waits for order fill confirmations.<br>3. **`Opened`**: The state is set to `Opened` only after both opening orders are confirmed as filled. Now, the strategy exclusively searches for a profitable opportunity to close the existing position.<br>4. **`Closing`**: Similar to `Opening`, this is an intermediate state entered after closing orders are submitted.<br>5. The cycle completes and returns to the `Closed` state after both closing orders are filled. |
| **Connectors** | The strategy relies on real-time events from the exchange connectors. Aside from market updates, the connectors also listen to `OrderFill` events. The strategy is subscribed to these events. Handlers like `did_complete_buy_order` will trigger on `OrderFill` events, helping state transition. |
| **Failure Scenario** | If one of the two legs were to fail / not be filled indefinitely, the strategy will be stuck in the `Opening` or `Closing` state. All further calls to `main()` will be bypassed, leaving an unhedged position and requiring manual intervention from the user. |

# 2. Analysis & Improvement

### Provide code snippets or pseudocode to modify `order_amount` from strategy params to `max_possible_arbitrage_amount`, make modifications from each coding blocks that were affected.

Plot of average prices for BTC bid and ask against cumulative volume. Example snapshot of bids and asks from 2 separate orderbooks, spot and perp.

<img width="1042" height="545" alt="image" src="https://github.com/user-attachments/assets/3d1299f8-03c6-4f16-b132-62dc66fd17b3" />

The same plot except we assume the prices have crossed, and prices have already been treated with slippage buffers. Along with a plot of the percentage profit and absolute profit against volume / order amount.

<img width="1096" height="912" alt="image" src="https://github.com/user-attachments/assets/a19a922b-4e61-4cd8-b0c3-5e0b40829fbc" />

We let `max_possible_arbitrage_amount` be the max possible amount we are comfortable trading in each clip. We then can choose to optimise for various things. We will not be optimising for max-percentage-profit, this can be proven to be taking bbo (see pct profit plot). We will also not be optimising for largest possible arbitrage amount (the intersection), instead, we will be optimising for the maximum profit amount. `max_possible_arbitrage_amount` is merely the limit of our search space.
If we maximise for percentage-profit: take 0.1 BTC
If we maximise for amount: take ~0.33 BTC
__If we maximise for profit: take 0.2 BTC__

It can be shown that there will always be a maxima for absolute profit (unless flat line, as it it the product of monotonically increasing/decreasing to/from 0 plots of price-difference and volume). It can also be shown that the maxima will exist by hitting an entire order level, where the next order level would only give diminishing returns.

Our algorithm for finding the new `order_amount` for execution can make use of either binary search or a linear walk to search for this global maxima point of absolute profit. We will be searching through the bids and asks at each order level.

We can greedily optimise for profit when transitioning from `Closed` to `Opened`. For the reverse, we can simply take `min(self.perp_positions[0].amount, order_amount)`, for this case, we will transit from `Opened` to `Opening`.