### PR TITLE
(fix) Fixes the use of the `HEADLESS_MODE` env var

### DIFF
--- a/bin/hummingbot_quickstart.py
+++ b/bin/hummingbot_quickstart.py
@@ -60,7 +60,10 @@ class CmdlineParser(argparse.ArgumentParser):
                           help="Try to automatically set config / logs / data dir permissions, "
                                "useful for Docker containers.")
         self.add_argument("--headless",
-                          action="store_true",
+                          type=bool,
+                          nargs='?',
+                          const=True,
+                          default=None,
                           help="Run in headless mode without CLI interface.")
 
 


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] Tests all pass
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Hi hb team!

Currently, the `HEADLESS_MODE` env var is ignored because `args.headless` is never `None` (hummingbot_quickstart.py:271). This is a fix for the issue.

**Tests performed by the developer**:

Manually tested the solution.

**Tips for QA testing**:

Run hb in headless mode using the env var to confirm it fails, then run it with the fix to confirm it works.