### PR TITLE
Add ping payload to keep Hyperliquid candle feed alive for token pairs with less trading activity

### DIFF
--- a/hummingbot/data_feed/candles_feed/hyperliquid_perpetual_candles/constants.py
+++ b/hummingbot/data_feed/candles_feed/hyperliquid_perpetual_candles/constants.py
@@ -29,3 +29,6 @@ MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST = 500
 RATE_LIMITS = [
     RateLimit(REST_URL, limit=1200, time_interval=60, linked_limits=[LinkedLimitWeightPair("raw", 1)])
 ]
+
+PING_TIMEOUT = 30.0
+PING_PAYLOAD = {"method": "ping"}

--- a/hummingbot/data_feed/candles_feed/hyperliquid_perpetual_candles/hyperliquid_perpetual_candles.py
+++ b/hummingbot/data_feed/candles_feed/hyperliquid_perpetual_candles/hyperliquid_perpetual_candles.py
@@ -21,6 +21,7 @@ class HyperliquidPerpetualCandles(CandlesBase):
         self._tokens = None
         self._base_asset = trading_pair.split("-")[0]
         super().__init__(trading_pair, interval, max_records)
+        self._ping_timeout = CONSTANTS.PING_TIMEOUT
 
     @property
     def name(self):
@@ -138,3 +139,7 @@ class HyperliquidPerpetualCandles(CandlesBase):
             candles_row_dict["taker_buy_base_volume"] = 0.
             candles_row_dict["taker_buy_quote_volume"] = 0.
             return candles_row_dict
+
+    @property
+    def _ping_payload(self):
+        return CONSTANTS.PING_PAYLOAD

--- a/hummingbot/data_feed/candles_feed/hyperliquid_spot_candles/constants.py
+++ b/hummingbot/data_feed/candles_feed/hyperliquid_spot_candles/constants.py
@@ -29,3 +29,6 @@ MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST = 500
 RATE_LIMITS = [
     RateLimit(REST_URL, limit=1200, time_interval=60, linked_limits=[LinkedLimitWeightPair("raw", 1)])
 ]
+
+PING_TIMEOUT = 30.0
+PING_PAYLOAD = {"method": "ping"}

--- a/hummingbot/data_feed/candles_feed/hyperliquid_spot_candles/hyperliquid_spot_candles.py
+++ b/hummingbot/data_feed/candles_feed/hyperliquid_spot_candles/hyperliquid_spot_candles.py
@@ -24,6 +24,7 @@ class HyperliquidSpotCandles(CandlesBase):
         self._base_asset = trading_pair.split("-")[0]
         self._universe_ready = asyncio.Event()
         super().__init__(trading_pair, interval, max_records)
+        self._ping_timeout = CONSTANTS.PING_TIMEOUT
 
     @property
     def name(self):
@@ -144,6 +145,10 @@ class HyperliquidSpotCandles(CandlesBase):
 
     async def initialize_exchange_data(self):
         await self._initialize_coins_dict()
+
+    @property
+    def _ping_payload(self):
+        return CONSTANTS.PING_PAYLOAD
 
     async def _initialize_coins_dict(self):
         rest_assistant = await self._api_factory.get_rest_assistant()


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] Tests all pass
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
- Currently, the candle feed for Hyperliquid doesn't have the heartbeat or ping function implemented yet so if you use the candle feed for token pairs with less trade activity like `USDHL-USDC` the websocket connection will easily get closed because there is no data transmitted within 60 second (https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/websocket/timeouts-and-heartbeats/)
- This fix will increase the stability of candle feed for Hyperliquid since it keep the websocket connection alive by pinging every 30 seconds.


**Tests performed by the developer**:
- Run basic pmm dynamic controller on  `USDHL-USDC` pair with candle feed from hyperliquid with the same pair for over a day. Candle feed is stable with not disconnection


**Tips for QA testing**:
- Try to use candle feed on pair with less trade activity on hyperliquid like `USDHL-USDC` or other stablecoin pairs.
