### PR TITLE
feat: added binance testnet for spot

### DIFF
--- a/hummingbot/connector/exchange/binance/binance_constants.py
+++ b/hummingbot/connector/exchange/binance/binance_constants.py
@@ -2,6 +2,7 @@ from hummingbot.core.api_throttler.data_types import LinkedLimitWeightPair, Rate
 from hummingbot.core.data_type.in_flight_order import OrderState
 
 DEFAULT_DOMAIN = "com"
+TESTNET_DOMAIN = "binance_testnet"
 
 HBOT_ORDER_ID_PREFIX = "x-MG43PCSN"
 MAX_ORDER_ID_LEN = 32
@@ -9,6 +10,9 @@ MAX_ORDER_ID_LEN = 32
 # Base URL
 REST_URL = "https://api.binance.{}/api/"
 WSS_URL = "wss://stream.binance.{}:9443/ws"
+
+TESTNET_REST_URL = "https://testnet.binance.vision/api/"
+TESTNET_WSS_URL = "wss://stream.testnet.binance.vision/ws"
 
 PUBLIC_API_VERSION = "v3"
 PRIVATE_API_VERSION = "v3"

--- a/hummingbot/connector/exchange/binance/binance_utils.py
+++ b/hummingbot/connector/exchange/binance/binance_utils.py
@@ -63,10 +63,10 @@ class BinanceConfigMap(BaseConnectorConfigMap):
 
 KEYS = BinanceConfigMap.model_construct()
 
-OTHER_DOMAINS = ["binance_us"]
-OTHER_DOMAINS_PARAMETER = {"binance_us": "us"}
-OTHER_DOMAINS_EXAMPLE_PAIR = {"binance_us": "BTC-USDT"}
-OTHER_DOMAINS_DEFAULT_FEES = {"binance_us": DEFAULT_FEES}
+OTHER_DOMAINS = ["binance_us", "binance_testnet"]
+OTHER_DOMAINS_PARAMETER = {"binance_us": "us", "binance_testnet": "binance_testnet"}
+OTHER_DOMAINS_EXAMPLE_PAIR = {"binance_us": "BTC-USDT", "binance_testnet": "BTC-USDT"}
+OTHER_DOMAINS_DEFAULT_FEES = {"binance_us": DEFAULT_FEES, "binance_testnet": DEFAULT_FEES}
 
 
 class BinanceUSConfigMap(BaseConnectorConfigMap):
@@ -92,4 +92,27 @@ class BinanceUSConfigMap(BaseConnectorConfigMap):
     model_config = ConfigDict(title="binance_us")
 
 
-OTHER_DOMAINS_KEYS = {"binance_us": BinanceUSConfigMap.model_construct()}
+class BinanceTestnetConfigMap(BaseConnectorConfigMap):
+    connector: str = "binance_testnet"
+    binance_testnet_api_key: SecretStr = Field(
+        default=...,
+        json_schema_extra={
+            "prompt": "Enter your Binance Testnet API key",
+            "is_secure": True,
+            "is_connect_key": True,
+            "prompt_on_new": True,
+        }
+    )
+    binance_testnet_api_secret: SecretStr = Field(
+        default=...,
+        json_schema_extra={
+            "prompt": "Enter your Binance Testnet API secret",
+            "is_secure": True,
+            "is_connect_key": True,
+            "prompt_on_new": True,
+        }
+    )
+    model_config = ConfigDict(title="binance_testnet")
+
+
+OTHER_DOMAINS_KEYS = {"binance_us": BinanceUSConfigMap.model_construct(), "binance_testnet": BinanceTestnetConfigMap.model_construct()}

--- a/hummingbot/connector/exchange/binance/binance_web_utils.py
+++ b/hummingbot/connector/exchange/binance/binance_web_utils.py
@@ -16,6 +16,8 @@ def public_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> st
     :param domain: the Binance domain to connect to ("com" or "us"). The default value is "com"
     :return: the full URL to the endpoint
     """
+    if domain == CONSTANTS.TESTNET_DOMAIN:
+        return CONSTANTS.TESTNET_REST_URL + CONSTANTS.PUBLIC_API_VERSION + path_url
     return CONSTANTS.REST_URL.format(domain) + CONSTANTS.PUBLIC_API_VERSION + path_url
 
 
@@ -26,6 +28,8 @@ def private_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> s
     :param domain: the Binance domain to connect to ("com" or "us"). The default value is "com"
     :return: the full URL to the endpoint
     """
+    if domain == CONSTANTS.TESTNET_DOMAIN:
+        return CONSTANTS.TESTNET_REST_URL + CONSTANTS.PRIVATE_API_VERSION + path_url
     return CONSTANTS.REST_URL.format(domain) + CONSTANTS.PRIVATE_API_VERSION + path_url
 
 


### PR DESCRIPTION
This pull request adds support for the Binance Testnet environment to the connector, allowing users to connect and trade using testnet credentials and endpoints. The main changes include new constants for testnet domains and URLs, updates to configuration maps to handle testnet API keys and secrets, and logic to route API requests to the correct testnet endpoints.