### PR TITLE
fix: allow decimal values in gateway config updates

### DIFF
--- a/hummingbot/client/command/gateway_config_command.py
+++ b/hummingbot/client/command/gateway_config_command.py
@@ -294,18 +294,15 @@ class GatewayConfigCommand:
                     self.notify(f"Error: Expected boolean value (true/false), got '{value}'")
                     return None
 
-            elif isinstance(current_value, int):
-                # Integer conversion
+            elif isinstance(current_value, (int, float)):
+                # Numeric conversion - accept both int and float values
+                # This allows reverting from integer to decimal values
                 try:
-                    return int(value)
-                except ValueError:
-                    self.notify(f"Error: Expected integer value, got '{value}'")
-                    return None
-
-            elif isinstance(current_value, float):
-                # Float conversion
-                try:
-                    return float(value)
+                    parsed = float(value)
+                    # Return int if the value is a whole number and current is int
+                    if isinstance(current_value, int) and parsed == int(parsed):
+                        return int(parsed)
+                    return parsed
                 except ValueError:
                     self.notify(f"Error: Expected numeric value, got '{value}'")
                     return None


### PR DESCRIPTION
## Summary
- Combined `int` and `float` type checks into a single numeric check in `_validate_config_value`
- Allows decimal values (e.g., `1.2`, `0.001`) to be accepted even when the current stored value is an integer
- Returns integers for whole numbers when appropriate to preserve type consistency

## Problem
Gateway config update fails for decimal values like `baseFeeMultiplier 1.2` and `priorityFee 0.001` with "Expected integer value" error.

**Root cause:** When a user changes a value like `baseFeeMultiplier` from `1.2` to `2`, Python stores it as an `int`. When trying to revert to `1.2`, the validation sees the current value is `int` and rejects the decimal input.

## Test plan
- [x] Change `baseFeeMultiplier` from `1.2` to `2`, then revert to `1.2`
- [x] Change `priorityFee` from `0.001` to `1`, then revert to `0.001`
- [x] Verify integer values still work (e.g., `port: 15888`)

Fixes https://github.com/hummingbot/gateway/issues/557

🤖 Generated with [Claude Code](https://claude.com/claude-code)