### PR TITLE
fix/bitget_perpetual fix for issue #7891 (Wrong PnL reported)

### DIFF
--- a/hummingbot/connector/derivative/bitget_perpetual/bitget_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/bitget_perpetual/bitget_perpetual_derivative.py
@@ -895,7 +895,7 @@ class BitgetPerpetualDerivative(PerpetualDerivativePyBase):
         if trade_id is not None:
             trade_id = str(trade_id)
             fee_asset = trade_msg["fillFeeCoin"]
-            fee_amount = Decimal(trade_msg["fillFee"])
+            fee_amount = -Decimal(trade_msg["fillFee"])
             position_actions = {
                 "open": PositionAction.OPEN,
                 "close": PositionAction.CLOSE,

--- a/hummingbot/connector/derivative/bitget_perpetual/bitget_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/bitget_perpetual/bitget_perpetual_derivative.py
@@ -895,7 +895,7 @@ class BitgetPerpetualDerivative(PerpetualDerivativePyBase):
         if trade_id is not None:
             trade_id = str(trade_id)
             fee_asset = trade_msg["fillFeeCoin"]
-            fee_amount = Decimal(trade_msg["fillFee"])
+            fee_amount = abs(Decimal(trade_msg["fillFee"]))
             position_actions = {
                 "open": PositionAction.OPEN,
                 "close": PositionAction.CLOSE,

--- a/hummingbot/connector/derivative/bitget_perpetual/bitget_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/bitget_perpetual/bitget_perpetual_derivative.py
@@ -895,7 +895,7 @@ class BitgetPerpetualDerivative(PerpetualDerivativePyBase):
         if trade_id is not None:
             trade_id = str(trade_id)
             fee_asset = trade_msg["fillFeeCoin"]
-            fee_amount = abs(Decimal(trade_msg["fillFee"]))
+            fee_amount = Decimal(trade_msg["fillFee"])
             position_actions = {
                 "open": PositionAction.OPEN,
                 "close": PositionAction.CLOSE,

--- a/test/hummingbot/connector/derivative/bitget_perpetual/test_bitget_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/bitget_perpetual/test_bitget_perpetual_derivative.py
@@ -20,6 +20,7 @@ from hummingbot.core.data_type.common import OrderType, PositionAction, Position
 from hummingbot.core.data_type.funding_info import FundingInfo
 from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState
 from hummingbot.core.data_type.trade_fee import DeductedFromReturnsTradeFee, TokenAmount, TradeFeeBase, TradeFeeSchema
+from hummingbot.core.event.events import BuyOrderCompletedEvent, OrderFilledEvent
 
 
 class BitgetPerpetualDerivativeTests(AbstractPerpetualDerivativeTests.PerpetualDerivativeTests):
@@ -1822,6 +1823,146 @@ class BitgetPerpetualDerivativeTests(AbstractPerpetualDerivativeTests.PerpetualD
         mock_api.get(regex_url, body=json.dumps(response))
 
         return return_url
+
+    @aioresponses()
+    async def test_user_stream_update_for_order_full_fill(self, mock_api):
+        self.exchange._set_current_timestamp(1640780000)
+        self.exchange.start_tracking_order(
+            order_id=self.client_order_id_prefix + "1",
+            exchange_order_id=str(self.expected_exchange_order_id),
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            trade_type=TradeType.BUY,
+            price=Decimal("10000"),
+            amount=Decimal("1"),
+        )
+        order = self.exchange.in_flight_orders[self.client_order_id_prefix + "1"]
+
+        order_event = self.order_event_for_full_fill_websocket_update(order=order)
+        trade_event = self.trade_event_for_full_fill_websocket_update(order=order)
+
+        mock_queue = AsyncMock()
+        event_messages = []
+        if trade_event:
+            event_messages.append(trade_event)
+        if order_event:
+            event_messages.append(order_event)
+        event_messages.append(asyncio.CancelledError)
+        mock_queue.get.side_effect = event_messages
+        self.exchange._user_stream_tracker._user_stream = mock_queue
+
+        if self.is_order_fill_http_update_executed_during_websocket_order_event_processing:
+            self.configure_full_fill_trade_response(
+                order=order,
+                mock_api=mock_api)
+
+        try:
+            await (self.exchange._user_stream_event_listener())
+        except asyncio.CancelledError:
+            pass
+        # Execute one more synchronization to ensure the async task that processes the update is finished
+        await (order.wait_until_completely_filled())
+        await asyncio.sleep(0.1)
+
+        fill_event: OrderFilledEvent = self.order_filled_logger.event_log[0]
+        self.assertEqual(self.exchange.current_timestamp, fill_event.timestamp)
+        self.assertEqual(order.client_order_id, fill_event.order_id)
+        self.assertEqual(order.trading_pair, fill_event.trading_pair)
+        self.assertEqual(order.trade_type, fill_event.trade_type)
+        self.assertEqual(order.order_type, fill_event.order_type)
+        self.assertEqual(order.price, fill_event.price)
+        self.assertEqual(order.amount, fill_event.amount)
+        expected_fee = DeductedFromReturnsTradeFee(
+            percent_token=self.quote_asset,
+            flat_fees=[TokenAmount(token=self.quote_asset, amount=-Decimal("0.1"))],
+        )
+        self.assertEqual(expected_fee, fill_event.trade_fee)
+
+        buy_event: BuyOrderCompletedEvent = self.buy_order_completed_logger.event_log[0]
+        self.assertEqual(self.exchange.current_timestamp, buy_event.timestamp)
+        self.assertEqual(order.client_order_id, buy_event.order_id)
+        self.assertEqual(order.base_asset, buy_event.base_asset)
+        self.assertEqual(order.quote_asset, buy_event.quote_asset)
+        self.assertEqual(order.amount, buy_event.base_asset_amount)
+        self.assertEqual(order.amount * fill_event.price, buy_event.quote_asset_amount)
+        self.assertEqual(order.order_type, buy_event.order_type)
+        self.assertEqual(order.exchange_order_id, buy_event.exchange_order_id)
+        self.assertNotIn(order.client_order_id, self.exchange.in_flight_orders)
+        self.assertTrue(order.is_filled)
+        self.assertTrue(order.is_done)
+
+        self.assertTrue(
+            self.is_logged(
+                "INFO",
+                f"BUY order {order.client_order_id} completely filled."
+            )
+        )
+
+    @aioresponses()
+    async def test_lost_order_user_stream_full_fill_events_are_processed(self, mock_api):
+        self.exchange._set_current_timestamp(1640780000)
+        self.exchange.start_tracking_order(
+            order_id=self.client_order_id_prefix + "1",
+            exchange_order_id=str(self.expected_exchange_order_id),
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            trade_type=TradeType.BUY,
+            price=Decimal("10000"),
+            amount=Decimal("1"),
+        )
+        order = self.exchange.in_flight_orders[self.client_order_id_prefix + "1"]
+
+        for _ in range(self.exchange._order_tracker._lost_order_count_limit + 1):
+            await (
+                self.exchange._order_tracker.process_order_not_found(client_order_id=order.client_order_id))
+
+        self.assertNotIn(order.client_order_id, self.exchange.in_flight_orders)
+
+        order_event = self.order_event_for_full_fill_websocket_update(order=order)
+        trade_event = self.trade_event_for_full_fill_websocket_update(order=order)
+
+        mock_queue = AsyncMock()
+        event_messages = []
+        if trade_event:
+            event_messages.append(trade_event)
+        if order_event:
+            event_messages.append(order_event)
+        event_messages.append(asyncio.CancelledError)
+        mock_queue.get.side_effect = event_messages
+        self.exchange._user_stream_tracker._user_stream = mock_queue
+
+        if self.is_order_fill_http_update_executed_during_websocket_order_event_processing:
+            self.configure_full_fill_trade_response(
+                order=order,
+                mock_api=mock_api)
+
+        try:
+            await (self.exchange._user_stream_event_listener())
+        except asyncio.CancelledError:
+            pass
+        # Execute one more synchronization to ensure the async task that processes the update is finished
+        await (order.wait_until_completely_filled())
+        await asyncio.sleep(0.1)
+
+        fill_event: OrderFilledEvent = self.order_filled_logger.event_log[0]
+        self.assertEqual(self.exchange.current_timestamp, fill_event.timestamp)
+        self.assertEqual(order.client_order_id, fill_event.order_id)
+        self.assertEqual(order.trading_pair, fill_event.trading_pair)
+        self.assertEqual(order.trade_type, fill_event.trade_type)
+        self.assertEqual(order.order_type, fill_event.order_type)
+        self.assertEqual(order.price, fill_event.price)
+        self.assertEqual(order.amount, fill_event.amount)
+        expected_fee = DeductedFromReturnsTradeFee(
+            percent_token=self.quote_asset,
+            flat_fees=[TokenAmount(token=self.quote_asset, amount=-Decimal("0.1"))],
+        )
+        self.assertEqual(expected_fee, fill_event.trade_fee)
+
+        self.assertEqual(0, len(self.buy_order_completed_logger.event_log))
+        self.assertNotIn(order.client_order_id, self.exchange.in_flight_orders)
+        self.assertNotIn(order.client_order_id, self.exchange._order_tracker.lost_orders)
+        self.assertTrue(order.is_filled)
+        self.assertTrue(order.is_failure)
 
     def _simulate_trading_rules_initialized(self):
         rule = self.trading_rules_request_mock_response["data"][0]


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [X] Your code builds clean without any errors or warnings
- [X] Tests all pass
- [X] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

This is a fix for bitget_perpetual connector which is reporting negative fees.
This PR is intended to fix issue #7891

The fix is coherent to what is done in the spot connector. For reference:
https://github.com/hummingbot/hummingbot/blob/30e284c450484b000a83e03cbeb0fd253ceba04b/hummingbot/connector/exchange/bitget/bitget_exchange.py#L424

**Tests performed by the developer**:

Here is a quick test I've just performed:
<img width="407" height="152" alt="image" src="https://github.com/user-attachments/assets/eccdfe05-8fcc-4294-9f22-965d17e9aba1" />
Trade P&L - Fees paid = -1.32 - 0.0895 = -1.4095 (Total P&L)
Result OK

**Tips for QA testing**:

Check PnL calculation with `history` command