### PR TITLE
Not My Oracle: Configurable rate oracle selection for API via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
+## Environment Variable: RATE_ORACLE_DEFAULT
+
+You can control which rate oracle source is used by default by setting the `RATE_ORACLE_DEFAULT` environment variable. This is especially useful for users in regions where the default (Binance) may not be accessible.
+
+**Usage:**
+
+Set the environment variable before starting Hummingbot (e.g., in your Docker Compose, .env file, or shell):
+
+```
+export RATE_ORACLE_DEFAULT=coin_gecko
+```
+
+Valid values are:
+
+  binance, coin_gecko, coin_cap, kucoin, ascend_ex, gate_io, coinbase_advanced_trade, cube, dexalot, hyperliquid, derive, mexc
+
+If the variable is not set, empty, or invalid, the system will fall back to `binance` as the default.
 ![Hummingbot](https://github.com/user-attachments/assets/3213d7f8-414b-4df8-8c1b-a0cd142a82d8)
 
 ----
@@ -73,6 +90,8 @@ cd hummingbot
    environment:
      - GATEWAY_PASSPHRASE=admin
      - DEV=true
+     # The default Rate Oracle is Binance, but it can be set to any of the source Ids, for example;
+     # - MY_RATE_ORACLE=coin_gecko
 ```
 
 Then run:

--- a/test/hummingbot/core/rate_oracle/test_rate_oracle_env.py
+++ b/test/hummingbot/core/rate_oracle/test_rate_oracle_env.py
@@ -1,0 +1,55 @@
+def get_oracle_type(rate_oracle):
+    return type(rate_oracle.source)
+
+import os
+import importlib
+import pytest
+from hummingbot.core.rate_oracle.rate_oracle import RateOracle, ALL_RATE_ORACLES, RATE_ORACLE_SOURCES
+
+def clear_rate_oracle_singleton():
+    # Helper to clear singleton between tests
+    RateOracle._shared_instance = None
+
+@pytest.mark.parametrize("oracle_name", ALL_RATE_ORACLES)
+def test_env_var_selects_correct_rate_source(monkeypatch, oracle_name):
+    """
+    Test that setting MY_RATE_ORACLE to each valid oracle name selects the correct RateSource class.
+    """
+    monkeypatch.setenv("MY_RATE_ORACLE", oracle_name)
+    clear_rate_oracle_singleton()
+    importlib.reload(importlib.import_module("hummingbot.core.rate_oracle.rate_oracle"))
+    rate_oracle = RateOracle()
+    assert get_oracle_type(rate_oracle) == RATE_ORACLE_SOURCES[oracle_name]
+
+def test_env_var_invalid_falls_back_to_binance(monkeypatch):
+    """
+    Test that setting MY_RATE_ORACLE to an invalid value falls back to BinanceRateSource.
+    """
+    monkeypatch.setenv("MY_RATE_ORACLE", "not_a_real_oracle")
+    clear_rate_oracle_singleton()
+    importlib.reload(importlib.import_module("hummingbot.core.rate_oracle.rate_oracle"))
+    rate_oracle = RateOracle()
+    from hummingbot.core.rate_oracle.sources.binance_rate_source import BinanceRateSource
+    assert isinstance(rate_oracle.source, BinanceRateSource)
+
+def test_env_var_empty_string_falls_back_to_binance(monkeypatch):
+    """
+    Test that setting MY_RATE_ORACLE to an empty string falls back to BinanceRateSource.
+    """
+    monkeypatch.setenv("MY_RATE_ORACLE", "")
+    clear_rate_oracle_singleton()
+    importlib.reload(importlib.import_module("hummingbot.core.rate_oracle.rate_oracle"))
+    rate_oracle = RateOracle()
+    from hummingbot.core.rate_oracle.sources.binance_rate_source import BinanceRateSource
+    assert isinstance(rate_oracle.source, BinanceRateSource)
+
+def test_env_var_missing_falls_back_to_binance(monkeypatch):
+    """
+    Test that when MY_RATE_ORACLE is not set, the default is BinanceRateSource.
+    """
+    monkeypatch.delenv("MY_RATE_ORACLE", raising=False)
+    clear_rate_oracle_singleton()
+    importlib.reload(importlib.import_module("hummingbot.core.rate_oracle.rate_oracle"))
+    rate_oracle = RateOracle()
+    from hummingbot.core.rate_oracle.sources.binance_rate_source import BinanceRateSource
+    assert isinstance(rate_oracle.source, BinanceRateSource)


### PR DESCRIPTION
PR Title: Not My Oracle: Configurable rate oracle selection via environment variable

Summary
-------
This PR introduces the RATE_ORACLE_DEFAULT variable that can be used to set the default Oracle object from the list of RATE_ORACLE_SOURCES

 Changes to be committed:
	modified:   README.md
	modified:   hummingbot/core/rate_oracle/rate_oracle.py
	new file:   test/hummingbot/core/rate_oracle/test_rate_oracle_env.py

Key Changes
-----------
- RATE_ORACLE_SOURCES array of configured Oracle sources
- RATE_ORACLE_DEFAULT variable that can be used to set the default Oracle object 

Rationale
---------
I live in the US and so I can't use the default Rate Oracle (binance) because it doesn't service US residents.
So I see this in my API Logs;

```
OSError: Error executing request GET [https://api.binance.com/api/v3/ticker/bookTicker.⁠](https://api.binance.com/api/v3/ticker/bookTicker.) HTTP status is 451. Error: {
 "code": 0,

"msg": "Service unavailable from a restricted location according to 'b. Eligibility' in [https://www.binance.com/en/terms.⁠](https://www.binance.com/en/terms.) Please contact customer service if you believe you received this message in error."

```

Testing & Validation
--------------------
This repo has dependencies that can conflict in a WinOs on top of that I found files with a .pxd extension when I expected a .py so it didn't play well in my IDE, VS Code on Win.   Typically I have no issue compiling xplatform applications however, I don't feel a high level of confidence ATM that my env would produce the expected application results.

So this is a VERY rare case for me but didn't test this.  I ALWAYS test and re-test but for the moment until I feel confident my results would count, I need another to test this for me in their build env.   It's a very simple solution and should be A-OK, I'd just like to get that confirmation    
