### PR TITLE
fix(dexalot): handle invalid decimal values and missing clock reference

### DIFF
--- a/hummingbot/connector/exchange/dexalot/dexalot_exchange.py
+++ b/hummingbot/connector/exchange/dexalot/dexalot_exchange.py
@@ -36,6 +36,7 @@ from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFa
 
 class DexalotExchange(ExchangePyBase):
     UPDATE_ORDER_STATUS_MIN_INTERVAL = 10.0
+    DEFAULT_ORDERS_PROCESSING_DELTA_TIME = 0.5  # Default sleep time when clock is not available
 
     web_utils = web_utils
 
@@ -852,7 +853,7 @@ class DexalotExchange(ExchangePyBase):
                 await asyncio.shield(task)
                 sleep_time = (self.clock.tick_size * 0.5
                               if self.clock is not None
-                              else self._orders_processing_delta_time)
+                              else self.DEFAULT_ORDERS_PROCESSING_DELTA_TIME)
                 await self._sleep(sleep_time)
             except NotImplementedError:
                 raise
@@ -860,7 +861,10 @@ class DexalotExchange(ExchangePyBase):
                 raise
             except Exception:
                 self.logger().exception("Unexpected error while processing queued individual orders", exc_info=True)
-                await self._sleep(self.clock.tick_size * 0.5)
+                sleep_time = (self.clock.tick_size * 0.5
+                              if self.clock is not None
+                              else self.DEFAULT_ORDERS_PROCESSING_DELTA_TIME)
+                await self._sleep(sleep_time)
 
     async def _cancel_and_create_queued_orders(self):
         if len(self._orders_queued_to_cancel) > 0 or len(self._orders_queued_to_create) > 0:

--- a/hummingbot/core/rate_oracle/sources/dexalot_rate_source.py
+++ b/hummingbot/core/rate_oracle/sources/dexalot_rate_source.py
@@ -30,9 +30,23 @@ class DexalotRateSource(RateSourceBase):
                     # Ignore results for which their symbols is not tracked by the connector
                     continue
 
-                if Decimal(str(record["low"])) > 0 and Decimal(str(record["high"])) > 0:
-                    results[pair] = (Decimal(str(record["low"])) +
-                                     Decimal(str(record["high"]))) / Decimal("2")
+                try:
+                    low_value = record.get("low")
+                    high_value = record.get("high")
+                    # Validate that values exist and are convertible to Decimal
+                    if low_value is None or high_value is None:
+                        continue
+                    low_str = str(low_value).strip()
+                    high_str = str(high_value).strip()
+                    if not low_str or not high_str:
+                        continue
+                    low = Decimal(low_str)
+                    high = Decimal(high_str)
+                    if low > 0 and high > 0:
+                        results[pair] = (low + high) / Decimal("2")
+                except (ValueError, ArithmeticError):
+                    # Skip records with invalid price data
+                    continue
         except Exception:
             self.logger().exception(
                 msg="Unexpected error while retrieving rates from Dexalot. Check the log file for more info.",


### PR DESCRIPTION
## Summary

Fixes #7335 - Dexalot rate oracle errors and shutdown exceptions.

This PR addresses two related bugs in the Dexalot connector:

### 1. Rate Oracle Decimal Conversion Error
- **Problem**: `decimal.InvalidOperation` when parsing price data from Dexalot API
- **Root cause**: API sometimes returns empty strings, null, or invalid values for "low" and "high" price fields
- **Fix**: Added validation to check for null/empty values before decimal conversion, with try/except to gracefully skip invalid records

### 2. Missing Attribute During Shutdown  
- **Problem**: `'DexalotExchange' object has no attribute '_orders_processing_delta_time'` and `'NoneType' object has no attribute 'tick_size'`
- **Root cause**: `_orders_processing_delta_time` was referenced but never defined, and `self.clock` can be None during shutdown
- **Fix**: Added `DEFAULT_ORDERS_PROCESSING_DELTA_TIME` class constant (0.5s) and used it as fallback when clock is unavailable

## Test Plan

- [ ] Verify rate oracle no longer throws exceptions with malformed API data
- [ ] Verify clean shutdown without AttributeError or NoneType errors
- [ ] Run existing Dexalot connector tests

---

🤖 Generated with [Claude Code](https://claude.ai/code)