### PR TITLE
fix / enable HIP-3 markets by default and remove related validation t…

### DIFF
--- a/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_derivative.py
@@ -52,7 +52,7 @@ class HyperliquidPerpetualDerivative(PerpetualDerivativePyBase):
             trading_pairs: Optional[List[str]] = None,
             trading_required: bool = True,
             domain: str = CONSTANTS.DOMAIN,
-            enable_hip3_markets: bool = False,
+            enable_hip3_markets: bool = True,
     ):
         self.hyperliquid_perpetual_address = hyperliquid_perpetual_address
         self.hyperliquid_perpetual_secret_key = hyperliquid_perpetual_secret_key

--- a/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_utils.py
+++ b/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_utils.py
@@ -75,15 +75,6 @@ class HyperliquidPerpetualConfigMap(BaseConnectorConfigMap):
             "prompt_on_new": True,
         }
     )
-    enable_hip3_markets: bool = Field(
-        default=False,
-        json_schema_extra={
-            "prompt": "Do you want to Enable HIP-3 (DEX) markets? (Yes/No)",
-            "is_secure": False,
-            "is_connect_key": True,
-            "prompt_on_new": True,
-        }
-    )
     hyperliquid_perpetual_address: SecretStr = Field(
         default=...,
         json_schema_extra={
@@ -120,12 +111,6 @@ class HyperliquidPerpetualConfigMap(BaseConnectorConfigMap):
     @field_validator("use_vault", mode="before")
     @classmethod
     def validate_use_vault(cls, value: str):
-        """Used for client-friendly error output."""
-        return validate_bool(value)
-
-    @field_validator("enable_hip3_markets", mode="before")
-    @classmethod
-    def validate_enable_hip3_markets(cls, value: str):
         """Used for client-friendly error output."""
         return validate_bool(value)
 
@@ -168,15 +153,6 @@ class HyperliquidPerpetualTestnetConfigMap(BaseConnectorConfigMap):
             "prompt_on_new": True,
         }
     )
-    enable_hip3_markets: bool = Field(
-        default=False,
-        json_schema_extra={
-            "prompt": "Do you want to Enable HIP-3 (DEX) markets? (Yes/No)",
-            "is_secure": False,
-            "is_connect_key": True,
-            "prompt_on_new": True,
-        }
-    )
     hyperliquid_perpetual_testnet_address: SecretStr = Field(
         default=...,
         json_schema_extra={
@@ -213,12 +189,6 @@ class HyperliquidPerpetualTestnetConfigMap(BaseConnectorConfigMap):
     @field_validator("use_vault", mode="before")
     @classmethod
     def validate_use_vault(cls, value: str):
-        """Used for client-friendly error output."""
-        return validate_bool(value)
-
-    @field_validator("enable_hip3_markets", mode="before")
-    @classmethod
-    def validate_enable_hip3_markets(cls, value: str):
         """Used for client-friendly error output."""
         return validate_bool(value)
 

--- a/test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_utils.py
+++ b/test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_utils.py
@@ -90,26 +90,3 @@ class HyperliquidPerpetualUtilsTests(TestCase):
         corrected_address = HyperliquidPerpetualTestnetConfigMap.validate_address("HL:zzz8z8z")
 
         self.assertEqual(corrected_address, "zzz8z8z")
-
-    def test_cls_validate_enable_hip3_markets_succeed(self):
-        """Test enable_hip3_markets validation with valid values."""
-        truthy = {"yes", "y", "true", "1"}
-        falsy = {"no", "n", "false", "0"}
-        true_validations = [HyperliquidPerpetualConfigMap.validate_enable_hip3_markets(value) for value in truthy]
-        false_validations = [HyperliquidPerpetualConfigMap.validate_enable_hip3_markets(value) for value in falsy]
-
-        for validation in true_validations:
-            self.assertTrue(validation)
-
-        for validation in false_validations:
-            self.assertFalse(validation)
-
-    def test_cls_testnet_validate_enable_hip3_markets_succeed(self):
-        """Test enable_hip3_markets validation for testnet config."""
-        self.assertTrue(HyperliquidPerpetualTestnetConfigMap.validate_enable_hip3_markets("yes"))
-        self.assertFalse(HyperliquidPerpetualTestnetConfigMap.validate_enable_hip3_markets("no"))
-
-    def test_enable_hip3_markets_default_is_false(self):
-        """Test that enable_hip3_markets defaults to False."""
-        config = HyperliquidPerpetualConfigMap.model_construct()
-        self.assertFalse(config.enable_hip3_markets)


### PR DESCRIPTION
This pull request simplifies the configuration for enabling HIP-3 (DEX) markets in the Hyperliquid Perpetual connector. The main change is the removal of the `enable_hip3_markets` configuration option and its associated validation and tests. HIP-3 markets are now always enabled by default in the connector's initialization.

Configuration simplification:

* Removed the `enable_hip3_markets` field from both `HyperliquidPerpetualConfigMap` and `HyperliquidPerpetualTestnetConfigMap`, eliminating the user prompt and related schema metadata. [[1]](diffhunk://#diff-5447ce00040ee852498311624a87b3d0144dd6781ae240c1b13b580924d002b5L78-L86) [[2]](diffhunk://#diff-5447ce00040ee852498311624a87b3d0144dd6781ae240c1b13b580924d002b5L171-L179)
* Deleted the validators for `enable_hip3_markets` in both config map classes, since the field no longer exists. [[1]](diffhunk://#diff-5447ce00040ee852498311624a87b3d0144dd6781ae240c1b13b580924d002b5L126-L131) [[2]](diffhunk://#diff-5447ce00040ee852498311624a87b3d0144dd6781ae240c1b13b580924d002b5L219-L224)
* Removed all unit tests related to `enable_hip3_markets` validation and default value checks.

Connector behavior change:

* Changed the default value of `enable_hip3_markets` in the connector's constructor to `True`, making HIP-3 markets always enabled and no longer configurable.…ests

**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] Tests all pass
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:



**Tests performed by the developer**:



**Tips for QA testing**:

