### PR TITLE
fix: correct MEXC rate limit model (per-endpoint IP+UID pools)

### DIFF
--- a/hummingbot/connector/exchange/mexc/mexc_constants.py
+++ b/hummingbot/connector/exchange/mexc/mexc_constants.py
@@ -42,13 +42,20 @@ TIME_IN_FORCE_FOK = "FOK"  # Fill or kill
 # Rate Limit Type
 IP_REQUEST_WEIGHT = "IP_REQUEST_WEIGHT"
 UID_REQUEST_WEIGHT = "UID_REQUEST_WEIGHT"
+GENERAL_ANTISPAM_CEX_THRESHHOULD = "GENERAL_ANTISPAM_CEX_THRESHHOULD"
+
+# Separately Specified Endpoint Rate Limits for different methods
+GET_ORDER_LIMIT_ID = f"GET {ORDER_PATH_URL}"
+POST_OR_DELETE_ORDER_LIMIT_ID = f"(POST or DELETE) {ORDER_PATH_URL}"
 
 # Rate Limit time intervals
 ONE_MINUTE = 60
+TEN_SECONDS = 10
 ONE_SECOND = 1
 ONE_DAY = 86400
 
-MAX_REQUEST = 5000
+# IP or UID Rate limit per 10 sec
+MAX_REQUEST = 500
 
 # Order States
 ORDER_STATE = {
@@ -84,31 +91,35 @@ USER_ORDERS_ENDPOINT_NAME = "spot@private.orders.v3.api.pb"
 USER_BALANCE_ENDPOINT_NAME = "spot@private.account.v3.api.pb"
 WS_CONNECTION_TIME_INTERVAL = 20
 RATE_LIMITS = [
-    RateLimit(limit_id=IP_REQUEST_WEIGHT, limit=20000, time_interval=ONE_MINUTE),
-    RateLimit(limit_id=UID_REQUEST_WEIGHT, limit=240000, time_interval=ONE_MINUTE),
-    # Weighted Limits
-    RateLimit(limit_id=TICKER_PRICE_CHANGE_PATH_URL, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
-              linked_limits=[LinkedLimitWeightPair(IP_REQUEST_WEIGHT, 1)]),
-    RateLimit(limit_id=TICKER_BOOK_PATH_URL, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
-              linked_limits=[LinkedLimitWeightPair(IP_REQUEST_WEIGHT, 2)]),
-    RateLimit(limit_id=EXCHANGE_INFO_PATH_URL, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
-              linked_limits=[LinkedLimitWeightPair(IP_REQUEST_WEIGHT, 10)]),
-    RateLimit(limit_id=SUPPORTED_SYMBOL_PATH_URL, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
-              linked_limits=[LinkedLimitWeightPair(IP_REQUEST_WEIGHT, 10)]),
-    RateLimit(limit_id=SNAPSHOT_PATH_URL, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
-              linked_limits=[LinkedLimitWeightPair(IP_REQUEST_WEIGHT, 50)]),
-    RateLimit(limit_id=MEXC_USER_STREAM_PATH_URL, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
-              linked_limits=[LinkedLimitWeightPair(UID_REQUEST_WEIGHT, 1)]),
-    RateLimit(limit_id=SERVER_TIME_PATH_URL, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
-              linked_limits=[LinkedLimitWeightPair(IP_REQUEST_WEIGHT, 1)]),
-    RateLimit(limit_id=PING_PATH_URL, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
-              linked_limits=[LinkedLimitWeightPair(IP_REQUEST_WEIGHT, 1)]),
-    RateLimit(limit_id=ACCOUNTS_PATH_URL, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
-              linked_limits=[LinkedLimitWeightPair(UID_REQUEST_WEIGHT, 10)]),
-    RateLimit(limit_id=MY_TRADES_PATH_URL, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
-              linked_limits=[LinkedLimitWeightPair(UID_REQUEST_WEIGHT, 10)]),
-    RateLimit(limit_id=ORDER_PATH_URL, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
-              linked_limits=[LinkedLimitWeightPair(UID_REQUEST_WEIGHT, 2)])
+    # MexC Infrastructure-level rate limiting: ≈ 300-500 per sec (observed in tests)
+    RateLimit(limit_id=GENERAL_ANTISPAM_CEX_THRESHHOULD, limit=400, time_interval=ONE_SECOND),
+    # Weighted Limits (UID / IP for each endpoint)
+    RateLimit(limit_id=TICKER_PRICE_CHANGE_PATH_URL, limit=MAX_REQUEST, time_interval=TEN_SECONDS, weight=1,
+              linked_limits=[LinkedLimitWeightPair(GENERAL_ANTISPAM_CEX_THRESHHOULD)]),
+    RateLimit(limit_id=TICKER_BOOK_PATH_URL, limit=MAX_REQUEST, time_interval=TEN_SECONDS, weight=1,
+              linked_limits=[LinkedLimitWeightPair(GENERAL_ANTISPAM_CEX_THRESHHOULD)]),
+    RateLimit(limit_id=EXCHANGE_INFO_PATH_URL, limit=MAX_REQUEST, time_interval=TEN_SECONDS, weight=10,
+              linked_limits=[LinkedLimitWeightPair(GENERAL_ANTISPAM_CEX_THRESHHOULD)]),
+    RateLimit(limit_id=SUPPORTED_SYMBOL_PATH_URL, limit=MAX_REQUEST, time_interval=TEN_SECONDS, weight=1,
+              linked_limits=[LinkedLimitWeightPair(GENERAL_ANTISPAM_CEX_THRESHHOULD)]),
+    RateLimit(limit_id=SNAPSHOT_PATH_URL, limit=MAX_REQUEST, time_interval=TEN_SECONDS, weight=1,
+              linked_limits=[LinkedLimitWeightPair(GENERAL_ANTISPAM_CEX_THRESHHOULD)]),
+    # There are no limits specified for this endpoint in the documentation
+    # so this can be assumed to use a UID pool.
+    RateLimit(limit_id=MEXC_USER_STREAM_PATH_URL, limit=MAX_REQUEST, time_interval=TEN_SECONDS, weight=1,
+              linked_limits=[LinkedLimitWeightPair(GENERAL_ANTISPAM_CEX_THRESHHOULD)]),
+    RateLimit(limit_id=SERVER_TIME_PATH_URL, limit=MAX_REQUEST, time_interval=TEN_SECONDS, weight=1,
+              linked_limits=[LinkedLimitWeightPair(GENERAL_ANTISPAM_CEX_THRESHHOULD)]),
+    RateLimit(limit_id=PING_PATH_URL, limit=MAX_REQUEST, time_interval=TEN_SECONDS, weight=1,
+              linked_limits=[LinkedLimitWeightPair(GENERAL_ANTISPAM_CEX_THRESHHOULD)]),
+    RateLimit(limit_id=ACCOUNTS_PATH_URL, limit=MAX_REQUEST, time_interval=TEN_SECONDS, weight=10,
+              linked_limits=[LinkedLimitWeightPair(GENERAL_ANTISPAM_CEX_THRESHHOULD)]),
+    RateLimit(limit_id=MY_TRADES_PATH_URL, limit=MAX_REQUEST, time_interval=TEN_SECONDS, weight=10,
+              linked_limits=[LinkedLimitWeightPair(GENERAL_ANTISPAM_CEX_THRESHHOULD)]),
+    RateLimit(limit_id=POST_OR_DELETE_ORDER_LIMIT_ID, limit=MAX_REQUEST, time_interval=TEN_SECONDS, weight=1,
+              linked_limits=[LinkedLimitWeightPair(GENERAL_ANTISPAM_CEX_THRESHHOULD)]),
+    RateLimit(limit_id=GET_ORDER_LIMIT_ID, limit=MAX_REQUEST, time_interval=TEN_SECONDS, weight=2,
+              linked_limits=[LinkedLimitWeightPair(GENERAL_ANTISPAM_CEX_THRESHHOULD)])
 ]
 
 ORDER_NOT_EXIST_ERROR_CODE = -2013

--- a/hummingbot/connector/exchange/mexc/mexc_exchange.py
+++ b/hummingbot/connector/exchange/mexc/mexc_exchange.py
@@ -188,6 +188,7 @@ class MexcExchange(ExchangePyBase):
         try:
             order_result = await self._api_post(
                 path_url=CONSTANTS.ORDER_PATH_URL,
+                limit_id=CONSTANTS.POST_OR_DELETE_ORDER_LIMIT_ID,
                 data=api_params,
                 is_auth_required=True)
             o_id = str(order_result["orderId"])
@@ -211,6 +212,7 @@ class MexcExchange(ExchangePyBase):
         }
         cancel_result = await self._api_delete(
             path_url=CONSTANTS.ORDER_PATH_URL,
+            limit_id=CONSTANTS.POST_OR_DELETE_ORDER_LIMIT_ID,
             params=api_params,
             is_auth_required=True)
         if cancel_result.get("status") == "NEW":
@@ -487,6 +489,7 @@ class MexcExchange(ExchangePyBase):
         trading_pair = await self.exchange_symbol_associated_to_pair(trading_pair=tracked_order.trading_pair)
         updated_order_data = await self._api_get(
             path_url=CONSTANTS.ORDER_PATH_URL,
+            limit_id=CONSTANTS.GET_ORDER_LIMIT_ID,
             params={
                 "symbol": trading_pair,
                 "origClientOrderId": tracked_order.client_order_id},


### PR DESCRIPTION
#### How are MexC limits currently declared in Hummingbot ?
---

<img width="1501" height="911" alt="Screenshot_2026-02-07_19-25-09" src="https://github.com/user-attachments/assets/237cdbfb-3c9e-4925-8536-772605664d02" />

_(The general antispam threshold is omitted)_

#### How are MexC limits actually structured?
---

**Official [MEXC API Docs / Limits Description](https://www.mexc.com/api-docs/spot-v3/general-info#limits-description):**

>«According to the **two modes of IP and UID (account)** limit, **each are independent**."»
>«Endpoints are marked according to IP or UID limit and their corresponding weight value.»
>«**Each endpoint** with IP limits has an **independent 500 every 10 second** limit.»
>«**Each endpoint** with UID limits has an **independent 500 every 10 second** limit.»

At first glance, it may seem that each endpoint can only have one Rate Limit Pool of the two: either the IP Pool or the UID Pool.
However, the MEXC developers themselves assign both weights to some methods:

>«**Weight(IP):** 1, **Weight(UID):** 1» ([New order method](https://www.mexc.com/api-docs/spot-v3/spot-account-trade#new-order))

This clearly demonstrates that endpoints can actually have both limits at once. An error 429 occurs as soon as one of them is exhausted; otherwise, the UID (account) rate limit would lose its purpose, as it could be bypassed using proxy networks (physical IP rotation).

It is also mentioned that the UID Pool only exists for those endpoints that require API keys to be used

> «The account is used as the basic unit of speed limit for the endpoints that need to carry access keys»

It is noted that you can simultaneously have a maximum of 60 listen keys for WebSocket subscriptions (a listen key can be obtained via `POST /api/v3/userDataStream`):

>«Each UID can apply for a maximum of 60 listen keys (excluding invalid listen keys). Each listen key maximum support 5 websocket connection (which means each uid can applies for a maximum of 60 listen keys and 300 ws links).»

At the same time, for the Listen Keys endpoint methods (`/api/v3/userDataStream`), standard UID / IP limits are not specified.

#### Let's outline the identified differences between the current description of limits in Hummingbot and the real structure of limiting in MEXC:

1. **A shared pool for limits does not exist** — instead, each endpoint receives its own independent 500 points per pool every 10 seconds

2. **Each individual endpoint requiring API keys has 2 pools at once** — UID (500 units / 10 sec) and IP (500 units / 10 sec). An error 429 is returned as soon as one of them is exhausted.

3. **Other (public) endpoints cannot have a UID Pool** because they do not require API keys (they have only one pool — the IP Pool).

4. **The** **/api/v3/order** **endpoint has a weight of 2** if used with the `GET` method ([Order status](https://www.google.com/url?sa=E&q=https%3A%2F%2Fwww.mexc.com%2Fapi-docs%2Fspot-v3%2Fspot-account-trade%23query-order)), but it has a **weight of 1** if used with the `POST` ([New order](https://www.google.com/url?sa=E&q=https%3A%2F%2Fwww.mexc.com%2Fapi-docs%2Fspot-v3%2Fspot-account-trade%23new-order)) or `DELETE` ([Cancel order](https://www.google.com/url?sa=E&q=https%3A%2F%2Fwww.mexc.com%2Fapi-docs%2Fspot-v3%2Fspot-account-trade%23cancel-order)) methods.

#### The real internal structure of MexC limits _(diagram)_:


<img width="1472" height="879" alt="Screenshot_2026-02-07_19-34-10" src="https://github.com/user-attachments/assets/d355dea5-60d9-49f1-be59-de895fbef0f4" />

_(mexc Rate Limits (real, without antispam requests treshould).canvas)_

### Research results

**Excluding multi-account scenarios:**
-  The server (one public IP) handles no external accounts;
-  We trade solely using our own account.
<img width="1107" height="851" alt="Screenshot_2026-02-07_19-37-18" src="https://github.com/user-attachments/assets/277c6a4a-2024-46dd-ac4f-471ae25f8502" />

**Simplified diagram:** 
<img width="1335" height="910" alt="Screenshot_2026-02-07_19-42-09" src="https://github.com/user-attachments/assets/94a84c36-4b32-4988-acb0-b7d2a2dbae6e" />
_(mexc Rate Limits (real, 1 account).canvas)_

**All discrepancies in the limit logic have been resolved (see updated files).**