### PR TITLE
fix: Bug Report: Binance get_price() Method Fails with BTC-USDT Format

### DIFF
--- a/hummingbot/connector/exchange_py_base.py
+++ b/hummingbot/connector/exchange_py_base.py
@@ -883,11 +883,11 @@ class ExchangePyBase(ExchangeBase, ABC):
 
     async def _update_trading_rules(self):
         exchange_info = await self._make_trading_rules_request()
+        self._initialize_trading_pair_symbols_from_exchange_info(exchange_info=exchange_info)
         trading_rules_list = await self._format_trading_rules(exchange_info)
         self._trading_rules.clear()
         for trading_rule in trading_rules_list:
             self._trading_rules[trading_rule.trading_pair] = trading_rule
-        self._initialize_trading_pair_symbols_from_exchange_info(exchange_info=exchange_info)
 
     async def _api_get(self, *args, **kwargs):
         kwargs["method"] = RESTMethod.GET


### PR DESCRIPTION
This PR fixes a bug where `get_price()` in the Binance connector (and others based on `ExchangePyBase`) would fail when called with the standard `BTC-USDT` format.

### Root Cause:
The `_update_trading_rules` method in `ExchangePyBase` was updating the symbol mapping *after* formatting the trading rules. Sub-classes like `BinanceExchange` rely on the symbol mapping to associate exchange symbols with Hummingbot trading pairs during rule formatting. On the first run, or if new symbols were added, this would cause rules to be skipped or raise a `KeyError` when `get_price()` attempted to quantize the price.

### Changes:
- Updated `_update_trading_rules` to initialize/update the symbol map before calling `_format_trading_rules`.

Closes #7980