### PR TITLE
fix: Kucoin perpetual - funding info crashes when predictedFundingFeeRate is empty

### DIFF
--- a/hummingbot/connector/derivative/kucoin_perpetual/kucoin_perpetual_api_order_book_data_source.py
+++ b/hummingbot/connector/derivative/kucoin_perpetual/kucoin_perpetual_api_order_book_data_source.py
@@ -48,12 +48,18 @@ class KucoinPerpetualAPIOrderBookDataSource(PerpetualAPIOrderBookDataSource):
             symbol_info = funding_info_response["data"]
         else:
             symbol_info = funding_info_response["data"][0]
+
+        index_price = symbol_info.get("indexPrice")
+        mark_price = symbol_info.get("markPrice")
+        next_funding_time = symbol_info.get("nextFundingRateTime")
+        rate = symbol_info.get("predictedFundingFeeRate")
+
         funding_info = FundingInfo(
             trading_pair=trading_pair,
-            index_price=Decimal(str(symbol_info["indexPrice"])),
-            mark_price=Decimal(str(symbol_info["markPrice"])),
-            next_funding_utc_timestamp=int(pd.Timestamp(symbol_info["nextFundingRateTime"]).timestamp()),
-            rate=Decimal(str(symbol_info["predictedFundingFeeRate"])),
+            index_price=Decimal(str(index_price)) if index_price else Decimal("0"),
+            mark_price=Decimal(str(mark_price)) if mark_price else Decimal("0"),
+            next_funding_utc_timestamp=int(pd.Timestamp(next_funding_time).timestamp()) if next_funding_time else 0,
+            rate=Decimal(str(rate)) if rate else Decimal("0"),
         )
         return funding_info
 


### PR DESCRIPTION
This PR fixes a crash in the Kucoin Perpetual connector when the API returns an empty or missing value for `predictedFundingFeeRate`.

### Changes:
- Added guards for `indexPrice`, `markPrice`, `nextFundingRateTime`, and `predictedFundingFeeRate`.
- Fallback to `Decimal("0")` or `0` as appropriate to prevent `decimal.InvalidOperation`.

Addresses issue #7994. CC @rapcmia