### PR TITLE
fix: Bug Report: ValueError: Connector 'binance_perpetual' not found when using 'binance_perpetual_testnet'

### DIFF
--- a/hummingbot/connector/derivative/binance_perpetual/binance_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/binance_perpetual/binance_perpetual_derivative.py
@@ -62,7 +62,7 @@ class BinancePerpetualDerivative(PerpetualDerivativePyBase):
 
     @property
     def name(self) -> str:
-        return CONSTANTS.EXCHANGE_NAME
+        return self._domain
 
     @property
     def authenticator(self) -> BinancePerpetualAuth:


### PR DESCRIPTION
This PR fixes a bug where `BinancePerpetualDerivative` would always report its name as `binance_perpetual`, even when configured for the testnet (`binance_perpetual_testnet`). This caused a `ValueError` in strategies like `spot_perpetual_arbitrage` which attempt to look up the connector by its configured name.

### Changes:
- Updated the `name` property in `BinancePerpetualDerivative` to return `self._domain`.

Closes #7893