### PR TITLE
(fix) Bug Report: Binance get_price() Method Fails with BTC-USDT Format

### DIFF
--- a/hummingbot/connector/exchange_py_base.py
+++ b/hummingbot/connector/exchange_py_base.py
@@ -883,11 +883,11 @@ class ExchangePyBase(ExchangeBase, ABC):
 
     async def _update_trading_rules(self):
         exchange_info = await self._make_trading_rules_request()
+        self._initialize_trading_pair_symbols_from_exchange_info(exchange_info=exchange_info)
         trading_rules_list = await self._format_trading_rules(exchange_info)
         self._trading_rules.clear()
         for trading_rule in trading_rules_list:
             self._trading_rules[trading_rule.trading_pair] = trading_rule
-        self._initialize_trading_pair_symbols_from_exchange_info(exchange_info=exchange_info)
 
     async def _api_get(self, *args, **kwargs):
         kwargs["method"] = RESTMethod.GET


### PR DESCRIPTION
This PR fixes a bug where the Binance connector's `get_price()` method would fail when a trading pair was provided in the `BTC-USDT` format.

### Changes:
- Reordered `_update_trading_rules` to initialize trading pair symbols before formatting rules.
- This ensures that `BTC-USDT` is correctly mapped to `BTCUSDT` before being used in price lookups.

Closes #7980