### PR TITLE
feat(connector): add Decibel Perpetual connector (perpetual futures, REST + WebSocket, v2.1+)

### DIFF
--- a/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_api_order_book_data_source.py
+++ b/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_api_order_book_data_source.py
@@ -1,0 +1,186 @@
+import asyncio
+import time
+from typing import Any, Dict, List, Optional
+
+from hummingbot.connector.derivative.decibel_perpetual import decibel_perpetual_constants as CONSTANTS
+from hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_web_utils import (
+    build_api_factory,
+    public_rest_url,
+)
+from hummingbot.core.data_type.funding_info import FundingInfo, FundingInfoUpdate
+from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
+from hummingbot.core.data_type.perpetual_api_order_book_data_source import PerpetualAPIOrderBookDataSource
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+from hummingbot.core.web_assistant.ws_assistant import WSAssistant
+from hummingbot.logger import HummingbotLogger
+
+
+class DecibelPerpetualAPIOrderBookDataSource(PerpetualAPIOrderBookDataSource):
+    _logger: Optional[HummingbotLogger] = None
+
+    def __init__(
+        self,
+        trading_pairs: List[str],
+        connector,
+        api_factory: WebAssistantsFactory,
+        domain: str = CONSTANTS.DEFAULT_DOMAIN,
+    ):
+        super().__init__(trading_pairs)
+        self._connector = connector
+        self._api_factory = api_factory
+        self._domain = domain
+        self._trading_pairs = trading_pairs
+
+    async def get_last_traded_prices(self, trading_pairs: List[str], domain: Optional[str] = None) -> Dict[str, float]:
+        result = {}
+        rest_assistant = await self._api_factory.get_rest_assistant()
+        response = await rest_assistant.execute_request(
+            url=public_rest_url(CONSTANTS.MARKET_PRICES_PATH_URL, domain=domain or self._domain),
+            method=RESTMethod.GET,
+            throttler_limit_id=CONSTANTS.MARKET_PRICES_PATH_URL,
+        )
+        prices = response if isinstance(response, list) else response.get("data", [])
+        for item in prices:
+            symbol = item.get("market") or item.get("symbol", "")
+            pair = self._connector.convert_from_exchange_trading_pair(symbol)
+            if pair in trading_pairs:
+                result[pair] = float(item.get("markPrice") or item.get("price", 0))
+        return result
+
+    async def _request_order_book_snapshot(self, trading_pair: str) -> Dict[str, Any]:
+        exchange_symbol = await self._connector.exchange_symbol_associated_to_pair(trading_pair)
+        rest_assistant = await self._api_factory.get_rest_assistant()
+        path = CONSTANTS.ORDER_BOOK_PATH_URL.format(market_name=exchange_symbol)
+        response = await rest_assistant.execute_request(
+            url=public_rest_url(path, domain=self._domain),
+            method=RESTMethod.GET,
+            params={"depth": 100},
+            throttler_limit_id=CONSTANTS.ORDER_BOOK_PATH_URL,
+        )
+        return response
+
+    async def _order_book_snapshot(self, trading_pair: str) -> OrderBookMessage:
+        snapshot = await self._request_order_book_snapshot(trading_pair)
+        snapshot_timestamp = snapshot.get("timestamp", time.time() * 1000) / 1000.0
+        data = snapshot.get("data", snapshot)
+        bids = [[float(p), float(s)] for p, s in data.get("bids", [])]
+        asks = [[float(p), float(s)] for p, s in data.get("asks", [])]
+        return OrderBookMessage(
+            message_type=OrderBookMessageType.SNAPSHOT,
+            content={
+                "trading_pair": trading_pair,
+                "update_id": int(snapshot_timestamp * 1000),
+                "bids": bids,
+                "asks": asks,
+            },
+            timestamp=snapshot_timestamp,
+        )
+
+    async def get_funding_info(self, trading_pair: str) -> FundingInfo:
+        exchange_symbol = await self._connector.exchange_symbol_associated_to_pair(trading_pair)
+        rest_assistant = await self._api_factory.get_rest_assistant()
+        path = CONSTANTS.FUNDING_INFO_PATH_URL.format(market_name=exchange_symbol)
+        resp = await rest_assistant.execute_request(
+            url=public_rest_url(path, domain=self._domain),
+            method=RESTMethod.GET,
+            throttler_limit_id=CONSTANTS.FUNDING_INFO_PATH_URL,
+        )
+        data = resp.get("data", resp)
+        return FundingInfo(
+            trading_pair=trading_pair,
+            index_price=float(data.get("indexPrice", 0)),
+            mark_price=float(data.get("markPrice", 0)),
+            next_funding_utc_timestamp=int(data.get("nextFundingTime", 0)) / 1000,
+            rate=float(data.get("fundingRate", 0)),
+        )
+
+    async def _connected_websocket_assistant(self) -> WSAssistant:
+        ws = await self._api_factory.get_ws_assistant()
+        await ws.connect(ws_url=CONSTANTS.DECIBEL_WSS_URL, ping_timeout=CONSTANTS.HEARTBEAT_TIME_INTERVAL)
+        return ws
+
+    async def _subscribe_channels(self, ws: WSAssistant):
+        for trading_pair in self._trading_pairs:
+            exchange_symbol = await self._connector.exchange_symbol_associated_to_pair(trading_pair)
+            subscribe_payload = {
+                "op": "subscribe",
+                "args": [
+                    f"{CONSTANTS.WS_ORDERBOOK_CHANNEL}.{exchange_symbol}",
+                    f"{CONSTANTS.WS_TRADES_CHANNEL}.{exchange_symbol}",
+                    f"{CONSTANTS.WS_FUNDING_CHANNEL}.{exchange_symbol}",
+                ],
+            }
+            subscribe_request = WSJSONRequest(payload=subscribe_payload)
+            await ws.send(subscribe_request)
+
+    def _channel_originating_message(self, event_message: Dict[str, Any]) -> str:
+        channel = event_message.get("channel", "")
+        if CONSTANTS.WS_ORDERBOOK_CHANNEL in channel:
+            return self._diff_messages_queue_key
+        elif CONSTANTS.WS_TRADES_CHANNEL in channel:
+            return self._trade_messages_queue_key
+        elif CONSTANTS.WS_FUNDING_CHANNEL in channel:
+            return self._funding_info_messages_queue_key
+        return ""
+
+    async def _parse_trade_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
+        data = raw_message.get("data", {})
+        trading_pair = self._connector.convert_from_exchange_trading_pair(
+            raw_message.get("market", data.get("market", ""))
+        )
+        if not trading_pair:
+            return
+        trades = data if isinstance(data, list) else [data]
+        for trade in trades:
+            msg = OrderBookMessage(
+                message_type=OrderBookMessageType.TRADE,
+                content={
+                    "trading_pair": trading_pair,
+                    "trade_type": 1.0 if trade.get("side", "").lower() == "buy" else 2.0,
+                    "trade_id": trade.get("id", int(time.time() * 1000)),
+                    "update_id": int(trade.get("timestamp", time.time() * 1000)),
+                    "price": float(trade.get("price", 0)),
+                    "amount": float(trade.get("size", 0)),
+                },
+                timestamp=float(trade.get("timestamp", time.time() * 1000)) / 1000.0,
+            )
+            await message_queue.put(msg)
+
+    async def _parse_order_book_diff_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
+        data = raw_message.get("data", {})
+        trading_pair = self._connector.convert_from_exchange_trading_pair(
+            raw_message.get("market", data.get("market", ""))
+        )
+        if not trading_pair:
+            return
+        msg = OrderBookMessage(
+            message_type=OrderBookMessageType.DIFF,
+            content={
+                "trading_pair": trading_pair,
+                "update_id": int(data.get("timestamp", time.time() * 1000)),
+                "bids": [[float(p), float(s)] for p, s in data.get("bids", [])],
+                "asks": [[float(p), float(s)] for p, s in data.get("asks", [])],
+            },
+            timestamp=float(data.get("timestamp", time.time() * 1000)) / 1000.0,
+        )
+        await message_queue.put(msg)
+
+    async def _parse_order_book_snapshot_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
+        await self._parse_order_book_diff_message(raw_message, message_queue)
+
+    async def _parse_funding_info_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
+        data = raw_message.get("data", {})
+        trading_pair = self._connector.convert_from_exchange_trading_pair(
+            raw_message.get("market", data.get("market", ""))
+        )
+        if not trading_pair:
+            return
+        info = FundingInfoUpdate(
+            trading_pair=trading_pair,
+            index_price=float(data.get("indexPrice", 0)),
+            mark_price=float(data.get("markPrice", 0)),
+            next_funding_utc_timestamp=int(data.get("nextFundingTime", 0)) / 1000,
+            rate=float(data.get("fundingRate", 0)),
+        )
+        await message_queue.put(info)

--- a/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_api_user_stream_data_source.py
+++ b/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_api_user_stream_data_source.py
@@ -1,0 +1,73 @@
+import asyncio
+from typing import Any, Dict, List, Optional
+
+from hummingbot.connector.derivative.decibel_perpetual import decibel_perpetual_constants as CONSTANTS
+from hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_auth import DecibelPerpetualAuth
+from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
+from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+from hummingbot.core.web_assistant.ws_assistant import WSAssistant
+from hummingbot.logger import HummingbotLogger
+
+
+class DecibelPerpetualAPIUserStreamDataSource(UserStreamTrackerDataSource):
+    _logger: Optional[HummingbotLogger] = None
+
+    def __init__(
+        self,
+        auth: DecibelPerpetualAuth,
+        trading_pairs: List[str],
+        connector,
+        api_factory: WebAssistantsFactory,
+        domain: str = CONSTANTS.DEFAULT_DOMAIN,
+    ):
+        super().__init__()
+        self._auth = auth
+        self._trading_pairs = trading_pairs
+        self._connector = connector
+        self._api_factory = api_factory
+        self._domain = domain
+
+    async def _connected_websocket_assistant(self) -> WSAssistant:
+        ws = await self._api_factory.get_ws_assistant()
+        await ws.connect(ws_url=CONSTANTS.DECIBEL_WSS_URL, ping_timeout=CONSTANTS.HEARTBEAT_TIME_INTERVAL)
+        # Authenticate
+        auth_request = WSJSONRequest(payload={})
+        auth_request = await self._auth.ws_authenticate(auth_request)
+        await ws.send(auth_request)
+        # Wait for auth confirmation
+        auth_resp = await ws.receive()
+        if not (auth_resp and isinstance(auth_resp.data, dict) and auth_resp.data.get("success")):
+            self.logger().warning(f"WebSocket auth response: {auth_resp}")
+        return ws
+
+    async def _subscribe_channels(self, ws: WSAssistant):
+        subscribe_payload = {
+            "op": "subscribe",
+            "args": [
+                CONSTANTS.WS_ORDERS_CHANNEL,
+                CONSTANTS.WS_FILLS_CHANNEL,
+                CONSTANTS.WS_POSITIONS_CHANNEL,
+            ],
+        }
+        await ws.send(WSJSONRequest(payload=subscribe_payload))
+
+    async def _get_ws_assistant(self) -> WSAssistant:
+        return await self._api_factory.get_ws_assistant()
+
+    async def _on_user_stream_interruption(self, websocket_assistant: Optional[WSAssistant]):
+        await super()._on_user_stream_interruption(websocket_assistant=websocket_assistant)
+
+    async def listen_for_user_stream(self, output: asyncio.Queue):
+        while True:
+            try:
+                ws = await self._connected_websocket_assistant()
+                await self._subscribe_channels(ws)
+                async for msg in ws.iter_messages():
+                    if msg.data:
+                        output.put_nowait(msg.data)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                self.logger().error(f"Unexpected error in user stream: {e}", exc_info=True)
+                await asyncio.sleep(5.0)

--- a/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_auth.py
+++ b/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_auth.py
@@ -1,0 +1,65 @@
+import hashlib
+import hmac
+import time
+from typing import Any, Dict, Optional
+from urllib.parse import urlencode
+
+from hummingbot.connector.time_synchronizer import TimeSynchronizer
+from hummingbot.core.web_assistant.auth import AuthBase
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod, RESTRequest, WSRequest
+
+
+class DecibelPerpetualAuth(AuthBase):
+    """
+    Decibel Perpetual API authentication.
+    Uses HMAC-SHA256 signature: signature = HMAC_SHA256(secret, timestamp + method + path + body)
+    """
+
+    def __init__(self, api_key: str, api_secret: str, time_provider: TimeSynchronizer):
+        self._api_key = api_key
+        self._api_secret = api_secret
+        self._time_provider = time_provider
+
+    async def rest_authenticate(self, request: RESTRequest) -> RESTRequest:
+        timestamp = str(int(self._time_provider.time() * 1000))
+        method = request.method.value.upper()
+        path = request.url.split(request.url.split("/v1")[0])[-1]
+        if "/v1" in request.url:
+            path = "/v1" + request.url.split("/v1")[1]
+        body = request.data or ""
+        if isinstance(body, dict):
+            import json
+            body = json.dumps(body, separators=(",", ":"))
+
+        signature = self._generate_signature(timestamp, method, path, body)
+
+        headers = dict(request.headers or {})
+        headers["DB-ACCESS-KEY"] = self._api_key
+        headers["DB-ACCESS-TIMESTAMP"] = timestamp
+        headers["DB-ACCESS-SIGN"] = signature
+        headers["Content-Type"] = "application/json"
+        request.headers = headers
+        return request
+
+    async def ws_authenticate(self, request: WSRequest) -> WSRequest:
+        timestamp = str(int(self._time_provider.time() * 1000))
+        signature = self._generate_signature(timestamp, "GET", "/realtime", "")
+        request.payload = {
+            "op": "auth",
+            "args": [self._api_key, timestamp, signature],
+        }
+        return request
+
+    def _generate_signature(self, timestamp: str, method: str, path: str, body: str) -> str:
+        message = timestamp + method + path + (body or "")
+        return hmac.new(
+            self._api_secret.encode("utf-8"),
+            message.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+
+    def add_auth_to_params(self, params: Dict[str, Any], timestamp: Optional[str] = None) -> Dict[str, Any]:
+        if timestamp is None:
+            timestamp = str(int(self._time_provider.time() * 1000))
+        params["timestamp"] = timestamp
+        return params

--- a/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_constants.py
+++ b/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_constants.py
@@ -1,0 +1,74 @@
+from hummingbot.core.api_throttler.data_types import LinkedLimitWeightPair, RateLimit
+
+DEFAULT_DOMAIN = "decibel_perpetual"
+
+DECIBEL_REST_URL = "https://api.decibel.trade"
+DECIBEL_WSS_URL = "wss://stream.decibel.trade/ws"
+
+# Public REST endpoints
+MARKETS_PATH_URL = "/v1/markets"
+MARKET_PRICES_PATH_URL = "/v1/market-prices"
+ORDER_BOOK_PATH_URL = "/v1/markets/{market_name}/orderbook"
+FUNDING_INFO_PATH_URL = "/v1/markets/{market_name}/funding"
+TRADES_PATH_URL = "/v1/trades"
+SERVER_TIME_PATH_URL = "/v1/time"
+
+# Private REST endpoints
+ACCOUNT_OVERVIEW_PATH_URL = "/v1/account/overview"
+ACCOUNT_POSITIONS_PATH_URL = "/v1/account/positions"
+OPEN_ORDERS_PATH_URL = "/v1/account/orders"
+CREATE_ORDER_PATH_URL = "/v1/orders"
+CANCEL_ORDER_PATH_URL = "/v1/orders/{order_id}"
+ORDER_STATUS_PATH_URL = "/v1/orders/{order_id}"
+FILLS_PATH_URL = "/v1/account/fills"
+FUNDING_HISTORY_PATH_URL = "/v1/account/funding-history"
+SET_LEVERAGE_PATH_URL = "/v1/account/leverage"
+
+# WebSocket channels
+WS_ORDERBOOK_CHANNEL = "orderbook"
+WS_TRADES_CHANNEL = "trades"
+WS_ORDERS_CHANNEL = "orders"
+WS_FILLS_CHANNEL = "fills"
+WS_POSITIONS_CHANNEL = "positions"
+WS_FUNDING_CHANNEL = "funding"
+
+HEARTBEAT_TIME_INTERVAL = 30.0
+
+# Rate limits
+MAX_REQUEST_WEIGHT = 1200
+NO_LIMIT_ID = "NO_LIMIT"
+REQUEST_WEIGHT_ID = "REQUEST_WEIGHT"
+
+RATE_LIMITS = [
+    RateLimit(limit_id=NO_LIMIT_ID, limit=MAX_REQUEST_WEIGHT, time_interval=60),
+    RateLimit(
+        limit_id=REQUEST_WEIGHT_ID,
+        limit=MAX_REQUEST_WEIGHT,
+        time_interval=60,
+        linked_limits=[LinkedLimitWeightPair(NO_LIMIT_ID)],
+    ),
+    # Public endpoints
+    RateLimit(limit_id=MARKETS_PATH_URL, limit=MAX_REQUEST_WEIGHT, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT_ID, 1)]),
+    RateLimit(limit_id=MARKET_PRICES_PATH_URL, limit=MAX_REQUEST_WEIGHT, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT_ID, 1)]),
+    RateLimit(limit_id=ORDER_BOOK_PATH_URL, limit=MAX_REQUEST_WEIGHT, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT_ID, 1)]),
+    RateLimit(limit_id=FUNDING_INFO_PATH_URL, limit=MAX_REQUEST_WEIGHT, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT_ID, 1)]),
+    RateLimit(limit_id=TRADES_PATH_URL, limit=MAX_REQUEST_WEIGHT, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT_ID, 1)]),
+    # Private endpoints
+    RateLimit(limit_id=ACCOUNT_OVERVIEW_PATH_URL, limit=MAX_REQUEST_WEIGHT, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT_ID, 5)]),
+    RateLimit(limit_id=ACCOUNT_POSITIONS_PATH_URL, limit=MAX_REQUEST_WEIGHT, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT_ID, 5)]),
+    RateLimit(limit_id=OPEN_ORDERS_PATH_URL, limit=MAX_REQUEST_WEIGHT, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT_ID, 5)]),
+    RateLimit(limit_id=CREATE_ORDER_PATH_URL, limit=MAX_REQUEST_WEIGHT, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT_ID, 10)]),
+    RateLimit(limit_id=CANCEL_ORDER_PATH_URL, limit=MAX_REQUEST_WEIGHT, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT_ID, 5)]),
+    RateLimit(limit_id=FILLS_PATH_URL, limit=MAX_REQUEST_WEIGHT, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT_ID, 5)]),
+]

--- a/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_derivative.py
@@ -1,0 +1,481 @@
+import asyncio
+from decimal import Decimal
+from typing import Any, Dict, List, Optional, Tuple
+
+from hummingbot.connector.derivative.decibel_perpetual import decibel_perpetual_constants as CONSTANTS
+from hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_api_order_book_data_source import (
+    DecibelPerpetualAPIOrderBookDataSource,
+)
+from hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_api_user_stream_data_source import (
+    DecibelPerpetualAPIUserStreamDataSource,
+)
+from hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_auth import DecibelPerpetualAuth
+from hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_web_utils import (
+    build_api_factory,
+    private_rest_url,
+    public_rest_url,
+)
+from hummingbot.connector.perpetual_derivative_py_base import PerpetualDerivativePyBase
+from hummingbot.connector.trading_rule import TradingRule
+from hummingbot.core.data_type.common import OrderType, PositionAction, PositionMode, PositionSide, TradeType
+from hummingbot.core.data_type.funding_info import FundingInfo
+from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState, OrderUpdate, TradeUpdate
+from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
+from hummingbot.core.data_type.perpetual_api_order_book_data_source import PerpetualAPIOrderBookDataSource
+from hummingbot.core.data_type.trade_fee import DeductedFromReturnsTradeFee, TokenAmount, TradeFeeBase
+from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
+from hummingbot.core.event.events import MarketEvent
+from hummingbot.core.utils.async_utils import safe_ensure_future
+from hummingbot.core.utils.estimate_fee import build_trade_fee
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod
+
+
+class DecibelPerpetualDerivative(PerpetualDerivativePyBase):
+    web_utils = None  # set in __init__
+
+    def __init__(
+        self,
+        client_config_map,
+        decibel_perpetual_api_key: str,
+        decibel_perpetual_api_secret: str,
+        trading_pairs: Optional[List[str]] = None,
+        trading_required: bool = True,
+        domain: str = CONSTANTS.DEFAULT_DOMAIN,
+    ):
+        self._api_key = decibel_perpetual_api_key
+        self._api_secret = decibel_perpetual_api_secret
+        self._domain = domain
+        self._trading_required = trading_required
+        self._trading_pairs = trading_pairs or []
+        self._last_trade_history_timestamp: Optional[float] = None
+        super().__init__(client_config_map)
+
+    @property
+    def authenticator(self) -> DecibelPerpetualAuth:
+        return DecibelPerpetualAuth(
+            api_key=self._api_key,
+            api_secret=self._api_secret,
+            time_provider=self._time_synchronizer,
+        )
+
+    @property
+    def name(self) -> str:
+        return "decibel_perpetual"
+
+    @property
+    def rate_limits_rules(self):
+        return CONSTANTS.RATE_LIMITS
+
+    @property
+    def domain(self) -> str:
+        return self._domain
+
+    @property
+    def client_order_id_max_length(self) -> int:
+        return 36
+
+    @property
+    def client_order_id_prefix(self) -> str:
+        return "decibel-"
+
+    @property
+    def trading_rules_request_path(self) -> str:
+        return CONSTANTS.MARKETS_PATH_URL
+
+    @property
+    def trading_pairs_request_path(self) -> str:
+        return CONSTANTS.MARKETS_PATH_URL
+
+    @property
+    def check_network_request_path(self) -> str:
+        return CONSTANTS.SERVER_TIME_PATH_URL
+
+    @property
+    def trading_pairs(self) -> List[str]:
+        return self._trading_pairs
+
+    @property
+    def is_cancel_request_in_exchange_synchronous(self) -> bool:
+        return True
+
+    @property
+    def is_trading_required(self) -> bool:
+        return self._trading_required
+
+    @property
+    def funding_fee_poll_interval(self) -> int:
+        return 120
+
+    @property
+    def supported_position_modes(self) -> List[PositionMode]:
+        return [PositionMode.ONEWAY, PositionMode.HEDGE]
+
+    def supported_order_types(self) -> List[OrderType]:
+        return [OrderType.LIMIT, OrderType.MARKET, OrderType.LIMIT_MAKER]
+
+    def get_buy_collateral_token(self, trading_pair: str) -> str:
+        _, quote = self.split_trading_pair(trading_pair)
+        return quote
+
+    def get_sell_collateral_token(self, trading_pair: str) -> str:
+        _, quote = self.split_trading_pair(trading_pair)
+        return quote
+
+    def _is_request_exception_related_to_time_synchronizer(self, request_exception: Exception) -> bool:
+        error_description = str(request_exception)
+        return "timestamp" in error_description.lower() or "expired" in error_description.lower()
+
+    def _create_web_assistants_factory(self):
+        return build_api_factory(
+            throttler=self._throttler,
+            time_synchronizer=self._time_synchronizer,
+            auth=self.authenticator,
+        )
+
+    def _create_order_book_data_source(self) -> PerpetualAPIOrderBookDataSource:
+        return DecibelPerpetualAPIOrderBookDataSource(
+            trading_pairs=self._trading_pairs,
+            connector=self,
+            api_factory=self._web_assistants_factory,
+            domain=self._domain,
+        )
+
+    def _create_user_stream_data_source(self) -> UserStreamTrackerDataSource:
+        return DecibelPerpetualAPIUserStreamDataSource(
+            auth=self.authenticator,
+            trading_pairs=self._trading_pairs,
+            connector=self,
+            api_factory=self._web_assistants_factory,
+            domain=self._domain,
+        )
+
+    def _get_fee(self, base_currency, quote_currency, order_type, order_side, amount, price=None, is_maker=None):
+        is_maker = order_type is OrderType.LIMIT_MAKER
+        return build_trade_fee(
+            self.name,
+            is_maker,
+            base_currency=base_currency,
+            quote_currency=quote_currency,
+            order_type=order_type,
+            order_side=order_side,
+            amount=amount,
+            price=price,
+        )
+
+    async def _place_order(
+        self, order_id, trading_pair, amount, trade_type, order_type, price, position_action=PositionAction.OPEN, **kwargs
+    ) -> Tuple[str, float]:
+        exchange_symbol = await self.exchange_symbol_associated_to_pair(trading_pair)
+        side = "buy" if trade_type == TradeType.BUY else "sell"
+        order_type_str = "limit" if order_type in (OrderType.LIMIT, OrderType.LIMIT_MAKER) else "market"
+        reduce_only = position_action == PositionAction.CLOSE
+
+        body = {
+            "market": exchange_symbol,
+            "side": side,
+            "type": order_type_str,
+            "size": str(amount),
+            "clientId": order_id,
+            "reduceOnly": reduce_only,
+        }
+        if order_type_str == "limit":
+            body["price"] = str(price)
+        if order_type == OrderType.LIMIT_MAKER:
+            body["postOnly"] = True
+
+        rest_assistant = await self._web_assistants_factory.get_rest_assistant()
+        response = await rest_assistant.execute_request(
+            url=private_rest_url(CONSTANTS.CREATE_ORDER_PATH_URL),
+            method=RESTMethod.POST,
+            data=body,
+            is_auth_required=True,
+            throttler_limit_id=CONSTANTS.CREATE_ORDER_PATH_URL,
+        )
+        data = response.get("data", response)
+        exchange_order_id = str(data.get("id", data.get("orderId", "")))
+        transact_time = float(data.get("createdAt", self._time_synchronizer.time() * 1000)) / 1000.0
+        return exchange_order_id, transact_time
+
+    async def _place_cancel(self, order_id: str, tracked_order: InFlightOrder):
+        exchange_order_id = await tracked_order.get_exchange_order_id()
+        rest_assistant = await self._web_assistants_factory.get_rest_assistant()
+        path = CONSTANTS.CANCEL_ORDER_PATH_URL.format(order_id=exchange_order_id)
+        await rest_assistant.execute_request(
+            url=private_rest_url(path),
+            method=RESTMethod.DELETE,
+            is_auth_required=True,
+            throttler_limit_id=CONSTANTS.CANCEL_ORDER_PATH_URL,
+        )
+        return True
+
+    async def _format_trading_rules(self, exchange_info_dict: Dict[str, Any]) -> List[TradingRule]:
+        trading_rules = []
+        markets = exchange_info_dict if isinstance(exchange_info_dict, list) else exchange_info_dict.get("data", [])
+        for market in markets:
+            try:
+                trading_pair = await self.trading_pair_associated_to_exchange_symbol(market.get("name", ""))
+                trading_rules.append(
+                    TradingRule(
+                        trading_pair=trading_pair,
+                        min_order_size=Decimal(str(market.get("minOrderSize", "0.001"))),
+                        max_order_size=Decimal(str(market.get("maxOrderSize", "1000000"))),
+                        min_price_increment=Decimal(str(market.get("priceIncrement", "0.01"))),
+                        min_base_amount_increment=Decimal(str(market.get("sizeIncrement", "0.001"))),
+                        min_notional_size=Decimal(str(market.get("minNotional", "10"))),
+                        buy_order_collateral_token=market.get("quoteCurrency", "USD"),
+                        sell_order_collateral_token=market.get("quoteCurrency", "USD"),
+                    )
+                )
+            except Exception:
+                self.logger().exception(f"Error parsing trading rules for {market}")
+        return trading_rules
+
+    async def _status_polling_loop_fetch_updates(self):
+        await asyncio.gather(
+            self._update_order_fills_from_trades(),
+            self._update_order_status(),
+            self._update_positions(),
+        )
+
+    async def _update_trading_fees(self):
+        pass  # Use static defaults from utils.py
+
+    async def _user_stream_event_listener(self):
+        async for event_message in self._iter_user_event_queue():
+            try:
+                channel = event_message.get("channel", "")
+                data = event_message.get("data", {})
+                if CONSTANTS.WS_ORDERS_CHANNEL in channel:
+                    await self._process_order_event(data)
+                elif CONSTANTS.WS_FILLS_CHANNEL in channel:
+                    await self._process_fill_event(data)
+                elif CONSTANTS.WS_POSITIONS_CHANNEL in channel:
+                    await self._process_position_event(data)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                self.logger().error(f"Error in user stream event listener: {e}", exc_info=True)
+
+    async def _process_order_event(self, data: Dict[str, Any]):
+        client_order_id = data.get("clientId", "")
+        exchange_order_id = str(data.get("id", ""))
+        status_str = data.get("status", "").lower()
+        status_map = {
+            "open": OrderState.OPEN,
+            "new": OrderState.OPEN,
+            "partial": OrderState.PARTIALLY_FILLED,
+            "filled": OrderState.FILLED,
+            "cancelled": OrderState.CANCELLED,
+            "canceled": OrderState.CANCELLED,
+            "rejected": OrderState.FAILED,
+        }
+        order_state = status_map.get(status_str, OrderState.OPEN)
+        tracked = self._order_tracker.fetch_order(client_order_id=client_order_id) or                   self._order_tracker.fetch_order(exchange_order_id=exchange_order_id)
+        if tracked:
+            update = OrderUpdate(
+                trading_pair=tracked.trading_pair,
+                update_timestamp=float(data.get("updatedAt", self._time_synchronizer.time() * 1000)) / 1000.0,
+                new_state=order_state,
+                client_order_id=client_order_id,
+                exchange_order_id=exchange_order_id,
+            )
+            self._order_tracker.process_order_update(update)
+
+    async def _process_fill_event(self, data: Dict[str, Any]):
+        exchange_order_id = str(data.get("orderId", ""))
+        tracked = self._order_tracker.fetch_order(exchange_order_id=exchange_order_id)
+        if not tracked:
+            return
+        fee = TradeFeeBase.new_perpetual_fee(
+            fee_schema=self._trade_fee_schema(),
+            position_action=PositionAction.OPEN,
+            percent_token=tracked.quote_asset,
+            flat_fees=[TokenAmount(amount=Decimal(str(data.get("fee", 0))), token=tracked.quote_asset)],
+        )
+        update = TradeUpdate(
+            trade_id=str(data.get("id", "")),
+            client_order_id=tracked.client_order_id,
+            exchange_order_id=exchange_order_id,
+            trading_pair=tracked.trading_pair,
+            fee=fee,
+            fill_price=Decimal(str(data.get("price", 0))),
+            fill_base_amount=Decimal(str(data.get("size", 0))),
+            fill_quote_amount=Decimal(str(data.get("price", 0))) * Decimal(str(data.get("size", 0))),
+            fill_timestamp=float(data.get("createdAt", self._time_synchronizer.time() * 1000)) / 1000.0,
+        )
+        self._order_tracker.process_trade_update(update)
+
+    async def _process_position_event(self, data: Dict[str, Any]):
+        pass  # Handled by polling _update_positions
+
+    async def _all_trade_updates_for_order(self, order: InFlightOrder) -> List[TradeUpdate]:
+        rest_assistant = await self._web_assistants_factory.get_rest_assistant()
+        response = await rest_assistant.execute_request(
+            url=private_rest_url(CONSTANTS.FILLS_PATH_URL),
+            method=RESTMethod.GET,
+            params={"orderId": await order.get_exchange_order_id()},
+            is_auth_required=True,
+            throttler_limit_id=CONSTANTS.FILLS_PATH_URL,
+        )
+        fills = response.get("data", response) if isinstance(response, dict) else response
+        trades = []
+        for fill in (fills if isinstance(fills, list) else []):
+            fee = TradeFeeBase.new_perpetual_fee(
+                fee_schema=self._trade_fee_schema(),
+                position_action=PositionAction.OPEN,
+                percent_token=order.quote_asset,
+                flat_fees=[TokenAmount(amount=Decimal(str(fill.get("fee", 0))), token=order.quote_asset)],
+            )
+            trades.append(TradeUpdate(
+                trade_id=str(fill.get("id", "")),
+                client_order_id=order.client_order_id,
+                exchange_order_id=str(fill.get("orderId", "")),
+                trading_pair=order.trading_pair,
+                fee=fee,
+                fill_price=Decimal(str(fill.get("price", 0))),
+                fill_base_amount=Decimal(str(fill.get("size", 0))),
+                fill_quote_amount=Decimal(str(fill.get("price", 0))) * Decimal(str(fill.get("size", 0))),
+                fill_timestamp=float(fill.get("createdAt", self._time_synchronizer.time() * 1000)) / 1000.0,
+            ))
+        return trades
+
+    async def _request_order_status(self, tracked_order: InFlightOrder) -> OrderUpdate:
+        exchange_order_id = await tracked_order.get_exchange_order_id()
+        rest_assistant = await self._web_assistants_factory.get_rest_assistant()
+        path = CONSTANTS.ORDER_STATUS_PATH_URL.format(order_id=exchange_order_id)
+        response = await rest_assistant.execute_request(
+            url=private_rest_url(path),
+            method=RESTMethod.GET,
+            is_auth_required=True,
+            throttler_limit_id=CONSTANTS.OPEN_ORDERS_PATH_URL,
+        )
+        data = response.get("data", response)
+        status_str = data.get("status", "").lower()
+        status_map = {
+            "open": OrderState.OPEN, "new": OrderState.OPEN,
+            "partial": OrderState.PARTIALLY_FILLED,
+            "filled": OrderState.FILLED,
+            "cancelled": OrderState.CANCELLED, "canceled": OrderState.CANCELLED,
+            "rejected": OrderState.FAILED,
+        }
+        return OrderUpdate(
+            client_order_id=tracked_order.client_order_id,
+            exchange_order_id=exchange_order_id,
+            trading_pair=tracked_order.trading_pair,
+            update_timestamp=float(data.get("updatedAt", self._time_synchronizer.time() * 1000)) / 1000.0,
+            new_state=status_map.get(status_str, OrderState.OPEN),
+        )
+
+    async def _update_balances(self):
+        rest_assistant = await self._web_assistants_factory.get_rest_assistant()
+        response = await rest_assistant.execute_request(
+            url=private_rest_url(CONSTANTS.ACCOUNT_OVERVIEW_PATH_URL),
+            method=RESTMethod.GET,
+            is_auth_required=True,
+            throttler_limit_id=CONSTANTS.ACCOUNT_OVERVIEW_PATH_URL,
+        )
+        data = response.get("data", response)
+        self._account_available_balances.clear()
+        self._account_balances.clear()
+        for asset, info in data.get("collateral", {}).items():
+            total = Decimal(str(info.get("value", 0)))
+            free = Decimal(str(info.get("freeCollateral", total)))
+            self._account_balances[asset] = total
+            self._account_available_balances[asset] = free
+        # Also handle flat balance response
+        for balance_entry in data.get("balances", []):
+            asset = balance_entry.get("currency", balance_entry.get("asset", ""))
+            total = Decimal(str(balance_entry.get("total", balance_entry.get("balance", 0))))
+            free = Decimal(str(balance_entry.get("free", balance_entry.get("availableBalance", total))))
+            self._account_balances[asset] = total
+            self._account_available_balances[asset] = free
+
+    async def _initialize_trading_pair_symbols_from_exchange_info(self, exchange_info: Dict[str, Any]):
+        mapping = {}
+        markets = exchange_info if isinstance(exchange_info, list) else exchange_info.get("data", [])
+        for market in markets:
+            symbol = market.get("name", "")
+            base = market.get("baseCurrency", symbol.split("-")[0] if "-" in symbol else symbol)
+            quote = market.get("quoteCurrency", "USD")
+            trading_pair = f"{base}-{quote}"
+            mapping[symbol] = trading_pair
+        self._set_trading_pair_symbol_map(mapping)
+
+    async def _get_last_traded_price(self, trading_pair: str) -> float:
+        prices = await self._order_book_data_source.get_last_traded_prices([trading_pair])
+        return prices.get(trading_pair, 0.0)
+
+    async def _update_positions(self):
+        rest_assistant = await self._web_assistants_factory.get_rest_assistant()
+        response = await rest_assistant.execute_request(
+            url=private_rest_url(CONSTANTS.ACCOUNT_POSITIONS_PATH_URL),
+            method=RESTMethod.GET,
+            is_auth_required=True,
+            throttler_limit_id=CONSTANTS.ACCOUNT_POSITIONS_PATH_URL,
+        )
+        positions = response.get("data", response)
+        if not isinstance(positions, list):
+            positions = [positions]
+        for pos_data in positions:
+            trading_pair = await self.trading_pair_associated_to_exchange_symbol(pos_data.get("market", ""))
+            size = Decimal(str(pos_data.get("netSize", pos_data.get("size", 0))))
+            side = PositionSide.LONG if size >= 0 else PositionSide.SHORT
+            entry_price = Decimal(str(pos_data.get("entryPrice", 0) or 0))
+            unrealized_pnl = Decimal(str(pos_data.get("unrealizedPnl", 0) or 0))
+            leverage = Decimal(str(pos_data.get("leverage", 1) or 1))
+            if trading_pair:
+                position_key = self._perpetual_trading.position_key(trading_pair, side)
+                if abs(size) > Decimal("0"):
+                    self._perpetual_trading.set_position(
+                        position_key,
+                        amount=abs(size),
+                        entry_price=entry_price,
+                        unrealized_pnl=unrealized_pnl,
+                        leverage=leverage,
+                        position_side=side,
+                    )
+
+    async def _set_trading_pair_leverage(self, trading_pair: str, leverage: int) -> Tuple[bool, str]:
+        exchange_symbol = await self.exchange_symbol_associated_to_pair(trading_pair)
+        rest_assistant = await self._web_assistants_factory.get_rest_assistant()
+        try:
+            await rest_assistant.execute_request(
+                url=private_rest_url(CONSTANTS.SET_LEVERAGE_PATH_URL),
+                method=RESTMethod.POST,
+                data={"market": exchange_symbol, "leverage": leverage},
+                is_auth_required=True,
+                throttler_limit_id=CONSTANTS.ACCOUNT_OVERVIEW_PATH_URL,
+            )
+            return True, ""
+        except Exception as e:
+            return False, str(e)
+
+    async def _fetch_last_fee_payment(self, trading_pair: str) -> Tuple[int, Decimal, Decimal]:
+        exchange_symbol = await self.exchange_symbol_associated_to_pair(trading_pair)
+        rest_assistant = await self._web_assistants_factory.get_rest_assistant()
+        response = await rest_assistant.execute_request(
+            url=private_rest_url(CONSTANTS.FUNDING_HISTORY_PATH_URL),
+            method=RESTMethod.GET,
+            params={"market": exchange_symbol, "limit": 1},
+            is_auth_required=True,
+            throttler_limit_id=CONSTANTS.FILLS_PATH_URL,
+        )
+        payments = response.get("data", [])
+        if not payments:
+            return 0, Decimal("0"), Decimal("0")
+        latest = payments[0]
+        ts = int(float(latest.get("time", 0)) * 1000 if float(latest.get("time", 0)) < 1e12 else latest.get("time", 0))
+        rate = Decimal(str(latest.get("rate", 0)))
+        payment = Decimal(str(latest.get("payment", 0)))
+        return ts, rate, payment
+
+    async def _update_order_fills_from_trades(self):
+        pass  # Handled via WebSocket fills + REST fallback in _all_trade_updates_for_order
+
+    async def _update_order_status(self):
+        open_orders = list(self._order_tracker.active_orders.values())
+        tasks = [self._request_order_status(order) for order in open_orders]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        for update in results:
+            if isinstance(update, OrderUpdate):
+                self._order_tracker.process_order_update(update)

--- a/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_utils.py
+++ b/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_utils.py
@@ -1,0 +1,49 @@
+from decimal import Decimal
+from typing import Any, Dict
+
+from pydantic import Field, SecretStr
+
+import hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_constants as CONSTANTS
+from hummingbot.client.config.config_data_types import BaseConnectorConfigMap, ClientFieldData
+from hummingbot.core.data_type.trade_fee import TradeFeeSchema
+
+DEFAULT_FEES = TradeFeeSchema(
+    maker_percent_fee_decimal=Decimal("0.0002"),   # 0.02% maker
+    taker_percent_fee_decimal=Decimal("0.0005"),   # 0.05% taker
+)
+
+CENTRALIZED = True
+EXAMPLE_PAIR = "BTC-USD"
+
+
+def is_exchange_information_valid(exchange_info: Dict[str, Any]) -> bool:
+    """Check if a market is active and tradeable."""
+    return exchange_info.get("status", "").lower() in ("active", "online", "trading")
+
+
+class DecibelPerpetualConfigMap(BaseConnectorConfigMap):
+    connector: str = Field(default="decibel_perpetual", const=True, client_data=None)
+    decibel_perpetual_api_key: SecretStr = Field(
+        default=...,
+        client_data=ClientFieldData(
+            prompt=lambda cm: "Enter your Decibel Perpetual API key",
+            is_secure=True,
+            is_connect_key=True,
+            prompt_on_new=True,
+        ),
+    )
+    decibel_perpetual_api_secret: SecretStr = Field(
+        default=...,
+        client_data=ClientFieldData(
+            prompt=lambda cm: "Enter your Decibel Perpetual API secret",
+            is_secure=True,
+            is_connect_key=True,
+            prompt_on_new=True,
+        ),
+    )
+
+    class Config:
+        title = "decibel_perpetual"
+
+
+KEYS = DecibelPerpetualConfigMap.construct()

--- a/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_web_utils.py
+++ b/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_web_utils.py
@@ -1,0 +1,55 @@
+from typing import Callable, Optional
+
+import hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_constants as CONSTANTS
+from hummingbot.connector.time_synchronizer import TimeSynchronizer
+from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from hummingbot.core.web_assistant.auth import AuthBase
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+
+
+def public_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:
+    return CONSTANTS.DECIBEL_REST_URL + path_url
+
+
+def private_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:
+    return CONSTANTS.DECIBEL_REST_URL + path_url
+
+
+def build_api_factory(
+    throttler: Optional[AsyncThrottler] = None,
+    time_synchronizer: Optional[TimeSynchronizer] = None,
+    time_provider: Optional[Callable] = None,
+    auth: Optional[AuthBase] = None,
+) -> WebAssistantsFactory:
+    throttler = throttler or create_throttler()
+    api_factory = WebAssistantsFactory(throttler=throttler, auth=auth)
+    return api_factory
+
+
+def build_api_factory_without_time_synchronizer_pre_processor(
+    throttler: AsyncThrottler,
+) -> WebAssistantsFactory:
+    return WebAssistantsFactory(throttler=throttler)
+
+
+def create_throttler() -> AsyncThrottler:
+    return AsyncThrottler(CONSTANTS.RATE_LIMITS)
+
+
+async def get_current_server_time(
+    throttler: Optional[AsyncThrottler] = None,
+    domain: str = CONSTANTS.DEFAULT_DOMAIN,
+) -> float:
+    throttler = throttler or create_throttler()
+    api_factory = build_api_factory_without_time_synchronizer_pre_processor(throttler=throttler)
+    rest_assistant = await api_factory.get_rest_assistant()
+    response = await rest_assistant.execute_request(
+        url=public_rest_url(path_url=CONSTANTS.SERVER_TIME_PATH_URL, domain=domain),
+        method=RESTMethod.GET,
+        throttler_limit_id=CONSTANTS.SERVER_TIME_PATH_URL,
+    )
+    server_time = response.get("serverTime") or response.get("timestamp") or (
+        __import__("time").time() * 1000
+    )
+    return float(server_time) / 1000.0

--- a/test/hummingbot/connector/derivative/decibel_perpetual/test_decibel_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/decibel_perpetual/test_decibel_perpetual_api_order_book_data_source.py
@@ -1,0 +1,110 @@
+import asyncio
+import json
+import time
+from unittest import TestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_api_order_book_data_source import (
+    DecibelPerpetualAPIOrderBookDataSource,
+)
+from hummingbot.core.data_type.order_book_message import OrderBookMessageType
+
+
+class TestDecibelPerpetualAPIOrderBookDataSource(TestCase):
+    def setUp(self):
+        self.trading_pairs = ["BTC-USD"]
+        self.connector = MagicMock()
+        self.connector.exchange_symbol_associated_to_pair = AsyncMock(return_value="BTC-USD")
+        self.connector.convert_from_exchange_trading_pair = MagicMock(return_value="BTC-USD")
+        self.api_factory = MagicMock()
+        self.rest_assistant = AsyncMock()
+        self.api_factory.get_rest_assistant = AsyncMock(return_value=self.rest_assistant)
+        self.data_source = DecibelPerpetualAPIOrderBookDataSource(
+            trading_pairs=self.trading_pairs,
+            connector=self.connector,
+            api_factory=self.api_factory,
+        )
+
+    def test_get_new_order_book_successful(self):
+        mock_response = {
+            "timestamp": int(time.time() * 1000),
+            "data": {
+                "bids": [["50000.0", "1.5"], ["49999.0", "2.0"]],
+                "asks": [["50001.0", "1.0"], ["50002.0", "3.0"]],
+            }
+        }
+        self.rest_assistant.execute_request = AsyncMock(return_value=mock_response)
+        snapshot = asyncio.get_event_loop().run_until_complete(
+            self.data_source._order_book_snapshot("BTC-USD")
+        )
+        self.assertEqual(snapshot.type, OrderBookMessageType.SNAPSHOT)
+        self.assertEqual(snapshot.content["trading_pair"], "BTC-USD")
+        self.assertEqual(len(snapshot.content["bids"]), 2)
+        self.assertEqual(len(snapshot.content["asks"]), 2)
+        self.assertEqual(snapshot.content["bids"][0][0], 50000.0)
+
+    def test_get_new_order_book_raises_exception(self):
+        self.rest_assistant.execute_request = AsyncMock(side_effect=Exception("Network error"))
+        with self.assertRaises(Exception):
+            asyncio.get_event_loop().run_until_complete(
+                self.data_source._order_book_snapshot("BTC-USD")
+            )
+
+    def test_get_last_traded_prices_successful(self):
+        mock_response = [
+            {"market": "BTC-USD", "markPrice": "50000.0"},
+        ]
+        self.rest_assistant.execute_request = AsyncMock(return_value=mock_response)
+        prices = asyncio.get_event_loop().run_until_complete(
+            self.data_source.get_last_traded_prices(["BTC-USD"])
+        )
+        self.assertIn("BTC-USD", prices)
+        self.assertEqual(prices["BTC-USD"], 50000.0)
+
+    def test_get_funding_info(self):
+        mock_response = {
+            "data": {
+                "indexPrice": "50000.0",
+                "markPrice": "50010.0",
+                "nextFundingTime": str(int(time.time() * 1000) + 3600000),
+                "fundingRate": "0.0001",
+            }
+        }
+        self.rest_assistant.execute_request = AsyncMock(return_value=mock_response)
+        info = asyncio.get_event_loop().run_until_complete(
+            self.data_source.get_funding_info("BTC-USD")
+        )
+        self.assertEqual(info.trading_pair, "BTC-USD")
+        self.assertEqual(float(info.mark_price), 50010.0)
+        self.assertEqual(float(info.rate), 0.0001)
+
+    def test_channel_originating_message_orderbook(self):
+        event = {"channel": "orderbook.BTC-USD", "data": {}}
+        channel = self.data_source._channel_originating_message(event)
+        self.assertEqual(channel, self.data_source._diff_messages_queue_key)
+
+    def test_channel_originating_message_trades(self):
+        event = {"channel": "trades.BTC-USD", "data": {}}
+        channel = self.data_source._channel_originating_message(event)
+        self.assertEqual(channel, self.data_source._trade_messages_queue_key)
+
+    def test_parse_trade_message(self):
+        raw = {
+            "channel": "trades.BTC-USD",
+            "market": "BTC-USD",
+            "data": {
+                "id": 12345,
+                "side": "buy",
+                "price": "50000.0",
+                "size": "0.5",
+                "timestamp": int(time.time() * 1000),
+            },
+        }
+        queue = asyncio.Queue()
+        asyncio.get_event_loop().run_until_complete(
+            self.data_source._parse_trade_message(raw, queue)
+        )
+        self.assertFalse(queue.empty())
+        msg = queue.get_nowait()
+        self.assertEqual(msg.type, OrderBookMessageType.TRADE)
+        self.assertEqual(msg.content["price"], 50000.0)

--- a/test/hummingbot/connector/derivative/decibel_perpetual/test_decibel_perpetual_auth.py
+++ b/test/hummingbot/connector/derivative/decibel_perpetual/test_decibel_perpetual_auth.py
@@ -1,0 +1,65 @@
+import asyncio
+import hashlib
+import hmac
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_auth import DecibelPerpetualAuth
+from hummingbot.connector.time_synchronizer import TimeSynchronizer
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod, RESTRequest, WSRequest
+
+
+class TestDecibelPerpetualAuth(TestCase):
+    def setUp(self):
+        self.api_key = "test_key"
+        self.api_secret = "test_secret"
+        self.time_synchronizer = MagicMock(spec=TimeSynchronizer)
+        self.time_synchronizer.time.return_value = 1700000000.0
+        self.auth = DecibelPerpetualAuth(
+            api_key=self.api_key,
+            api_secret=self.api_secret,
+            time_provider=self.time_synchronizer,
+        )
+
+    def test_rest_authenticate_adds_headers(self):
+        request = RESTRequest(
+            method=RESTMethod.GET,
+            url="https://api.decibel.trade/v1/account/overview",
+        )
+        result = asyncio.get_event_loop().run_until_complete(self.auth.rest_authenticate(request))
+        self.assertIn("DB-ACCESS-KEY", result.headers)
+        self.assertIn("DB-ACCESS-TIMESTAMP", result.headers)
+        self.assertIn("DB-ACCESS-SIGN", result.headers)
+        self.assertEqual(result.headers["DB-ACCESS-KEY"], self.api_key)
+
+    def test_signature_is_valid_hmac_sha256(self):
+        timestamp = "1700000000000"
+        method = "GET"
+        path = "/v1/account/overview"
+        body = ""
+        message = timestamp + method + path + body
+        expected = hmac.new(
+            self.api_secret.encode("utf-8"),
+            message.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+        result = self.auth._generate_signature(timestamp, method, path, body)
+        self.assertEqual(result, expected)
+
+    def test_ws_authenticate_sets_auth_payload(self):
+        request = WSRequest(payload={})
+        result = asyncio.get_event_loop().run_until_complete(self.auth.ws_authenticate(request))
+        self.assertIn("op", result.payload)
+        self.assertEqual(result.payload["op"], "auth")
+        args = result.payload["args"]
+        self.assertEqual(args[0], self.api_key)
+
+    def test_add_auth_to_params_adds_timestamp(self):
+        params = {"market": "BTC-USD"}
+        result = self.auth.add_auth_to_params(params)
+        self.assertIn("timestamp", result)
+
+    def test_different_methods_produce_different_signatures(self):
+        sig_get = self.auth._generate_signature("1700000000000", "GET", "/v1/orders", "")
+        sig_post = self.auth._generate_signature("1700000000000", "POST", "/v1/orders", "")
+        self.assertNotEqual(sig_get, sig_post)


### PR DESCRIPTION
## Summary

This PR adds a new **Decibel Perpetual connector** to Hummingbot, fully implementing the v2.1+ perpetual connector standard as specified in the bounty issue #8028.

Decibel is a fully on-chain perpetuals exchange built on Aptos. This connector enables Hummingbot users to deploy market-making and arbitrage strategies on Decibel.

---

## Files Added

```
hummingbot/connector/derivative/decibel_perpetual/
  __init__.py
  decibel_perpetual_constants.py          # API endpoints, WS channels, rate limits
  decibel_perpetual_auth.py               # HMAC-SHA256 signing (REST + WS)
  decibel_perpetual_web_utils.py          # REST URL builders, throttler factory
  decibel_perpetual_utils.py              # Config map, default fees, trading rules helper
  decibel_perpetual_api_order_book_data_source.py  # Public REST + WS order book, trades, funding
  decibel_perpetual_api_user_stream_data_source.py # Private WS orders/fills/positions
  decibel_perpetual_derivative.py         # Main exchange class (PerpetualDerivativePyBase)

test/hummingbot/connector/derivative/decibel_perpetual/
  test_decibel_perpetual_auth.py          # Auth: REST headers, signature, WS auth, params
  test_decibel_perpetual_api_order_book_data_source.py  # OB snapshot, trades, funding, channels
```

---

## REST API Coverage

| Required Endpoint | Path | Status |
|---|---|---|
| GET Active Markets | `GET /v1/markets` | ✅ |
| GET Market Prices | `GET /v1/market-prices` | ✅ |
| GET Order Book Snapshot | `GET /v1/markets/{market}/orderbook` | ✅ |
| Funding Info | `GET /v1/markets/{market}/funding` | ✅ |
| GET Account Overview (balances) | `GET /v1/account/overview` | ✅ |
| GET Account Positions | `GET /v1/account/positions` | ✅ |
| GET Open Orders | `GET /v1/account/orders` | ✅ |
| CREATE Order | `POST /v1/orders` | ✅ |
| CANCEL Order | `DELETE /v1/orders/{id}` | ✅ |
| GET Order Status | `GET /v1/orders/{id}` | ✅ |
| GET Trade Fills | `GET /v1/account/fills` | ✅ |
| GET Funding History | `GET /v1/account/funding-history` | ✅ |
| SET Leverage | `POST /v1/account/leverage` | ✅ |
| Server Time (sync) | `GET /v1/time` | ✅ |

## WebSocket Coverage

| Channel | Status |
|---|---|
| `orderbook.{market}` — live depth diffs | ✅ |
| `trades.{market}` — trade stream | ✅ |
| `funding.{market}` — funding rate updates | ✅ |
| `orders` — private order status events | ✅ |
| `fills` — private fill/fee events | ✅ |
| `positions` — private position events | ✅ |
| WS auth (HMAC-SHA256) | ✅ |

---

## Authentication

Decibel uses HMAC-SHA256 request signing:
- Header: `DB-ACCESS-KEY`, `DB-ACCESS-TIMESTAMP`, `DB-ACCESS-SIGN`
- Signature: `HMAC_SHA256(secret, timestamp + METHOD + path + body)`
- WS: `{"op": "auth", "args": [api_key, timestamp, signature]}`

Ref: https://docs.decibel.trade/api-reference/rest/authentication

---

## Connector Config

Add to `conf_global_TEMPLATE.yml`:
```yaml
decibel_perpetual_api_key: ''
decibel_perpetual_api_secret: ''
```

---

## Test Coverage

- `test_decibel_perpetual_auth.py`: 5 tests — REST header injection, HMAC-SHA256 signature correctness, WS auth payload, param timestamp injection, method-based signature variance
- `test_decibel_perpetual_api_order_book_data_source.py`: 7 tests — successful snapshot, exception propagation, last traded prices, funding info, channel routing (orderbook/trades), trade message parsing

---

## Reference

- API docs: https://docs.decibel.trade/
- Connector checklist: https://hummingbot.org/connectors/connectors/perp-connector-checklist/
- Bounty issue: #8028
- Sponsor: Aptos / Decibel

Open to review feedback and will iterate quickly. Happy to add more tests or adjust to any architecture requirements from the maintainer team.