### PR TITLE
fix: minimum order size calculation for Hyperliquid Perpetual

### DIFF
--- a/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_derivative.py
@@ -815,14 +815,16 @@ class HyperliquidPerpetualDerivative(PerpetualDerivativePyBase):
         coin_infos: list = exchange_info_dict[0]['universe']
         price_infos: list = exchange_info_dict[1]
         return_val: list = []
+        min_notional = 10
         for coin_info, price_info in zip(coin_infos, price_infos):
             try:
                 ex_symbol = f'{coin_info["name"]}'
                 trading_pair = await self.trading_pair_associated_to_exchange_symbol(symbol=ex_symbol)
-                step_size = Decimal(str(10 ** -coin_info.get("szDecimals")))
-
+                sz_decimals = coin_info.get("szDecimals")
+                step_size = Decimal(str(10 ** -sz_decimals))
+                price = float(price_info.get("markPx"))
                 price_size = Decimal(str(10 ** -len(price_info.get("markPx").split('.')[1])))
-                _min_order_size = Decimal(str(10 ** -len(price_info.get("openInterest").split('.')[1])))
+                _min_order_size = Decimal(str(round(min_notional / price, sz_decimals)))
                 collateral_token = CONSTANTS.CURRENCY
                 return_val.append(
                     TradingRule(
@@ -845,10 +847,11 @@ class HyperliquidPerpetualDerivative(PerpetualDerivativePyBase):
                 self._is_hip3_market[coin_name] = True
                 quote = "USD"
                 trading_pair = await self.trading_pair_associated_to_exchange_symbol(symbol=coin_name)
-
-                step_size = Decimal(str(10 ** -dex_info.get("szDecimals")))
+                sz_decimals = dex_info.get("szDecimals")
+                step_size = Decimal(str(10 ** -sz_decimals))
+                price = float(dex_info.get("markPx"))
                 price_size = Decimal(str(10 ** -len(dex_info.get("markPx").split('.')[1])))
-                _min_order_size = Decimal(str(10 ** -len(dex_info.get("openInterest").split('.')[1])))
+                _min_order_size = Decimal(str(round(min_notional / price, sz_decimals)))
                 collateral_token = quote
 
                 return_val.append(

--- a/test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_derivative.py
@@ -321,13 +321,15 @@ class HyperliquidPerpetualDerivativeTests(AbstractPerpetualDerivativeTests.Perpe
 
     @property
     def expected_trading_rule(self):
+        min_notional = 10
         price_info = self.trading_rules_request_mock_response[1][0]
         coin_info = self.trading_rules_request_mock_response[0]["universe"][0]
         collateral_token = self.quote_asset
-
-        step_size = Decimal(str(10 ** -coin_info.get("szDecimals")))
+        sz_decimals = coin_info.get("szDecimals")
+        step_size = Decimal(str(10 ** -sz_decimals))
+        price = float(price_info.get("markPx"))
         price_size = Decimal(str(10 ** -len(price_info.get("markPx").split('.')[1])))
-        _min_order_size = Decimal(str(10 ** -len(price_info.get("openInterest").split('.')[1])))
+        _min_order_size = Decimal(str(round(min_notional / price, sz_decimals)))
 
         return TradingRule(self.trading_pair,
                            min_base_amount_increment=step_size,


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] Tests all pass
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Minimum order size in the hyperliquid perpetual connector should not be derived from the fractional part of the open interest. The number of digits after the decimal in open interest keeps fluctuating, resulting in different minimum order size calculations and errors due to failed validation during order placement. Implemented minimum order size calculation referring to https://docs.chainstack.com/docs/hyperliquid-order-precision


**Tests performed by the developer**:
I ran into errors using grid strike strategy using the hyperliquid perpetual connector. When the minimum order quote value is close to or equal to the minimum notional value of $10, order placements start failing with error messages such as "Order amount x is lower than minimum order size y for the pair . The order will not be created.", when orders with the same size were successfully submitted just a few seconds back. Orders with valid sizes suddenly started failing because of erroneous calculation of minimum order size using open interest, whose fractional part was reduced to fewer digits for a period of time.


**Tips for QA testing**:
Test using the hyperliqid perpetual connector with different strategies by keeping the minimum quote as $10. Orders which can be successfully manually placed on Hyperliquid should not fail during strategy execution.