### PR TITLE
Fix #7929: Bad JSON Parsing in RESTResponse

### DIFF
--- a/hummingbot/core/web_assistant/connections/data_types.py
+++ b/hummingbot/core/web_assistant/connections/data_types.py
@@ -117,7 +117,10 @@ class RESTResponse:
             byte_string = await self._aiohttp_response.read()
             if isinstance(byte_string, bytes):
                 decoded_string = byte_string.decode('utf-8')
-                json_ = json.loads(decoded_string)
+                try:
+                    json_ = json.loads(decoded_string)
+                except json.JSONDecodeError:
+                    json_ = decoded_string
             else:
                 json_ = await self._aiohttp_response.json()
         else:

--- a/test/hummingbot/core/web_assistant/connections/test_data_types.py
+++ b/test/hummingbot/core/web_assistant/connections/test_data_types.py
@@ -69,6 +69,22 @@ class DataTypesTest(IsolatedAsyncioWrapperTestCase):
         self.assertEqual(body, json_)
 
     @aioresponses()
+    async def test_rest_response_with_non_json_text_plain_returns_raw_string(self, mocked_api):
+        url = "https://some.url"
+        body = "pong"
+        headers = {"content-type": "text/plain"}
+        mocked_api.get(url=url, body=body, headers=headers)
+        aiohttp_client_session = aiohttp.ClientSession()
+        aiohttp_response = await (aiohttp_client_session.get(url))
+
+        response = RESTResponse(aiohttp_response)
+
+        json_ = await (response.json())
+
+        self.assertEqual(body, json_)
+        await (aiohttp_client_session.close())
+
+    @aioresponses()
     async def test_rest_response_repr(self, mocked_api):
         url = "https://some.url"
         body = {"one": 1}


### PR DESCRIPTION
Fixes #7929

## Summary
This PR fixes: Bad JSON Parsing in RESTResponse

## Changes
```
hummingbot/core/web_assistant/connections/data_types.py  |  5 ++++-
 .../core/web_assistant/connections/test_data_types.py    | 16 ++++++++++++++++
 2 files changed, 20 insertions(+), 1 deletion(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: medium. Happy to make any adjustments!*