### PR TITLE
Fix #7953: Bybit - order_book bid and ask size not matched with exchang

### DIFF
--- a/hummingbot/connector/exchange/bybit/bybit_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/bybit/bybit_api_order_book_data_source.py
@@ -234,7 +234,7 @@ class BybitAPIOrderBookDataSource(OrderBookTrackerDataSource):
                 trading_pair = await self._connector.trading_pair_associated_to_exchange_symbol(
                     symbol=data["s"])
                 order_book_message: OrderBookMessage = BybitOrderBook.snapshot_message_from_exchange_websocket(
-                    data, json_msg["ts"], {"trading_pair": trading_pair})
+                    data, json_msg["ts"] * 1e-3, {"trading_pair": trading_pair})
                 snapshot_queue.put_nowait(order_book_message)
             except asyncio.CancelledError:
                 raise


### PR DESCRIPTION
Fixes #7953

## Summary
This PR fixes: Bybit - order_book bid and ask size not matched with exchange

## Changes
```
hummingbot/connector/exchange/bybit/bybit_api_order_book_data_source.py | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*