### PR TITLE
Fix #8018: Bug Report / Unexpected behavior : keep_position=True, but e

### DIFF
--- a/hummingbot/strategy_v2/executors/executor_orchestrator.py
+++ b/hummingbot/strategy_v2/executors/executor_orchestrator.py
@@ -295,7 +295,7 @@ class ExecutorOrchestrator:
         for controller_id, executors_list in self.active_executors.items():
             for executor in executors_list:
                 if not executor.is_closed:
-                    executor.early_stop()
+                    executor.early_stop(keep_position=True)
         for i in range(max_executors_close_attempts):
             if all([executor.executor_info.is_done for executors_list in self.active_executors.values()
                     for executor in executors_list]):

--- a/test/hummingbot/strategy_v2/executors/test_executor_orchestrator.py
+++ b/test/hummingbot/strategy_v2/executors/test_executor_orchestrator.py
@@ -354,7 +354,7 @@ class TestExecutorOrchestrator(unittest.TestCase):
             position_executor.executor_info.is_done = True
             self.orchestrator.active_executors["test"] = [position_executor]
             await self.orchestrator.stop()
-            position_executor.early_stop.assert_called_once()
+            position_executor.early_stop.assert_called_once_with(keep_position=True)
 
         asyncio.run(test_async())
 


### PR DESCRIPTION
Fixes #8018

## Summary
This PR fixes: Bug Report / Unexpected behavior : keep_position=True, but executors closed with market close orders

## Changes
```
hummingbot/strategy_v2/executors/executor_orchestrator.py           | 2 +-
 test/hummingbot/strategy_v2/executors/test_executor_orchestrator.py | 2 +-
 2 files changed, 2 insertions(+), 2 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: medium. Happy to make any adjustments!*