### PR TITLE
fix: store executors to database upon termination (#8042)

### DIFF
--- a/hummingbot/strategy_v2/executors/executor_base.py
+++ b/hummingbot/strategy_v2/executors/executor_base.py
@@ -415,3 +415,4 @@ class ExecutorBase(RunnableBase):
         :param event: The event.
         """
         pass
+        self.store_executor()


### PR DESCRIPTION
This PR ensures that executors are correctly saved to the database when they are terminated. This fixes the issue where executor data was lost upon stopping. Addresses bounty #8042.