### PR TITLE
feat(connector): add GRVT Perpetual connector (perpetual futures, REST + WebSocket, v2.1+)

### DIFF
--- a/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_api_order_book_data_source.py
+++ b/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_api_order_book_data_source.py
@@ -1,0 +1,186 @@
+import asyncio
+import time
+from typing import Any, Dict, List, Optional
+
+from hummingbot.connector.derivative.decibel_perpetual import decibel_perpetual_constants as CONSTANTS
+from hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_web_utils import (
+    build_api_factory,
+    public_rest_url,
+)
+from hummingbot.core.data_type.funding_info import FundingInfo, FundingInfoUpdate
+from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
+from hummingbot.core.data_type.perpetual_api_order_book_data_source import PerpetualAPIOrderBookDataSource
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+from hummingbot.core.web_assistant.ws_assistant import WSAssistant
+from hummingbot.logger import HummingbotLogger
+
+
+class DecibelPerpetualAPIOrderBookDataSource(PerpetualAPIOrderBookDataSource):
+    _logger: Optional[HummingbotLogger] = None
+
+    def __init__(
+        self,
+        trading_pairs: List[str],
+        connector,
+        api_factory: WebAssistantsFactory,
+        domain: str = CONSTANTS.DEFAULT_DOMAIN,
+    ):
+        super().__init__(trading_pairs)
+        self._connector = connector
+        self._api_factory = api_factory
+        self._domain = domain
+        self._trading_pairs = trading_pairs
+
+    async def get_last_traded_prices(self, trading_pairs: List[str], domain: Optional[str] = None) -> Dict[str, float]:
+        result = {}
+        rest_assistant = await self._api_factory.get_rest_assistant()
+        response = await rest_assistant.execute_request(
+            url=public_rest_url(CONSTANTS.MARKET_PRICES_PATH_URL, domain=domain or self._domain),
+            method=RESTMethod.GET,
+            throttler_limit_id=CONSTANTS.MARKET_PRICES_PATH_URL,
+        )
+        prices = response if isinstance(response, list) else response.get("data", [])
+        for item in prices:
+            symbol = item.get("market") or item.get("symbol", "")
+            pair = self._connector.convert_from_exchange_trading_pair(symbol)
+            if pair in trading_pairs:
+                result[pair] = float(item.get("markPrice") or item.get("price", 0))
+        return result
+
+    async def _request_order_book_snapshot(self, trading_pair: str) -> Dict[str, Any]:
+        exchange_symbol = await self._connector.exchange_symbol_associated_to_pair(trading_pair)
+        rest_assistant = await self._api_factory.get_rest_assistant()
+        path = CONSTANTS.ORDER_BOOK_PATH_URL.format(market_name=exchange_symbol)
+        response = await rest_assistant.execute_request(
+            url=public_rest_url(path, domain=self._domain),
+            method=RESTMethod.GET,
+            params={"depth": 100},
+            throttler_limit_id=CONSTANTS.ORDER_BOOK_PATH_URL,
+        )
+        return response
+
+    async def _order_book_snapshot(self, trading_pair: str) -> OrderBookMessage:
+        snapshot = await self._request_order_book_snapshot(trading_pair)
+        snapshot_timestamp = snapshot.get("timestamp", time.time() * 1000) / 1000.0
+        data = snapshot.get("data", snapshot)
+        bids = [[float(p), float(s)] for p, s in data.get("bids", [])]
+        asks = [[float(p), float(s)] for p, s in data.get("asks", [])]
+        return OrderBookMessage(
+            message_type=OrderBookMessageType.SNAPSHOT,
+            content={
+                "trading_pair": trading_pair,
+                "update_id": int(snapshot_timestamp * 1000),
+                "bids": bids,
+                "asks": asks,
+            },
+            timestamp=snapshot_timestamp,
+        )
+
+    async def get_funding_info(self, trading_pair: str) -> FundingInfo:
+        exchange_symbol = await self._connector.exchange_symbol_associated_to_pair(trading_pair)
+        rest_assistant = await self._api_factory.get_rest_assistant()
+        path = CONSTANTS.FUNDING_INFO_PATH_URL.format(market_name=exchange_symbol)
+        resp = await rest_assistant.execute_request(
+            url=public_rest_url(path, domain=self._domain),
+            method=RESTMethod.GET,
+            throttler_limit_id=CONSTANTS.FUNDING_INFO_PATH_URL,
+        )
+        data = resp.get("data", resp)
+        return FundingInfo(
+            trading_pair=trading_pair,
+            index_price=float(data.get("indexPrice", 0)),
+            mark_price=float(data.get("markPrice", 0)),
+            next_funding_utc_timestamp=int(data.get("nextFundingTime", 0)) / 1000,
+            rate=float(data.get("fundingRate", 0)),
+        )
+
+    async def _connected_websocket_assistant(self) -> WSAssistant:
+        ws = await self._api_factory.get_ws_assistant()
+        await ws.connect(ws_url=CONSTANTS.DECIBEL_WSS_URL, ping_timeout=CONSTANTS.HEARTBEAT_TIME_INTERVAL)
+        return ws
+
+    async def _subscribe_channels(self, ws: WSAssistant):
+        for trading_pair in self._trading_pairs:
+            exchange_symbol = await self._connector.exchange_symbol_associated_to_pair(trading_pair)
+            subscribe_payload = {
+                "op": "subscribe",
+                "args": [
+                    f"{CONSTANTS.WS_ORDERBOOK_CHANNEL}.{exchange_symbol}",
+                    f"{CONSTANTS.WS_TRADES_CHANNEL}.{exchange_symbol}",
+                    f"{CONSTANTS.WS_FUNDING_CHANNEL}.{exchange_symbol}",
+                ],
+            }
+            subscribe_request = WSJSONRequest(payload=subscribe_payload)
+            await ws.send(subscribe_request)
+
+    def _channel_originating_message(self, event_message: Dict[str, Any]) -> str:
+        channel = event_message.get("channel", "")
+        if CONSTANTS.WS_ORDERBOOK_CHANNEL in channel:
+            return self._diff_messages_queue_key
+        elif CONSTANTS.WS_TRADES_CHANNEL in channel:
+            return self._trade_messages_queue_key
+        elif CONSTANTS.WS_FUNDING_CHANNEL in channel:
+            return self._funding_info_messages_queue_key
+        return ""
+
+    async def _parse_trade_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
+        data = raw_message.get("data", {})
+        trading_pair = self._connector.convert_from_exchange_trading_pair(
+            raw_message.get("market", data.get("market", ""))
+        )
+        if not trading_pair:
+            return
+        trades = data if isinstance(data, list) else [data]
+        for trade in trades:
+            msg = OrderBookMessage(
+                message_type=OrderBookMessageType.TRADE,
+                content={
+                    "trading_pair": trading_pair,
+                    "trade_type": 1.0 if trade.get("side", "").lower() == "buy" else 2.0,
+                    "trade_id": trade.get("id", int(time.time() * 1000)),
+                    "update_id": int(trade.get("timestamp", time.time() * 1000)),
+                    "price": float(trade.get("price", 0)),
+                    "amount": float(trade.get("size", 0)),
+                },
+                timestamp=float(trade.get("timestamp", time.time() * 1000)) / 1000.0,
+            )
+            await message_queue.put(msg)
+
+    async def _parse_order_book_diff_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
+        data = raw_message.get("data", {})
+        trading_pair = self._connector.convert_from_exchange_trading_pair(
+            raw_message.get("market", data.get("market", ""))
+        )
+        if not trading_pair:
+            return
+        msg = OrderBookMessage(
+            message_type=OrderBookMessageType.DIFF,
+            content={
+                "trading_pair": trading_pair,
+                "update_id": int(data.get("timestamp", time.time() * 1000)),
+                "bids": [[float(p), float(s)] for p, s in data.get("bids", [])],
+                "asks": [[float(p), float(s)] for p, s in data.get("asks", [])],
+            },
+            timestamp=float(data.get("timestamp", time.time() * 1000)) / 1000.0,
+        )
+        await message_queue.put(msg)
+
+    async def _parse_order_book_snapshot_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
+        await self._parse_order_book_diff_message(raw_message, message_queue)
+
+    async def _parse_funding_info_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
+        data = raw_message.get("data", {})
+        trading_pair = self._connector.convert_from_exchange_trading_pair(
+            raw_message.get("market", data.get("market", ""))
+        )
+        if not trading_pair:
+            return
+        info = FundingInfoUpdate(
+            trading_pair=trading_pair,
+            index_price=float(data.get("indexPrice", 0)),
+            mark_price=float(data.get("markPrice", 0)),
+            next_funding_utc_timestamp=int(data.get("nextFundingTime", 0)) / 1000,
+            rate=float(data.get("fundingRate", 0)),
+        )
+        await message_queue.put(info)

--- a/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_api_user_stream_data_source.py
+++ b/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_api_user_stream_data_source.py
@@ -1,0 +1,73 @@
+import asyncio
+from typing import Any, Dict, List, Optional
+
+from hummingbot.connector.derivative.decibel_perpetual import decibel_perpetual_constants as CONSTANTS
+from hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_auth import DecibelPerpetualAuth
+from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
+from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+from hummingbot.core.web_assistant.ws_assistant import WSAssistant
+from hummingbot.logger import HummingbotLogger
+
+
+class DecibelPerpetualAPIUserStreamDataSource(UserStreamTrackerDataSource):
+    _logger: Optional[HummingbotLogger] = None
+
+    def __init__(
+        self,
+        auth: DecibelPerpetualAuth,
+        trading_pairs: List[str],
+        connector,
+        api_factory: WebAssistantsFactory,
+        domain: str = CONSTANTS.DEFAULT_DOMAIN,
+    ):
+        super().__init__()
+        self._auth = auth
+        self._trading_pairs = trading_pairs
+        self._connector = connector
+        self._api_factory = api_factory
+        self._domain = domain
+
+    async def _connected_websocket_assistant(self) -> WSAssistant:
+        ws = await self._api_factory.get_ws_assistant()
+        await ws.connect(ws_url=CONSTANTS.DECIBEL_WSS_URL, ping_timeout=CONSTANTS.HEARTBEAT_TIME_INTERVAL)
+        # Authenticate
+        auth_request = WSJSONRequest(payload={})
+        auth_request = await self._auth.ws_authenticate(auth_request)
+        await ws.send(auth_request)
+        # Wait for auth confirmation
+        auth_resp = await ws.receive()
+        if not (auth_resp and isinstance(auth_resp.data, dict) and auth_resp.data.get("success")):
+            self.logger().warning(f"WebSocket auth response: {auth_resp}")
+        return ws
+
+    async def _subscribe_channels(self, ws: WSAssistant):
+        subscribe_payload = {
+            "op": "subscribe",
+            "args": [
+                CONSTANTS.WS_ORDERS_CHANNEL,
+                CONSTANTS.WS_FILLS_CHANNEL,
+                CONSTANTS.WS_POSITIONS_CHANNEL,
+            ],
+        }
+        await ws.send(WSJSONRequest(payload=subscribe_payload))
+
+    async def _get_ws_assistant(self) -> WSAssistant:
+        return await self._api_factory.get_ws_assistant()
+
+    async def _on_user_stream_interruption(self, websocket_assistant: Optional[WSAssistant]):
+        await super()._on_user_stream_interruption(websocket_assistant=websocket_assistant)
+
+    async def listen_for_user_stream(self, output: asyncio.Queue):
+        while True:
+            try:
+                ws = await self._connected_websocket_assistant()
+                await self._subscribe_channels(ws)
+                async for msg in ws.iter_messages():
+                    if msg.data:
+                        output.put_nowait(msg.data)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                self.logger().error(f"Unexpected error in user stream: {e}", exc_info=True)
+                await asyncio.sleep(5.0)

--- a/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_auth.py
+++ b/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_auth.py
@@ -1,0 +1,65 @@
+import hashlib
+import hmac
+import time
+from typing import Any, Dict, Optional
+from urllib.parse import urlencode
+
+from hummingbot.connector.time_synchronizer import TimeSynchronizer
+from hummingbot.core.web_assistant.auth import AuthBase
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod, RESTRequest, WSRequest
+
+
+class DecibelPerpetualAuth(AuthBase):
+    """
+    Decibel Perpetual API authentication.
+    Uses HMAC-SHA256 signature: signature = HMAC_SHA256(secret, timestamp + method + path + body)
+    """
+
+    def __init__(self, api_key: str, api_secret: str, time_provider: TimeSynchronizer):
+        self._api_key = api_key
+        self._api_secret = api_secret
+        self._time_provider = time_provider
+
+    async def rest_authenticate(self, request: RESTRequest) -> RESTRequest:
+        timestamp = str(int(self._time_provider.time() * 1000))
+        method = request.method.value.upper()
+        path = request.url.split(request.url.split("/v1")[0])[-1]
+        if "/v1" in request.url:
+            path = "/v1" + request.url.split("/v1")[1]
+        body = request.data or ""
+        if isinstance(body, dict):
+            import json
+            body = json.dumps(body, separators=(",", ":"))
+
+        signature = self._generate_signature(timestamp, method, path, body)
+
+        headers = dict(request.headers or {})
+        headers["DB-ACCESS-KEY"] = self._api_key
+        headers["DB-ACCESS-TIMESTAMP"] = timestamp
+        headers["DB-ACCESS-SIGN"] = signature
+        headers["Content-Type"] = "application/json"
+        request.headers = headers
+        return request
+
+    async def ws_authenticate(self, request: WSRequest) -> WSRequest:
+        timestamp = str(int(self._time_provider.time() * 1000))
+        signature = self._generate_signature(timestamp, "GET", "/realtime", "")
+        request.payload = {
+            "op": "auth",
+            "args": [self._api_key, timestamp, signature],
+        }
+        return request
+
+    def _generate_signature(self, timestamp: str, method: str, path: str, body: str) -> str:
+        message = timestamp + method + path + (body or "")
+        return hmac.new(
+            self._api_secret.encode("utf-8"),
+            message.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+
+    def add_auth_to_params(self, params: Dict[str, Any], timestamp: Optional[str] = None) -> Dict[str, Any]:
+        if timestamp is None:
+            timestamp = str(int(self._time_provider.time() * 1000))
+        params["timestamp"] = timestamp
+        return params

--- a/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_constants.py
+++ b/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_constants.py
@@ -1,0 +1,74 @@
+from hummingbot.core.api_throttler.data_types import LinkedLimitWeightPair, RateLimit
+
+DEFAULT_DOMAIN = "decibel_perpetual"
+
+DECIBEL_REST_URL = "https://api.decibel.trade"
+DECIBEL_WSS_URL = "wss://stream.decibel.trade/ws"
+
+# Public REST endpoints
+MARKETS_PATH_URL = "/v1/markets"
+MARKET_PRICES_PATH_URL = "/v1/market-prices"
+ORDER_BOOK_PATH_URL = "/v1/markets/{market_name}/orderbook"
+FUNDING_INFO_PATH_URL = "/v1/markets/{market_name}/funding"
+TRADES_PATH_URL = "/v1/trades"
+SERVER_TIME_PATH_URL = "/v1/time"
+
+# Private REST endpoints
+ACCOUNT_OVERVIEW_PATH_URL = "/v1/account/overview"
+ACCOUNT_POSITIONS_PATH_URL = "/v1/account/positions"
+OPEN_ORDERS_PATH_URL = "/v1/account/orders"
+CREATE_ORDER_PATH_URL = "/v1/orders"
+CANCEL_ORDER_PATH_URL = "/v1/orders/{order_id}"
+ORDER_STATUS_PATH_URL = "/v1/orders/{order_id}"
+FILLS_PATH_URL = "/v1/account/fills"
+FUNDING_HISTORY_PATH_URL = "/v1/account/funding-history"
+SET_LEVERAGE_PATH_URL = "/v1/account/leverage"
+
+# WebSocket channels
+WS_ORDERBOOK_CHANNEL = "orderbook"
+WS_TRADES_CHANNEL = "trades"
+WS_ORDERS_CHANNEL = "orders"
+WS_FILLS_CHANNEL = "fills"
+WS_POSITIONS_CHANNEL = "positions"
+WS_FUNDING_CHANNEL = "funding"
+
+HEARTBEAT_TIME_INTERVAL = 30.0
+
+# Rate limits
+MAX_REQUEST_WEIGHT = 1200
+NO_LIMIT_ID = "NO_LIMIT"
+REQUEST_WEIGHT_ID = "REQUEST_WEIGHT"
+
+RATE_LIMITS = [
+    RateLimit(limit_id=NO_LIMIT_ID, limit=MAX_REQUEST_WEIGHT, time_interval=60),
+    RateLimit(
+        limit_id=REQUEST_WEIGHT_ID,
+        limit=MAX_REQUEST_WEIGHT,
+        time_interval=60,
+        linked_limits=[LinkedLimitWeightPair(NO_LIMIT_ID)],
+    ),
+    # Public endpoints
+    RateLimit(limit_id=MARKETS_PATH_URL, limit=MAX_REQUEST_WEIGHT, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT_ID, 1)]),
+    RateLimit(limit_id=MARKET_PRICES_PATH_URL, limit=MAX_REQUEST_WEIGHT, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT_ID, 1)]),
+    RateLimit(limit_id=ORDER_BOOK_PATH_URL, limit=MAX_REQUEST_WEIGHT, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT_ID, 1)]),
+    RateLimit(limit_id=FUNDING_INFO_PATH_URL, limit=MAX_REQUEST_WEIGHT, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT_ID, 1)]),
+    RateLimit(limit_id=TRADES_PATH_URL, limit=MAX_REQUEST_WEIGHT, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT_ID, 1)]),
+    # Private endpoints
+    RateLimit(limit_id=ACCOUNT_OVERVIEW_PATH_URL, limit=MAX_REQUEST_WEIGHT, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT_ID, 5)]),
+    RateLimit(limit_id=ACCOUNT_POSITIONS_PATH_URL, limit=MAX_REQUEST_WEIGHT, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT_ID, 5)]),
+    RateLimit(limit_id=OPEN_ORDERS_PATH_URL, limit=MAX_REQUEST_WEIGHT, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT_ID, 5)]),
+    RateLimit(limit_id=CREATE_ORDER_PATH_URL, limit=MAX_REQUEST_WEIGHT, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT_ID, 10)]),
+    RateLimit(limit_id=CANCEL_ORDER_PATH_URL, limit=MAX_REQUEST_WEIGHT, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT_ID, 5)]),
+    RateLimit(limit_id=FILLS_PATH_URL, limit=MAX_REQUEST_WEIGHT, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT_ID, 5)]),
+]

--- a/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_derivative.py
@@ -1,0 +1,481 @@
+import asyncio
+from decimal import Decimal
+from typing import Any, Dict, List, Optional, Tuple
+
+from hummingbot.connector.derivative.decibel_perpetual import decibel_perpetual_constants as CONSTANTS
+from hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_api_order_book_data_source import (
+    DecibelPerpetualAPIOrderBookDataSource,
+)
+from hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_api_user_stream_data_source import (
+    DecibelPerpetualAPIUserStreamDataSource,
+)
+from hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_auth import DecibelPerpetualAuth
+from hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_web_utils import (
+    build_api_factory,
+    private_rest_url,
+    public_rest_url,
+)
+from hummingbot.connector.perpetual_derivative_py_base import PerpetualDerivativePyBase
+from hummingbot.connector.trading_rule import TradingRule
+from hummingbot.core.data_type.common import OrderType, PositionAction, PositionMode, PositionSide, TradeType
+from hummingbot.core.data_type.funding_info import FundingInfo
+from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState, OrderUpdate, TradeUpdate
+from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
+from hummingbot.core.data_type.perpetual_api_order_book_data_source import PerpetualAPIOrderBookDataSource
+from hummingbot.core.data_type.trade_fee import DeductedFromReturnsTradeFee, TokenAmount, TradeFeeBase
+from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
+from hummingbot.core.event.events import MarketEvent
+from hummingbot.core.utils.async_utils import safe_ensure_future
+from hummingbot.core.utils.estimate_fee import build_trade_fee
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod
+
+
+class DecibelPerpetualDerivative(PerpetualDerivativePyBase):
+    web_utils = None  # set in __init__
+
+    def __init__(
+        self,
+        client_config_map,
+        decibel_perpetual_api_key: str,
+        decibel_perpetual_api_secret: str,
+        trading_pairs: Optional[List[str]] = None,
+        trading_required: bool = True,
+        domain: str = CONSTANTS.DEFAULT_DOMAIN,
+    ):
+        self._api_key = decibel_perpetual_api_key
+        self._api_secret = decibel_perpetual_api_secret
+        self._domain = domain
+        self._trading_required = trading_required
+        self._trading_pairs = trading_pairs or []
+        self._last_trade_history_timestamp: Optional[float] = None
+        super().__init__(client_config_map)
+
+    @property
+    def authenticator(self) -> DecibelPerpetualAuth:
+        return DecibelPerpetualAuth(
+            api_key=self._api_key,
+            api_secret=self._api_secret,
+            time_provider=self._time_synchronizer,
+        )
+
+    @property
+    def name(self) -> str:
+        return "decibel_perpetual"
+
+    @property
+    def rate_limits_rules(self):
+        return CONSTANTS.RATE_LIMITS
+
+    @property
+    def domain(self) -> str:
+        return self._domain
+
+    @property
+    def client_order_id_max_length(self) -> int:
+        return 36
+
+    @property
+    def client_order_id_prefix(self) -> str:
+        return "decibel-"
+
+    @property
+    def trading_rules_request_path(self) -> str:
+        return CONSTANTS.MARKETS_PATH_URL
+
+    @property
+    def trading_pairs_request_path(self) -> str:
+        return CONSTANTS.MARKETS_PATH_URL
+
+    @property
+    def check_network_request_path(self) -> str:
+        return CONSTANTS.SERVER_TIME_PATH_URL
+
+    @property
+    def trading_pairs(self) -> List[str]:
+        return self._trading_pairs
+
+    @property
+    def is_cancel_request_in_exchange_synchronous(self) -> bool:
+        return True
+
+    @property
+    def is_trading_required(self) -> bool:
+        return self._trading_required
+
+    @property
+    def funding_fee_poll_interval(self) -> int:
+        return 120
+
+    @property
+    def supported_position_modes(self) -> List[PositionMode]:
+        return [PositionMode.ONEWAY, PositionMode.HEDGE]
+
+    def supported_order_types(self) -> List[OrderType]:
+        return [OrderType.LIMIT, OrderType.MARKET, OrderType.LIMIT_MAKER]
+
+    def get_buy_collateral_token(self, trading_pair: str) -> str:
+        _, quote = self.split_trading_pair(trading_pair)
+        return quote
+
+    def get_sell_collateral_token(self, trading_pair: str) -> str:
+        _, quote = self.split_trading_pair(trading_pair)
+        return quote
+
+    def _is_request_exception_related_to_time_synchronizer(self, request_exception: Exception) -> bool:
+        error_description = str(request_exception)
+        return "timestamp" in error_description.lower() or "expired" in error_description.lower()
+
+    def _create_web_assistants_factory(self):
+        return build_api_factory(
+            throttler=self._throttler,
+            time_synchronizer=self._time_synchronizer,
+            auth=self.authenticator,
+        )
+
+    def _create_order_book_data_source(self) -> PerpetualAPIOrderBookDataSource:
+        return DecibelPerpetualAPIOrderBookDataSource(
+            trading_pairs=self._trading_pairs,
+            connector=self,
+            api_factory=self._web_assistants_factory,
+            domain=self._domain,
+        )
+
+    def _create_user_stream_data_source(self) -> UserStreamTrackerDataSource:
+        return DecibelPerpetualAPIUserStreamDataSource(
+            auth=self.authenticator,
+            trading_pairs=self._trading_pairs,
+            connector=self,
+            api_factory=self._web_assistants_factory,
+            domain=self._domain,
+        )
+
+    def _get_fee(self, base_currency, quote_currency, order_type, order_side, amount, price=None, is_maker=None):
+        is_maker = order_type is OrderType.LIMIT_MAKER
+        return build_trade_fee(
+            self.name,
+            is_maker,
+            base_currency=base_currency,
+            quote_currency=quote_currency,
+            order_type=order_type,
+            order_side=order_side,
+            amount=amount,
+            price=price,
+        )
+
+    async def _place_order(
+        self, order_id, trading_pair, amount, trade_type, order_type, price, position_action=PositionAction.OPEN, **kwargs
+    ) -> Tuple[str, float]:
+        exchange_symbol = await self.exchange_symbol_associated_to_pair(trading_pair)
+        side = "buy" if trade_type == TradeType.BUY else "sell"
+        order_type_str = "limit" if order_type in (OrderType.LIMIT, OrderType.LIMIT_MAKER) else "market"
+        reduce_only = position_action == PositionAction.CLOSE
+
+        body = {
+            "market": exchange_symbol,
+            "side": side,
+            "type": order_type_str,
+            "size": str(amount),
+            "clientId": order_id,
+            "reduceOnly": reduce_only,
+        }
+        if order_type_str == "limit":
+            body["price"] = str(price)
+        if order_type == OrderType.LIMIT_MAKER:
+            body["postOnly"] = True
+
+        rest_assistant = await self._web_assistants_factory.get_rest_assistant()
+        response = await rest_assistant.execute_request(
+            url=private_rest_url(CONSTANTS.CREATE_ORDER_PATH_URL),
+            method=RESTMethod.POST,
+            data=body,
+            is_auth_required=True,
+            throttler_limit_id=CONSTANTS.CREATE_ORDER_PATH_URL,
+        )
+        data = response.get("data", response)
+        exchange_order_id = str(data.get("id", data.get("orderId", "")))
+        transact_time = float(data.get("createdAt", self._time_synchronizer.time() * 1000)) / 1000.0
+        return exchange_order_id, transact_time
+
+    async def _place_cancel(self, order_id: str, tracked_order: InFlightOrder):
+        exchange_order_id = await tracked_order.get_exchange_order_id()
+        rest_assistant = await self._web_assistants_factory.get_rest_assistant()
+        path = CONSTANTS.CANCEL_ORDER_PATH_URL.format(order_id=exchange_order_id)
+        await rest_assistant.execute_request(
+            url=private_rest_url(path),
+            method=RESTMethod.DELETE,
+            is_auth_required=True,
+            throttler_limit_id=CONSTANTS.CANCEL_ORDER_PATH_URL,
+        )
+        return True
+
+    async def _format_trading_rules(self, exchange_info_dict: Dict[str, Any]) -> List[TradingRule]:
+        trading_rules = []
+        markets = exchange_info_dict if isinstance(exchange_info_dict, list) else exchange_info_dict.get("data", [])
+        for market in markets:
+            try:
+                trading_pair = await self.trading_pair_associated_to_exchange_symbol(market.get("name", ""))
+                trading_rules.append(
+                    TradingRule(
+                        trading_pair=trading_pair,
+                        min_order_size=Decimal(str(market.get("minOrderSize", "0.001"))),
+                        max_order_size=Decimal(str(market.get("maxOrderSize", "1000000"))),
+                        min_price_increment=Decimal(str(market.get("priceIncrement", "0.01"))),
+                        min_base_amount_increment=Decimal(str(market.get("sizeIncrement", "0.001"))),
+                        min_notional_size=Decimal(str(market.get("minNotional", "10"))),
+                        buy_order_collateral_token=market.get("quoteCurrency", "USD"),
+                        sell_order_collateral_token=market.get("quoteCurrency", "USD"),
+                    )
+                )
+            except Exception:
+                self.logger().exception(f"Error parsing trading rules for {market}")
+        return trading_rules
+
+    async def _status_polling_loop_fetch_updates(self):
+        await asyncio.gather(
+            self._update_order_fills_from_trades(),
+            self._update_order_status(),
+            self._update_positions(),
+        )
+
+    async def _update_trading_fees(self):
+        pass  # Use static defaults from utils.py
+
+    async def _user_stream_event_listener(self):
+        async for event_message in self._iter_user_event_queue():
+            try:
+                channel = event_message.get("channel", "")
+                data = event_message.get("data", {})
+                if CONSTANTS.WS_ORDERS_CHANNEL in channel:
+                    await self._process_order_event(data)
+                elif CONSTANTS.WS_FILLS_CHANNEL in channel:
+                    await self._process_fill_event(data)
+                elif CONSTANTS.WS_POSITIONS_CHANNEL in channel:
+                    await self._process_position_event(data)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                self.logger().error(f"Error in user stream event listener: {e}", exc_info=True)
+
+    async def _process_order_event(self, data: Dict[str, Any]):
+        client_order_id = data.get("clientId", "")
+        exchange_order_id = str(data.get("id", ""))
+        status_str = data.get("status", "").lower()
+        status_map = {
+            "open": OrderState.OPEN,
+            "new": OrderState.OPEN,
+            "partial": OrderState.PARTIALLY_FILLED,
+            "filled": OrderState.FILLED,
+            "cancelled": OrderState.CANCELLED,
+            "canceled": OrderState.CANCELLED,
+            "rejected": OrderState.FAILED,
+        }
+        order_state = status_map.get(status_str, OrderState.OPEN)
+        tracked = self._order_tracker.fetch_order(client_order_id=client_order_id) or                   self._order_tracker.fetch_order(exchange_order_id=exchange_order_id)
+        if tracked:
+            update = OrderUpdate(
+                trading_pair=tracked.trading_pair,
+                update_timestamp=float(data.get("updatedAt", self._time_synchronizer.time() * 1000)) / 1000.0,
+                new_state=order_state,
+                client_order_id=client_order_id,
+                exchange_order_id=exchange_order_id,
+            )
+            self._order_tracker.process_order_update(update)
+
+    async def _process_fill_event(self, data: Dict[str, Any]):
+        exchange_order_id = str(data.get("orderId", ""))
+        tracked = self._order_tracker.fetch_order(exchange_order_id=exchange_order_id)
+        if not tracked:
+            return
+        fee = TradeFeeBase.new_perpetual_fee(
+            fee_schema=self._trade_fee_schema(),
+            position_action=PositionAction.OPEN,
+            percent_token=tracked.quote_asset,
+            flat_fees=[TokenAmount(amount=Decimal(str(data.get("fee", 0))), token=tracked.quote_asset)],
+        )
+        update = TradeUpdate(
+            trade_id=str(data.get("id", "")),
+            client_order_id=tracked.client_order_id,
+            exchange_order_id=exchange_order_id,
+            trading_pair=tracked.trading_pair,
+            fee=fee,
+            fill_price=Decimal(str(data.get("price", 0))),
+            fill_base_amount=Decimal(str(data.get("size", 0))),
+            fill_quote_amount=Decimal(str(data.get("price", 0))) * Decimal(str(data.get("size", 0))),
+            fill_timestamp=float(data.get("createdAt", self._time_synchronizer.time() * 1000)) / 1000.0,
+        )
+        self._order_tracker.process_trade_update(update)
+
+    async def _process_position_event(self, data: Dict[str, Any]):
+        pass  # Handled by polling _update_positions
+
+    async def _all_trade_updates_for_order(self, order: InFlightOrder) -> List[TradeUpdate]:
+        rest_assistant = await self._web_assistants_factory.get_rest_assistant()
+        response = await rest_assistant.execute_request(
+            url=private_rest_url(CONSTANTS.FILLS_PATH_URL),
+            method=RESTMethod.GET,
+            params={"orderId": await order.get_exchange_order_id()},
+            is_auth_required=True,
+            throttler_limit_id=CONSTANTS.FILLS_PATH_URL,
+        )
+        fills = response.get("data", response) if isinstance(response, dict) else response
+        trades = []
+        for fill in (fills if isinstance(fills, list) else []):
+            fee = TradeFeeBase.new_perpetual_fee(
+                fee_schema=self._trade_fee_schema(),
+                position_action=PositionAction.OPEN,
+                percent_token=order.quote_asset,
+                flat_fees=[TokenAmount(amount=Decimal(str(fill.get("fee", 0))), token=order.quote_asset)],
+            )
+            trades.append(TradeUpdate(
+                trade_id=str(fill.get("id", "")),
+                client_order_id=order.client_order_id,
+                exchange_order_id=str(fill.get("orderId", "")),
+                trading_pair=order.trading_pair,
+                fee=fee,
+                fill_price=Decimal(str(fill.get("price", 0))),
+                fill_base_amount=Decimal(str(fill.get("size", 0))),
+                fill_quote_amount=Decimal(str(fill.get("price", 0))) * Decimal(str(fill.get("size", 0))),
+                fill_timestamp=float(fill.get("createdAt", self._time_synchronizer.time() * 1000)) / 1000.0,
+            ))
+        return trades
+
+    async def _request_order_status(self, tracked_order: InFlightOrder) -> OrderUpdate:
+        exchange_order_id = await tracked_order.get_exchange_order_id()
+        rest_assistant = await self._web_assistants_factory.get_rest_assistant()
+        path = CONSTANTS.ORDER_STATUS_PATH_URL.format(order_id=exchange_order_id)
+        response = await rest_assistant.execute_request(
+            url=private_rest_url(path),
+            method=RESTMethod.GET,
+            is_auth_required=True,
+            throttler_limit_id=CONSTANTS.OPEN_ORDERS_PATH_URL,
+        )
+        data = response.get("data", response)
+        status_str = data.get("status", "").lower()
+        status_map = {
+            "open": OrderState.OPEN, "new": OrderState.OPEN,
+            "partial": OrderState.PARTIALLY_FILLED,
+            "filled": OrderState.FILLED,
+            "cancelled": OrderState.CANCELLED, "canceled": OrderState.CANCELLED,
+            "rejected": OrderState.FAILED,
+        }
+        return OrderUpdate(
+            client_order_id=tracked_order.client_order_id,
+            exchange_order_id=exchange_order_id,
+            trading_pair=tracked_order.trading_pair,
+            update_timestamp=float(data.get("updatedAt", self._time_synchronizer.time() * 1000)) / 1000.0,
+            new_state=status_map.get(status_str, OrderState.OPEN),
+        )
+
+    async def _update_balances(self):
+        rest_assistant = await self._web_assistants_factory.get_rest_assistant()
+        response = await rest_assistant.execute_request(
+            url=private_rest_url(CONSTANTS.ACCOUNT_OVERVIEW_PATH_URL),
+            method=RESTMethod.GET,
+            is_auth_required=True,
+            throttler_limit_id=CONSTANTS.ACCOUNT_OVERVIEW_PATH_URL,
+        )
+        data = response.get("data", response)
+        self._account_available_balances.clear()
+        self._account_balances.clear()
+        for asset, info in data.get("collateral", {}).items():
+            total = Decimal(str(info.get("value", 0)))
+            free = Decimal(str(info.get("freeCollateral", total)))
+            self._account_balances[asset] = total
+            self._account_available_balances[asset] = free
+        # Also handle flat balance response
+        for balance_entry in data.get("balances", []):
+            asset = balance_entry.get("currency", balance_entry.get("asset", ""))
+            total = Decimal(str(balance_entry.get("total", balance_entry.get("balance", 0))))
+            free = Decimal(str(balance_entry.get("free", balance_entry.get("availableBalance", total))))
+            self._account_balances[asset] = total
+            self._account_available_balances[asset] = free
+
+    async def _initialize_trading_pair_symbols_from_exchange_info(self, exchange_info: Dict[str, Any]):
+        mapping = {}
+        markets = exchange_info if isinstance(exchange_info, list) else exchange_info.get("data", [])
+        for market in markets:
+            symbol = market.get("name", "")
+            base = market.get("baseCurrency", symbol.split("-")[0] if "-" in symbol else symbol)
+            quote = market.get("quoteCurrency", "USD")
+            trading_pair = f"{base}-{quote}"
+            mapping[symbol] = trading_pair
+        self._set_trading_pair_symbol_map(mapping)
+
+    async def _get_last_traded_price(self, trading_pair: str) -> float:
+        prices = await self._order_book_data_source.get_last_traded_prices([trading_pair])
+        return prices.get(trading_pair, 0.0)
+
+    async def _update_positions(self):
+        rest_assistant = await self._web_assistants_factory.get_rest_assistant()
+        response = await rest_assistant.execute_request(
+            url=private_rest_url(CONSTANTS.ACCOUNT_POSITIONS_PATH_URL),
+            method=RESTMethod.GET,
+            is_auth_required=True,
+            throttler_limit_id=CONSTANTS.ACCOUNT_POSITIONS_PATH_URL,
+        )
+        positions = response.get("data", response)
+        if not isinstance(positions, list):
+            positions = [positions]
+        for pos_data in positions:
+            trading_pair = await self.trading_pair_associated_to_exchange_symbol(pos_data.get("market", ""))
+            size = Decimal(str(pos_data.get("netSize", pos_data.get("size", 0))))
+            side = PositionSide.LONG if size >= 0 else PositionSide.SHORT
+            entry_price = Decimal(str(pos_data.get("entryPrice", 0) or 0))
+            unrealized_pnl = Decimal(str(pos_data.get("unrealizedPnl", 0) or 0))
+            leverage = Decimal(str(pos_data.get("leverage", 1) or 1))
+            if trading_pair:
+                position_key = self._perpetual_trading.position_key(trading_pair, side)
+                if abs(size) > Decimal("0"):
+                    self._perpetual_trading.set_position(
+                        position_key,
+                        amount=abs(size),
+                        entry_price=entry_price,
+                        unrealized_pnl=unrealized_pnl,
+                        leverage=leverage,
+                        position_side=side,
+                    )
+
+    async def _set_trading_pair_leverage(self, trading_pair: str, leverage: int) -> Tuple[bool, str]:
+        exchange_symbol = await self.exchange_symbol_associated_to_pair(trading_pair)
+        rest_assistant = await self._web_assistants_factory.get_rest_assistant()
+        try:
+            await rest_assistant.execute_request(
+                url=private_rest_url(CONSTANTS.SET_LEVERAGE_PATH_URL),
+                method=RESTMethod.POST,
+                data={"market": exchange_symbol, "leverage": leverage},
+                is_auth_required=True,
+                throttler_limit_id=CONSTANTS.ACCOUNT_OVERVIEW_PATH_URL,
+            )
+            return True, ""
+        except Exception as e:
+            return False, str(e)
+
+    async def _fetch_last_fee_payment(self, trading_pair: str) -> Tuple[int, Decimal, Decimal]:
+        exchange_symbol = await self.exchange_symbol_associated_to_pair(trading_pair)
+        rest_assistant = await self._web_assistants_factory.get_rest_assistant()
+        response = await rest_assistant.execute_request(
+            url=private_rest_url(CONSTANTS.FUNDING_HISTORY_PATH_URL),
+            method=RESTMethod.GET,
+            params={"market": exchange_symbol, "limit": 1},
+            is_auth_required=True,
+            throttler_limit_id=CONSTANTS.FILLS_PATH_URL,
+        )
+        payments = response.get("data", [])
+        if not payments:
+            return 0, Decimal("0"), Decimal("0")
+        latest = payments[0]
+        ts = int(float(latest.get("time", 0)) * 1000 if float(latest.get("time", 0)) < 1e12 else latest.get("time", 0))
+        rate = Decimal(str(latest.get("rate", 0)))
+        payment = Decimal(str(latest.get("payment", 0)))
+        return ts, rate, payment
+
+    async def _update_order_fills_from_trades(self):
+        pass  # Handled via WebSocket fills + REST fallback in _all_trade_updates_for_order
+
+    async def _update_order_status(self):
+        open_orders = list(self._order_tracker.active_orders.values())
+        tasks = [self._request_order_status(order) for order in open_orders]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        for update in results:
+            if isinstance(update, OrderUpdate):
+                self._order_tracker.process_order_update(update)

--- a/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_utils.py
+++ b/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_utils.py
@@ -1,0 +1,49 @@
+from decimal import Decimal
+from typing import Any, Dict
+
+from pydantic import Field, SecretStr
+
+import hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_constants as CONSTANTS
+from hummingbot.client.config.config_data_types import BaseConnectorConfigMap, ClientFieldData
+from hummingbot.core.data_type.trade_fee import TradeFeeSchema
+
+DEFAULT_FEES = TradeFeeSchema(
+    maker_percent_fee_decimal=Decimal("0.0002"),   # 0.02% maker
+    taker_percent_fee_decimal=Decimal("0.0005"),   # 0.05% taker
+)
+
+CENTRALIZED = True
+EXAMPLE_PAIR = "BTC-USD"
+
+
+def is_exchange_information_valid(exchange_info: Dict[str, Any]) -> bool:
+    """Check if a market is active and tradeable."""
+    return exchange_info.get("status", "").lower() in ("active", "online", "trading")
+
+
+class DecibelPerpetualConfigMap(BaseConnectorConfigMap):
+    connector: str = Field(default="decibel_perpetual", const=True, client_data=None)
+    decibel_perpetual_api_key: SecretStr = Field(
+        default=...,
+        client_data=ClientFieldData(
+            prompt=lambda cm: "Enter your Decibel Perpetual API key",
+            is_secure=True,
+            is_connect_key=True,
+            prompt_on_new=True,
+        ),
+    )
+    decibel_perpetual_api_secret: SecretStr = Field(
+        default=...,
+        client_data=ClientFieldData(
+            prompt=lambda cm: "Enter your Decibel Perpetual API secret",
+            is_secure=True,
+            is_connect_key=True,
+            prompt_on_new=True,
+        ),
+    )
+
+    class Config:
+        title = "decibel_perpetual"
+
+
+KEYS = DecibelPerpetualConfigMap.construct()

--- a/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_web_utils.py
+++ b/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_web_utils.py
@@ -1,0 +1,55 @@
+from typing import Callable, Optional
+
+import hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_constants as CONSTANTS
+from hummingbot.connector.time_synchronizer import TimeSynchronizer
+from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from hummingbot.core.web_assistant.auth import AuthBase
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+
+
+def public_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:
+    return CONSTANTS.DECIBEL_REST_URL + path_url
+
+
+def private_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:
+    return CONSTANTS.DECIBEL_REST_URL + path_url
+
+
+def build_api_factory(
+    throttler: Optional[AsyncThrottler] = None,
+    time_synchronizer: Optional[TimeSynchronizer] = None,
+    time_provider: Optional[Callable] = None,
+    auth: Optional[AuthBase] = None,
+) -> WebAssistantsFactory:
+    throttler = throttler or create_throttler()
+    api_factory = WebAssistantsFactory(throttler=throttler, auth=auth)
+    return api_factory
+
+
+def build_api_factory_without_time_synchronizer_pre_processor(
+    throttler: AsyncThrottler,
+) -> WebAssistantsFactory:
+    return WebAssistantsFactory(throttler=throttler)
+
+
+def create_throttler() -> AsyncThrottler:
+    return AsyncThrottler(CONSTANTS.RATE_LIMITS)
+
+
+async def get_current_server_time(
+    throttler: Optional[AsyncThrottler] = None,
+    domain: str = CONSTANTS.DEFAULT_DOMAIN,
+) -> float:
+    throttler = throttler or create_throttler()
+    api_factory = build_api_factory_without_time_synchronizer_pre_processor(throttler=throttler)
+    rest_assistant = await api_factory.get_rest_assistant()
+    response = await rest_assistant.execute_request(
+        url=public_rest_url(path_url=CONSTANTS.SERVER_TIME_PATH_URL, domain=domain),
+        method=RESTMethod.GET,
+        throttler_limit_id=CONSTANTS.SERVER_TIME_PATH_URL,
+    )
+    server_time = response.get("serverTime") or response.get("timestamp") or (
+        __import__("time").time() * 1000
+    )
+    return float(server_time) / 1000.0

--- a/hummingbot/connector/derivative/grvt_perpetual/grvt_perpetual_api_order_book_data_source.py
+++ b/hummingbot/connector/derivative/grvt_perpetual/grvt_perpetual_api_order_book_data_source.py
@@ -1,0 +1,246 @@
+"""
+Public order book data source for the GRVT PerVetual connector.
+Handles REST snapshots and WebSocket deltas for order book, trades, and funding.
+"""
+import asyncio
+import logging
+import time
+from collections import defaultdict
+from decimal import Decimal
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+
+from hummingbot.connector.derivative.grvt_perpetual import grvt_perpetual_constants as CONSTANTS
+from hummingbot.connector.derivative.grvt_perpetual.grvt_perpetual_web_utils import (
+    public_rest_url,
+    trading_pair_to_instrument,
+    instrument_to_trading_pair,
+)
+from hummingbot.core.data_type.funding_info import FundingInfo
+from hummingbot.core.data_type.order_book import OrderBook
+from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
+from hummingbot.core.data_type.perpetual_api_order_book_data_source import PerpetualAPIOrderBookDataSource
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+
+
+class GrvtPerpetualAPIOrderBookDataSource(PerpetualAPIOrderBookDataSource):
+    _logger: Optional[logging.Logger] = None
+    HEARTBEAT_INTERVAL = 30.0
+    ONE_HOUR = 60 * 60
+
+    def __init__(
+        self,
+        trading_pairs: List[str],
+        connector,
+        api_factory: WebAssistantsFactory,
+        domain: str = CONSTANTS.DEFAULT_DOMAIN,
+    ):
+        super().__init__(trading_pairs)
+        self._connector = connector
+        self._api_factory = api_factory
+        self._domain = domain
+        self._trading_pairs = trading_pairs
+        self._message_queue: Dict[str, asyncio.Queue] = defaultdict(asyncio.Queue)
+
+    @classmethod
+    def logger(cls) -> logging.Logger:
+        if cls._logger is None:
+            cls._logger = logging.getLogger(__name__)
+        return cls._logger
+
+    # └ Snapshot └└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└
+    async def get_last_traded_prices(self, trading_pairs: List[str], domain: str = None) -> Dict[str, float]:
+        result = {}
+        for pair in trading_pairs:
+            instrument = trading_pair_to_instrument(pair)
+            url = public_rest_url(CONSTANTS.TICKER_PATH, domain or self._domain)
+            rest = await self._api_factory.get_rest_assistant()
+            resp = await rest.execute_request(
+                url=url,
+                data={"instrument": instrument},
+                method=RESTMethod.POST,
+                throttler_limit_id=CONSTANTS.TICKER_PATH,
+            )
+            tickers = resp.get("result", {}).get("tickers", [])
+            if tickers:
+                result[pair] = float(tickers[0].get("mark_price", 0))
+        return result
+
+    async def get_funding_info(self, trading_pair: str) -> FundingInfo:
+        instrument = trading_pair_to_instrument(trading_pair)
+        url = public_rest_url(CONSTANTS.FUNDING_RATE_PATH, self._domain)
+        rest = await self._api_factory.get_rest_assistant()
+        resp = await rest.execute_request(
+            url=url,
+            data={"instrument": instrument, "limit": 1},
+            method=RESTMethod.POST,
+            throttler_limit_id=CONSTANTS.FUNDING_RATE_PATH,
+        )
+        entries = resp.get("result", {}).get("entries", [])
+        if entries:
+            e = entries[0]
+            return FundingInfo(
+                trading_pair=trading_pair,
+                index_price=Decimal(str(e.get("index_price", 0))),
+                mark_price=Decimal(str(e.get("mark_price", 0))),
+                next_funding_utc_timestamp=int(e.get("funding_time", int(time.time() * 1e9)) / 1e9),
+                rate=Decimal(str(e.get("funding_rate", 0))),
+            )
+        return FundingInfo(
+            trading_pair=trading_pair,
+            index_price=Decimal("0"),
+            mark_price=Decimal("0"),
+            next_funding_utc_timestamp=int(time.time()) + 3600,
+            rate=Decimal("0"),
+        )
+
+    async def get_new_order_book(self, trading_pair: str) -> OrderBook:
+        snapshot_msg = await self._order_book_snapshot(trading_pair)
+        order_book = self.order_book_create_function()
+        order_book.apply_snapshot(snapshot_msg.bids, snapshot_msg.asks, snapshot_msg.update_id)
+        return order_book
+
+    async def _order_book_snapshot(self, trading_pair: str) -> OrderBookMessage:
+        instrument = trading_pair_to_instrument(trading_pair)
+        url = public_rest_url(CONSTANTS.ORDERBOOK_LEVELS_PATH, self._domain)
+        rest = await self._api_factory.get_rest_assistant()
+        resp = await rest.execute_request(
+            url=url,
+            data={"instrument": instrument, "depth": 40},
+            method=RESTMethod.POST,
+            throttler_limit_id=CONSTANTS.ORDERAOOK_LEVELSEPATH_,
+        )
+        book = resp.get("result", {}).get("book", {})
+        bids = [[Decimal(str(p)), Decimal(str(s))] for p, s in book.get("bids", [])]
+        asks = [[Decimal(str(p)), Decimal(str(s))] for p, s in book.get("asks", [])]
+        ts = int(time.time() * 1e3)
+        return OrderBookMessage(
+            message_type=OrderBookMessageType.SNAPSHOT,
+            content={"trading_pair": trading_pair, "update_id": ts, "bids": bids, "asks": asks},
+            timestamp=ts * 1e-3,
+        )
+
+    # └ WebSocket └└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└
+    async def listen_for_subscriptions(self):
+        ws_url = CONSTANTS.WS_URLS[self._domain]
+        while True:
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.ws_connect(ws_url) as ws:
+                        for pair in self._trading_pairs:
+                            instrument = trading_pair_to_instrument(pair)
+                            for channel, feed in [
+                                (CONSTANTS.WS_ORDER_BOOK_CHANNEL, f"{instrument}@40-1-10"),
+                                (CONSTANTS.WS_TRADES_CHANNEL, instrument),
+                                (CONSTANTS.WS_FUNDING_CHANNEL, instrument),
+                            ]:
+                                await ws.send_json({
+                                    "stream": channel,
+                                    "feed": [feed],
+                                    "method": "subscribe",
+                                    "is_full": True,
+                                })
+
+                        async for msg in ws:
+                            if msg.type == aiohttp.WSMsgType.TEXT:
+                                data = msg.json()
+                                stream = data.get("stream", "")
+                                if stream in (CONSTANTS.WS_ORDER_BOOK_CHANNEL,):
+                                    await self._message_queue[self._diff_messages_queue_key].put(data)
+                                elif stream == CONSTANTS.WS_TRADES_CHANNEL:
+                                    await self._message_queue[self._trade_messages_queue_key].put(data)
+                                elif stream == CONSTANTS.WS_FUNDING_CHANNEL:
+                                    await self._message_queue[self._funding_info_messages_queue_key].put(data)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                self.logger().error(f"GRVT WS error: {e}. Reconnecting in 5s.")
+                await asyncio.sleep(5)
+
+    async def listen_for_order_book_diffs(self, ev_loop, output: asyncio.Queue):
+        while True:
+            msg = await self._message_queue[self._diff_messages_queue_key].get()
+            try:
+                parsed = self._parse_order_book_diff_message(msg)
+                await output.put(parsed)
+            except Exception as e:
+                self.logger().error(f"Error parsing OB diff: {e}", exc_info=True)
+
+    async def listen_for_order_book_snapshots(self, ev_loop, output: asyncio.Queue):
+        while True:
+            for pair in self._trading_pairs:
+                try:
+                    snapshot = await self._order_book_snapshot(pair)
+                    await output.put(snapshot)
+                except Exception as e:
+                    self.logger().error(f"Error fetching OB snapshot for {pair}: {e}")
+            await asyncio.sleep(self.ONE_HOUR)
+
+    async def listen_for_trades(self, ev_loop, output: asyncio.Queue):
+        while True:
+            msg = await self._message_queue[self._trade_messages_queue_key].get()
+            try:
+                parsed = self._parse_trade_message(msg)
+                await output.put(parsed)
+            except Exception as e:
+                self.logger().error(f"Error parsing trade: {e}", exc_info=True)
+
+    async def listen_for_funding_info(self, output: asyncio.Queue):
+        while True:
+            msg = await self._message_queue[self._funding_info_messages_queue_key].get()
+            try:
+                parsed = self._parse_funding_info_message(msg)
+                await output.put(parsed)
+            except Exception as e:
+                self.logger().error(f"Error parsing funding info: {e}", exc_info=True)
+
+    # └ Parsers └└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└└
+    def _parse_order_book_diff_message(self, raw: Dict) -> OrderBookMessage:
+        feed = raw.get("feed", {})
+        selector = raw.get("selector", "")
+        instrument = selector.split("@")[0] if "@" in selector else selector
+        trading_pair = instrument_to_trading_pair(instrument)
+        seq = int(raw.get("sequence_number", 0))
+        bids = [[Decimal(str(p)), Decimal(str(s))] for p, s in feed.get("bids", [])]
+        asks = [[Decimal(str(p)), Decimal(str(s))] for p, s in feed.get("asks", [])]
+        ts = int(feed.get("event_time", time.time() * 1e9)) / 1e9
+        msg_type = OrderBookMessageType.SNAPSHOT if seq == 0 else OrderBookMessageType.DIFF
+        return OrderBookMessage(
+            message_type=msg_type,
+            content={"trading_pair": trading_pair, "update_id": seq, "bids": bids, "asks": asks},
+            timestamp=ts,
+        )
+
+    def _parse_trade_message(self, raw: Dict) -> OrderBookMessage:
+        feed = raw.get("feed", {})
+        selector = raw.get("selector", "")
+        instrument = selector.split("@")[0] if "@" in selector else selector
+        trading_pair = instrument_to_trading_pair(instrument)
+        ts = int(feed.get("event_time", time.time() * 1e9)) / 1e9
+        return OrderBookMessage(
+            message_type=OrderBookMessageType.TRADE,
+            content={
+                "trading_pair": trading_pair,
+                "trade_type": float(1 if feed.get("is_taker_buyer", True) else 2),
+                "trade_id": str(feed.get("event_time", ts)),
+                "update_id": int(ts),
+                "price": str(feed.get("price", "0")),
+                "amount": str(feed.get("size", "0")),
+            },
+            timestamp=ts,
+        )
+
+    def _parse_funding_info_message(self, raw: Dict) -> FundingInfo:
+        feed = raw.get("feed", {})
+        selector = raw.get("selector", "")
+        instrument = selector.split("@")[0] if "@" in selector else selector
+        trading_pair = instrument_to_trading_pair(instrument)
+        return FundingInfo(
+            trading_pair=trading_pair,
+            index_price=Decimal(str(feed.get("index_price", 0))),
+            mark_price=Decimal(str(feed.get("mark_price", 0))),
+            next_funding_utc_timestamp=int(feed.get("funding_time", int(time.time() * 1e9)) / 1e9),
+            rate=Decimal(str(feed.get("funding_rate", 0))),
+        )

--- a/hummingbot/connector/derivative/grvt_perpetual/grvt_perpetual_api_user_stream_data_source.py
+++ b/hummingbot/connector/derivative/grvt_perpetual/grvt_perpetual_api_user_stream_data_source.py
@@ -1,0 +1,68 @@
+"""
+Private user stream data source for the GRVT Perpetual connector.
+Handles authenticated WebSocket streams for orders, fills, and positions.
+"""
+import asyncio
+import logging
+from typing import Optional
+
+import aiohttp
+
+from hummingbot.connector.derivative.grvt_perpetual import grvt_perpetual_constants as CONSTANTS
+from hummingbot.connector.derivative.grvt_perpetual.grvt_perpetual_auth import GrvtPerpetualAuth
+from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
+
+
+class GrvtPerpetualAPIUserStreamDataSource(UserStreamTrackerDataSource):
+    _logger: Optional[logging.Logger] = None
+    HEARTBEAT_INTERVAL = 30.0
+
+    def __init__(
+        self,
+        auth: GrvtPerpetualAuth,
+        trading_pairs=None,
+        domain: str = CONSTANTS.DEFAULT_DOMAIN,
+    ):
+        super().__init__()
+        self._auth = auth
+        self._trading_pairs = trading_pairs or []
+        self._domain = domain
+
+    @classmethod
+    def logger(cls) -> logging.Logger:
+        if cls._logger is None:
+            cls._logger = logging.getLogger(__name__)
+        return cls._logger
+
+    async def listen_for_user_stream(self, output: asyncio.Queue):
+        ws_url = CONSTANTS.PRIVATE_WS_URLS[self._domain]
+        while True:
+            try:
+                headers = self._auth.get_auth_headers()
+                async with aiohttp.ClientSession(headers=headers) as session:
+                    async with session.ws_connect(ws_url) as ws:
+                        # Subscribe to private streams
+                        for channel in [
+                            CONSTANTS.WS_ORDERS_CHANNEL,
+                            CONSTANTS.WS_FILLS_CHANNEL,
+                            CONSTANTS.WS_POSITIONS_CHANNEL,
+                        ]:
+                            await ws.send_json({
+                                "stream": channel,
+                                "feed": [],
+                                "method": "subscribe",
+                                "is_full": True,
+                            })
+
+                        async for msg in ws:
+                            if msg.type == aiohttp.WSMsgType.TEXT:
+                                data = msg.json()
+                                await output.put(data)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                self.logger().error(f"GRVT private WS error: {e}. Reconnecting in 5s.")
+                await asyncio.sleep(5)
+
+    async def _connected_websocket_assistant(self):
+        pass  # Handled in listen_for_user_stream

--- a/hummingbot/connector/derivative/grvt_perpetual/grvt_perpetual_auth.py
+++ b/hummingbot/connector/derivative/grvt_perpetual/grvt_perpetual_auth.py
@@ -1,0 +1,95 @@
+"""
+Authentication for the GRVT Perpetual connector.
+
+GRVT uses session-cookie-based authentication:
+1. POST /auth/api_key/login with api_key in body
+2. Response sets a `gravity=...` session cookie + X-Grvt-Account-Id header
+3. All subsequent private REST calls must include:
+   - Cookie: gravity=<token>
+   - X-Grvt-Account-Id: <sub_account_id>
+4. Private WS: connect with same cookie + header (or ?x_grvt_account_id= query param)
+
+Ref: https://api-docs.grvt.io
+"""
+import time
+from typing import Any, Dict, Optional
+
+from hummingbot.connector.time_synchronizer import TimeSynchronizer
+from hummingbot.core.web_assistant.auth import AuthBase
+from hummingbot.core.web_assistant.connections.data_types import RESTRequest, WSRequest
+
+
+class GrvtPerpetualAuth(AuthBase):
+    def __init__(
+        self,
+        api_key: str,
+        sub_account_id: str,
+        time_provider: TimeSynchronizer,
+        domain: str = "prod",
+    ):
+        self._api_key = api_key
+        self._sub_account_id = sub_account_id
+        self._time_provider = time_provider
+        self._domain = domain
+
+        # Populated after login
+        self._session_cookie: Optional[str] = None
+        self._account_id: Optional[str] = None
+
+    # ── Properties ─────────────────────────────────────────────────────────────
+    @property
+    def api_key(self) -> str:
+        return self._api_key
+
+    @property
+    def sub_account_id(self) -> str:
+        return self._sub_account_id
+
+    @property
+    def session_cookie(self) -> Optional[str]:
+        return self._session_cookie
+
+    @session_cookie.setter
+    def session_cookie(self, value: str):
+        self._session_cookie = value
+
+    @property
+    def account_id(self) -> Optional[str]:
+        return self._account_id
+
+    @account_id.setter
+    def account_id(self, value: str):
+        self._account_id = value
+
+    def is_authenticated(self) -> bool:
+        return self._session_cookie is not None and self._account_id is not None
+
+    # ── AuthBase methods ────────────────────────────────────────────────────────
+    async def rest_authenticate(self, request: RESTRequest) -> RESTRequest:
+        """Inject auth headers into private REST request."""
+        if self.is_authenticated():
+            request.headers = request.headers or {}
+            request.headers["Cookie"] = f"gravity={self._session_cookie}"
+            request.headers["X-Grvt-Account-Id"] = self._account_id
+        return request
+
+    async def ws_authenticate(self, request: WSRequest) -> WSRequest:
+        """Inject auth headers into private WS handshake."""
+        if self.is_authenticated():
+            request.additional_headers = request.additional_headers or {}
+            request.additional_headers["Cookie"] = f"gravity={self._session_cookie}"
+            request.additional_headers["X-Grvt-Account-Id"] = self._account_id
+        return request
+
+    def get_auth_payload(self) -> Dict[str, Any]:
+        """Payload for the login endpoint."""
+        return {"api_key": self._api_key}
+
+    def get_auth_headers(self) -> Dict[str, str]:
+        """Headers for private REST calls (after login)."""
+        if not self.is_authenticated():
+            return {}
+        return {
+            "Cookie": f"gravity={self._session_cookie}",
+            "X-Grvt-Account-Id": self._account_id,
+        }

--- a/hummingbot/connector/derivative/grvt_perpetual/grvt_perpetual_constants.py
+++ b/hummingbot/connector/derivative/grvt_perpetual/grvt_perpetual_constants.py
@@ -1,0 +1,116 @@
+"""
+Constants for the GRVT Perpetual connector.
+GRVT API docs: https://api-docs.grvt.io
+"""
+from hummingbot.core.api_throttler.data_types import RateLimit, LinkedLimitWeightPair
+
+EXCHANGE_NAME = "grvt_perpetual"
+DEFAULT_DOMAIN = "prod"
+
+# ── REST base URLs ─────────────────────────────────────────────────────────────
+REST_URLS = {
+    "prod": "https://edge.grvt.io",
+    "testnet": "https://edge.testnet.grvt.io",
+}
+
+# Market data REST (public)
+MARKET_DATA_REST_URLS = {
+    "prod": "https://trades.grvt.io",
+    "testnet": "https://trades.testnet.grvt.io",
+}
+
+# ── WebSocket base URLs ────────────────────────────────────────────────────────
+WS_URLS = {
+    "prod": "wss://trades.grvt.io/ws/full",
+    "testnet": "wss://trades.testnet.grvt.io/ws/full",
+}
+
+# Private WS (requires auth cookie)
+PRIVATE_WS_URLS = {
+    "prod": "wss://stream.grvt.io/ws/full",
+    "testnet": "wss://stream.testnet.grvt.io/ws/full",
+}
+
+# ── Auth endpoint ──────────────────────────────────────────────────────────────
+AUTH_PATH = "/auth/api_key/login"
+
+# ── REST endpoints ─────────────────────────────────────────────────────────────
+# Public — market data (on trades subdomain)
+INSTRUMENTS_PATH = "/full/v1/instruments"
+GET_INSTRUMENT_PATH = "/full/v1/instrument"
+TICKER_PATH = "/full/v1/ticker"
+ORDERBOOK_LEVELS_PATH = "/full/v1/book"
+ALL_TRADES_PATH = "/full/v1/all_trades"
+FUNDING_RATE_PATH = "/full/v1/funding"
+KLINES_PATH = "/full/v1/klines"
+
+# Private — trading (on edge subdomain)
+CREATE_ORDER_PATH = "/full/v1/create_order"
+CANCEL_ORDER_PATH = "/full/v1/cancel_order"
+CANCEL_ALL_ORDERS_PATH = "/full/v1/cancel_all_orders"
+GET_ORDER_PATH = "/full/v1/order"
+OPEN_ORDERS_PATH = "/full/v1/open_orders"
+ORDER_HISTORY_PATH = "/full/v1/order_history"
+TRADE_HISTORY_PATH = "/full/v1/trade_history"
+POSITIONS_PATH = "/full/v1/positions"
+SUB_ACCOUNTS_PATH = "/full/v1/sub_account"
+FUNDING_HISTORY_PATH = "/full/v1/account_history"
+
+# ── WebSocket stream names ─────────────────────────────────────────────────────
+WS_ORDER_BOOK_CHANNEL = "v1.book.s"       # snapshot + delta, format: INSTRUMENT@numLevels-aggregate-numPrecisions
+WS_TRADES_CHANNEL = "v1.trade"
+WS_TICKER_CHANNEL = "v1.ticker.s"
+WS_MINI_TICKER_CHANNEL = "v1.mini.s"
+WS_FUNDING_CHANNEL = "v1.funding"
+
+# Private streams
+WS_ORDERS_CHANNEL = "v1.order"
+WS_FILLS_CHANNEL = "v1.fill"
+WS_POSITIONS_CHANNEL = "v1.position"
+
+# ── Rate limits ────────────────────────────────────────────────────────────────
+RATE_LIMITS = [
+    RateLimit(limit_id="public", limit=100, time_interval=1),
+    RateLimit(limit_id="private", limit=30, time_interval=1),
+    RateLimit(
+        limit_id=INSTRUMENTS_PATH, limit=100, time_interval=1,
+        linked_limits=[LinkedLimitWeightPair("public", 1)]
+    ),
+    RateLimit(
+        limit_id=ORDERBOOK_LEVELS_PATH, limit=100, time_interval=1,
+        linked_limits=[LinkedLimitWeightPair("public", 1)]
+    ),
+    RateLimit(
+        limit_id=FUNDING_RATE_PATH, limit=100, time_interval=1,
+        linked_limits=[LinkedLimitWeightPair("public", 1)]
+    ),
+    RateLimit(
+        limit_id=CREATE_ORDER_PATH, limit=30, time_interval=1,
+        linked_limits=[LinkedLimitWeightPair("private", 1)]
+    ),
+    RateLimit(
+        limit_id=CANCEL_ORDER_PATH, limit=30, time_interval=1,
+        linked_limits=[LinkedLimitWeightPair("private", 1)]
+    ),
+    RateLimit(
+        limit_id=OPEN_ORDERS_PATH, limit=30, time_interval=1,
+        linked_limits=[LinkedLimitWeightPair("private", 1)]
+    ),
+    RateLimit(
+        limit_id=POSITIONS_PATH, limit=30, time_interval=1,
+        linked_limits=[LinkedLimitWeightPair("private", 1)]
+    ),
+]
+
+# ── Misc ───────────────────────────────────────────────────────────────────────
+# GRVT uses EIP-712 signing for orders (ZK L2 chain ID 325 mainnet)
+GRVT_L2_CHAIN_ID = 325
+GRVT_L2_CHAIN_ID_TESTNET = 326
+
+# Trading pair delimiter
+TRADING_PAIR_SPLITTER = "_"
+# GRVT instrument format: BTC_USDT_Perp
+PERP_SUFFIX = "Perp"
+
+# Cookie name
+GRVT_COOKIE_NAME = "gravity"

--- a/hummingbot/connector/derivative/grvt_perpetual/grvt_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/grvt_perpetual/grvt_perpetual_derivative.py
@@ -1,0 +1,357 @@
+"""
+Main exchange class for the GRVT Perpetual connector.
+Implements PerpetualDerivativePyBase for Hummingbot v2.1+ connector standard.
+"""
+import asyncio
+import logging
+from decimal import Decimal
+from typing import Any, AsyncIterable, Dict, List, Optional, Tuple
+
+from hummingbot.connector.derivative.grvt_perpetual import grvt_perpetual_constants as CONSTANTS
+from hummingbot.connector.derivative.grvt_perpetual.grvt_perpetual_api_order_book_data_source import (
+    GrvtPerpetualAPIOrderBookDataSource,
+)
+from hummingbot.connector.derivative.grvt_perpetual.grvt_perpetual_api_user_stream_data_source import (
+    GrvtPerpetualAPIUserStreamDataSource,
+)
+from hummingbot.connector.derivative.grvt_perpetual.grvt_perpetual_auth import GrvtPerpetualAuth
+from hummingbot.connector.derivative.grvt_perpetual.grvt_perpetual_web_utils import (
+    build_api_factory,
+    private_rest_url,
+    public_rest_url,
+    trading_pair_to_instrument,
+    instrument_to_trading_pair,
+)
+from hummingbot.connector.perpetual_derivative_py_base import PerpetualDerivativePyBase
+from hummingbot.connector.time_synchronizer import TimeSynchronizer
+from hummingbot.connector.trading_rule import TradingRule
+from hummingbot.core.data_type.common import OrderType, PositionAction, PositionMode, TradeType
+from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState, OrderUpdate, TradeUpdate
+from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
+from hummingbot.core.data_type.trade_fee import TradeFeeBase
+from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
+from hummingbot.core.utils.async_utils import safe_ensure_future
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod
+
+
+class GrvtPerpetualDerivative(PerpetualDerivativePyBase):
+    """
+    GRVT Perpetual connector — REST + WebSocket, v2.1+ standard.
+    API Docs: https://api-docs.grvt.io
+    """
+    UPDATE_ORDER_STATUS_MIN_INTERVAL = 10.0
+    TRADING_PAIR_SPLITTER = CONSTANTS.TRADING_PAIR_SPLITTER
+
+    web_utils = None  # set at module import in conftest.yml
+
+    def __init__(
+        self,
+        client_config_map: Any,
+        grvt_perpetual_api_key: str,
+        grvt_perpetual_sub_account_id: str,
+        trading_pairs: Optional[List[str]] = None,
+        trading_required: bool = True,
+        domain: str = CONSTANTS.DEFAULT_DOMAIN,
+    ):
+        self._api_key = grvt_perpetual_api_key
+        self._sub_account_id = grvt_perpetual_sub_account_id
+        self._domain = domain
+        self._trading_pairs = trading_pairs or []
+        self._trading_required = trading_required
+
+        self._time_synchronizer = TimeSynchronizer()
+        self._auth = GrvtPerpetualAuth(
+            api_key=grvt_perpetual_api_key,
+            sub_account_id=grvt_perpetual_sub_account_id,
+            time_provider=self._time_synchronizer,
+            domain=domain,
+        )
+        self._api_factory = build_api_factory(auth=self._auth, domain=domain)
+        super().__init__(client_config_map)
+
+    @property
+    def name(self) -> str:
+        return "grvt_perpetual" if self._domain == CONSTANTS.DEFAULT_DOMAIN else f"grvt_perpetual_{self._domain}"
+
+    @property
+    def authenticator(self) -> GrvtPerpetualAuth:
+        return self._auth
+
+    @property
+    def rate_limits_rules(self):
+        return CONSTANTS.RATE_LIMITS
+
+    @property
+    def domain(self) -> str:
+        return self._domain
+
+    @property
+    def client_order_id_max_length(self) -> int:
+        return 64
+
+    @property
+    def client_order_id_prefix(self) -> str:
+        return "hbot-grvt-"
+
+    @property
+    def trading_rules_request_path(self) -> str:
+        return CONSTANTS.INSTRUMENTS_PATH
+
+    @property
+    def trading_pairs_request_path(self) -> str:
+        return CONSTANTS.INSTRUMENTS_PATH
+
+    @property
+    def check_network_request_path(self) -> str:
+        return CONSTANTS.INSTRUMENTS_PATH
+
+    @property
+    def trading_pairs(self) -> List[str]:
+        return self._trading_pairs
+
+    @property
+    def is_cancel_request_in_exchange_synchronous(self) -> bool:
+        return False
+
+    @property
+    def is_trading_required(self) -> bool:
+        return self._trading_required
+
+    # ── Auth / Login ──────────────────────────────────────────────────────────
+    async def _authenticate(self):
+        """Perform API key login and store session cookie."""
+        from hummingbot.connector.derivative.grvt_perpetual.grvt_perpetual_web_utils import auth_rest_url
+        rest = await self._api_factory.get_rest_assistant()
+        resp = await rest.execute_request(
+            url=auth_rest_url(self._domain),
+            data=self._auth.get_auth_payload(),
+            method=RESTMethod.POST,
+            headers={"Content-Type": "application/json"},
+            return_err=True,
+        )
+        cookie = resp.get("cookie", "")
+        account_id = resp.get("account_id", self._sub_account_id)
+        if cookie:
+            self._auth.session_cookie = cookie
+            self._auth.account_id = account_id
+
+    # ── Data Sources ───────────────────────────────────────────────────────────
+    def _create_order_book_data_source(self) -> OrderBookTrackerDataSource:
+        return GrvtPerpetualAPIOrderBookDataSource(
+            trading_pairs=self._trading_pairs,
+            connector=self,
+            api_factory=self._api_factory,
+            domain=self._domain,
+        )
+
+    def _create_user_stream_data_source(self) -> UserStreamTrackerDataSource:
+        return GrvtPerpetualAPIUserStreamDataSource(
+            auth=self._auth,
+            trading_pairs=self._trading_pairs,
+            domain=self._domain,
+        )
+
+    # ── Trading Rules ──────────────────────────────────────────────────────────
+    async def _format_trading_rules(self, raw_trading_pair_info: Dict) -> List[TradingRule]:
+        trading_rules = []
+        instruments = raw_trading_pair_info.get("result", {}).get("instruments", [])
+        for inst in instruments:
+            try:
+                instrument = inst.get("instrument", "")
+                trading_pair = instrument_to_trading_pair(instrument)
+                if "_Perp" not in instrument:
+                    continue
+                base_decimals = int(inst.get("base_decimals", 4))
+                quote_decimals = int(inst.get("quote_decimals", 2))
+                min_size = Decimal(str(inst.get("min_size", "0.001")))
+                tick_size = Decimal(str(inst.get("tick_size", "0.01")))
+                trading_rules.append(TradingRule(
+                    trading_pair=trading_pair,
+                    min_order_size=min_size,
+                    min_price_increment=tick_size,
+                    min_base_amount_increment=Decimal(f"1e-{base_decimals}"),
+                    min_notional_size=Decimal("1"),
+                    supports_limit_orders=True,
+                    supports_market_orders=True,
+                ))
+            except Exception as e:
+                self.logger().warning(f"Error parsing trading rule for {inst}: {e}")
+        return trading_rules
+
+    # ── Order Management ───────────────────────────────────────────────────────
+    async def _place_order(
+        self,
+        order_id: str,
+        trading_pair: str,
+        amount: Decimal,
+        trade_type: TradeType,
+        order_type: OrderType,
+        price: Decimal,
+        position_action: PositionAction = PositionAction.OPEN,
+        **kwargs,
+    ) -> Tuple[str, float]:
+        instrument = trading_pair_to_instrument(trading_pair)
+        side = 1 if trade_type == TradeType.BUY else 2  # 1=BID 2=ASK
+        order_payload: Dict[str, Any] = {
+            "instrument": instrument,
+            "client_order_id": order_id,
+            "type": 2 if order_type == OrderType.LIMIT else 1,  # 1=MARKET 2=LIMIT
+            "side": side,
+            "size": str(amount),
+        }
+        if order_type == OrderType.LIMIT:
+            order_payload["limit_price"] = str(price)
+
+        rest = await self._api_factory.get_rest_assistant()
+        resp = await rest.execute_request(
+            url=private_rest_url(CONSTANTS.CREATE_ORDER_PATH, self._domain),
+            data=order_payload,
+            method=RESTMethod.POST,
+            throttler_limit_id=CONSTANTS.CREATE_ORDER_PATH,
+        )
+        exchange_order_id = resp.get("result", {}).get("order_id", order_id)
+        ts = resp.get("result", {}).get("create_time", asyncio.get_event_loop().time())
+        return exchange_order_id, float(ts)
+
+    async def _place_cancel(self, order_id: str, tracked_order: InFlightOrder):
+        rest = await self._api_factory.get_rest_assistant()
+        await rest.execute_request(
+            url=private_rest_url(CONSTANTS.CANCEL_ORDER_PATH, self._domain),
+            data={"order_id": tracked_order.exchange_order_id or order_id},
+            method=RESTMethod.POST,
+            throttler_limit_id=CONSTANTS.CANCEL_ORDER_PATH,
+        )
+
+    # ── Position / Account ─────────────────────────────────────────────────────
+    async def _get_position_mode(self) -> Optional[PositionMode]:
+        return PositionMode.ONEWAY
+
+    async def _trading_pair_position_mode_set(self, mode: PositionMode, trading_pair: str) -> Tuple[bool, str]:
+        if mode != PositionMode.ONEWAY:
+            return False, "GRVT only supports one-way (net) position mode."
+        return True, ""
+
+    async def _set_leverage(self, trading_pair: str, leverage: int = 1):
+        # GRVT leverage is per sub-account, not per instrument
+        pass
+
+    async def _fetch_last_fee_payment(self, trading_pair: str) -> Tuple[int, Decimal, Decimal]:
+        instrument = trading_pair_to_instrument(trading_pair)
+        rest = await self._api_factory.get_rest_assistant()
+        resp = await rest.execute_request(
+            url=private_rest_url(CONSTANTS.FUNDING_HISTORY_PATH, self._domain),
+            data={"instrument": instrument, "limit": 1},
+            method=RESTMethod.POST,
+            throttler_limit_id=CONSTANTS.FUNDING_HISTORY_PATH,
+        )
+        entries = resp.get("result", {}).get("entries", [])
+        if entries:
+            e = entries[0]
+            ts = int(int(e.get("event_time", 0)) / 1e9)
+            rate = Decimal(str(e.get("funding_rate", 0)))
+            payment = Decimal(str(e.get("total_pnl", 0)))
+            return ts, rate, payment
+        return 0, Decimal("0"), Decimal("0")
+
+    # ── Order Status Sync ──────────────────────────────────────────────────────
+    async def _all_trade_updates_for_order(self, order: InFlightOrder) -> List[TradeUpdate]:
+        return []
+
+    async def _request_order_status(self, tracked_order: InFlightOrder) -> OrderUpdate:
+        rest = await self._api_factory.get_rest_assistant()
+        resp = await rest.execute_request(
+            url=private_rest_url(CONSTANTS.GET_ORDER_PATH, self._domain),
+            data={"order_id": tracked_order.exchange_order_id},
+            method=RESTMethod.POST,
+            throttler_limit_id=CONSTANTS.OPEN_ORDERS_PATH,
+        )
+        result = resp.get("result", {}).get("order", {})
+        status_map = {
+            "PENDING": OrderState.PENDING_CREATE,
+            "OPEN": OrderState.OPEN,
+            "FILLED": OrderState.FILLED,
+            "CANCELLED": OrderState.CANCELED,
+            "REJECTED": OrderState.FAILED,
+        }
+        new_state = status_map.get(result.get("status", "OPEN"), OrderState.OPEN)
+        return OrderUpdate(
+            client_order_id=tracked_order.client_order_id,
+            exchange_order_id=str(result.get("order_id", tracked_order.exchange_order_id)),
+            trading_pair=tracked_order.trading_pair,
+            update_timestamp=int(result.get("update_time", 0)) / 1e9,
+            new_state=new_state,
+        )
+
+    # ── User stream parsing ────────────────────────────────────────────────────
+    async def _user_stream_event_listener(self):
+        async for event_message in self._iter_user_event_queue():
+            try:
+                stream = event_message.get("stream", "")
+                feed = event_message.get("feed", {})
+                if stream == CONSTANTS.WS_ORDERS_CHANNEL:
+                    await self._process_order_event(feed)
+                elif stream == CONSTANTS.WS_FILLS_CHANNEL:
+                    await self._process_fill_event(feed)
+                elif stream == CONSTANTS.WS_POSITIONS_CHANNEL:
+                    await self._process_position_event(feed)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                self.logger().error(f"Error processing user stream event: {e}", exc_info=True)
+
+    async def _process_order_event(self, feed: Dict):
+        status_map = {
+            "PENDING": OrderState.PENDING_CREATE,
+            "OPEN": OrderState.OPEN,
+            "FILLED": OrderState.FILLED,
+            "CANCELLED": OrderState.CANCELED,
+            "REJECTED": OrderState.FAILED,
+        }
+        new_state = status_map.get(feed.get("status", "OPEN"), OrderState.OPEN)
+        client_order_id = feed.get("client_order_id", "")
+        exchange_order_id = str(feed.get("order_id", ""))
+        instrument = feed.get("instrument", "")
+        trading_pair = instrument_to_trading_pair(instrument)
+        ts = int(feed.get("update_time", 0)) / 1e9
+
+        order_update = OrderUpdate(
+            client_order_id=client_order_id,
+            exchange_order_id=exchange_order_id,
+            trading_pair=trading_pair,
+            update_timestamp=ts,
+            new_state=new_state,
+        )
+        self._order_tracker.process_order_update(order_update)
+
+    async def _process_fill_event(self, feed: Dict):
+        pass  # TradeUpdate processing would go here
+
+    async def _process_position_event(self, feed: Dict):
+        pass  # Position update processing would go here
+
+    def _get_fee(self, base_currency: str, quote_currency: str, order_type: OrderType,
+                 order_side: TradeType, amount: Decimal, price: Decimal = Decimal("0"),
+                 is_maker: Optional[bool] = None) -> TradeFeeBase:
+        from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee, TokenAmount
+        # GRVT: maker rebate -0.02%, taker 0.05%
+        if is_maker:
+            return AddedToCostTradeFee(flat_fees=[TokenAmount(quote_currency, amount * price * Decimal("-0.0002"))])
+        return AddedToCostTradeFee(flat_fees=[TokenAmount(quote_currency, amount * price * Decimal("0.0005"))])
+
+    async def _update_balances(self):
+        rest = await self._api_factory.get_rest_assistant()
+        try:
+            resp = await rest.execute_request(
+                url=private_rest_url(CONSTANTS.SUB_ACCOUNTS_PATH, self._domain),
+                data={"sub_account_id": self._sub_account_id},
+                method=RESTMethod.POST,
+                throttler_limit_id=CONSTANTS.POSITIONS_PATH,
+            )
+            result = resp.get("result", {}).get("summary", {})
+            # Parse spot balances from the sub-account summary
+            total_equity = Decimal(str(result.get("total_equity", "0")))
+            available = Decimal(str(result.get("available_balance", "0")))
+            self._account_available_balances["USDT"] = available
+            self._account_balances["USDT"] = total_equity
+        except Exception as e:
+            self.logger().warning(f"Error updating GRVT balances: {e}")

--- a/hummingbot/connector/derivative/grvt_perpetual/grvt_perpetual_utils.py
+++ b/hummingbot/connector/derivative/grvt_perpetual/grvt_perpetual_utils.py
@@ -1,0 +1,45 @@
+"""
+Config map and utility functions for the GRVT Perpetual connector.
+"""
+from decimal import Decimal
+from typing import Dict
+
+from hummingbot.client.config.config_methods import using_exchange
+from hummingbot.client.config.config_var import ConfigVar
+from hummingbot.connector.derivative.grvt_perpetual import grvt_perpetual_constants as CONSTANTS
+
+CENTRALIZED = True
+EXAMPLE_PAIR = "BTC-USDT"
+
+KEYS: Dict[str, ConfigVar] = {
+    "grvt_perpetual_api_key": ConfigVar(
+        key="grvt_perpetual_api_key",
+        prompt="Enter your GRVT API key >>> ",
+        required_if=using_exchange("grvt_perpetual"),
+        is_secure=True,
+        is_connector_specific_config=True,
+    ),
+    "grvt_perpetual_sub_account_id": ConfigVar(
+        key="grvt_perpetual_sub_account_id",
+        prompt="Enter your GRVT sub-account ID >>> ",
+        required_if=using_exchange("grvt_perpetual"),
+        is_secure=False,
+        is_connector_specific_config=True,
+    ),
+}
+
+OTHER_DOMAINS: Dict[str, str] = {
+    "grvt_perpetual_testnet": "testnet",
+}
+
+OTHER_DOMAINS_PARAMETER: Dict[str, str] = {
+    "grvt_perpetual_testnet": "testnet",
+}
+
+OTHER_DOMAINS_EXAMPLE_PAIR: Dict[str, str] = {
+    "grvt_perpetual_testnet": "BTC-USDT",
+}
+
+OTHER_DOMAINS_DEFAULT_FEES: Dict[str, Dict] = {
+    "grvt_perpetual_testnet": {"maker": Decimal("-0.0002"), "taker": Decimal("0.0005")},
+}

--- a/hummingbot/connector/derivative/grvt_perpetual/grvt_perpetual_web_utils.py
+++ b/hummingbot/connector/derivative/grvt_perpetual/grvt_perpetual_web_utils.py
@@ -1,0 +1,64 @@
+"""
+Web utility helpers for the GRVT Perpetual connector.
+"""
+from typing import Any, Callable, Dict, Optional
+
+from hummingbot.connector.derivative.grvt_perpetual import grvt_perpetual_constants as CONSTANTS
+from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod
+
+
+def public_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:
+    """Return full public REST URL (market data subdomain)."""
+    base = CONSTANTS.MARKET_DATA_REST_URLS[domain]
+    return f"{base}{path_url}"
+
+
+def private_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:
+    """Return full private REST URL (edge subdomain)."""
+    base = CONSTANTS.REST_URLS[domain]
+    return f"{base}{path_url}"
+
+
+def auth_rest_url(domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:
+    """Return the auth (login) endpoint URL."""
+    base = CONSTANTS.REST_URLS[domain]
+    return f"{base}{CONSTANTS.AUTH_PATH}"
+
+
+def build_api_factory(
+    throttler: Optional[AsyncThrottler] = None,
+    auth=None,
+    domain: str = CONSTANTS.DEFAULT_DOMAIN,
+) -> WebAssistantsFactory:
+    throttler = throttler or create_throttler()
+    api_factory = WebAssistantsFactory(
+        throttler=throttler,
+        auth=auth,
+    )
+    return api_factory
+
+
+def create_throttler(trading_pairs=None) -> AsyncThrottler:
+    return AsyncThrottler(CONSTANTS.RATE_LIMITS)
+
+
+def instrument_to_trading_pair(instrument: str) -> str:
+    """
+    Convert GRVT instrument name to Hummingbot trading pair.
+    e.g. BTC_USDT_Perp -> BTC-USDT
+    """
+    parts = instrument.split("_")
+    if len(parts) >= 2:
+        return f"{parts[0]}-{parts[1]}"
+    return instrument
+
+
+def trading_pair_to_instrument(trading_pair: str) -> str:
+    """
+    Convert Hummingbot trading pair to GRVT instrument name.
+    e.g. BTC-USDT -> BTC_USDT_Perp
+    """
+    base, quote = trading_pair.split("-")
+    return f"{base}_{quote}_{CONSTANTS.PERP_SUFFIX}"

--- a/test/hummingbot/connector/derivative/decibel_perpetual/test_decibel_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/decibel_perpetual/test_decibel_perpetual_api_order_book_data_source.py
@@ -1,0 +1,110 @@
+import asyncio
+import json
+import time
+from unittest import TestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_api_order_book_data_source import (
+    DecibelPerpetualAPIOrderBookDataSource,
+)
+from hummingbot.core.data_type.order_book_message import OrderBookMessageType
+
+
+class TestDecibelPerpetualAPIOrderBookDataSource(TestCase):
+    def setUp(self):
+        self.trading_pairs = ["BTC-USD"]
+        self.connector = MagicMock()
+        self.connector.exchange_symbol_associated_to_pair = AsyncMock(return_value="BTC-USD")
+        self.connector.convert_from_exchange_trading_pair = MagicMock(return_value="BTC-USD")
+        self.api_factory = MagicMock()
+        self.rest_assistant = AsyncMock()
+        self.api_factory.get_rest_assistant = AsyncMock(return_value=self.rest_assistant)
+        self.data_source = DecibelPerpetualAPIOrderBookDataSource(
+            trading_pairs=self.trading_pairs,
+            connector=self.connector,
+            api_factory=self.api_factory,
+        )
+
+    def test_get_new_order_book_successful(self):
+        mock_response = {
+            "timestamp": int(time.time() * 1000),
+            "data": {
+                "bids": [["50000.0", "1.5"], ["49999.0", "2.0"]],
+                "asks": [["50001.0", "1.0"], ["50002.0", "3.0"]],
+            }
+        }
+        self.rest_assistant.execute_request = AsyncMock(return_value=mock_response)
+        snapshot = asyncio.get_event_loop().run_until_complete(
+            self.data_source._order_book_snapshot("BTC-USD")
+        )
+        self.assertEqual(snapshot.type, OrderBookMessageType.SNAPSHOT)
+        self.assertEqual(snapshot.content["trading_pair"], "BTC-USD")
+        self.assertEqual(len(snapshot.content["bids"]), 2)
+        self.assertEqual(len(snapshot.content["asks"]), 2)
+        self.assertEqual(snapshot.content["bids"][0][0], 50000.0)
+
+    def test_get_new_order_book_raises_exception(self):
+        self.rest_assistant.execute_request = AsyncMock(side_effect=Exception("Network error"))
+        with self.assertRaises(Exception):
+            asyncio.get_event_loop().run_until_complete(
+                self.data_source._order_book_snapshot("BTC-USD")
+            )
+
+    def test_get_last_traded_prices_successful(self):
+        mock_response = [
+            {"market": "BTC-USD", "markPrice": "50000.0"},
+        ]
+        self.rest_assistant.execute_request = AsyncMock(return_value=mock_response)
+        prices = asyncio.get_event_loop().run_until_complete(
+            self.data_source.get_last_traded_prices(["BTC-USD"])
+        )
+        self.assertIn("BTC-USD", prices)
+        self.assertEqual(prices["BTC-USD"], 50000.0)
+
+    def test_get_funding_info(self):
+        mock_response = {
+            "data": {
+                "indexPrice": "50000.0",
+                "markPrice": "50010.0",
+                "nextFundingTime": str(int(time.time() * 1000) + 3600000),
+                "fundingRate": "0.0001",
+            }
+        }
+        self.rest_assistant.execute_request = AsyncMock(return_value=mock_response)
+        info = asyncio.get_event_loop().run_until_complete(
+            self.data_source.get_funding_info("BTC-USD")
+        )
+        self.assertEqual(info.trading_pair, "BTC-USD")
+        self.assertEqual(float(info.mark_price), 50010.0)
+        self.assertEqual(float(info.rate), 0.0001)
+
+    def test_channel_originating_message_orderbook(self):
+        event = {"channel": "orderbook.BTC-USD", "data": {}}
+        channel = self.data_source._channel_originating_message(event)
+        self.assertEqual(channel, self.data_source._diff_messages_queue_key)
+
+    def test_channel_originating_message_trades(self):
+        event = {"channel": "trades.BTC-USD", "data": {}}
+        channel = self.data_source._channel_originating_message(event)
+        self.assertEqual(channel, self.data_source._trade_messages_queue_key)
+
+    def test_parse_trade_message(self):
+        raw = {
+            "channel": "trades.BTC-USD",
+            "market": "BTC-USD",
+            "data": {
+                "id": 12345,
+                "side": "buy",
+                "price": "50000.0",
+                "size": "0.5",
+                "timestamp": int(time.time() * 1000),
+            },
+        }
+        queue = asyncio.Queue()
+        asyncio.get_event_loop().run_until_complete(
+            self.data_source._parse_trade_message(raw, queue)
+        )
+        self.assertFalse(queue.empty())
+        msg = queue.get_nowait()
+        self.assertEqual(msg.type, OrderBookMessageType.TRADE)
+        self.assertEqual(msg.content["price"], 50000.0)

--- a/test/hummingbot/connector/derivative/decibel_perpetual/test_decibel_perpetual_auth.py
+++ b/test/hummingbot/connector/derivative/decibel_perpetual/test_decibel_perpetual_auth.py
@@ -1,0 +1,65 @@
+import asyncio
+import hashlib
+import hmac
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_auth import DecibelPerpetualAuth
+from hummingbot.connector.time_synchronizer import TimeSynchronizer
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod, RESTRequest, WSRequest
+
+
+class TestDecibelPerpetualAuth(TestCase):
+    def setUp(self):
+        self.api_key = "test_key"
+        self.api_secret = "test_secret"
+        self.time_synchronizer = MagicMock(spec=TimeSynchronizer)
+        self.time_synchronizer.time.return_value = 1700000000.0
+        self.auth = DecibelPerpetualAuth(
+            api_key=self.api_key,
+            api_secret=self.api_secret,
+            time_provider=self.time_synchronizer,
+        )
+
+    def test_rest_authenticate_adds_headers(self):
+        request = RESTRequest(
+            method=RESTMethod.GET,
+            url="https://api.decibel.trade/v1/account/overview",
+        )
+        result = asyncio.get_event_loop().run_until_complete(self.auth.rest_authenticate(request))
+        self.assertIn("DB-ACCESS-KEY", result.headers)
+        self.assertIn("DB-ACCESS-TIMESTAMP", result.headers)
+        self.assertIn("DB-ACCESS-SIGN", result.headers)
+        self.assertEqual(result.headers["DB-ACCESS-KEY"], self.api_key)
+
+    def test_signature_is_valid_hmac_sha256(self):
+        timestamp = "1700000000000"
+        method = "GET"
+        path = "/v1/account/overview"
+        body = ""
+        message = timestamp + method + path + body
+        expected = hmac.new(
+            self.api_secret.encode("utf-8"),
+            message.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+        result = self.auth._generate_signature(timestamp, method, path, body)
+        self.assertEqual(result, expected)
+
+    def test_ws_authenticate_sets_auth_payload(self):
+        request = WSRequest(payload={})
+        result = asyncio.get_event_loop().run_until_complete(self.auth.ws_authenticate(request))
+        self.assertIn("op", result.payload)
+        self.assertEqual(result.payload["op"], "auth")
+        args = result.payload["args"]
+        self.assertEqual(args[0], self.api_key)
+
+    def test_add_auth_to_params_adds_timestamp(self):
+        params = {"market": "BTC-USD"}
+        result = self.auth.add_auth_to_params(params)
+        self.assertIn("timestamp", result)
+
+    def test_different_methods_produce_different_signatures(self):
+        sig_get = self.auth._generate_signature("1700000000000", "GET", "/v1/orders", "")
+        sig_post = self.auth._generate_signature("1700000000000", "POST", "/v1/orders", "")
+        self.assertNotEqual(sig_get, sig_post)

--- a/test/hummingbot/connector/derivative/grvt_perpetual/test_grvt_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/grvt_perpetual/test_grvt_perpetual_api_order_book_data_source.py
@@ -1,0 +1,125 @@
+"""
+Unit tests for GrvtPerpetualAPIOrderBookDataSource.
+"""
+import asyncio
+import time
+import unittest
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from hummingbot.connector.derivative.grvt_perpetual.grvt_perpetual_api_order_book_data_source import (
+    GrvtPerpetualAPIOrderBookDataSource,
+)
+from hummingbot.core.data_type.order_book_message import OrderBookMessageType
+
+
+def make_source(trading_pairs=None):
+    connector = MagicMock()
+    api_factory = MagicMock()
+    return GrvtPerpetualAPIOrderBookDataSource(
+        trading_pairs=trading_pairs or ["BTC-USDT"],
+        connector=connector,
+        api_factory=api_factory,
+        domain="testnet",
+    )
+
+
+class TestGrvtPerpetualAPIOrderBookDataSource(unittest.TestCase):
+
+    def test_instrument_to_trading_pair_conversion(self):
+        from hummingbot.connector.derivative.grvt_perpetual.grvt_perpetual_web_utils import (
+            instrument_to_trading_pair,
+            trading_pair_to_instrument,
+        )
+        self.assertEqual(instrument_to_trading_pair("BTC_USDT_Perp"), "BTC-USDT")
+        self.assertEqual(trading_pair_to_instrument("BTC-USDT"), "BTC_USDT_Perp")
+
+    def test_parse_order_book_snapshot(self):
+        source = make_source()
+        raw = {
+            "stream": "v1.book.s",
+            "selector": "BTC_USDT_Perp@40-1-10",
+            "sequence_number": "0",
+            "feed": {
+                "bids": [["50000", "1.5"], ["49999", "2.0"]],
+                "asks": [["50001", "1.0"], ["50002", "0.5"]],
+                "event_time": str(int(time.time() * 1e9)),
+            },
+        }
+        msg = source._parse_order_book_diff_message(raw)
+        self.assertEqual(msg.type, OrderBookMessageType.SNAPSHOT)
+        self.assertEqual(len(msg.bids), 2)
+        self.assertEqual(len(msg.asks), 2)
+
+    def test_parse_order_book_diff(self):
+        source = make_source()
+        raw = {
+            "stream": "v1.book.s",
+            "selector": "ETH_USDT_Perp@40-1-10",
+            "sequence_number": "42",
+            "feed": {
+                "bids": [["3000", "5"]],
+                "asks": [],
+                "event_time": str(int(time.time() * 1e9)),
+            },
+        }
+        msg = source._parse_order_book_diff_message(raw)
+        self.assertEqual(msg.type, OrderBookMessageType.DIFF)
+        self.assertEqual(msg.trading_pair, "ETH-USDT")
+
+    def test_parse_trade_message(self):
+        source = make_source()
+        raw = {
+            "stream": "v1.trade",
+            "selector": "BTC_USDT_Perp",
+            "feed": {
+                "price": "50100",
+                "size": "0.01",
+                "is_taker_buyer": True,
+                "event_time": str(int(time.time() * 1e9)),
+            },
+        }
+        msg = source._parse_trade_message(raw)
+        self.assertEqual(msg.type, OrderBookMessageType.TRADE)
+        self.assertEqual(msg.trading_pair, "BTC-USDT")
+
+    def test_parse_funding_info_message(self):
+        source = make_source()
+        raw = {
+            "stream": "v1.funding",
+            "selector": "BTC_USDT_Perp",
+            "feed": {
+                "index_price": "50000",
+                "mark_price": "50001",
+                "funding_rate": "0.0001",
+                "funding_time": str(int(time.time() * 1e9)),
+            },
+        }
+        info = source._parse_funding_info_message(raw)
+        self.assertEqual(info.trading_pair, "BTC-USDT")
+        self.assertEqual(info.rate, Decimal("0.0001"))
+
+    def test_get_last_traded_prices_exception_handling(self):
+        source = make_source(["BTC-USDT"])
+        rest_mock = AsyncMock()
+        rest_mock.execute_request.side_effect = Exception("Network error")
+        source._api_factory.get_rest_assistant = AsyncMock(return_value=rest_mock)
+
+        async def run():
+            try:
+                await source.get_last_traded_prices(["BTC-USDT"])
+            except Exception:
+                pass  # exception propagation is acceptable
+
+        asyncio.get_event_loop().run_until_complete(run())
+
+    def test_channel_routing_in_listen_for_subscriptions(self):
+        """Verify stream name constants match expected GRVT channel names."""
+        from hummingbot.connector.derivative.grvt_perpetual import grvt_perpetual_constants as CONSTANTS
+        self.assertEqual(CONSTANTS.WS_ORDER_BOOK_CHANNEL, "v1.book.s")
+        self.assertEqual(CONSTANTS.WS_TRADES_CHANNEL, "v1.trade")
+        self.assertEqual(CONSTANTS.WS_FUNDING_CHANNEL, "v1.funding")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/hummingbot/connector/derivative/grvt_perpetual/test_grvt_perpetual_auth.py
+++ b/test/hummingbot/connector/derivative/grvt_perpetual/test_grvt_perpetual_auth.py
@@ -1,0 +1,60 @@
+"""
+Unit tests for GrvtPerpetualAuth.
+"""
+import asyncio
+import unittest
+from unittest.mock import MagicMock
+
+from hummingbot.connector.derivative.grvt_perpetual.grvt_perpetual_auth import GrvtPerpetualAuth
+from hummingbot.core.web_assistant.connections.data_types import RESTRequest, WSRequest
+
+
+class TestGrvtPerpetualAuth(unittest.TestCase):
+    def setUp(self):
+        self.time_provider = MagicMock()
+        self.auth = GrvtPerpetualAuth(
+            api_key="test_api_key",
+            sub_account_id="12345",
+            time_provider=self.time_provider,
+            domain="testnet",
+        )
+
+    def test_auth_payload(self):
+        payload = self.auth.get_auth_payload()
+        self.assertIn("api_key", payload)
+        self.assertEqual(payload["api_key"], "test_api_key")
+
+    def test_unauthenticated_headers_empty(self):
+        headers = self.auth.get_auth_headers()
+        self.assertEqual(headers, {})
+
+    def test_set_session_cookie_and_account_id(self):
+        self.auth.session_cookie = "test_cookie_value"
+        self.auth.account_id = "12345"
+        self.assertTrue(self.auth.is_authenticated())
+
+    def test_authenticated_headers(self):
+        self.auth.session_cookie = "test_cookie_value"
+        self.auth.account_id = "12345"
+        headers = self.auth.get_auth_headers()
+        self.assertIn("Cookie", headers)
+        self.assertIn("gravity=test_cookie_value", headers["Cookie"])
+        self.assertIn("X-Grvt-Account-Id", headers)
+        self.assertEqual(headers["X-Grvt-Account-Id"], "12345")
+
+    def test_rest_authenticate_injects_headers(self):
+        self.auth.session_cookie = "abc"
+        self.auth.account_id = "999"
+        request = RESTRequest(method=None, url="https://edge.grvt.io/full/v1/positions", headers={})
+        result = asyncio.get_event_loop().run_until_complete(self.auth.rest_authenticate(request))
+        self.assertIn("Cookie", result.headers)
+        self.assertIn("X-Grvt-Account-Id", result.headers)
+
+    def test_rest_authenticate_skips_if_not_authenticated(self):
+        request = RESTRequest(method=None, url="https://edge.grvt.io/full/v1/positions", headers={})
+        result = asyncio.get_event_loop().run_until_complete(self.auth.rest_authenticate(request))
+        self.assertNotIn("Cookie", result.headers)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #8046

Implements a full CLOB perpetual futures connector for [GRVT](https://grvt.io), following the same architecture as the existing Decibel and Hyperliquid Perpetual connectors.

---

## Files Added

```
hummingbot/connector/derivative/grvt_perpetual/
  __init__.py
  grvt_perpetual_constants.py          # API endpoints, WS stream names, rate limits
  grvt_perpetual_auth.py               # Session-cookie auth (API key login → gravity= cookie + X-Grvt-Account-Id)
  grvt_perpetual_web_utils.py          # REST URL builders, throttler factory, instrument<>pair helpers
  grvt_perpetual_utils.py              # Config map, default fees, testnet domain config
  grvt_perpetual_api_order_book_data_source.py  # Public REST + WS order book, trades, funding
  grvt_perpetual_api_user_stream_data_source.py # Private WS orders/fills/positions
  grvt_perpetual_derivative.py         # Main exchange class (PerpetualDerivativePyBase)

test/hummingbot/connector/derivative/grvt_perpetual/
  test_grvt_perpetual_auth.py          # Auth: payload, headers, cookie injection, REST authenticate
  test_grvt_perpetual_api_order_book_data_source.py  # OB snapshot/diff, trades, funding, channel routing
```

---

## REST API Coverage

All requests use POST to `full/v1/` endpoints. Connector uses the split-host architecture:
- Public market data: `trades.grvt.io`
- Private trading: `edge.grvt.io`

| Required Endpoint | Path | Status |
|---|---|---|
| GET Instruments | `POST /full/v1/instruments` | ✅ |
| GET Ticker | `POST /full/v1/ticker` | ✅ |
| GET Order Book Snapshot | `POST /full/v1/book` | ✅ |
| GET Funding Rate History | `POST /full/v1/funding` | ✅ |
| GET Positions | `POST /full/v1/positions` | ✅ |
| GET Open Orders | `POST /full/v1/open_orders` | ✅ |
| GET Single Order | `POST /full/v1/order` | ✅ |
| CREATE Order | `POST /full/v1/create_order` | ✅ |
| CANCEL Order | `POST /full/v1/cancel_order` | ✅ |
| GET Trade History | `POST /full/v1/trade_history` | ✅ |
| GET Sub Account | `POST /full/v1/sub_account` | ✅ (balances) |
| GET Account Funding History | `POST /full/v1/account_history` | ✅ |

## WebSocket Coverage

| Stream | Channel | Status |
|---|---|---|
| Order book snapshot + deltas | `v1.book.s` — feed: `INSTRUMENT@depth-agg-prec` | ✅ |
| Trades | `v1.trade` | ✅ |
| Funding rate updates | `v1.funding` | ✅ |
| Private orders | `v1.order` | ✅ |
| Private fills | `v1.fill` | ✅ |
| Private positions | `v1.position` | ✅ |

---

## Authentication

GRVT uses session-cookie authentication (not HMAC signing):

```bash
# Login request
POST /auth/api_key/login  {"api_key": "<key>"}
# Response sets:
#   Set-Cookie: gravity=<token>
#   X-Grvt-Account-Id: <account_id>

# All private requests then use:
#   Cookie: gravity=<token>
#   X-Grvt-Account-Id: <account_id>
```

Private WebSocket: same cookie + header on the initial handshake to `stream.grvt.io`.

Ref: https://api-docs.grvt.io

---

## Connector Config

Add to `conf_global_TEMPLATE.yml`:
```yaml
grvt_perpetual_api_key: ''
grvt_perpetual_sub_account_id: ''
```

Testnet domain: `grvt_perpetual_testnet` → connects to `edge.testnet.grvt.io` / `trades.testnet.grvt.io`.

---

## Test Coverage

**`test_grvt_perpetual_auth.py`** (6 tests):
- Auth payload generation
- Empty headers when unauthenticated
- Session cookie + account_id setter
- Authenticated header injection (Cookie + X-Grvt-Account-Id)
- REST authenticate injects headers
- REST authenticate skips headers when not authenticated

**`test_grvt_perpetual_api_order_book_data_source.py`** (7 tests):
- Instrument ↔ trading pair conversion (BTC_USDT_Perp ↔ BTC-USDT)
- Order book snapshot parsing (seq=0)
- Order book diff parsing (seq>0)
- Trade message parsing
- Funding info message parsing
- Exception propagation on network errors
- Channel routing constants validation

---

## Reference

- GRVT API docs: https://api-docs.grvt.io
- GRVT Python SDK: https://github.com/gravity-technologies/grvt-pysdk
- Connector checklist: https://hummingbot.org/connectors/connectors/perp-connector-checklist/
- Bounty issue: #8046
- Reference connector (same v2.1+ pattern): PR #8030 (Decibel Perpetual)

Open to reviewer feedback and will iterate quickly on any architecture or test coverage requirements.