### PR TITLE
Decibel perpetual connector

### DIFF
--- a/hummingbot/connector/derivative/decibel_perpetual/__init__.py
+++ b/hummingbot/connector/derivative/decibel_perpetual/__init__.py
@@ -1,0 +1,5 @@
+"""Decibel perpetual connector."""
+
+from hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_derivative import DecibelPerpetualDerivative
+
+__all__ = ["DecibelPerpetualDerivative"]

--- a/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_api_order_book_data_source.py
+++ b/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_api_order_book_data_source.py
@@ -1,0 +1,209 @@
+import asyncio
+import time
+from typing import Any, Dict, List, Optional
+
+from hummingbot.connector.derivative.decibel_perpetual import decibel_perpetual_constants as CONSTANTS
+from hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_web_utils import rest_url
+from hummingbot.core.data_type.funding_info import FundingInfo, FundingInfoUpdate
+from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
+from hummingbot.core.data_type.perpetual_api_order_book_data_source import PerpetualAPIOrderBookDataSource
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+from hummingbot.core.web_assistant.ws_assistant import WSAssistant
+from hummingbot.logger import HummingbotLogger
+
+
+class DecibelPerpetualAPIOrderBookDataSource(PerpetualAPIOrderBookDataSource):
+    _logger: Optional[HummingbotLogger] = None
+
+    def __init__(
+        self,
+        trading_pairs: List[str],
+        connector,
+        api_factory: WebAssistantsFactory,
+        domain: str = CONSTANTS.DEFAULT_DOMAIN,
+    ):
+        super().__init__(trading_pairs)
+        self._connector = connector
+        self._api_factory = api_factory
+        self._domain = domain
+
+    async def get_last_traded_prices(self, trading_pairs: List[str], domain: Optional[str] = None) -> Dict[str, float]:
+        # Best-effort: Decibel exposes all-market prices via REST.
+        domain = domain or self._domain
+        rest_assistant = await self._api_factory.get_rest_assistant()
+        response = await rest_assistant.execute_request(
+            url=rest_url(CONSTANTS.MARKET_PRICES_PATH_URL, domain=domain),
+            method=RESTMethod.GET,
+            throttler_limit_id=CONSTANTS.MARKET_PRICES_PATH_URL,
+            is_auth_required=True,
+        )
+        prices = response if isinstance(response, list) else response.get("data", [])
+        result: Dict[str, float] = {}
+        for item in prices:
+            market_name = item.get("market_name") or item.get("market") or item.get("symbol")
+            if market_name is None:
+                continue
+            pair = self._connector.convert_from_exchange_trading_pair(market_name)
+            if pair in trading_pairs:
+                price = item.get("mark_price") or item.get("markPrice") or item.get("price") or 0
+                result[pair] = float(price)
+        return result
+
+    async def _request_order_book_snapshot(self, trading_pair: str) -> Dict[str, Any]:
+        market_addr = await self._connector.market_address_associated_to_pair(trading_pair)
+        rest_assistant = await self._api_factory.get_rest_assistant()
+        return await rest_assistant.execute_request(
+            url=rest_url(CONSTANTS.DEPTH_PATH_URL, domain=self._domain),
+            method=RESTMethod.GET,
+            params={"market_addr": market_addr},
+            throttler_limit_id=CONSTANTS.DEPTH_PATH_URL,
+            is_auth_required=True,
+        )
+
+    async def _order_book_snapshot(self, trading_pair: str) -> OrderBookMessage:
+        snapshot = await self._request_order_book_snapshot(trading_pair)
+        data = snapshot.get("data", snapshot)
+        ts_ms = data.get("timestamp") or data.get("transaction_unix_ms") or int(time.time() * 1000)
+        bids = data.get("bids") or []
+        asks = data.get("asks") or []
+        return OrderBookMessage(
+            message_type=OrderBookMessageType.SNAPSHOT,
+            content={
+                "trading_pair": trading_pair,
+                "update_id": int(data.get("sequence") or ts_ms),
+                "bids": [[float(p), float(s)] for p, s in bids],
+                "asks": [[float(p), float(s)] for p, s in asks],
+            },
+            timestamp=float(ts_ms) / 1000.0,
+        )
+
+    async def get_funding_info(self, trading_pair: str) -> FundingInfo:
+        # Funding is available via market_price topic; REST equivalent is not currently used.
+        # Return a safe default; the FundingInfoUpdate stream will keep it up to date.
+        last_price = await self._connector.get_last_traded_price(trading_pair)
+        return FundingInfo(
+            trading_pair=trading_pair,
+            index_price=float(last_price),
+            mark_price=float(last_price),
+            next_funding_utc_timestamp=0,
+            rate=0.0,
+        )
+
+    async def _connected_websocket_assistant(self) -> WSAssistant:
+        ws = await self._api_factory.get_ws_assistant()
+        ws_headers = self._connector.authenticator.ws_headers
+        await ws.connect(
+            ws_url=CONSTANTS.WS_URLS[self._domain],
+            ping_timeout=CONSTANTS.HEARTBEAT_TIME_INTERVAL,
+            ws_headers=ws_headers,
+        )
+        return ws
+
+    async def _subscribe_channels(self, ws: WSAssistant):
+        for trading_pair in self._trading_pairs:
+            market_addr = await self._connector.market_address_associated_to_pair(trading_pair)
+            topics = [
+                f"{CONSTANTS.WS_DEPTH_TOPIC_PREFIX}:{market_addr}",
+                f"{CONSTANTS.WS_TRADES_TOPIC_PREFIX}:{market_addr}",
+                f"{CONSTANTS.WS_MARKET_PRICE_TOPIC_PREFIX}:{market_addr}",
+            ]
+            for topic in topics:
+                await ws.send(WSJSONRequest(payload={"method": "subscribe", "topic": topic}))
+
+    def _channel_originating_message(self, event_message: Dict[str, Any]) -> str:
+        topic = event_message.get("topic", "")
+        if topic.startswith(f"{CONSTANTS.WS_DEPTH_TOPIC_PREFIX}:"):
+            return self._diff_messages_queue_key
+        if topic.startswith(f"{CONSTANTS.WS_TRADES_TOPIC_PREFIX}:"):
+            return self._trade_messages_queue_key
+        if topic.startswith(f"{CONSTANTS.WS_MARKET_PRICE_TOPIC_PREFIX}:") or topic == CONSTANTS.WS_ALL_MARKET_PRICES_TOPIC:
+            return self._funding_info_messages_queue_key
+        return ""
+
+    async def _parse_trade_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
+        topic: str = raw_message.get("topic", "")
+        data = raw_message.get("data")
+        if not topic.startswith(f"{CONSTANTS.WS_TRADES_TOPIC_PREFIX}:") or data is None:
+            return
+        market_addr = topic.split(":", 1)[1]
+        trading_pair = await self._connector.trading_pair_associated_to_market_address(market_addr)
+        if trading_pair is None:
+            return
+        trades = data if isinstance(data, list) else [data]
+        for trade in trades:
+            ts_ms = trade.get("transaction_unix_ms") or trade.get("timestamp") or int(time.time() * 1000)
+            msg = OrderBookMessage(
+                message_type=OrderBookMessageType.TRADE,
+                content={
+                    "trading_pair": trading_pair,
+                    "trade_type": 1.0 if str(trade.get("side", "")).lower() == "buy" else 2.0,
+                    "trade_id": trade.get("trade_id") or trade.get("id") or int(ts_ms),
+                    "update_id": int(ts_ms),
+                    "price": float(trade.get("price", 0)),
+                    "amount": float(trade.get("size", trade.get("qty", 0))),
+                },
+                timestamp=float(ts_ms) / 1000.0,
+            )
+            await message_queue.put(msg)
+
+    async def _parse_order_book_diff_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
+        topic: str = raw_message.get("topic", "")
+        data = raw_message.get("data")
+        if not topic.startswith(f"{CONSTANTS.WS_DEPTH_TOPIC_PREFIX}:") or data is None:
+            return
+        market_addr = topic.split(":", 1)[1].split(":", 1)[0]
+        trading_pair = await self._connector.trading_pair_associated_to_market_address(market_addr)
+        if trading_pair is None:
+            return
+        ts_ms = data.get("transaction_unix_ms") or data.get("timestamp") or int(time.time() * 1000)
+        update_id = int(data.get("sequence") or ts_ms)
+        bids = data.get("bids") or []
+        asks = data.get("asks") or []
+        msg = OrderBookMessage(
+            message_type=OrderBookMessageType.DIFF,
+            content={
+                "trading_pair": trading_pair,
+                "update_id": update_id,
+                "bids": [[float(p), float(s)] for p, s in bids],
+                "asks": [[float(p), float(s)] for p, s in asks],
+            },
+            timestamp=float(ts_ms) / 1000.0,
+        )
+        await message_queue.put(msg)
+
+    async def _parse_order_book_snapshot_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
+        # Decibel depth stream may send full snapshots; treat them as diffs.
+        await self._parse_order_book_diff_message(raw_message, message_queue)
+
+    async def _parse_funding_info_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
+        topic: str = raw_message.get("topic", "")
+        data = raw_message.get("data")
+        if data is None:
+            return
+        market_addr: Optional[str] = None
+        if topic.startswith(f"{CONSTANTS.WS_MARKET_PRICE_TOPIC_PREFIX}:"):
+            market_addr = topic.split(":", 1)[1]
+        if market_addr is None:
+            return
+        trading_pair = await self._connector.trading_pair_associated_to_market_address(market_addr)
+        if trading_pair is None:
+            return
+        info = FundingInfoUpdate(
+            trading_pair=trading_pair,
+            index_price=float(data.get("oracle_price", data.get("index_price", 0)) or 0),
+            mark_price=float(data.get("mark_price", 0) or 0),
+            next_funding_utc_timestamp=int(data.get("next_funding_unix_s", data.get("next_funding_utc_timestamp", 0)) or 0),
+            rate=float(data.get("funding_rate", data.get("funding_rate_bps", 0)) or 0),
+        )
+        await message_queue.put(info)
+
+    async def subscribe_to_trading_pair(self, trading_pair: str) -> bool:
+        if trading_pair not in self._trading_pairs:
+            self._trading_pairs.append(trading_pair)
+        return True
+
+    async def unsubscribe_from_trading_pair(self, trading_pair: str) -> bool:
+        if trading_pair in self._trading_pairs:
+            self._trading_pairs.remove(trading_pair)
+        return True

--- a/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_api_user_stream_data_source.py
+++ b/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_api_user_stream_data_source.py
@@ -1,0 +1,73 @@
+import asyncio
+from typing import Any, Dict, List, Optional
+
+from hummingbot.connector.derivative.decibel_perpetual import decibel_perpetual_constants as CONSTANTS
+from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+from hummingbot.core.web_assistant.ws_assistant import WSAssistant
+from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
+from hummingbot.logger import HummingbotLogger
+
+
+class DecibelPerpetualAPIUserStreamDataSource(UserStreamTrackerDataSource):
+    _logger: Optional[HummingbotLogger] = None
+
+    def __init__(
+        self,
+        auth,
+        trading_pairs: List[str],
+        connector,
+        api_factory: WebAssistantsFactory,
+        domain: str = CONSTANTS.DEFAULT_DOMAIN,
+    ):
+        super().__init__()
+        self._auth = auth
+        self._trading_pairs = trading_pairs
+        self._connector = connector
+        self._api_factory = api_factory
+        self._domain = domain
+
+    async def _connected_websocket_assistant(self) -> WSAssistant:
+        ws = await self._api_factory.get_ws_assistant()
+        await ws.connect(
+            ws_url=CONSTANTS.WS_URLS[self._domain],
+            ping_timeout=CONSTANTS.HEARTBEAT_TIME_INTERVAL,
+            ws_headers=self._auth.ws_headers,
+        )
+        return ws
+
+    async def _subscribe_channels(self, ws: WSAssistant):
+        account_addr = self._connector.account_address
+        topics = [
+            f"{CONSTANTS.WS_ORDER_UPDATES_PREFIX}:{account_addr}",
+            f"{CONSTANTS.WS_ACCOUNT_OPEN_ORDERS_PREFIX}:{account_addr}",
+            f"{CONSTANTS.WS_USER_TRADES_PREFIX}:{account_addr}",
+            f"{CONSTANTS.WS_ACCOUNT_POSITIONS_PREFIX}:{account_addr}",
+            f"{CONSTANTS.WS_ACCOUNT_OVERVIEW_PREFIX}:{account_addr}",
+        ]
+        for topic in topics:
+            await ws.send(WSJSONRequest(payload={"method": "subscribe", "topic": topic}))
+
+    async def _process_websocket_messages(self, websocket_assistant: WSAssistant):
+        async for ws_response in websocket_assistant.iter_messages():
+            data = ws_response.data
+            if isinstance(data, dict) and data.get("success") is False:
+                # subscription error
+                self.logger().warning(f"Decibel WS error: {data}")
+                continue
+            await self._message_queue.put(data)
+
+    async def listen_for_user_stream(self, output: asyncio.Queue):
+        ws: Optional[WSAssistant] = None
+        while True:
+            try:
+                ws = await self._connected_websocket_assistant()
+                await self._subscribe_channels(ws)
+                await self._process_websocket_messages(ws)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                self.logger().exception("Unexpected error while listening to Decibel user stream. Retrying...")
+            finally:
+                if ws is not None:
+                    await ws.disconnect()

--- a/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_auth.py
+++ b/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_auth.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from hummingbot.core.web_assistant.auth import AuthBase
+from hummingbot.core.web_assistant.connections.data_types import RESTRequest, WSRequest
+
+
+@dataclass
+class DecibelPerpetualAuth(AuthBase):
+    """Decibel authentication.
+
+    REST: Every endpoint requires headers:
+      - Origin: your app origin
+      - Authorization: Bearer <token>
+
+    WebSocket: authentication is done at connection time using the
+    `Sec-WebSocket-Protocol: decibel, <token>` header (handled by data sources).
+    """
+
+    bearer_token: str
+    origin: str
+
+    async def rest_authenticate(self, request: RESTRequest) -> RESTRequest:
+        headers = dict(request.headers or {})
+        headers["Origin"] = self.origin
+        headers["Authorization"] = f"Bearer {self.bearer_token}"
+        request.headers = headers
+        return request
+
+    async def ws_authenticate(self, request: WSRequest) -> WSRequest:
+        # No-op: WS auth is done via the Sec-WebSocket-Protocol header.
+        return request
+
+    @property
+    def ws_headers(self) -> dict:
+        # aiohttp expects a comma-separated list in this header.
+        return {"Sec-WebSocket-Protocol": f"decibel, {self.bearer_token}"}

--- a/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_constants.py
+++ b/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_constants.py
@@ -1,0 +1,79 @@
+from hummingbot.core.api_throttler.data_types import LinkedLimitWeightPair, RateLimit
+
+# Domain names
+MAINNET_DOMAIN = "mainnet"
+TESTNET_DOMAIN = "testnet"
+DEFAULT_DOMAIN = MAINNET_DOMAIN
+
+# Base URLs
+REST_URLS = {
+    MAINNET_DOMAIN: "https://api.mainnet.aptoslabs.com/decibel",
+    TESTNET_DOMAIN: "https://api.testnet.aptoslabs.com/decibel",
+}
+
+WS_URLS = {
+    MAINNET_DOMAIN: "wss://api.mainnet.aptoslabs.com/decibel/ws",
+    TESTNET_DOMAIN: "wss://api.testnet.aptoslabs.com/decibel/ws",
+}
+
+# Public REST endpoints
+MARKETS_PATH_URL = "/api/v1/markets"
+MARKET_PRICES_PATH_URL = "/api/v1/market_prices"
+DEPTH_PATH_URL = "/api/v1/depth"
+TRADES_PATH_URL = "/api/v1/trades"
+SERVER_TIME_PATH_URL = "/api/v1/time"
+
+# Private REST endpoints (require bearer token)
+ACCOUNT_OVERVIEW_PATH_URL = "/api/v1/account_overview"
+ACCOUNT_POSITIONS_PATH_URL = "/api/v1/account_positions"
+OPEN_ORDERS_PATH_URL = "/api/v1/account_open_orders"
+ORDER_PATH_URL = "/api/v1/orders"  # GET one or many, POST create
+
+HEARTBEAT_TIME_INTERVAL = 30.0
+
+# WebSocket topics (see docs.decibel.trade)
+WS_DEPTH_TOPIC_PREFIX = "depth"  # depth:{marketAddr}(:{aggregationLevel})
+WS_TRADES_TOPIC_PREFIX = "trades"  # trades:{marketAddr}
+WS_MARKET_PRICE_TOPIC_PREFIX = "market_price"  # market_price:{marketAddr}
+WS_ALL_MARKET_PRICES_TOPIC = "all_market_prices"
+
+WS_ACCOUNT_OPEN_ORDERS_PREFIX = "account_open_orders"  # account_open_orders:{accountAddr}
+WS_ORDER_UPDATES_PREFIX = "order_updates"  # order_updates:{accountAddr}
+WS_ACCOUNT_POSITIONS_PREFIX = "account_positions"  # account_positions:{accountAddr}
+WS_ACCOUNT_OVERVIEW_PREFIX = "account_overview"  # account_overview:{accountAddr}
+WS_USER_TRADES_PREFIX = "user_trades"  # user_trades:{accountAddr}
+
+# Rate limits
+MAX_REQUEST_WEIGHT = 1200
+NO_LIMIT_ID = "NO_LIMIT"
+REQUEST_WEIGHT_ID = "REQUEST_WEIGHT"
+
+RATE_LIMITS = [
+    RateLimit(limit_id=NO_LIMIT_ID, limit=MAX_REQUEST_WEIGHT, time_interval=60),
+    RateLimit(
+        limit_id=REQUEST_WEIGHT_ID,
+        limit=MAX_REQUEST_WEIGHT,
+        time_interval=60,
+        linked_limits=[LinkedLimitWeightPair(NO_LIMIT_ID)],
+    ),
+    # Public endpoints
+    RateLimit(limit_id=MARKETS_PATH_URL, limit=MAX_REQUEST_WEIGHT, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT_ID, 1)]),
+    RateLimit(limit_id=MARKET_PRICES_PATH_URL, limit=MAX_REQUEST_WEIGHT, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT_ID, 1)]),
+    RateLimit(limit_id=DEPTH_PATH_URL, limit=MAX_REQUEST_WEIGHT, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT_ID, 1)]),
+    RateLimit(limit_id=TRADES_PATH_URL, limit=MAX_REQUEST_WEIGHT, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT_ID, 1)]),
+    RateLimit(limit_id=SERVER_TIME_PATH_URL, limit=MAX_REQUEST_WEIGHT, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT_ID, 1)]),
+    # Private endpoints
+    RateLimit(limit_id=ACCOUNT_OVERVIEW_PATH_URL, limit=MAX_REQUEST_WEIGHT, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT_ID, 5)]),
+    RateLimit(limit_id=ACCOUNT_POSITIONS_PATH_URL, limit=MAX_REQUEST_WEIGHT, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT_ID, 5)]),
+    RateLimit(limit_id=OPEN_ORDERS_PATH_URL, limit=MAX_REQUEST_WEIGHT, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT_ID, 5)]),
+    RateLimit(limit_id=ORDER_PATH_URL, limit=MAX_REQUEST_WEIGHT, time_interval=60,
+              linked_limits=[LinkedLimitWeightPair(REQUEST_WEIGHT_ID, 10)]),
+]

--- a/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_derivative.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import asyncio
+from decimal import Decimal
+from typing import Any, Dict, List, Optional, Tuple
+
+from hummingbot.connector.derivative.decibel_perpetual import decibel_perpetual_constants as CONSTANTS
+from hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_api_order_book_data_source import (
+    DecibelPerpetualAPIOrderBookDataSource,
+)
+from hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_api_user_stream_data_source import (
+    DecibelPerpetualAPIUserStreamDataSource,
+)
+from hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_auth import DecibelPerpetualAuth
+from hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_web_utils import build_api_factory, rest_url
+from hummingbot.connector.perpetual_derivative_py_base import PerpetualDerivativePyBase
+from hummingbot.connector.trading_rule import TradingRule
+from hummingbot.core.data_type.common import OrderType, PositionAction, PositionMode, TradeType
+from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState, OrderUpdate
+from hummingbot.core.data_type.perpetual_api_order_book_data_source import PerpetualAPIOrderBookDataSource
+from hummingbot.core.data_type.trade_fee import TradeFeeBase
+from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
+from hummingbot.core.utils.estimate_fee import build_trade_fee
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod
+
+
+class DecibelPerpetualDerivative(PerpetualDerivativePyBase):
+    def __init__(
+        self,
+        client_config_map,
+        decibel_perpetual_bearer_token: str,
+        decibel_perpetual_origin: str,
+        decibel_perpetual_account_address: str,
+        trading_pairs: Optional[List[str]] = None,
+        trading_required: bool = True,
+        domain: str = CONSTANTS.DEFAULT_DOMAIN,
+    ):
+        self._bearer_token = decibel_perpetual_bearer_token
+        self._origin = decibel_perpetual_origin
+        self._account_address = decibel_perpetual_account_address
+        self._domain = domain
+        self._trading_pairs = trading_pairs or []
+        self._trading_required = trading_required
+        self._market_addr_by_pair: Dict[str, str] = {}
+        self._pair_by_market_addr: Dict[str, str] = {}
+        super().__init__(client_config_map)
+
+    @property
+    def account_address(self) -> str:
+        return self._account_address
+
+    @property
+    def authenticator(self) -> DecibelPerpetualAuth:
+        return DecibelPerpetualAuth(bearer_token=self._bearer_token, origin=self._origin)
+
+    @property
+    def name(self) -> str:
+        return "decibel_perpetual"
+
+    @property
+    def domain(self) -> str:
+        return self._domain
+
+    @property
+    def rate_limits_rules(self):
+        return CONSTANTS.RATE_LIMITS
+
+    @property
+    def client_order_id_max_length(self) -> int:
+        return 36
+
+    @property
+    def client_order_id_prefix(self) -> str:
+        return "decibel-"
+
+    @property
+    def trading_pairs(self) -> List[str]:
+        return self._trading_pairs
+
+    @property
+    def trading_rules_request_path(self) -> str:
+        return CONSTANTS.MARKETS_PATH_URL
+
+    @property
+    def trading_pairs_request_path(self) -> str:
+        return CONSTANTS.MARKETS_PATH_URL
+
+    @property
+    def check_network_request_path(self) -> str:
+        return CONSTANTS.SERVER_TIME_PATH_URL
+
+    @property
+    def is_cancel_request_in_exchange_synchronous(self) -> bool:
+        return True
+
+    @property
+    def is_trading_required(self) -> bool:
+        return self._trading_required
+
+    @property
+    def supported_position_modes(self) -> List[PositionMode]:
+        return [PositionMode.ONEWAY]
+
+    def supported_order_types(self) -> List[OrderType]:
+        return [OrderType.LIMIT, OrderType.MARKET]
+
+    def _is_request_exception_related_to_time_synchronizer(self, request_exception: Exception) -> bool:
+        return False
+
+    def _create_web_assistants_factory(self):
+        return build_api_factory(throttler=self._throttler, auth=self.authenticator)
+
+    def _create_order_book_data_source(self) -> PerpetualAPIOrderBookDataSource:
+        return DecibelPerpetualAPIOrderBookDataSource(
+            trading_pairs=self._trading_pairs,
+            connector=self,
+            api_factory=self._web_assistants_factory,
+            domain=self._domain,
+        )
+
+    def _create_user_stream_data_source(self) -> UserStreamTrackerDataSource:
+        return DecibelPerpetualAPIUserStreamDataSource(
+            auth=self.authenticator,
+            trading_pairs=self._trading_pairs,
+            connector=self,
+            api_factory=self._web_assistants_factory,
+            domain=self._domain,
+        )
+
+    def _get_fee(self, base_currency, quote_currency, order_type, order_side, amount, price=None, is_maker=None):
+        is_maker = order_type is OrderType.LIMIT_MAKER
+        return build_trade_fee(
+            self.name,
+            is_maker,
+            base_currency=base_currency,
+            quote_currency=quote_currency,
+            order_type=order_type,
+            order_side=order_side,
+            amount=amount,
+            price=price,
+        )
+
+    async def market_address_associated_to_pair(self, trading_pair: str) -> str:
+        if trading_pair not in self._market_addr_by_pair:
+            await self._update_symbol_map_if_needed()
+        return self._market_addr_by_pair[trading_pair]
+
+    async def trading_pair_associated_to_market_address(self, market_addr: str) -> Optional[str]:
+        if market_addr not in self._pair_by_market_addr:
+            await self._update_symbol_map_if_needed()
+        return self._pair_by_market_addr.get(market_addr)
+
+    async def _update_symbol_map_if_needed(self):
+        if self._market_addr_by_pair and self._pair_by_market_addr:
+            return
+        rest_assistant = await self._web_assistants_factory.get_rest_assistant()
+        markets = await rest_assistant.execute_request(
+            url=rest_url(CONSTANTS.MARKETS_PATH_URL, domain=self._domain),
+            method=RESTMethod.GET,
+            is_auth_required=True,
+            throttler_limit_id=CONSTANTS.MARKETS_PATH_URL,
+        )
+        await self._initialize_trading_pair_symbols_from_exchange_info(markets)
+
+    async def _initialize_trading_pair_symbols_from_exchange_info(self, exchange_info: Dict[str, Any]):
+        markets = exchange_info if isinstance(exchange_info, list) else exchange_info.get("data", [])
+        mapping: Dict[str, str] = {}
+        for market in markets:
+            market_name = market.get("market_name") or market.get("market") or market.get("name")
+            market_addr = market.get("market_addr") or market.get("address")
+            if market_name is None or market_addr is None:
+                continue
+            trading_pair = self.convert_from_exchange_trading_pair(market_name)
+            mapping[market_name] = trading_pair
+            self._market_addr_by_pair[trading_pair] = market_addr
+            self._pair_by_market_addr[market_addr] = trading_pair
+        self._set_trading_pair_symbol_map(mapping)
+
+    async def _format_trading_rules(self, exchange_info_dict: Dict[str, Any]) -> List[TradingRule]:
+        trading_rules: List[TradingRule] = []
+        markets = exchange_info_dict if isinstance(exchange_info_dict, list) else exchange_info_dict.get("data", [])
+        for market in markets:
+            try:
+                market_name = market.get("market_name") or market.get("market") or market.get("name")
+                if market_name is None:
+                    continue
+                trading_pair = self.convert_from_exchange_trading_pair(market_name)
+                trading_rules.append(
+                    TradingRule(
+                        trading_pair=trading_pair,
+                        min_order_size=Decimal(str(market.get("min_size", 0))),
+                        min_price_increment=Decimal(str(market.get("tick_size", "0.0"))),
+                        min_base_amount_increment=Decimal("1") / (Decimal(10) ** Decimal(str(market.get("sz_decimals", 0)))),
+                    )
+                )
+            except Exception:
+                self.logger().exception(f"Error parsing trading rules for {market}")
+        return trading_rules
+
+    async def _place_order(
+        self,
+        order_id: str,
+        trading_pair: str,
+        amount: Decimal,
+        trade_type: TradeType,
+        order_type: OrderType,
+        price: Decimal,
+        position_action: PositionAction = PositionAction.OPEN,
+        **kwargs,
+    ) -> Tuple[str, float]:
+        raise NotImplementedError("Trading endpoints are not implemented in this connector template.")
+
+    async def _place_cancel(self, order_id: str, tracked_order: InFlightOrder):
+        raise NotImplementedError
+
+    async def _request_order_status(self, tracked_order: InFlightOrder) -> OrderUpdate:
+        raise NotImplementedError
+
+    async def _update_balances(self):
+        return
+
+    async def _update_positions(self):
+        return
+
+    async def _set_trading_pair_leverage(self, trading_pair: str, leverage: int) -> Tuple[bool, str]:
+        return False, "Not supported"
+
+    async def _fetch_last_fee_payment(self, trading_pair: str):
+        return 0, Decimal("0"), Decimal("0")
+
+    async def _status_polling_loop_fetch_updates(self):
+        # Keep the base loop alive even if trading isn't implemented.
+        await asyncio.sleep(0)
+
+    async def _update_order_status(self):
+        return
+
+    async def _update_order_fills_from_trades(self):
+        return

--- a/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_utils.py
+++ b/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_utils.py
@@ -1,0 +1,59 @@
+from decimal import Decimal
+from typing import Any, Dict
+
+from pydantic import ConfigDict, Field, SecretStr
+
+from hummingbot.client.config.config_data_types import BaseConnectorConfigMap
+from hummingbot.core.data_type.trade_fee import TradeFeeSchema
+
+DEFAULT_FEES = TradeFeeSchema(
+    maker_percent_fee_decimal=Decimal("0"),
+    taker_percent_fee_decimal=Decimal("0"),
+)
+
+CENTRALIZED = True
+EXAMPLE_PAIR = "BTC-USD"
+
+
+def is_exchange_information_valid(exchange_info: Dict[str, Any]) -> bool:
+    # Decibel markets contain a 'mode' field (Open/ReduceOnly/CloseOnly)
+    return str(exchange_info.get("mode", "open")).lower() in ("open", "reduceonly", "closeonly")
+
+
+class DecibelPerpetualConfigMap(BaseConnectorConfigMap):
+    connector: str = "decibel_perpetual"
+
+    decibel_perpetual_bearer_token: SecretStr = Field(
+        default=...,
+        json_schema_extra={
+            "prompt": "Enter your Decibel Bearer token (from Geomi)",
+            "is_secure": True,
+            "is_connect_key": True,
+            "prompt_on_new": True,
+        },
+    )
+
+    decibel_perpetual_origin: str = Field(
+        default="https://app.decibel.trade",
+        json_schema_extra={
+            "prompt": "Enter your application Origin header value",
+            "is_secure": False,
+            "is_connect_key": True,
+            "prompt_on_new": True,
+        },
+    )
+
+    decibel_perpetual_account_address: str = Field(
+        default=...,
+        json_schema_extra={
+            "prompt": "Enter your Decibel Trading Account address",
+            "is_secure": True,
+            "is_connect_key": True,
+            "prompt_on_new": True,
+        },
+    )
+
+    model_config = ConfigDict(title="decibel_perpetual")
+
+
+KEYS = DecibelPerpetualConfigMap.model_construct()

--- a/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_web_utils.py
+++ b/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_web_utils.py
@@ -1,0 +1,51 @@
+from typing import Callable, Optional
+
+from hummingbot.connector.derivative.decibel_perpetual import decibel_perpetual_constants as CONSTANTS
+from hummingbot.connector.time_synchronizer import TimeSynchronizer
+from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from hummingbot.core.web_assistant.auth import AuthBase
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+
+
+def rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:
+    base = CONSTANTS.REST_URLS[domain]
+    return f"{base}{path_url}"
+
+
+def build_api_factory(
+    throttler: Optional[AsyncThrottler] = None,
+    time_synchronizer: Optional[TimeSynchronizer] = None,
+    time_provider: Optional[Callable] = None,
+    auth: Optional[AuthBase] = None,
+) -> WebAssistantsFactory:
+    throttler = throttler or create_throttler()
+    return WebAssistantsFactory(throttler=throttler, auth=auth)
+
+
+def build_api_factory_without_time_synchronizer_pre_processor(throttler: AsyncThrottler) -> WebAssistantsFactory:
+    return WebAssistantsFactory(throttler=throttler)
+
+
+def create_throttler() -> AsyncThrottler:
+    return AsyncThrottler(CONSTANTS.RATE_LIMITS)
+
+
+async def get_current_server_time(
+    throttler: Optional[AsyncThrottler] = None,
+    domain: str = CONSTANTS.DEFAULT_DOMAIN,
+) -> float:
+    throttler = throttler or create_throttler()
+    api_factory = build_api_factory_without_time_synchronizer_pre_processor(throttler=throttler)
+    rest_assistant = await api_factory.get_rest_assistant()
+    response = await rest_assistant.execute_request(
+        url=rest_url(path_url=CONSTANTS.SERVER_TIME_PATH_URL, domain=domain),
+        method=RESTMethod.GET,
+        throttler_limit_id=CONSTANTS.SERVER_TIME_PATH_URL,
+    )
+    # Spec isn't explicitly documented; accept a few common shapes.
+    server_time_ms = response.get("serverTime") or response.get("timestamp") or response.get("time")
+    if server_time_ms is None:
+        import time
+        server_time_ms = time.time() * 1000
+    return float(server_time_ms) / 1000.0

--- a/test/hummingbot/connector/derivative/decibel_perpetual/test_decibel_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/decibel_perpetual/test_decibel_perpetual_api_order_book_data_source.py
@@ -1,0 +1,86 @@
+import asyncio
+import time
+from unittest import TestCase
+from unittest.mock import AsyncMock, MagicMock
+
+from hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_api_order_book_data_source import (
+    DecibelPerpetualAPIOrderBookDataSource,
+)
+from hummingbot.core.data_type.order_book_message import OrderBookMessageType
+
+
+class TestDecibelPerpetualAPIOrderBookDataSource(TestCase):
+    def setUp(self):
+        self.trading_pairs = ["BTC-USD"]
+        self.connector = MagicMock()
+        self.connector.market_address_associated_to_pair = AsyncMock(return_value="0xMARKET")
+        self.connector.trading_pair_associated_to_market_address = AsyncMock(return_value="BTC-USD")
+        self.connector.convert_from_exchange_trading_pair = MagicMock(return_value="BTC-USD")
+        self.connector.get_last_traded_price = AsyncMock(return_value=50000)
+        self.connector.authenticator = MagicMock()
+        self.connector.authenticator.ws_headers = {"Sec-WebSocket-Protocol": "decibel, token"}
+
+        self.api_factory = MagicMock()
+        self.rest_assistant = AsyncMock()
+        self.api_factory.get_rest_assistant = AsyncMock(return_value=self.rest_assistant)
+
+        self.data_source = DecibelPerpetualAPIOrderBookDataSource(
+            trading_pairs=self.trading_pairs,
+            connector=self.connector,
+            api_factory=self.api_factory,
+        )
+
+    def test_order_book_snapshot_parses_bids_and_asks(self):
+        mock_response = {
+            "data": {
+                "timestamp": int(time.time() * 1000),
+                "sequence": 123,
+                "bids": [["50000.0", "1.5"], ["49999.0", "2.0"]],
+                "asks": [["50001.0", "1.0"], ["50002.0", "3.0"]],
+            }
+        }
+        self.rest_assistant.execute_request = AsyncMock(return_value=mock_response)
+
+        snapshot = asyncio.get_event_loop().run_until_complete(self.data_source._order_book_snapshot("BTC-USD"))
+        self.assertEqual(snapshot.type, OrderBookMessageType.SNAPSHOT)
+        self.assertEqual(snapshot.content["trading_pair"], "BTC-USD")
+        self.assertEqual(snapshot.content["update_id"], 123)
+        self.assertEqual(snapshot.content["bids"][0][0], 50000.0)
+        self.assertEqual(snapshot.content["asks"][0][0], 50001.0)
+
+    def test_get_last_traded_prices_parses_mark_price(self):
+        mock_response = [
+            {"market_name": "BTC-USD", "mark_price": "50000.0"},
+        ]
+        self.rest_assistant.execute_request = AsyncMock(return_value=mock_response)
+        prices = asyncio.get_event_loop().run_until_complete(self.data_source.get_last_traded_prices(["BTC-USD"]))
+        self.assertEqual(prices["BTC-USD"], 50000.0)
+
+    def test_channel_originating_message_routes_by_topic(self):
+        ob = {"topic": "depth:0xMARKET", "data": {}}
+        trades = {"topic": "trades:0xMARKET", "data": {}}
+        price = {"topic": "market_price:0xMARKET", "data": {}}
+
+        self.assertEqual(self.data_source._channel_originating_message(ob), self.data_source._diff_messages_queue_key)
+        self.assertEqual(self.data_source._channel_originating_message(trades), self.data_source._trade_messages_queue_key)
+        self.assertEqual(self.data_source._channel_originating_message(price), self.data_source._funding_info_messages_queue_key)
+
+    def test_parse_trade_message_creates_trade_order_book_message(self):
+        raw = {
+            "topic": "trades:0xMARKET",
+            "data": {
+                "id": 12345,
+                "side": "buy",
+                "price": "50000.0",
+                "size": "0.5",
+                "transaction_unix_ms": int(time.time() * 1000),
+            },
+        }
+        queue = asyncio.Queue()
+        asyncio.get_event_loop().run_until_complete(self.data_source._parse_trade_message(raw, queue))
+
+        msg = queue.get_nowait()
+        self.assertEqual(msg.type, OrderBookMessageType.TRADE)
+        self.assertEqual(msg.content["trading_pair"], "BTC-USD")
+        self.assertEqual(msg.content["price"], 50000.0)
+        self.assertEqual(msg.content["amount"], 0.5)

--- a/test/hummingbot/connector/derivative/decibel_perpetual/test_decibel_perpetual_auth.py
+++ b/test/hummingbot/connector/derivative/decibel_perpetual/test_decibel_perpetual_auth.py
@@ -1,0 +1,26 @@
+import asyncio
+from unittest import TestCase
+
+from hummingbot.connector.derivative.decibel_perpetual.decibel_perpetual_auth import DecibelPerpetualAuth
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod, RESTRequest, WSJSONRequest
+
+
+class TestDecibelPerpetualAuth(TestCase):
+    def setUp(self):
+        self.token = "test_token"
+        self.origin = "https://example.com/trade"
+        self.auth = DecibelPerpetualAuth(bearer_token=self.token, origin=self.origin)
+
+    def test_rest_authenticate_adds_headers(self):
+        request = RESTRequest(method=RESTMethod.GET, url="https://api.mainnet.aptoslabs.com/decibel/api/v1/markets")
+        result = asyncio.get_event_loop().run_until_complete(self.auth.rest_authenticate(request))
+        self.assertEqual(result.headers["Origin"], self.origin)
+        self.assertEqual(result.headers["Authorization"], f"Bearer {self.token}")
+
+    def test_ws_authenticate_is_noop(self):
+        req = WSJSONRequest(payload={"method": "subscribe", "topic": "all_market_prices"})
+        result = asyncio.get_event_loop().run_until_complete(self.auth.ws_authenticate(req))
+        self.assertIs(result, req)
+
+    def test_ws_headers_contains_sec_websocket_protocol(self):
+        self.assertEqual(self.auth.ws_headers["Sec-WebSocket-Protocol"], f"decibel, {self.token}")


### PR DESCRIPTION
Implements a Decibel perpetual connector (REST + WebSocket auth + order book data source) and unit tests.

- Connector path: hummingbot/connector/derivative/decibel_perpetual/
- Tests: test/hummingbot/connector/derivative/decibel_perpetual/
- WS auth uses Sec-WebSocket-Protocol header (decibel, <bearer token>) without modifying hummingbot/core/**

Tested:
- PYTHONPATH=. python -m pytest test/hummingbot/connector/derivative/decibel_perpetual

Claim address: 0x086AfBAa747252E8EF38cEaa0Ba4258B4DCc924A