### PR TITLE
fix(cli): stabilize --conf autocomplete and script config name handling

### DIFF
--- a/hummingbot/client/command/create_command.py
+++ b/hummingbot/client/command/create_command.py
@@ -112,8 +112,15 @@ class CreateCommand:
     async def prompt_for_configuration_v2(self,  # type: HummingbotApplication
                                           script_to_config: str):
         try:
-            module = sys.modules.get(f"{settings.SCRIPT_STRATEGIES_MODULE}.{script_to_config}")
-            script_module = importlib.reload(module)
+            script_module_name = Path(script_to_config).stem
+            module = sys.modules.get(f"{settings.SCRIPT_STRATEGIES_MODULE}.{script_module_name}")
+            if module is not None:
+                script_module = importlib.reload(module)
+            else:
+                script_module = importlib.import_module(
+                    f".{script_module_name}",
+                    package=settings.SCRIPT_STRATEGIES_MODULE,
+                )
             config_class = next((member for member_name, member in inspect.getmembers(script_module)
                                  if
                                  inspect.isclass(member) and member not in [BaseClientModel, StrategyV2ConfigBase] and
@@ -122,7 +129,7 @@ class CreateCommand:
 
             await self.prompt_for_model_config(config_map)
             if not self.app.to_stop_config:
-                file_name = await self.save_config(script_to_config, config_map, SCRIPT_STRATEGY_CONF_DIR_PATH)
+                file_name = await self.save_config(script_module_name, config_map, SCRIPT_STRATEGY_CONF_DIR_PATH)
                 self.notify(f"A new config file has been created: {file_name}")
             self.app.change_prompt(prompt=">>> ")
             self.app.input_field.completer = load_completer(self)
@@ -130,7 +137,7 @@ class CreateCommand:
             self.app.hide_input = False
 
         except StopIteration:
-            raise InvalidScriptModule(f"The module {script_to_config} does not contain any subclass of BaseModel")
+            raise InvalidScriptModule(f"The module {script_module_name} does not contain any subclass of BaseModel")
         except Exception as e:
             self.notify(f"An error occurred: {str(e)}")
             self.reset_application_state()

--- a/hummingbot/client/config/config_helpers.py
+++ b/hummingbot/client/config/config_helpers.py
@@ -892,6 +892,9 @@ def default_strategy_file_path(strategy: str) -> str:
 
 
 def short_strategy_name(strategy: str) -> str:
+    # Script strategy names can be passed as "<name>.py". Normalize to bare module name
+    # so generated config files follow the expected conf_<name>_<n>.yml format.
+    strategy = Path(strategy).stem
     if strategy == "pure_market_making":
         return "pure_mm"
     elif strategy == "cross_exchange_market_making":

--- a/hummingbot/client/ui/completer.py
+++ b/hummingbot/client/ui/completer.py
@@ -371,11 +371,35 @@ class HummingbotCompleter(Completer):
 
     def _complete_script_strategy_files(self, document: Document) -> bool:
         text_before_cursor: str = document.text_before_cursor
-        return text_before_cursor.startswith("start --script ") and "--conf" not in text_before_cursor and ".py" not in text_before_cursor
+        if not text_before_cursor.startswith("start --script ") or "--conf" in text_before_cursor:
+            return False
+
+        script_and_args = text_before_cursor[len("start --script "):]
+        stripped_script_and_args = script_and_args.strip()
+
+        if stripped_script_and_args == "":
+            return True
+
+        # Keep completing script names while the first positional argument is still being typed.
+        return " " not in stripped_script_and_args and not script_and_args.endswith(" ")
 
     def _complete_conf_param_script_strategy_config(self, document: Document) -> bool:
         text_before_cursor: str = document.text_before_cursor
-        return text_before_cursor.startswith("start --script ") and "--conf" not in text_before_cursor
+        if not text_before_cursor.startswith("start --script ") or "--conf" in text_before_cursor:
+            return False
+
+        script_and_args = text_before_cursor[len("start --script "):]
+        stripped_script_and_args = script_and_args.strip()
+        if stripped_script_and_args == "":
+            return False
+
+        parts = stripped_script_and_args.split()
+        script_name = parts[0]
+        if script_name.startswith("-"):
+            return False
+
+        # Suggest --conf once the script argument has been completed.
+        return len(parts) == 1 and script_and_args.endswith(" ")
 
     def _complete_script_strategy_config(self, document: Document) -> bool:
         text_before_cursor: str = document.text_before_cursor

--- a/test/hummingbot/client/config/test_config_helpers.py
+++ b/test/hummingbot/client/config/test_config_helpers.py
@@ -94,6 +94,17 @@ strategy: pure_market_making
 
         self.assertEqual(cm, cm_loaded)
 
+    def test_short_strategy_name_strips_script_extension(self):
+        strategy_name = config_helpers.short_strategy_name("v2_funding_rate_arb.py")
+        self.assertEqual("v2_funding_rate_arb", strategy_name)
+
+    def test_default_strategy_file_path_omits_script_extension(self):
+        with TemporaryDirectory() as temp_dir:
+            with patch.object(config_helpers, "STRATEGIES_CONF_DIR_PATH", Path(temp_dir)):
+                file_name = config_helpers.default_strategy_file_path("v2_funding_rate_arb.py")
+
+        self.assertEqual("conf_v2_funding_rate_arb_1.yml", file_name)
+
     def test_decrypt_config_map_secret_values(self):
         class DummySubModel(BaseClientModel):
             secret_attr: SecretStr

--- a/test/hummingbot/client/ui/test_completer.py
+++ b/test/hummingbot/client/ui/test_completer.py
@@ -1,0 +1,37 @@
+import unittest
+from types import SimpleNamespace
+
+from prompt_toolkit.document import Document
+
+from hummingbot.client.ui.completer import HummingbotCompleter
+
+
+class HummingbotCompleterTest(unittest.TestCase):
+    def _completer(self) -> HummingbotCompleter:
+        completer = HummingbotCompleter.__new__(HummingbotCompleter)
+        completer.hummingbot_application = SimpleNamespace(app=SimpleNamespace(prompt_text=">>> "))
+        return completer
+
+    def test_start_script_completes_script_names_while_typing_first_argument(self):
+        completer = self._completer()
+
+        self.assertTrue(
+            completer._complete_script_strategy_files(Document(text="start --script v2_funding_rate_arb"))
+        )
+        self.assertFalse(
+            completer._complete_conf_param_script_strategy_config(Document(text="start --script v2_funding_rate_arb"))
+        )
+
+    def test_start_script_suggests_conf_flag_after_script_argument_without_py_extension(self):
+        completer = self._completer()
+
+        document = Document(text="start --script v2_funding_rate_arb ")
+        self.assertFalse(completer._complete_script_strategy_files(document))
+        self.assertTrue(completer._complete_conf_param_script_strategy_config(document))
+
+    def test_start_script_suggests_conf_flag_after_script_argument_with_py_extension(self):
+        completer = self._completer()
+
+        document = Document(text="start --script v2_funding_rate_arb.py ")
+        self.assertFalse(completer._complete_script_strategy_files(document))
+        self.assertTrue(completer._complete_conf_param_script_strategy_config(document))


### PR DESCRIPTION
## Summary
- Improve `start --script ...` completion flow so script-name completion and `--conf` suggestion do not interfere.
- Normalize script module/config naming via `Path(...).stem` so filenames containing `.py` (including `perpetual` scripts) generate expected config paths.
- Update `CreateCommand` module loading to consistently import/reload by normalized script module name.
- Add focused tests for completer and config helper normalization.

## Why
- #6807: `--conf` autocomplete interferes with script startup flow.
- #7298: scripts with `perpetual` in filename lose expected `--conf` behavior.

## Validation
- Added/updated focused tests in:
  - `test/hummingbot/client/ui/test_completer.py`
  - `test/hummingbot/client/config/test_config_helpers.py`

Closes #6807
Closes #7298
