### PR TITLE
fix(ui): correct Avellaneda prompt option autofill parsing

### DIFF
--- a/hummingbot/client/ui/completer.py
+++ b/hummingbot/client/ui/completer.py
@@ -181,9 +181,12 @@ class HummingbotCompleter(Completer):
 
     @property
     def _option_completer(self):
-        outer = re.compile(r"\((.+)\)")
-        inner_str = outer.search(self.prompt_text).group(1)
-        options = inner_str.split("/") if "/" in inner_str else []
+        options = []
+        groups = re.findall(r"\(([^()]*)\)", self.prompt_text)
+        for group in reversed(groups):
+            if "/" in group:
+                options = [option.strip() for option in group.split("/")]
+                break
         return WordCompleter(options, ignore_case=True)
 
     @property

--- a/test/hummingbot/client/ui/test_completer.py
+++ b/test/hummingbot/client/ui/test_completer.py
@@ -1,0 +1,33 @@
+import unittest
+from types import SimpleNamespace
+
+import hummingbot.client.command  # noqa: F401
+from prompt_toolkit.completion import CompleteEvent
+from prompt_toolkit.document import Document
+
+from hummingbot.client.ui.completer import HummingbotCompleter
+
+
+class HummingbotCompleterTest(unittest.TestCase):
+    def _completer_with_prompt(self, prompt: str) -> HummingbotCompleter:
+        completer = HummingbotCompleter.__new__(HummingbotCompleter)
+        completer.hummingbot_application = SimpleNamespace(app=SimpleNamespace(prompt_text=prompt))
+        return completer
+
+    def test_option_completer_uses_last_parenthesized_options(self):
+        prompt = (
+            "Should the strategy wait to receive a confirmation for orders cancellation "
+            "before creating a new set of orders? "
+            "(Not waiting requires enough available balance) (Yes/No) >>> "
+        )
+        completer = self._completer_with_prompt(prompt)
+
+        completions = [
+            completion.text
+            for completion in completer._option_completer.get_completions(
+                Document(text="n"),
+                CompleteEvent(completion_requested=True),
+            )
+        ]
+
+        self.assertEqual(["No"], completions)


### PR DESCRIPTION
## Summary
- fix option autofill parsing in `HummingbotCompleter._option_completer` by selecting the **last** parenthesized prompt group containing slash-separated options
- add a focused regression test for prompts that contain explanatory parentheses before `(Yes/No)` options

## Why
Issue #5519 reports that Avellaneda config prompt autofill shows incorrect text when typing `n`/`N` because the parser greedily matches earlier parenthesized text.

## Maintainer feedback from #8068 addressed
- this PR is now correctly opened against the `development` base branch per `CONTRIBUTING.md`
- branch naming follows `fix/...` convention: `fix/andrzej_5519_avellaneda_autofill`
- change scope remains minimal and focused only on prompt option parsing + regression test

## Testing
- `conda run -n hummingbot python setup.py build_ext --inplace`
- `conda run -n hummingbot python -m unittest test.hummingbot.client.ui.test_completer -v`

Closes #5519
