### PR TITLE
(fix) scope derivative completion and lock v2 start options

### DIFF
--- a/hummingbot/client/ui/completer.py
+++ b/hummingbot/client/ui/completer.py
@@ -209,10 +209,10 @@ class HummingbotCompleter(Completer):
                    if x in self.prompt_text.lower())
 
     def _complete_derivatives(self, document: Document) -> bool:
-        text_before_cursor: str = document.text_before_cursor
-        return "perpetual" in text_before_cursor or \
-               any(x for x in ("derivative connector", "derivative name", "name of derivative", "name of the derivative")
-                   if x in self.prompt_text.lower())
+        return any(
+            x in self.prompt_text.lower()
+            for x in ("derivative connector", "derivative name", "name of derivative", "name of the derivative")
+        )
 
     def _complete_connect_options(self, document: Document) -> bool:
         text_before_cursor: str = document.text_before_cursor

--- a/test/hummingbot/client/ui/test_completer.py
+++ b/test/hummingbot/client/ui/test_completer.py
@@ -1,0 +1,39 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from prompt_toolkit.document import Document
+
+# Importing HummingbotApplication first avoids parser/completer circular import at module load time.
+from hummingbot.client.hummingbot_application import HummingbotApplication  # noqa: F401
+from hummingbot.client.ui.completer import HummingbotCompleter
+from hummingbot.client.ui.parser import load_parser
+
+
+class HummingbotCompleterTest(unittest.TestCase):
+    @staticmethod
+    def _completer(prompt_text: str = ">>> ") -> HummingbotCompleter:
+        completer = HummingbotCompleter.__new__(HummingbotCompleter)
+        completer.hummingbot_application = SimpleNamespace(app=SimpleNamespace(prompt_text=prompt_text))
+        return completer
+
+    def test_complete_derivatives_does_not_trigger_from_perpetual_text_in_v2_command(self):
+        completer = self._completer()
+
+        document = Document(text="start --v2 conf_simple_perpetual_pmm_1.yml")
+
+        self.assertTrue(completer._complete_v2_config_files(document))
+        self.assertFalse(completer._complete_derivatives(document))
+
+    def test_complete_derivatives_triggers_for_derivative_prompt(self):
+        completer = self._completer(prompt_text="Select derivative connector >>> ")
+
+        self.assertTrue(completer._complete_derivatives(Document(text="")))
+
+    def test_start_command_parser_only_exposes_v2_option(self):
+        parser = load_parser(MagicMock(), {})
+        start_options = parser.subcommands_from("start")
+
+        self.assertIn("--v2", start_options)
+        self.assertNotIn("--script", start_options)
+        self.assertNotIn("--conf", start_options)


### PR DESCRIPTION
## Summary
- Scope derivative autocompletion to derivative-specific prompts only.
- Add focused regression tests for the post-#7986 flow:
  - `start --v2 ...` text containing `perpetual` does **not** trigger derivative completion.
  - Derivative prompts still trigger derivative completion.
  - `start` parser options include `--v2` and do not include deprecated `--script` / `--conf`.

## Root cause on current `development`
- `HummingbotCompleter._complete_derivatives()` matched any command text containing `perpetual`, which could hijack completion context outside derivative prompts.
- After #7986, `start --script`/`--conf` are deprecated and removed from parser flow; the old #6807 reproduction path is obsolete on `development`.

## Maintainer feedback addressed
- PR base is `development`.
- Fix is adapted to current supported flow (no deprecated `start --script` path changes).

## Validation
```bash
python -m pytest test/hummingbot/client/ui/test_completer.py -q
```
Result:
- 3 passed

Closes #7298
Refs #6807
