### PR TITLE
fix: replace eval() with json.loads() in ws_data_to_dict

### DIFF
--- a/hummingbot/connector/exchange/foxbit/foxbit_utils.py
+++ b/hummingbot/connector/exchange/foxbit/foxbit_utils.py
@@ -67,7 +67,7 @@ def is_exchange_information_valid(exchange_info: Dict[str, Any]) -> bool:
 
 
 def ws_data_to_dict(data: str) -> Dict[str, Any]:
-    return eval(data.replace(":null", ":None").replace(":false", ":False").replace(":true", ":True"))
+    return json.loads(data)
 
 
 def datetime_val_or_now(string_value: str,

--- a/test/hummingbot/connector/exchange/foxbit/test_foxbit_utils.py
+++ b/test/hummingbot/connector/exchange/foxbit/test_foxbit_utils.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 from datetime import datetime
 from decimal import Decimal
@@ -45,6 +46,22 @@ class FoxbitUtilTestCases(unittest.TestCase):
     def test_ws_data_to_dict(self):
         _expectedValue = [{'Key': 'field0', 'Value': 'Google'}, {'Key': 'field2', 'Value': None}, {'Key': 'field3', 'Value': 'São Paulo'}, {'Key': 'field4', 'Value': False}, {'Key': 'field5', 'Value': 'SAO PAULO'}, {'Key': 'field6', 'Value': '00000001'}, {'Key': 'field7', 'Value': True}]
         _msg = '[{"Key":"field0","Value":"Google"},{"Key":"field2","Value":null},{"Key":"field3","Value":"São Paulo"},{"Key":"field4","Value":false},{"Key":"field5","Value":"SAO PAULO"},{"Key":"field6","Value":"00000001"},{"Key":"field7","Value":true}]'
+        _retValue = utils.ws_data_to_dict(_msg)
+        self.assertEqual(_expectedValue, _retValue)
+
+    def test_ws_data_to_dict_rejects_code_injection(self):
+        # This is the test that would have caught the eval() bug.
+        # The old eval()-based implementation would execute arbitrary Python expressions;
+        # json.loads() must reject anything that is not valid JSON.
+        _malicious_input = '[__import__("os")]'
+        with self.assertRaises((ValueError, json.JSONDecodeError)):
+            utils.ws_data_to_dict(_malicious_input)
+
+    def test_ws_data_to_dict_handles_json_native_types(self):
+        # json.loads() handles null/false/true natively — the old .replace() chain
+        # that converted them to Python literals before eval() is no longer needed.
+        _msg = '{"a": null, "b": false, "c": true}'
+        _expectedValue = {"a": None, "b": False, "c": True}
         _retValue = utils.ws_data_to_dict(_msg)
         self.assertEqual(_expectedValue, _retValue)
 


### PR DESCRIPTION
## What

Replaces `eval()` with `json.loads()` in `foxbit_utils.ws_data_to_dict()`.

## Why

The function was calling `eval()` on raw WebSocket message strings. The `.replace()` calls before `eval()` were there because the input is JSON — but `json.loads()` handles `null`, `false`, and `true` natively, so `eval()` was never needed. Any caller passing network-received data through this function exposed it to code execution if the input was attacker-controlled.

Reported in issue #8083. Additional context and test artifacts are in the email thread at dev@hummingbot.io.

## Changes

- `hummingbot/connector/exchange/foxbit/foxbit_utils.py` — replace `eval(...)` with `json.loads(data)` on line 70
- `test/hummingbot/connector/exchange/foxbit/test_foxbit_utils.py` — two new tests:
  - `test_ws_data_to_dict_rejects_code_injection`: confirms injection attempts now raise `ValueError`
  - `test_ws_data_to_dict_handles_json_native_types`: confirms `null`/`false`/`true` are handled correctly without the old `.replace()` chain

**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] Tests all pass
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")