### PR TITLE
fix: replace eval() with json.loads() in foxbit order book handlers

### DIFF
--- a/hummingbot/connector/exchange/foxbit/foxbit_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/foxbit/foxbit_api_order_book_data_source.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
@@ -143,8 +144,8 @@ class FoxbitAPIOrderBookDataSource(OrderBookTrackerDataSource):
         return snapshot_msg
 
     async def _parse_trade_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
-        if CONSTANTS.WS_SUBSCRIBE_TRADES or CONSTANTS.WS_TRADE_RESPONSE in raw_message['n']:
-            full_msg = eval(raw_message['o'].replace(",false,", ",False,"))
+        if CONSTANTS.WS_SUBSCRIBE_TRADES in raw_message['n'] or CONSTANTS.WS_TRADE_RESPONSE in raw_message['n']:
+            full_msg = json.loads(raw_message['o'])
             for msg in full_msg:
                 instrument_id = int(msg[FoxbitTradeFields.INSTRUMENTID.value])
                 trading_pair = ""
@@ -161,8 +162,8 @@ class FoxbitAPIOrderBookDataSource(OrderBookTrackerDataSource):
                 message_queue.put_nowait(trade_message)
 
     async def _parse_order_book_diff_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
-        if CONSTANTS.WS_ORDER_BOOK_RESPONSE or CONSTANTS.WS_ORDER_STATE in raw_message['n']:
-            full_msg = eval(raw_message['o'])
+        if CONSTANTS.WS_ORDER_BOOK_RESPONSE in raw_message['n'] or CONSTANTS.WS_ORDER_STATE in raw_message['n']:
+            full_msg = json.loads(raw_message['o'])
             for msg in full_msg:
                 instrument_id = int(msg[FoxbitOrderBookFields.PRODUCTPAIRCODE.value])
 

--- a/test/hummingbot/connector/exchange/foxbit/test_foxbit_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/foxbit/test_foxbit_api_order_book_data_source.py
@@ -472,7 +472,7 @@ class FoxbitAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):
 
         msg: OrderBookMessage = await msg_queue.get()
 
-        expected_id = eval(diff_event["o"])[0][0]
+        expected_id = json.loads(diff_event["o"])[0][0]
         self.assertEqual(expected_id, msg.update_id)
 
     # Dynamic subscription tests
@@ -585,3 +585,81 @@ class FoxbitAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):
         self.assertTrue(
             self._is_logged("ERROR", f"Unexpected error occurred unsubscribing from {self.trading_pair}...")
         )
+
+    # Tests for the eval() -> json.loads() fix (issue #8084)
+
+    async def test_parse_trade_message_parses_valid_json(self):
+        """_parse_trade_message parses a well-formed JSON trade payload without error."""
+        # Index 1 is INSTRUMENTID; instrument_id 1 maps to COINALPHA-HBOT in setUp
+        raw_message = {
+            'n': CONSTANTS.WS_TRADE_RESPONSE,
+            'o': '[[194,1,"0.1","8432.0",787704,792085,1661952966311,0,0,0,0]]',
+        }
+        msg_queue: asyncio.Queue = asyncio.Queue()
+
+        await self.data_source._parse_trade_message(raw_message, msg_queue)
+
+        self.assertFalse(msg_queue.empty())
+        trade_msg: OrderBookMessage = msg_queue.get_nowait()
+        self.assertEqual(194, trade_msg.trade_id)
+
+    async def test_parse_trade_message_raises_on_invalid_json(self):
+        """_parse_trade_message raises json.JSONDecodeError for a malformed/injection payload."""
+        raw_message = {
+            'n': CONSTANTS.WS_TRADE_RESPONSE,
+            'o': '__import__("os").system("id")',
+        }
+        msg_queue: asyncio.Queue = asyncio.Queue()
+
+        with self.assertRaises(json.JSONDecodeError):
+            await self.data_source._parse_trade_message(raw_message, msg_queue)
+
+    async def test_parse_trade_message_skips_unrelated_event_type(self):
+        """_parse_trade_message does not enqueue messages for unrecognised event types."""
+        raw_message = {
+            'n': 'SomeUnrelatedEvent',
+            'o': '[[194,1,"0.1","8432.0",787704,792085,1661952966311,0,0,0,0]]',
+        }
+        msg_queue: asyncio.Queue = asyncio.Queue()
+
+        await self.data_source._parse_trade_message(raw_message, msg_queue)
+
+        self.assertTrue(msg_queue.empty())
+
+    async def test_parse_order_book_diff_message_parses_valid_json(self):
+        """_parse_order_book_diff_message parses a well-formed JSON order book payload."""
+        # Index 7 is PRODUCTPAIRCODE; instrument_id 1 maps to COINALPHA-HBOT in setUp
+        raw_message = {
+            'n': CONSTANTS.WS_ORDER_BOOK_RESPONSE,
+            'o': '[[187,0,1661952966257,1,8432,0,8432,1,7.6,1]]',
+        }
+        msg_queue: asyncio.Queue = asyncio.Queue()
+
+        await self.data_source._parse_order_book_diff_message(raw_message, msg_queue)
+
+        self.assertFalse(msg_queue.empty())
+        diff_msg: OrderBookMessage = msg_queue.get_nowait()
+        self.assertEqual(187, diff_msg.update_id)
+
+    async def test_parse_order_book_diff_message_raises_on_invalid_json(self):
+        """_parse_order_book_diff_message raises json.JSONDecodeError for a malformed/injection payload."""
+        raw_message = {
+            'n': CONSTANTS.WS_ORDER_BOOK_RESPONSE,
+            'o': '__import__("os").system("id")',
+        }
+        msg_queue: asyncio.Queue = asyncio.Queue()
+
+        with self.assertRaises(json.JSONDecodeError):
+            await self.data_source._parse_order_book_diff_message(raw_message, msg_queue)
+
+    async def test_parse_order_book_diff_message_skips_unrelated_event_type(self):
+        """_parse_order_book_diff_message does not enqueue messages for unrecognised event types."""
+        raw_message = {
+            'n': 'SomeUnrelatedEvent',
+            'o': '[[187,0,1661952966257,1,8432,0,8432,1,7.6,1]]',
+        }
+        msg_queue: asyncio.Queue = asyncio.Queue()
+
+        await self.data_source._parse_order_book_diff_message(raw_message, msg_queue)
+
+        self.assertTrue(msg_queue.empty())


### PR DESCRIPTION
## What

Replaces two `eval()` calls with `json.loads()` in `foxbit_api_order_book_data_source.py`, and fixes an `or` operator precedence bug in the guard conditions for both affected methods.

## Why

`_parse_trade_message` and `_parse_order_book_diff_message` were passing the `'o'` field of live WebSocket messages through `eval()`. Anyone able to influence what the Foxbit WebSocket sends — via MITM or a compromised exchange endpoint — could inject a payload that runs arbitrary Python code.

There's also a logic bug in both guard conditions. `if CONSTANTS.WS_SUBSCRIBE_TRADES or CONSTANTS.WS_TRADE_RESPONSE in raw_message['n']:` evaluates as `if (CONSTANTS.WS_SUBSCRIBE_TRADES) or (CONSTANTS.WS_TRADE_RESPONSE in raw_message['n']):`. Since `WS_SUBSCRIBE_TRADES` is a non-empty string it's always truthy, so every message falls through to `eval()` regardless of event type.

Reported in issue #8084. Additional context and test artifacts are in the email thread at dev@hummingbot.io.

## Changes

- `hummingbot/connector/exchange/foxbit/foxbit_api_order_book_data_source.py`:
  - `eval()` → `json.loads()` in both handlers
  - `if A or B in x:` → `if A in x or B in x:` in both guard conditions
- `test/hummingbot/connector/exchange/foxbit/test_foxbit_api_order_book_data_source.py`:
  - Tests for correct JSON parsing in both handlers
  - Tests confirming injection attempts raise `ValueError`/`JSONDecodeError`
  - Test confirming the guard condition now correctly filters unrelated messages

**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] Tests all pass
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")