### PR TITLE
(fix) validate zero-sum dca amounts in dman maker v2

### DIFF
--- a/controllers/market_making/dman_maker_v2.py
+++ b/controllers/market_making/dman_maker_v2.py
@@ -57,11 +57,15 @@ class DManMakerV2Config(MarketMakingControllerConfigBase):
         if v is None or v == "":
             return [1 for _ in validation_info.data['dca_spreads']]
         if isinstance(v, str):
-            return [float(x.strip()) for x in v.split(',')]
-        elif isinstance(v, list) and len(v) != len(validation_info.data['dca_spreads']):
+            parsed_amounts = [float(x.strip()) for x in v.split(',')]
+        else:
+            parsed_amounts = v
+        if isinstance(parsed_amounts, list) and len(parsed_amounts) != len(validation_info.data['dca_spreads']):
             raise ValueError(
                 f"The number of dca amounts must match the number of {validation_info.data['dca_spreads']}.")
-        return v
+        if sum(Decimal(str(amount)) for amount in parsed_amounts) <= Decimal("0"):
+            raise ValueError("The sum of dca amounts must be greater than 0.")
+        return parsed_amounts
 
 
 class DManMakerV2(MarketMakingControllerBase):

--- a/test/hummingbot/strategy_v2/controllers/test_dman_maker_v2.py
+++ b/test/hummingbot/strategy_v2/controllers/test_dman_maker_v2.py
@@ -1,0 +1,31 @@
+from decimal import Decimal
+from unittest import TestCase
+
+from controllers.market_making.dman_maker_v2 import DManMakerV2Config
+
+
+class TestDManMakerV2Config(TestCase):
+    def test_rejects_zero_sum_dca_amounts(self):
+        with self.assertRaisesRegex(ValueError, "sum of dca amounts must be greater than 0"):
+            DManMakerV2Config(
+                id="test",
+                controller_name="dman_maker_v2",
+                connector_name="hyperliquid_perpetual",
+                trading_pair="ETH-USDT",
+                total_amount_quote=Decimal("100"),
+                dca_spreads="0,0.01",
+                dca_amounts="0,0",
+            )
+
+    def test_allows_zero_amount_levels_when_total_is_positive(self):
+        config = DManMakerV2Config(
+            id="test",
+            controller_name="dman_maker_v2",
+            connector_name="hyperliquid_perpetual",
+            trading_pair="ETH-USDT",
+            total_amount_quote=Decimal("100"),
+            dca_spreads="0,0.01",
+            dca_amounts="0,1",
+        )
+
+        self.assertEqual(config.dca_amounts, [0.0, 1.0])


### PR DESCRIPTION
## Summary
This PR fixes #8109 by validating `dman_maker_v2` DCA amount inputs before the controller starts.

When `dca_amounts` summed to zero, the controller normalized the list during initialization and triggered a `ZeroDivisionError`. In practice that left the strategy tick loop stuck and the client unresponsive.

The fix moves that failure to config validation. Zero-sum DCA amounts now raise a clear `ValueError`, while configurations that intentionally disable only some levels with `0` values continue to work as long as the total remains positive.

## Changes
- validate that `dca_amounts` has the same length as `dca_spreads` after parsing
- reject `dca_amounts` whose total is less than or equal to zero
- add a regression test for the zero-sum case
- add a positive test proving zero-valued levels are still allowed when the total is positive

## Validation
- `conda run -n hummingbot pre-commit run --files controllers/market_making/dman_maker_v2.py test/hummingbot/strategy_v2/controllers/test_dman_maker_v2.py`
- `conda run -n hummingbot pytest test/hummingbot/strategy_v2/controllers/test_dman_maker_v2.py -v` *(blocked locally by a pre-existing compiled-extension vs numpy mismatch in the hummingbot env: `numpy.dtype size changed` during import)*
