### PR TITLE
fix/ Improve digit count when placing order on XRPL

### DIFF
--- a/hummingbot/connector/exchange/xrpl/xrpl_order_placement_strategy.py
+++ b/hummingbot/connector/exchange/xrpl/xrpl_order_placement_strategy.py
@@ -26,6 +26,28 @@ class XRPLOrderPlacementStrategy(ABC):
         """Create the appropriate transaction for the order type"""
         pass
 
+    @staticmethod
+    def _get_digit_counts(value: Decimal) -> Tuple[int, int]:
+        """Get the number of integer-part digits and fractional-part digits for a Decimal value.
+
+        Uses Decimal.normalize().as_tuple() to reliably count significant digits,
+        avoiding issues with scientific notation (e.g. '0E-15', '5E+3') that would
+        break naive str().split('.') approaches.
+
+        Returns:
+            Tuple of (integer_digits, fractional_digits)
+        """
+        sign, digits, exponent = value.normalize().as_tuple()
+        num_digits = len(digits)
+        if exponent >= 0:
+            # No fractional part: e.g. Decimal("100"), Decimal("5E+3")
+            return num_digits + exponent, 0
+        else:
+            # Has fractional part: e.g. Decimal("123.456"), Decimal("0.000001")
+            int_digits = max(1, num_digits + exponent)
+            frac_digits = -exponent
+            return int_digits, frac_digits
+
     def get_base_quote_amounts(
         self, price: Optional[Decimal] = None
     ) -> Tuple[Union[str, IssuedCurrencyAmount], Union[str, IssuedCurrencyAmount]]:
@@ -47,14 +69,17 @@ class XRPLOrderPlacementStrategy(ABC):
         )
 
         # Handle precision for base and quote amounts
-        total_digits_base = len(str(amount_in_base).split(".")[1]) + len(str(amount_in_base).split(".")[0])
-        if total_digits_base > CONSTANTS.XRPL_MAX_DIGIT:  # XRPL_MAX_DIGIT
-            adjusted_quantum = CONSTANTS.XRPL_MAX_DIGIT - len(str(amount_in_base).split(".")[0])
+        # Use _get_digit_counts to safely handle scientific notation (e.g. '0E-15', '5E+3')
+        int_digits_base, frac_digits_base = self._get_digit_counts(amount_in_base)
+        total_digits_base = int_digits_base + frac_digits_base
+        if total_digits_base > CONSTANTS.XRPL_MAX_DIGIT:
+            adjusted_quantum = CONSTANTS.XRPL_MAX_DIGIT - int_digits_base
             amount_in_base = Decimal(amount_in_base.quantize(Decimal(f"1e-{adjusted_quantum}"), rounding=ROUND_DOWN))
 
-        total_digits_quote = len(str(amount_in_quote).split(".")[1]) + len(str(amount_in_quote).split(".")[0])
-        if total_digits_quote > CONSTANTS.XRPL_MAX_DIGIT:  # XRPL_MAX_DIGIT
-            adjusted_quantum = CONSTANTS.XRPL_MAX_DIGIT - len(str(amount_in_quote).split(".")[0])
+        int_digits_quote, frac_digits_quote = self._get_digit_counts(amount_in_quote)
+        total_digits_quote = int_digits_quote + frac_digits_quote
+        if total_digits_quote > CONSTANTS.XRPL_MAX_DIGIT:
+            adjusted_quantum = CONSTANTS.XRPL_MAX_DIGIT - int_digits_quote
             amount_in_quote = Decimal(amount_in_quote.quantize(Decimal(f"1e-{adjusted_quantum}"), rounding=ROUND_DOWN))
 
         # Convert amounts based on currency type

--- a/test/hummingbot/connector/exchange/xrpl/test_xrpl_order_placement_strategy.py
+++ b/test/hummingbot/connector/exchange/xrpl/test_xrpl_order_placement_strategy.py
@@ -12,6 +12,7 @@ from hummingbot.connector.exchange.xrpl.xrpl_order_placement_strategy import (
     LimitOrderStrategy,
     MarketOrderStrategy,
     OrderPlacementStrategyFactory,
+    XRPLOrderPlacementStrategy,
 )
 from hummingbot.core.data_type.common import OrderType, TradeType
 from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState
@@ -244,7 +245,6 @@ class TestXRPLOrderPlacementStrategy(unittest.IsolatedAsyncioTestCase):
         self.connector._get_best_price.return_value = Decimal("0.5")
 
         # Mock the get_base_quote_amounts to return predefined values
-        # This avoids the issue with Decimal value splitting
         mock_get_base_quote.return_value = (
             IssuedCurrencyAmount(currency="USD", issuer="rP9jPyP5kyvFRb6ZiLdcyzmUZ1Zp5t2V7R", value="50"),
             xrp_to_drops(Decimal("100")),
@@ -294,7 +294,6 @@ class TestXRPLOrderPlacementStrategy(unittest.IsolatedAsyncioTestCase):
         self.connector._get_best_price.return_value = Decimal("0.5")
 
         # Mock the get_base_quote_amounts to return predefined values
-        # This avoids the issue with Decimal value splitting
         mock_get_base_quote.return_value = (
             IssuedCurrencyAmount(currency="USD", issuer="rP9jPyP5kyvFRb6ZiLdcyzmUZ1Zp5t2V7R", value="50"),
             xrp_to_drops(Decimal("100")),
@@ -376,3 +375,84 @@ class TestXRPLOrderPlacementStrategy(unittest.IsolatedAsyncioTestCase):
         # Test that ValueError is raised when calling get_base_quote_amounts
         with self.assertRaises(ValueError):
             strategy.get_base_quote_amounts()
+
+    def test_get_digit_counts_normal_decimal(self):
+        """Test _get_digit_counts with a normal decimal value."""
+        int_digits, frac_digits = XRPLOrderPlacementStrategy._get_digit_counts(Decimal("123.456"))
+        self.assertEqual(int_digits, 3)
+        self.assertEqual(frac_digits, 3)
+
+    def test_get_digit_counts_scientific_notation_zero(self):
+        """Test _get_digit_counts with '0E-15' — the exact value that caused the original crash.
+
+        normalize() converts 0E-15 to 0, so the digit count reflects that zero
+        has 1 integer digit and 0 fractional digits (no significant precision).
+        """
+        int_digits, frac_digits = XRPLOrderPlacementStrategy._get_digit_counts(Decimal("0E-15"))
+        self.assertEqual(int_digits, 1)
+        self.assertEqual(frac_digits, 0)
+
+    def test_get_digit_counts_integer(self):
+        """Test _get_digit_counts with a whole number (no decimal point in str)."""
+        int_digits, frac_digits = XRPLOrderPlacementStrategy._get_digit_counts(Decimal("100"))
+        self.assertEqual(int_digits, 3)
+        self.assertEqual(frac_digits, 0)
+
+    def test_get_digit_counts_scientific_positive_exponent(self):
+        """Test _get_digit_counts with positive exponent scientific notation."""
+        int_digits, frac_digits = XRPLOrderPlacementStrategy._get_digit_counts(Decimal("5E+3"))
+        self.assertEqual(int_digits, 4)
+        self.assertEqual(frac_digits, 0)
+
+    def test_get_digit_counts_small_decimal(self):
+        """Test _get_digit_counts with a small decimal value."""
+        int_digits, frac_digits = XRPLOrderPlacementStrategy._get_digit_counts(Decimal("0.000001"))
+        self.assertEqual(int_digits, 1)
+        self.assertEqual(frac_digits, 6)
+
+    def test_get_digit_counts_large_precision(self):
+        """Test _get_digit_counts with a value exceeding XRPL's 16-digit limit."""
+        # 17 significant digits — normalize() preserves all non-trailing-zero digits
+        int_digits, frac_digits = XRPLOrderPlacementStrategy._get_digit_counts(Decimal("12345.678901234567"))
+        self.assertEqual(int_digits, 5)
+        self.assertEqual(frac_digits, 12)
+
+    def test_get_digit_counts_trailing_zeros_stripped(self):
+        """Test that normalize() strips trailing fractional zeros (significant digits only)."""
+        int_digits, frac_digits = XRPLOrderPlacementStrategy._get_digit_counts(Decimal("15.50000"))
+        self.assertEqual(int_digits, 2)
+        self.assertEqual(frac_digits, 1)
+
+    @patch("hummingbot.connector.exchange.xrpl.xrpl_order_placement_strategy.IssuedCurrencyAmount")
+    async def test_get_base_quote_amounts_with_zero_price(self, mock_issued_currency):
+        """Test that get_base_quote_amounts does not crash with a zero price (0E-15).
+
+        This is a regression test for GitHub issue #8119 where BUY orders with
+        a zero price (from 100% buy spread in PMM v1) caused an IndexError
+        in the digit counting logic.
+        """
+        mock_issued_currency.return_value = IssuedCurrencyAmount(
+            currency="USD", issuer="rP9jPyP5kyvFRb6ZiLdcyzmUZ1Zp5t2V7R", value="0"
+        )
+
+        # Create a buy order with price that becomes 0E-15 after quantization
+        zero_price_order = InFlightOrder(
+            client_order_id=self.client_order_id,
+            exchange_order_id="zero_price",
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            trade_type=TradeType.BUY,
+            price=Decimal("0E-15"),
+            amount=Decimal("15.5"),
+            creation_timestamp=1640001112.223,
+            initial_state=OrderState.OPEN,
+        )
+
+        strategy = LimitOrderStrategy(self.connector, zero_price_order)
+
+        # This should NOT raise IndexError anymore
+        we_pay, we_get = strategy.get_base_quote_amounts()
+
+        # Verify it returns valid results (quote amount will be 0 since price is 0)
+        self.assertIsNotNone(we_pay)
+        self.assertIsNotNone(we_get)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] Tests all pass
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
- This should fix the issue https://github.com/hummingbot/hummingbot/issues/8119
- Improve the digit count logic to prevent crash when the order amount is in scientific notation


**Tests performed by the developer**:
- Run all tests to confirm the digit count is working


**Tips for QA testing**:
- Try reproduce the issue to see if the bug has been resolved or not