### PR TITLE
feat: Add GRVT perpetual connector

### DIFF
--- a/hummingbot/connector/derivative/grvt_perpetual/__init__.py
+++ b/hummingbot/connector/derivative/grvt_perpetual/__init__.py
@@ -1,0 +1,1 @@
+# Empty __init__.py file for GRVT Perpetual connector

--- a/hummingbot/connector/derivative/grvt_perpetual/dummy.pxd
+++ b/hummingbot/connector/derivative/grvt_perpetual/dummy.pxd
@@ -1,0 +1,1 @@
+# Dummy file for Cython compilation

--- a/hummingbot/connector/derivative/grvt_perpetual/dummy.pyx
+++ b/hummingbot/connector/derivative/grvt_perpetual/dummy.pyx
@@ -1,0 +1,1 @@
+# Dummy Cython file for GRVT Perpetual connector

--- a/hummingbot/connector/derivative/grvt_perpetual/grvt_perpetual_api_order_book_data_source.py
+++ b/hummingbot/connector/derivative/grvt_perpetual/grvt_perpetual_api_order_book_data_source.py
@@ -1,0 +1,309 @@
+import asyncio
+import time
+from collections import defaultdict
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional
+
+import hummingbot.connector.derivative.grvt_perpetual.grvt_perpetual_constants as CONSTANTS
+import hummingbot.connector.derivative.grvt_perpetual.grvt_perpetual_web_utils as web_utils
+from hummingbot.core.data_type.common import TradeType
+from hummingbot.core.data_type.funding_info import FundingInfo, FundingInfoUpdate
+from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
+from hummingbot.core.data_type.perpetual_api_order_book_data_source import PerpetualAPIOrderBookDataSource
+from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+from hummingbot.core.web_assistant.ws_assistant import WSAssistant
+from hummingbot.logger import HummingbotLogger
+
+if TYPE_CHECKING:
+    from hummingbot.connector.derivative.grvt_perpetual.grvt_perpetual_derivative import (
+        GRVTPerpetualDerivative,
+    )
+
+
+class GRVTPerpetualAPIOrderBookDataSource(PerpetualAPIOrderBookDataSource):
+    _gpobds_logger: Optional[HummingbotLogger] = None
+    _trading_pair_symbol_map: Dict[str, Mapping[str, str]] = {}
+    _mapping_initialization_lock = asyncio.Lock()
+    _DYNAMIC_SUBSCRIBE_ID_START = 100
+    _next_subscribe_id: int = _DYNAMIC_SUBSCRIBE_ID_START
+
+    def __init__(
+            self,
+            trading_pairs: List[str],
+            connector: 'GRVTPerpetualDerivative',
+            api_factory: WebAssistantsFactory,
+            domain: str = CONSTANTS.DOMAIN
+    ):
+        super().__init__(trading_pairs)
+        self._connector = connector
+        self._api_factory = api_factory
+        self._domain = domain
+        self._trading_pairs: List[str] = trading_pairs
+        self._message_queue: Dict[str, asyncio.Queue] = defaultdict(asyncio.Queue)
+        self._trade_messages_queue_key = CONSTANTS.TRADE_STREAM_ID
+        self._diff_messages_queue_key = CONSTANTS.DIFF_STREAM_ID
+        self._funding_info_messages_queue_key = CONSTANTS.FUNDING_INFO_STREAM_ID
+        self._snapshot_messages_queue_key = "order_book_snapshot"
+
+    async def get_last_traded_prices(self,
+                                     trading_pairs: List[str],
+                                     domain: Optional[str] = None) -> Dict[str, float]:
+        return await self._connector.get_last_traded_prices(trading_pairs=trading_pairs)
+
+    async def get_funding_info(self, trading_pair: str) -> FundingInfo:
+        symbol_info: Dict[str, Any] = await self._request_complete_funding_info(trading_pair)
+        funding_info = FundingInfo(
+            trading_pair=trading_pair,
+            index_price=Decimal(symbol_info.get("indexPrice", "0")),
+            mark_price=Decimal(symbol_info.get("markPrice", "0")),
+            next_funding_utc_timestamp=int(float(symbol_info.get("nextFundingTime", "0")) * 1e-3),
+            rate=Decimal(symbol_info.get("lastFundingRate", "0")),
+        )
+        return funding_info
+
+    async def _request_order_book_snapshot(self, trading_pair: str) -> Dict[str, Any]:
+        ex_trading_pair = await self._connector.exchange_symbol_associated_to_pair(trading_pair=trading_pair)
+
+        params = {
+            "symbol": ex_trading_pair,
+            "limit": 1000
+        }
+
+        data = await self._connector._api_get(
+            path_url=CONSTANTS.SNAPSHOT_REST_URL,
+            params=params)
+        return data
+
+    async def _order_book_snapshot(self, trading_pair: str) -> OrderBookMessage:
+        snapshot_response: Dict[str, Any] = await self._request_order_book_snapshot(trading_pair)
+        snapshot_timestamp: float = time.time()
+        snapshot_response.update({"trading_pair": trading_pair})
+        
+        # GRVT format: bids and asks are arrays of [price, quantity]
+        snapshot_msg: OrderBookMessage = OrderBookMessage(OrderBookMessageType.SNAPSHOT, {
+            "trading_pair": snapshot_response["trading_pair"],
+            "update_id": snapshot_response.get("lastUpdateId", snapshot_response.get("u", 0)),
+            "bids": [[bid[0], bid[1]] for bid in snapshot_response.get("bids", [])],
+            "asks": [[ask[0], ask[1]] for ask in snapshot_response.get("asks", [])]
+        }, timestamp=snapshot_timestamp)
+        return snapshot_msg
+
+    async def _connected_websocket_assistant(self) -> WSAssistant:
+        url = web_utils.wss_url(CONSTANTS.PUBLIC_WS_ENDPOINT, self._domain)
+        ws: WSAssistant = await self._api_factory.get_ws_assistant()
+        await ws.connect(ws_url=url, ping_timeout=CONSTANTS.HEARTBEAT_TIME_INTERVAL)
+        return ws
+
+    async def _subscribe_channels(self, ws: WSAssistant):
+        """
+        Subscribes to the trade events and diff orders events through the provided websocket connection.
+        :param ws: the websocket assistant used to connect to the exchange
+        """
+        try:
+            stream_id_channel_pairs = [
+                (CONSTANTS.DIFF_STREAM_ID, "depth"),
+                (CONSTANTS.TRADE_STREAM_ID, "trade"),
+                (CONSTANTS.FUNDING_INFO_STREAM_ID, "mark_price"),
+            ]
+            for stream_id, channel in stream_id_channel_pairs:
+                params = []
+                for trading_pair in self._trading_pairs:
+                    symbol = await self._connector.exchange_symbol_associated_to_pair(trading_pair=trading_pair)
+                    params.append(f"{symbol.lower()}:{channel}")
+                payload = {
+                    "method": "SUBSCRIBE",
+                    "params": params,
+                    "id": stream_id,
+                }
+                subscribe_request: WSJSONRequest = WSJSONRequest(payload)
+                await ws.send(subscribe_request)
+            self.logger().info("Subscribed to public order book, trade and funding info channels...")
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self.logger().exception("Unexpected error occurred subscribing to order book trading and delta streams...")
+            raise
+
+    def _channel_originating_message(self, event_message: Dict[str, Any]) -> str:
+        channel = ""
+        if "result" not in event_message:
+            stream_name = event_message.get("stream", "")
+            if "depth" in stream_name:
+                channel = self._diff_messages_queue_key
+            elif "trade" in stream_name:
+                channel = self._trade_messages_queue_key
+            elif "mark_price" in stream_name:
+                channel = self._funding_info_messages_queue_key
+        return channel
+
+    async def _parse_order_book_diff_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
+        timestamp: float = time.time()
+        data = raw_message.get("data", raw_message)
+        
+        # Convert exchange symbol to trading pair
+        if "s" in data:
+            data["s"] = await self._connector.trading_pair_associated_to_exchange_symbol(data["s"])
+        
+        order_book_message: OrderBookMessage = OrderBookMessage(OrderBookMessageType.DIFF, {
+            "trading_pair": data.get("s", raw_message.get("trading_pair", "")),
+            "update_id": data.get("u", data.get("lastUpdateId", 0)),
+            "bids": [[bid[0], bid[1]] for bid in data.get("b", data.get("bids", []))],
+            "asks": [[ask[0], ask[1]] for ask in data.get("a", data.get("asks", []))]
+        }, timestamp=timestamp)
+        message_queue.put_nowait(order_book_message)
+
+    async def _parse_trade_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
+        data = raw_message.get("data", raw_message)
+        
+        # Convert exchange symbol to trading pair
+        if "s" in data:
+            data["s"] = await self._connector.trading_pair_associated_to_exchange_symbol(data["s"])
+        
+        # GRVT trade message format
+        trade_message: OrderBookMessage = OrderBookMessage(OrderBookMessageType.TRADE, {
+            "trading_pair": data.get("s", ""),
+            "trade_type": float(TradeType.SELL.value) if data.get("m", False) else float(TradeType.BUY.value),
+            "trade_id": data.get("t", data.get("tradeId", 0)),
+            "update_id": data.get("E", data.get("eventTime", 0)),
+            "price": data.get("p", "0"),
+            "amount": data.get("q", data.get("quantity", "0"))
+        }, timestamp=(data.get("E", data.get("eventTime", 0))) * 1e-3)
+
+        message_queue.put_nowait(trade_message)
+
+    async def listen_for_order_book_snapshots(self, ev_loop: asyncio.BaseEventLoop, output: asyncio.Queue):
+        while True:
+            try:
+                for trading_pair in self._trading_pairs:
+                    snapshot_msg: OrderBookMessage = await self._order_book_snapshot(trading_pair)
+                    output.put_nowait(snapshot_msg)
+                    self.logger().debug(f"Saved order book snapshot for {trading_pair}")
+                delta = CONSTANTS.ONE_HOUR - time.time() % CONSTANTS.ONE_HOUR
+                await self._sleep(delta)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                self.logger().error(
+                    "Unexpected error occurred fetching orderbook snapshots. Retrying in 5 seconds...", exc_info=True
+                )
+                await self._sleep(5.0)
+
+    async def _parse_funding_info_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
+
+        data: Dict[str, Any] = raw_message.get("data", raw_message)
+        
+        trading_pair = data.get("s", "")
+        if trading_pair:
+            trading_pair = await self._connector.trading_pair_associated_to_exchange_symbol(trading_pair)
+
+        if trading_pair not in self._trading_pairs:
+            return
+        
+        funding_info = FundingInfoUpdate(
+            trading_pair=trading_pair,
+            index_price=Decimal(data.get("i", data.get("indexPrice", "0"))),
+            mark_price=Decimal(data.get("p", data.get("markPrice", "0"))),
+            next_funding_utc_timestamp=int(float(data.get("T", data.get("nextFundingTime", "0"))) * 1e-3),
+            rate=Decimal(data.get("r", data.get("lastFundingRate", "0"))),
+        )
+
+        message_queue.put_nowait(funding_info)
+
+    async def _request_complete_funding_info(self, trading_pair: str):
+        ex_trading_pair = await self._connector.exchange_symbol_associated_to_pair(trading_pair=trading_pair)
+        data = await self._connector._api_get(
+            path_url=CONSTANTS.MARK_PRICE_URL,
+            params={"symbol": ex_trading_pair},
+            is_auth_required=True)
+        return data
+
+    async def subscribe_to_trading_pair(self, trading_pair: str) -> bool:
+        """
+        Subscribes to order book, trade, and funding info channels for a single trading pair
+        on the existing WebSocket connection.
+
+        :param trading_pair: the trading pair to subscribe to
+        :return: True if subscription was successful, False otherwise
+        """
+        if self._ws_assistant is None:
+            self.logger().warning(
+                f"Cannot subscribe to {trading_pair}: WebSocket not connected"
+            )
+            return False
+
+        try:
+            symbol = await self._connector.exchange_symbol_associated_to_pair(trading_pair=trading_pair)
+
+            stream_id_channel_pairs = [
+                (self._get_next_subscribe_id(), "depth"),
+                (self._get_next_subscribe_id(), "trade"),
+                (self._get_next_subscribe_id(), "mark_price"),
+            ]
+
+            for stream_id, channel in stream_id_channel_pairs:
+                payload = {
+                    "method": "SUBSCRIBE",
+                    "params": [f"{symbol.lower()}:{channel}"],
+                    "id": stream_id,
+                }
+                subscribe_request: WSJSONRequest = WSJSONRequest(payload)
+                await self._ws_assistant.send(subscribe_request)
+
+            self.add_trading_pair(trading_pair)
+            self.logger().info(f"Subscribed to {trading_pair} order book, trade and funding info channels")
+            return True
+
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self.logger().exception(f"Error subscribing to {trading_pair}")
+            return False
+
+    async def unsubscribe_from_trading_pair(self, trading_pair: str) -> bool:
+        """
+        Unsubscribes from order book, trade, and funding info channels for a single trading pair
+        on the existing WebSocket connection.
+
+        :param trading_pair: the trading pair to unsubscribe from
+        :return: True if unsubscription was successful, False otherwise
+        """
+        if self._ws_assistant is None:
+            self.logger().warning(
+                f"Cannot unsubscribe from {trading_pair}: WebSocket not connected"
+            )
+            return False
+
+        try:
+            symbol = await self._connector.exchange_symbol_associated_to_pair(trading_pair=trading_pair)
+
+            unsubscribe_params = [
+                f"{symbol.lower()}:depth",
+                f"{symbol.lower()}:trade",
+                f"{symbol.lower()}:mark_price",
+            ]
+
+            payload = {
+                "method": "UNSUBSCRIBE",
+                "params": unsubscribe_params,
+                "id": self._get_next_subscribe_id(),
+            }
+            unsubscribe_request: WSJSONRequest = WSJSONRequest(payload)
+            await self._ws_assistant.send(unsubscribe_request)
+
+            self.remove_trading_pair(trading_pair)
+            self.logger().info(f"Unsubscribed from {trading_pair} order book, trade and funding info channels")
+            return True
+
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self.logger().exception(f"Error unsubscribing from {trading_pair}")
+            return False
+
+    @classmethod
+    def _get_next_subscribe_id(cls) -> int:
+        """Returns the next subscription ID and increments the counter."""
+        current_id = cls._next_subscribe_id
+        cls._next_subscribe_id += 1
+        return current_id

--- a/hummingbot/connector/derivative/grvt_perpetual/grvt_perpetual_api_user_stream_data_source.py
+++ b/hummingbot/connector/derivative/grvt_perpetual/grvt_perpetual_api_user_stream_data_source.py
@@ -1,0 +1,105 @@
+import asyncio
+import time
+from typing import TYPE_CHECKING, Optional
+
+import hummingbot.connector.derivative.grvt_perpetual.grvt_perpetual_constants as CONSTANTS
+import hummingbot.connector.derivative.grvt_perpetual.grvt_perpetual_web_utils as web_utils
+from hummingbot.connector.derivative.grvt_perpetual.grvt_perpetual_auth import GRVTPerpetualAuth
+from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
+from hummingbot.core.utils.async_utils import safe_ensure_future
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+from hummingbot.core.web_assistant.ws_assistant import WSAssistant
+from hummingbot.logger import HummingbotLogger
+
+if TYPE_CHECKING:
+    from hummingbot.connector.derivative.grvt_perpetual.grvt_perpetual_derivative import (
+        GRVTPerpetualDerivative,
+    )
+
+
+class GRVTPerpetualUserStreamDataSource(UserStreamTrackerDataSource):
+    """
+    User stream data source for GRVT Perpetual.
+    Handles WebSocket connections for user-specific data like orders and positions.
+    """
+    HEARTBEAT_TIME_INTERVAL = 30.0
+    MAX_RETRIES = 3
+    _logger: Optional[HummingbotLogger] = None
+
+    def __init__(
+            self,
+            auth: GRVTPerpetualAuth,
+            connector: 'GRVTPerpetualDerivative',
+            api_factory: WebAssistantsFactory,
+            domain: str = CONSTANTS.DOMAIN,
+    ):
+        super().__init__()
+        self._domain = domain
+        self._api_factory = api_factory
+        self._auth = auth
+        self._connector = connector
+        self._ws_assistant: Optional[WSAssistant] = None
+        self._manage_ws_task = None
+
+    async def _get_ws_assistant(self) -> WSAssistant:
+        """
+        Creates a new WSAssistant instance.
+        """
+        return await self._api_factory.get_ws_assistant()
+
+    async def _connected_websocket_assistant(self) -> WSAssistant:
+        """
+        Creates an instance of WSAssistant connected to the exchange.
+        """
+        ws = await self._get_ws_assistant()
+        
+        # GRVT uses authenticated WebSocket connection
+        url = web_utils.wss_url(CONSTANTS.PRIVATE_WS_ENDPOINT, self._domain)
+        
+        # Add auth parameters to URL if needed
+        # For GRVT, authentication might be done through the connection params
+        auth_params = self._auth.get_auth_headers()
+        
+        self.logger().info(f"Connecting to GRVT user stream at {url}")
+        await ws.connect(ws_url=url, ping_timeout=self.HEARTBEAT_TIME_INTERVAL)
+        self.logger().info("Successfully connected to user stream")
+
+        return ws
+
+    async def _subscribe_channels(self, websocket_assistant: WSAssistant):
+        """
+        Subscribes to the user event channels through the provided websocket connection.
+
+        :param websocket_assistant: the websocket assistant used to connect to the exchange
+        """
+        # GRVT typically uses specific channel subscriptions for user data
+        try:
+            # Subscribe to private channels
+            payload = {
+                "method": "SUBSCRIBE",
+                "params": ["order", "position", "balance"],
+                "id": 1,
+            }
+            
+            from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest
+            subscribe_request = WSJSONRequest(payload)
+            await websocket_assistant.send(subscribe_request)
+            
+            self.logger().info("Subscribed to user order, position, and balance channels")
+        except Exception as e:
+            self.logger().error(f"Error subscribing to user channels: {e}")
+            raise
+
+    async def _on_user_stream_interruption(self, websocket_assistant: Optional[WSAssistant]):
+        """
+        Handles websocket disconnection by cleaning up resources.
+
+        :param websocket_assistant: The websocket assistant that was disconnected
+        """
+        self.logger().info("User stream interrupted. Cleaning up...")
+
+        # Disconnect the websocket if it exists
+        if websocket_assistant:
+            await websocket_assistant.disconnect()
+        self._ws_assistant = None

--- a/hummingbot/connector/derivative/grvt_perpetual/grvt_perpetual_auth.py
+++ b/hummingbot/connector/derivative/grvt_perpetual/grvt_perpetual_auth.py
@@ -1,0 +1,110 @@
+import hashlib
+import hmac
+import time
+from collections import OrderedDict
+from typing import Any, Dict, Optional
+from urllib.parse import urlencode
+
+from hummingbot.connector.time_synchronizer import TimeSynchronizer
+from hummingbot.core.web_assistant.auth import AuthBase
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod, RESTRequest, WSRequest
+
+
+class GRVTPerpetualAuth(AuthBase):
+    """
+    Auth class required by GRVT Perpetual API
+    """
+
+    def __init__(self, api_key: str, api_secret: str, time_provider: Optional[TimeSynchronizer] = None):
+        self._api_key: str = api_key
+        self._api_secret: str = api_secret
+        self._time_provider: Optional[TimeSynchronizer] = time_provider
+
+    def generate_signature(self, method: str, path: str, params: Dict[str, Any] = None) -> str:
+        """
+        Generate signature for GRVT API authentication.
+        
+        GRVT uses HMAC-SHA256 signature with the following format:
+        {method}{path}{query_string}{body}{timestamp}
+        """
+        # Sort parameters
+        sorted_params = OrderedDict(sorted((params or {}).items()))
+        
+        # Create query string
+        query_string = urlencode(sorted_params)
+        
+        # Get timestamp in milliseconds
+        timestamp = str(int(time.time() * 1000))
+        
+        # Create message to sign
+        message = f"{method}{path}"
+        if query_string:
+            message += f"?{query_string}"
+        message += timestamp
+        
+        # Generate signature
+        secret = bytes(self._api_secret.encode("utf-8"))
+        signature = hmac.new(secret, message.encode("utf-8"), hashlib.sha256).hexdigest()
+        
+        return signature
+
+    async def rest_authenticate(self, request: RESTRequest) -> RESTRequest:
+        """
+        Add authentication headers and parameters to REST request.
+        """
+        timestamp = str(int(time.time() * 1000))
+        
+        # Get path from URL
+        url = request.url
+        path = url.split("?")[0] if "?" in url else url
+        
+        # Remove base URL to get path
+        for base_url in ["https://api.grvt.io", "https://api-testnet.grvt.io"]:
+            if base_url in path:
+                path = path.replace(base_url, "")
+                break
+        
+        # Parse params from URL if present
+        params = dict(request.params) if request.params else {}
+        if "?" in request.url:
+            query_params = request.url.split("?")[1].split("&")
+            for param in query_params:
+                if "=" in param:
+                    key, value = param.split("=", 1)
+                    params[key] = value
+        
+        # Generate signature
+        method = request.method.value.upper()
+        signature = self.generate_signature(method, path, params)
+        
+        # Add authentication headers
+        if request.headers is None:
+            request.headers = {}
+        request.headers["GRVT-API-KEY"] = self._api_key
+        request.headers["GRVT-TIMESTAMP"] = timestamp
+        request.headers["GRVT-SIGNATURE"] = signature
+        
+        return request
+
+    async def ws_authenticate(self, request: WSRequest) -> WSRequest:
+        """
+        Add authentication to WebSocket request.
+        For WebSocket, authentication is handled differently - typically through the connection URL.
+        """
+        return request
+
+    def get_auth_headers(self) -> Dict[str, str]:
+        """
+        Get authentication headers for requests.
+        """
+        timestamp = str(int(time.time() * 1000))
+        signature = self.generate_signature("GET", "/", {})
+        
+        return {
+            "GRVT-API-KEY": self._api_key,
+            "GRVT-TIMESTAMP": timestamp,
+            "GRVT-SIGNATURE": signature,
+        }
+
+    def header_for_authentication(self) -> Dict[str, str]:
+        return {"GRVT-API-KEY": self._api_key}

--- a/hummingbot/connector/derivative/grvt_perpetual/grvt_perpetual_config.py
+++ b/hummingbot/connector/derivative/grvt_perpetual/grvt_perpetual_config.py
@@ -1,0 +1,25 @@
+from .grvt_perpetual_utils import (
+    DEFAULT_FEES,
+    EXAMPLE_PAIR,
+    KEY_TO_ALLOWLIST,
+    KEYS,
+    OTHER_DOMAINS,
+    OTHER_DOMAINS_DEFAULT_FEES,
+    OTHER_DOMAINS_EXAMPLE_PAIR,
+    OTHER_DOMAINS_KEYS,
+    OTHER_DOMAINS_PARAMETER,
+)
+from .grvt_perpetual_derivative import GRVTPerpetualDerivative
+
+__all__ = [
+    "GRVTPerpetualDerivative",
+    "DEFAULT_FEES",
+    "EXAMPLE_PAIR",
+    "KEY_TO_ALLOWLIST",
+    "KEYS",
+    "OTHER_DOMAINS",
+    "OTHER_DOMAINS_DEFAULT_FEES",
+    "OTHER_DOMAINS_EXAMPLE_PAIR",
+    "OTHER_DOMAINS_KEYS",
+    "OTHER_DOMAINS_PARAMETER",
+]

--- a/hummingbot/connector/derivative/grvt_perpetual/grvt_perpetual_constants.py
+++ b/hummingbot/connector/derivative/grvt_perpetual/grvt_perpetual_constants.py
@@ -1,0 +1,130 @@
+from hummingbot.core.api_throttler.data_types import LinkedLimitWeightPair, RateLimit
+from hummingbot.core.data_type.in_flight_order import OrderState
+
+EXCHANGE_NAME = "grvt_perpetual"
+BROKER_ID = "hummingbot"
+MAX_ORDER_ID_LEN = 36
+
+DOMAIN = EXCHANGE_NAME
+TESTNET_DOMAIN = "grvt_perpetual_testnet"
+
+# GRVT API Endpoints
+# Mainnet: https://api.grvt.io
+# Testnet: https://api-testnet.grvt.io
+PERPETUAL_BASE_URL = "https://api.grvt.io/"
+TESTNET_BASE_URL = "https://api-testnet.grvt.io/"
+
+PERPETUAL_WS_URL = "wss://ws.grvt.io/"
+TESTNET_WS_URL = "wss://ws-testnet.grvt.io/"
+
+PUBLIC_WS_ENDPOINT = "ws"
+PRIVATE_WS_ENDPOINT = "ws/private"
+
+TIME_IN_FORCE_GTC = "GTC"  # Good till cancelled
+TIME_IN_FORCE_GTX = "GTX"  # Good Till Crossing
+TIME_IN_FORCE_IOC = "IOC"  # Immediate or cancel
+TIME_IN_FORCE_FOK = "FOK"  # Fill or kill
+
+# Public API Endpoints
+SNAPSHOT_REST_URL = "derivatives/v1/market/depth"
+TICKER_PRICE_URL = "derivatives/v1/market/ticker"
+TICKER_PRICE_CHANGE_URL = "derivatives/v1/market/ticker/24hr"
+EXCHANGE_INFO_URL = "derivatives/v1/market/exchangeInfo"
+RECENT_TRADES_URL = "derivatives/v1/market/trades"
+PING_URL = "derivatives/v1/market/ping"
+SERVER_TIME_PATH_URL = "derivatives/v1/market/time"
+MARK_PRICE_URL = "derivatives/v1/market/mark_price"
+
+# Private API Endpoints
+ORDER_URL = "derivatives/v1/order"
+CANCEL_ALL_OPEN_ORDERS_URL = "derivatives/v1/order/allOpenOrders"
+ACCOUNT_TRADE_LIST_URL = "derivatives/v1/userTrades"
+SET_LEVERAGE_URL = "derivatives/v1/account/leverage"
+GET_INCOME_HISTORY_URL = "derivatives/v1/account/income"
+CHANGE_POSITION_MODE_URL = "derivatives/v1/account/positionMode"
+
+# Private API v2 Endpoints
+ACCOUNT_INFO_URL = "derivatives/v2/account"
+POSITION_INFORMATION_URL = "derivatives/v2/positionRisk"
+
+# User Stream
+GRVT_USER_STREAM_ENDPOINT = "derivatives/v1/user/auth"
+GRVT_WS_AUTH_ENDPOINT = "auth"
+
+# Funding Settlement Time Span
+FUNDING_SETTLEMENT_DURATION = (0, 30)  # seconds before snapshot, seconds after snapshot
+
+# Order Statuses
+ORDER_STATE = {
+    "NEW": OrderState.OPEN,
+    "FILLED": OrderState.FILLED,
+    "PARTIALLY_FILLED": OrderState.PARTIALLY_FILLED,
+    "CANCELED": OrderState.CANCELED,
+    "CANCELLED": OrderState.CANCELED,
+    "EXPIRED": OrderState.CANCELED,
+    "REJECTED": OrderState.FAILED,
+}
+
+# Stream IDs
+DIFF_STREAM_ID = 1
+TRADE_STREAM_ID = 2
+FUNDING_INFO_STREAM_ID = 3
+HEARTBEAT_TIME_INTERVAL = 30.0
+
+# Rate Limit time intervals
+ONE_HOUR = 3600
+ONE_MINUTE = 60
+ONE_SECOND = 1
+ONE_DAY = 86400
+
+MAX_REQUEST = 1200
+
+RATE_LIMITS = [
+    # Pool Limits
+    RateLimit(limit_id="REQUEST_WEIGHT", limit=MAX_REQUEST, time_interval=ONE_MINUTE),
+    RateLimit(limit_id="ORDERS_1MIN", limit=600, time_interval=ONE_MINUTE),
+    RateLimit(limit_id="ORDERS_1SEC", limit=150, time_interval=10),
+    # Weight Limits for individual endpoints
+    RateLimit(limit_id=SNAPSHOT_REST_URL, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
+              linked_limits=[LinkedLimitWeightPair("REQUEST_WEIGHT", weight=20)]),
+    RateLimit(limit_id=TICKER_PRICE_URL, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
+              linked_limits=[LinkedLimitWeightPair("REQUEST_WEIGHT", weight=2)]),
+    RateLimit(limit_id=TICKER_PRICE_CHANGE_URL, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
+              linked_limits=[LinkedLimitWeightPair("REQUEST_WEIGHT", weight=1)]),
+    RateLimit(limit_id=EXCHANGE_INFO_URL, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
+              linked_limits=[LinkedLimitWeightPair("REQUEST_WEIGHT", weight=40)]),
+    RateLimit(limit_id=RECENT_TRADES_URL, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
+              linked_limits=[LinkedLimitWeightPair("REQUEST_WEIGHT", weight=1)]),
+    RateLimit(limit_id=GRVT_USER_STREAM_ENDPOINT, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
+              linked_limits=[LinkedLimitWeightPair("REQUEST_WEIGHT", weight=1)]),
+    RateLimit(limit_id=PING_URL, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
+              linked_limits=[LinkedLimitWeightPair("REQUEST_WEIGHT", weight=1)]),
+    RateLimit(limit_id=SERVER_TIME_PATH_URL, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
+              linked_limits=[LinkedLimitWeightPair("REQUEST_WEIGHT", weight=1)]),
+    RateLimit(limit_id=ORDER_URL, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
+              linked_limits=[LinkedLimitWeightPair("REQUEST_WEIGHT", weight=1),
+                             LinkedLimitWeightPair("ORDERS_1MIN", weight=1),
+                             LinkedLimitWeightPair("ORDERS_1SEC", weight=1)]),
+    RateLimit(limit_id=CANCEL_ALL_OPEN_ORDERS_URL, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
+              linked_limits=[LinkedLimitWeightPair("REQUEST_WEIGHT", weight=1)]),
+    RateLimit(limit_id=ACCOUNT_TRADE_LIST_URL, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
+              linked_limits=[LinkedLimitWeightPair("REQUEST_WEIGHT", weight=5)]),
+    RateLimit(limit_id=SET_LEVERAGE_URL, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
+              linked_limits=[LinkedLimitWeightPair("REQUEST_WEIGHT", weight=1)]),
+    RateLimit(limit_id=GET_INCOME_HISTORY_URL, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
+              linked_limits=[LinkedLimitWeightPair("REQUEST_WEIGHT", weight=30)]),
+    RateLimit(limit_id=CHANGE_POSITION_MODE_URL, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
+              linked_limits=[LinkedLimitWeightPair("REQUEST_WEIGHT", weight=1)]),
+    RateLimit(limit_id=ACCOUNT_INFO_URL, limit=MAX_REQUEST, time_interval=ONE_MINUTE,
+              linked_limits=[LinkedLimitWeightPair("REQUEST_WEIGHT", weight=5)]),
+    RateLimit(limit_id=POSITION_INFORMATION_URL, limit=MAX_REQUEST, time_interval=ONE_MINUTE, weight=5,
+              linked_limits=[LinkedLimitWeightPair("REQUEST_WEIGHT", weight=5)]),
+    RateLimit(limit_id=MARK_PRICE_URL, limit=MAX_REQUEST, time_interval=ONE_MINUTE, weight=1,
+              linked_limits=[LinkedLimitWeightPair("REQUEST_WEIGHT", weight=1)]),
+]
+
+# Error codes
+ORDER_NOT_EXIST_ERROR_CODE = -1
+ORDER_NOT_EXIST_MESSAGE = "Order does not exist"
+UNKNOWN_ORDER_ERROR_CODE = -1
+UNKNOWN_ORDER_MESSAGE = "Unknown order"

--- a/hummingbot/connector/derivative/grvt_perpetual/grvt_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/grvt_perpetual/grvt_perpetual_derivative.py
@@ -1,0 +1,849 @@
+import asyncio
+import time
+from collections import defaultdict
+from decimal import Decimal
+from typing import Any, AsyncIterable, Dict, List, Optional, Tuple
+
+from bidict import bidict
+
+from hummingbot.connector.constants import s_decimal_NaN
+from hummingbot.connector.derivative.grvt_perpetual import (
+    grvt_perpetual_constants as CONSTANTS,
+    grvt_perpetual_web_utils as web_utils,
+)
+from hummingbot.connector.derivative.grvt_perpetual.grvt_perpetual_api_order_book_data_source import (
+    GRVTPerpetualAPIOrderBookDataSource,
+)
+from hummingbot.connector.derivative.grvt_perpetual.grvt_perpetual_auth import GRVTPerpetualAuth
+from hummingbot.connector.derivative.grvt_perpetual.grvt_perpetual_api_user_stream_data_source import (
+    GRVTPerpetualUserStreamDataSource,
+)
+from hummingbot.connector.derivative.position import Position
+from hummingbot.connector.perpetual_derivative_py_base import PerpetualDerivativePyBase
+from hummingbot.connector.trading_rule import TradingRule
+from hummingbot.connector.utils import combine_to_hb_trading_pair
+from hummingbot.core.api_throttler.data_types import RateLimit
+from hummingbot.core.data_type.common import OrderType, PositionAction, PositionMode, PositionSide, TradeType
+from hummingbot.core.data_type.in_flight_order import OrderState, InFlightOrder, OrderUpdate, TradeUpdate
+from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
+from hummingbot.core.data_type.trade_fee import TokenAmount, TradeFeeBase
+from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
+from hummingbot.core.utils.async_utils import safe_gather
+from hummingbot.core.utils.estimate_fee import build_trade_fee
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+
+gpd_logger = None
+
+
+class GRVTPerpetualDerivative(PerpetualDerivativePyBase):
+    """
+    GRVT Perpetual connector for Hummingbot.
+    """
+    web_utils = web_utils
+    SHORT_POLL_INTERVAL = 5.0
+    UPDATE_ORDER_STATUS_MIN_INTERVAL = 10.0
+    LONG_POLL_INTERVAL = 120.0
+
+    def __init__(
+            self,
+            balance_asset_limit: Optional[Dict[str, Dict[str, Decimal]]] = None,
+            rate_limits_share_pct: Decimal = Decimal("100"),
+            grvt_perpetual_api_key: str = None,
+            grvt_perpetual_api_secret: str = None,
+            trading_pairs: Optional[List[str]] = None,
+            trading_required: bool = True,
+            domain: str = CONSTANTS.DOMAIN,
+    ):
+        self.grvt_perpetual_api_key = grvt_perpetual_api_key
+        self.grvt_perpetual_secret_key = grvt_perpetual_api_secret
+        self._trading_required = trading_required
+        self._trading_pairs = trading_pairs
+        self._domain = domain
+        self._position_mode = None
+        self._last_trade_history_timestamp = None
+        super().__init__(balance_asset_limit, rate_limits_share_pct)
+
+    @property
+    def name(self) -> str:
+        return CONSTANTS.EXCHANGE_NAME
+
+    @property
+    def authenticator(self) -> GRVTPerpetualAuth:
+        return GRVTPerpetualAuth(self.grvt_perpetual_api_key, self.grvt_perpetual_secret_key,
+                                  self._time_synchronizer)
+
+    @property
+    def rate_limits_rules(self) -> List[RateLimit]:
+        return CONSTANTS.RATE_LIMITS
+
+    @property
+    def domain(self) -> str:
+        return self._domain
+
+    @property
+    def client_order_id_max_length(self) -> int:
+        return CONSTANTS.MAX_ORDER_ID_LEN
+
+    @property
+    def client_order_id_prefix(self) -> str:
+        return CONSTANTS.BROKER_ID
+
+    @property
+    def trading_rules_request_path(self) -> str:
+        return CONSTANTS.EXCHANGE_INFO_URL
+
+    @property
+    def trading_pairs_request_path(self) -> str:
+        return CONSTANTS.EXCHANGE_INFO_URL
+
+    @property
+    def check_network_request_path(self) -> str:
+        return CONSTANTS.PING_URL
+
+    @property
+    def trading_pairs(self):
+        return self._trading_pairs
+
+    @property
+    def is_cancel_request_in_exchange_synchronous(self) -> bool:
+        return True
+
+    @property
+    def is_trading_required(self) -> bool:
+        return self._trading_required
+
+    @property
+    def funding_fee_poll_interval(self) -> int:
+        return 600
+
+    def supported_order_types(self) -> List[OrderType]:
+        """
+        :return a list of OrderType supported by this connector
+        """
+        return [OrderType.LIMIT, OrderType.MARKET, OrderType.LIMIT_MAKER]
+
+    def supported_position_modes(self):
+        """
+        This method needs to be overridden to provide the accurate information depending on the exchange.
+        """
+        return [PositionMode.ONEWAY, PositionMode.HEDGE]
+
+    def get_buy_collateral_token(self, trading_pair: str) -> str:
+        trading_rule: TradingRule = self._trading_rules[trading_pair]
+        return trading_rule.buy_order_collateral_token
+
+    def get_sell_collateral_token(self, trading_pair: str) -> str:
+        trading_rule: TradingRule = self._trading_rules[trading_pair]
+        return trading_rule.sell_order_collateral_token
+
+    def _is_request_exception_related_to_time_synchronizer(self, request_exception: Exception):
+        error_description = str(request_exception)
+        is_time_synchronizer_related = ("timestamp" in error_description.lower()
+                                        and "invalid" in error_description.lower())
+        return is_time_synchronizer_related
+
+    def _is_order_not_found_during_status_update_error(self, status_update_exception: Exception) -> bool:
+        return (str(CONSTANTS.ORDER_NOT_EXIST_ERROR_CODE) in str(status_update_exception)
+                or CONSTANTS.ORDER_NOT_EXIST_MESSAGE.lower() in str(status_update_exception).lower())
+
+    def _is_order_not_found_during_cancelation_error(self, cancelation_exception: Exception) -> bool:
+        return (str(CONSTANTS.UNKNOWN_ORDER_ERROR_CODE) in str(cancelation_exception)
+                or CONSTANTS.UNKNOWN_ORDER_MESSAGE.lower() in str(cancelation_exception).lower())
+
+    def _create_web_assistants_factory(self) -> WebAssistantsFactory:
+        return web_utils.build_api_factory(
+            throttler=self._throttler,
+            time_synchronizer=self._time_synchronizer,
+            domain=self._domain,
+            auth=self._auth)
+
+    def _create_order_book_data_source(self) -> OrderBookTrackerDataSource:
+        return GRVTPerpetualAPIOrderBookDataSource(
+            trading_pairs=self._trading_pairs,
+            connector=self,
+            api_factory=self._web_assistants_factory,
+            domain=self.domain,
+        )
+
+    def _create_user_stream_data_source(self) -> UserStreamTrackerDataSource:
+        return GRVTPerpetualUserStreamDataSource(
+            auth=self._auth,
+            connector=self,
+            api_factory=self._web_assistants_factory,
+            domain=self.domain,
+        )
+
+    def _get_fee(self,
+                 base_currency: str,
+                 quote_currency: str,
+                 order_type: OrderType,
+                 order_side: TradeType,
+                 position_action: PositionAction,
+                 amount: Decimal,
+                 price: Decimal = s_decimal_NaN,
+                 is_maker: Optional[bool] = None) -> TradeFeeBase:
+        is_maker = is_maker or False
+        fee = build_trade_fee(
+            self.name,
+            is_maker,
+            base_currency=base_currency,
+            quote_currency=quote_currency,
+            order_type=order_type,
+            order_side=order_side,
+            amount=amount,
+            price=price,
+        )
+        return fee
+
+    async def _update_trading_fees(self):
+        """
+        Update fees information from the exchange
+        """
+        pass
+
+    async def _status_polling_loop_fetch_updates(self):
+        await safe_gather(
+            self._update_order_fills_from_trades(),
+            self._update_order_status(),
+            self._update_balances(),
+            self._update_positions(),
+        )
+
+    async def _place_cancel(self, order_id: str, tracked_order: InFlightOrder):
+        symbol = await self.exchange_symbol_associated_to_pair(trading_pair=tracked_order.trading_pair)
+        api_params = {
+            "orderId": tracked_order.exchange_order_id or order_id,
+            "symbol": symbol,
+        }
+        
+        cancel_result = await self._api_delete(
+            path_url=CONSTANTS.ORDER_URL,
+            params=api_params,
+            is_auth_required=True)
+        
+        # Check for order not found
+        if cancel_result.get("code") == -1 and "not found" in str(cancel_result.get("msg", "")).lower():
+            self.logger().debug(f"The order {order_id} does not exist on GRVT Perpetuals. "
+                                f"No cancelation needed.")
+            await self._order_tracker.process_order_not_found(order_id)
+            raise IOError(f"{cancel_result.get('code')} - {cancel_result.get('msg', 'Unknown error')}")
+        
+        if cancel_result.get("status") in ["CANCELED", "cancelled"]:
+            return True
+        return False
+
+    async def _place_order(
+            self,
+            order_id: str,
+            trading_pair: str,
+            amount: Decimal,
+            trade_type: TradeType,
+            order_type: OrderType,
+            price: Decimal,
+            position_action: PositionAction = PositionAction.NIL,
+            **kwargs,
+    ) -> Tuple[str, float]:
+
+        amount_str = f"{amount:f}"
+        price_str = f"{price:f}"
+        symbol = await self.exchange_symbol_associated_to_pair(trading_pair=trading_pair)
+        
+        api_params = {
+            "symbol": symbol,
+            "side": "BUY" if trade_type is TradeType.BUY else "SELL",
+            "quantity": amount_str,
+            "type": "MARKET" if order_type is OrderType.MARKET else "LIMIT",
+            "clientOrderId": order_id
+        }
+        
+        if order_type.is_limit_type():
+            api_params["price"] = price_str
+        
+        if order_type == OrderType.LIMIT:
+            api_params["timeInForce"] = CONSTANTS.TIME_IN_FORCE_GTC
+        elif order_type == OrderType.LIMIT_MAKER:
+            api_params["timeInForce"] = CONSTANTS.TIME_IN_FORCE_GTX
+            
+        if self.position_mode == PositionMode.HEDGE:
+            if position_action == PositionAction.OPEN:
+                api_params["positionSide"] = "LONG" if trade_type is TradeType.BUY else "SHORT"
+            else:
+                api_params["positionSide"] = "SHORT" if trade_type is TradeType.BUY else "LONG"
+        
+        try:
+            order_result = await self._api_post(
+                path_url=CONSTANTS.ORDER_URL,
+                data=api_params,
+                is_auth_required=True)
+            
+            o_id = str(order_result.get("orderId", order_result.get("id", "UNKNOWN")))
+            transact_time = order_result.get("updateTime", order_result.get("createdAt", time.time() * 1000)) * 1e-3
+        except IOError as e:
+            error_description = str(e)
+            is_server_overloaded = ("status is 503" in error_description
+                                    or "service unavailable" in error_description.lower())
+            if is_server_overloaded:
+                o_id = "UNKNOWN"
+                transact_time = time.time()
+            else:
+                raise
+        return o_id, transact_time
+
+    async def _all_trade_updates_for_order(self, order: InFlightOrder) -> List[TradeUpdate]:
+        trade_updates = []
+        try:
+            exchange_order_id = await order.get_exchange_order_id()
+            trading_pair = await self.exchange_symbol_associated_to_pair(trading_pair=order.trading_pair)
+            
+            all_fills_response = await self._api_get(
+                path_url=CONSTANTS.ACCOUNT_TRADE_LIST_URL,
+                params={
+                    "symbol": trading_pair,
+                },
+                is_auth_required=True)
+
+            for trade in all_fills_response:
+                order_id = str(trade.get("orderId"))
+                if order_id == exchange_order_id:
+                    position_side = trade.get("positionSide", "LONG")
+                    position_action = (PositionAction.OPEN
+                                       if (order.trade_type is TradeType.BUY and position_side == "LONG"
+                                           or order.trade_type is TradeType.SELL and position_side == "SHORT")
+                                       else PositionAction.CLOSE)
+                    
+                    fee = TradeFeeBase.new_perpetual_fee(
+                        fee_schema=self.trade_fee_schema(),
+                        position_action=position_action,
+                        percent_token=trade.get("commissionAsset", order.quote_asset),
+                        flat_fees=[TokenAmount(amount=Decimal(trade.get("commission", "0")), 
+                                              token=trade.get("commissionAsset", order.quote_asset))]
+                    )
+                    
+                    trade_update: TradeUpdate = TradeUpdate(
+                        trade_id=str(trade.get("id", trade.get("tradeId", "0"))),
+                        client_order_id=order.client_order_id,
+                        exchange_order_id=trade.get("orderId"),
+                        trading_pair=order.trading_pair,
+                        fill_timestamp=trade.get("time", 0) * 1e-3,
+                        fill_price=Decimal(trade.get("price", "0")),
+                        fill_base_amount=Decimal(trade.get("qty", "0")),
+                        fill_quote_amount=Decimal(trade.get("quoteQty", "0")),
+                        fee=fee,
+                    )
+                    trade_updates.append(trade_update)
+
+        except asyncio.TimeoutError:
+            raise IOError(f"Skipped order update with order fills for {order.client_order_id} "
+                          "- waiting for exchange order id.")
+
+        return trade_updates
+
+    async def _request_order_status(self, tracked_order: InFlightOrder) -> OrderUpdate:
+        trading_pair = await self.exchange_symbol_associated_to_pair(trading_pair=tracked_order.trading_pair)
+        
+        order_update = await self._api_get(
+            path_url=CONSTANTS.ORDER_URL,
+            params={
+                "symbol": trading_pair,
+                "orderId": tracked_order.exchange_order_id or tracked_order.client_order_id
+            },
+            is_auth_required=True)
+        
+        if "code" in order_update:
+            if self._is_request_exception_related_to_time_synchronizer(request_exception=order_update):
+                _order_update = OrderUpdate(
+                    trading_pair=tracked_order.trading_pair,
+                    update_timestamp=self.current_timestamp,
+                    new_state=tracked_order.current_state,
+                    client_order_id=tracked_order.client_order_id,
+                )
+                return _order_update
+        
+        status = order_update.get("status", "NEW")
+        
+        _order_update: OrderUpdate = OrderUpdate(
+            trading_pair=tracked_order.trading_pair,
+            update_timestamp=order_update.get("updateTime", order_update.get("updatedAt", time.time() * 1000)) * 1e-3,
+            new_state=CONSTANTS.ORDER_STATE.get(status, OrderState.OPEN),
+            client_order_id=order_update.get("clientOrderId", tracked_order.client_order_id),
+            exchange_order_id=order_update.get("orderId"),
+        )
+        return _order_update
+
+    async def _iter_user_event_queue(self) -> AsyncIterable[Dict[str, any]]:
+        while True:
+            try:
+                yield await self._user_stream_tracker.user_stream.get()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                self.logger().network(
+                    "Unknown error. Retrying after 1 seconds.",
+                    exc_info=True,
+                    app_warning_msg="Could not fetch user events from GRVT. Check API key and network connection.",
+                )
+                await self._sleep(1.0)
+
+    async def _user_stream_event_listener(self):
+        """
+        Wait for new messages from _user_stream_tracker.user_stream queue and processes them according to their
+        message channels. The respective UserStreamDataSource queues these messages.
+        """
+        async for event_message in self._iter_user_event_queue():
+            try:
+                await self._process_user_stream_event(event_message)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                self.logger().error(f"Unexpected error in user stream listener loop: {e}", exc_info=True)
+                await self._sleep(5.0)
+
+    async def _process_user_stream_event(self, event_message: Dict[str, Any]):
+        event_type = event_message.get("e", event_message.get("eventType", ""))
+        
+        if event_type in ["ORDER_TRADE_UPDATE", "order_trade_update"]:
+            order_message = event_message.get("o", event_message)
+            client_order_id = order_message.get("c", order_message.get("clientOrderId", None))
+            tracked_order = self._order_tracker.all_fillable_orders.get(client_order_id)
+            
+            if tracked_order is not None:
+                trade_id: str = str(order_message.get("t", order_message.get("tradeId", "0")))
+
+                if trade_id != "0" and trade_id != "":  # Indicates that there has been a trade
+                    fee_asset = order_message.get("N", order_message.get("commissionAsset", tracked_order.quote_asset))
+                    fee_amount = Decimal(order_message.get("n", order_message.get("commission", "0")))
+                    position_side = order_message.get("ps", order_message.get("positionSide", "LONG"))
+                    
+                    position_action = (PositionAction.OPEN
+                                       if (tracked_order.trade_type is TradeType.BUY and position_side == "LONG"
+                                           or tracked_order.trade_type is TradeType.SELL and position_side == "SHORT")
+                                       else PositionAction.CLOSE)
+                    
+                    flat_fees = [] if fee_amount == Decimal("0") else [TokenAmount(amount=fee_amount, token=fee_asset)]
+
+                    fee = TradeFeeBase.new_perpetual_fee(
+                        fee_schema=self.trade_fee_schema(),
+                        position_action=position_action,
+                        percent_token=fee_asset,
+                        flat_fees=flat_fees,
+                    )
+
+                    trade_update: TradeUpdate = TradeUpdate(
+                        trade_id=trade_id,
+                        client_order_id=client_order_id,
+                        exchange_order_id=str(order_message.get("i", order_message.get("orderId", "0"))),
+                        trading_pair=tracked_order.trading_pair,
+                        fill_timestamp=order_message.get("T", order_message.get("tradeTime", 0)) * 1e-3,
+                        fill_price=Decimal(order_message.get("L", order_message.get("lastFillPrice", "0"))),
+                        fill_base_amount=Decimal(order_message.get("l", order_message.get("lastFillQty", "0"))),
+                        fill_quote_amount=Decimal(order_message.get("L", "0")) * Decimal(order_message.get("l", "0")),
+                        fee=fee,
+                    )
+                    self._order_tracker.process_trade_update(trade_update)
+
+            tracked_order = self._order_tracker.all_updatable_orders.get(client_order_id)
+            if tracked_order is not None:
+                order_status = order_message.get("X", order_message.get("status", "NEW"))
+                
+                order_update: OrderUpdate = OrderUpdate(
+                    trading_pair=tracked_order.trading_pair,
+                    update_timestamp=event_message.get("T", event_message.get("eventTime", time.time() * 1000)) * 1e-3,
+                    new_state=CONSTANTS.ORDER_STATE.get(order_status, OrderState.OPEN),
+                    client_order_id=client_order_id,
+                    exchange_order_id=str(order_message.get("i", order_message.get("orderId", "0"))),
+                )
+
+                self._order_tracker.process_order_update(order_update)
+
+        elif event_type in ["ACCOUNT_UPDATE", "account_update"]:
+            update_data = event_message.get("a", event_message)
+            
+            # Update balances
+            for asset in update_data.get("B", update_data.get("balances", [])):
+                asset_name = asset.get("a", asset.get("asset", ""))
+                self._account_balances[asset_name] = Decimal(asset.get("wb", asset.get("walletBalance", "0")))
+                self._account_available_balances[asset_name] = Decimal(asset.get("cw", asset.get("availableBalance", "0")))
+
+            # Update positions
+            for asset in update_data.get("P", update_data.get("positions", [])):
+                trading_pair = asset.get("s", asset.get("symbol", ""))
+                try:
+                    hb_trading_pair = await self.trading_pair_associated_to_exchange_symbol(trading_pair)
+                except KeyError:
+                    # Ignore results for which their symbols is not tracked by the connector
+                    continue
+
+                side = PositionSide[asset.get("ps", asset.get("positionSide", "LONG"))]
+                position = self._perpetual_trading.get_position(hb_trading_pair, side)
+                if position is not None:
+                    amount = Decimal(asset.get("pa", asset.get("positionAmount", "0")))
+                    if amount == Decimal("0"):
+                        pos_key = self._perpetual_trading.position_key(hb_trading_pair, side)
+                        self._perpetual_trading.remove_position(pos_key)
+                    else:
+                        position.update_position(position_side=PositionSide[asset.get("ps", "LONG")],
+                                                 unrealized_pnl=Decimal(asset.get("up", asset.get("unrealizedPnl", "0"))),
+                                                 entry_price=Decimal(asset.get("ep", asset.get("entryPrice", "0"))),
+                                                 amount=Decimal(asset.get("pa", "0")))
+                else:
+                    await self._update_positions()
+
+    async def _format_trading_rules(self, exchange_info_dict: Dict[str, Any]) -> List[TradingRule]:
+        """
+        Queries the necessary API endpoint and initialize the TradingRule object for each trading pair being traded.
+
+        Parameters
+        ----------
+        exchange_info_dict:
+            Trading rules dictionary response from the exchange
+        """
+        rules: list = exchange_info_dict.get("symbols", [])
+        return_val: list = []
+        
+        for rule in rules:
+            try:
+                if web_utils.is_exchange_information_valid(rule):
+                    trading_pair = await self.trading_pair_associated_to_exchange_symbol(symbol=rule["symbol"])
+                    filters = rule.get("filters", [])
+                    filt_dict = {fil["filterType"]: fil for fil in filters}
+
+                    min_order_size = Decimal(filt_dict.get("LOT_SIZE", {}).get("minQty", "0"))
+                    step_size = Decimal(filt_dict.get("LOT_SIZE", {}).get("stepSize", "0"))
+                    tick_size = Decimal(filt_dict.get("PRICE_FILTER", {}).get("tickSize", "0"))
+                    min_notional = Decimal(filt_dict.get("MIN_NOTIONAL", {}).get("notional", "0"))
+                    collateral_token = rule.get("marginAsset", rule.get("quoteAsset", "USDT"))
+
+                    return_val.append(
+                        TradingRule(
+                            trading_pair,
+                            min_order_size=min_order_size,
+                            min_price_increment=Decimal(tick_size),
+                            min_base_amount_increment=Decimal(step_size),
+                            min_notional_size=Decimal(min_notional),
+                            buy_order_collateral_token=collateral_token,
+                            sell_order_collateral_token=collateral_token,
+                        )
+                    )
+            except Exception as e:
+                self.logger().error(
+                    f"Error parsing the trading pair rule {rule}. Error: {e}. Skipping...", exc_info=True
+                )
+        return return_val
+
+    def _initialize_trading_pair_symbols_from_exchange_info(self, exchange_info: Dict[str, Any]):
+        mapping = bidict()
+        for symbol_data in filter(web_utils.is_exchange_information_valid, exchange_info.get("symbols", [])):
+            exchange_symbol = symbol_data.get("pair", symbol_data.get("symbol", ""))
+            base = symbol_data.get("baseAsset", symbol_data.get("base", ""))
+            quote = symbol_data.get("quoteAsset", symbol_data.get("quote", ""))
+            
+            if base and quote:
+                trading_pair = combine_to_hb_trading_pair(base, quote)
+                if trading_pair in mapping.inverse:
+                    self._resolve_trading_pair_symbols_duplicate(mapping, exchange_symbol, base, quote)
+                else:
+                    mapping[exchange_symbol] = trading_pair
+        self._set_trading_pair_symbol_map(mapping)
+
+    async def _get_last_traded_price(self, trading_pair: str) -> float:
+        exchange_symbol = await self.exchange_symbol_associated_to_pair(trading_pair=trading_pair)
+        params = {"symbol": exchange_symbol}
+        response = await self._api_get(
+            path_url=CONSTANTS.TICKER_PRICE_CHANGE_URL,
+            params=params)
+        price = float(response.get("lastPrice", response.get("lastPrice", "0")))
+        return price
+
+    def _resolve_trading_pair_symbols_duplicate(self, mapping: bidict, new_exchange_symbol: str, base: str, quote: str):
+        """Resolves name conflicts provoked by futures contracts."""
+        expected_exchange_symbol = f"{base}{quote}"
+        trading_pair = combine_to_hb_trading_pair(base, quote)
+        
+        if trading_pair in mapping.inverse:
+            current_exchange_symbol = mapping.inverse[trading_pair]
+            if current_exchange_symbol == expected_exchange_symbol:
+                pass
+            elif new_exchange_symbol == expected_exchange_symbol:
+                mapping.pop(current_exchange_symbol)
+                mapping[new_exchange_symbol] = trading_pair
+            else:
+                self.logger().error(
+                    f"Could not resolve the exchange symbols {new_exchange_symbol} and {current_exchange_symbol}")
+                mapping.pop(current_exchange_symbol)
+        else:
+            mapping[new_exchange_symbol] = trading_pair
+
+    async def _update_balances(self):
+        """
+        Calls the REST API to update total and available balances.
+        """
+        local_asset_names = set(self._account_balances.keys())
+        remote_asset_names = set()
+
+        account_info = await self._api_get(path_url=CONSTANTS.ACCOUNT_INFO_URL,
+                                           is_auth_required=True)
+        assets = account_info.get("assets", account_info.get("data", []))
+        for asset in assets:
+            asset_name = asset.get("asset", "")
+            available_balance = Decimal(asset.get("availableBalance", asset.get("available", "0")))
+            wallet_balance = Decimal(asset.get("walletBalance", asset.get("balance", "0")))
+            self._account_available_balances[asset_name] = available_balance
+            self._account_balances[asset_name] = wallet_balance
+            remote_asset_names.add(asset_name)
+
+        asset_names_to_remove = local_asset_names.difference(remote_asset_names)
+        for asset_name in asset_names_to_remove:
+            del self._account_available_balances[asset_name]
+            del self._account_balances[asset_name]
+
+    async def _update_positions(self):
+        positions = await self._api_get(path_url=CONSTANTS.POSITION_INFORMATION_URL,
+                                        is_auth_required=True)
+        
+        positions_list = positions.get("positions", positions.get("data", [])) if isinstance(positions, dict) else positions
+        
+        for position in positions_list:
+            trading_pair = position.get("symbol", "")
+            try:
+                hb_trading_pair = await self.trading_pair_associated_to_exchange_symbol(trading_pair)
+            except KeyError:
+                # Ignore results for which their symbols is not tracked by the connector
+                continue
+            
+            position_side = PositionSide[position.get("positionSide", position.get("ps", "LONG"))]
+            unrealized_pnl = Decimal(position.get("unRealizedProfit", position.get("up", "0")))
+            entry_price = Decimal(position.get("entryPrice", position.get("ep", "0")))
+            amount = Decimal(position.get("positionAmt", position.get("pa", "0")))
+            leverage = Decimal(position.get("leverage", position.get("lev", "1")))
+            
+            pos_key = self._perpetual_trading.position_key(hb_trading_pair, position_side)
+            
+            if amount != 0:
+                _position = Position(
+                    trading_pair=hb_trading_pair,
+                    position_side=position_side,
+                    unrealized_pnl=unrealized_pnl,
+                    entry_price=entry_price,
+                    amount=amount,
+                    leverage=leverage
+                )
+                self._perpetual_trading.set_position(pos_key, _position)
+            else:
+                self._perpetual_trading.remove_position(pos_key)
+
+    async def _update_order_fills_from_trades(self):
+        last_tick = int(self._last_poll_timestamp / self.UPDATE_ORDER_STATUS_MIN_INTERVAL)
+        current_tick = int(self.current_timestamp / self.UPDATE_ORDER_STATUS_MIN_INTERVAL)
+        
+        if current_tick > last_tick and len(self._order_tracker.active_orders) > 0:
+            trading_pairs_to_order_map: Dict[str, Dict[str, Any]] = defaultdict(lambda: {})
+            for order in self._order_tracker.active_orders.values():
+                trading_pairs_to_order_map[order.trading_pair][order.exchange_order_id] = order
+            trading_pairs = list(trading_pairs_to_order_map.keys())
+            
+            tasks = [
+                self._api_get(
+                    path_url=CONSTANTS.ACCOUNT_TRADE_LIST_URL,
+                    params={"symbol": await self.exchange_symbol_associated_to_pair(trading_pair=trading_pair)},
+                    is_auth_required=True,
+                )
+                for trading_pair in trading_pairs
+            ]
+            
+            self.logger().debug(f"Polling for order fills of {len(tasks)} trading_pairs.")
+            results = await safe_gather(*tasks, return_exceptions=True)
+
+            for trades, trading_pair in zip(results, trading_pairs):
+                order_map = trading_pairs_to_order_map.get(trading_pair)
+                if isinstance(trades, Exception):
+                    self.logger().network(
+                        f"Error fetching trades update for the order {trading_pair}: {trades}.",
+                        app_warning_msg=f"Failed to fetch trade update for {trading_pair}."
+                    )
+                    continue
+                
+                trades_list = trades.get("trades", trades.get("data", [])) if isinstance(trades, dict) else trades
+                
+                for trade in trades_list:
+                    order_id = str(trade.get("orderId", ""))
+                    if order_id in order_map:
+                        tracked_order: InFlightOrder = order_map.get(order_id)
+                        position_side = trade.get("positionSide", trade.get("ps", "LONG"))
+                        position_action = (PositionAction.OPEN
+                                           if (tracked_order.trade_type is TradeType.BUY and position_side == "LONG"
+                                               or tracked_order.trade_type is TradeType.SELL and position_side == "SHORT")
+                                           else PositionAction.CLOSE)
+                        
+                        fee = TradeFeeBase.new_perpetual_fee(
+                            fee_schema=self.trade_fee_schema(),
+                            position_action=position_action,
+                            percent_token=trade.get("commissionAsset", tracked_order.quote_asset),
+                            flat_fees=[TokenAmount(amount=Decimal(trade.get("commission", "0")), 
+                                                  token=trade.get("commissionAsset", tracked_order.quote_asset))]
+                        )
+                        
+                        trade_update: TradeUpdate = TradeUpdate(
+                            trade_id=str(trade.get("id", trade.get("tradeId", "0"))),
+                            client_order_id=tracked_order.client_order_id,
+                            exchange_order_id=trade.get("orderId"),
+                            trading_pair=tracked_order.trading_pair,
+                            fill_timestamp=trade.get("time", 0) * 1e-3,
+                            fill_price=Decimal(trade.get("price", "0")),
+                            fill_base_amount=Decimal(trade.get("qty", "0")),
+                            fill_quote_amount=Decimal(trade.get("quoteQty", "0")),
+                            fee=fee,
+                        )
+                        self._order_tracker.process_trade_update(trade_update)
+
+    async def _update_order_status(self):
+        """
+        Calls the REST API to get order/trade updates for each in-flight order.
+        """
+        last_tick = int(self._last_poll_timestamp / self.UPDATE_ORDER_STATUS_MIN_INTERVAL)
+        current_tick = int(self.current_timestamp / self.UPDATE_ORDER_STATUS_MIN_INTERVAL)
+        
+        if current_tick > last_tick and len(self._order_tracker.active_orders) > 0:
+            tracked_orders = list(self._order_tracker.active_orders.values())
+            
+            tasks = [
+                self._api_get(
+                    path_url=CONSTANTS.ORDER_URL,
+                    params={
+                        "symbol": await self.exchange_symbol_associated_to_pair(trading_pair=order.trading_pair),
+                        "orderId": order.exchange_order_id or order.client_order_id
+                    },
+                    is_auth_required=True,
+                    return_err=True,
+                )
+                for order in tracked_orders
+            ]
+            
+            self.logger().debug(f"Polling for order status updates of {len(tasks)} orders.")
+            results = await safe_gather(*tasks, return_exceptions=True)
+
+            for order_update, tracked_order in zip(results, tracked_orders):
+                client_order_id = tracked_order.client_order_id
+                
+                if client_order_id not in self._order_tracker.all_orders:
+                    continue
+                
+                if isinstance(order_update, Exception) or (isinstance(order_update, dict) and "code" in order_update):
+                    if isinstance(order_update, dict) and order_update.get("code") == -1:
+                        await self._order_tracker.process_order_not_found(client_order_id)
+                    else:
+                        self.logger().network(
+                            f"Error fetching status update for the order {client_order_id}: {order_update}."
+                        )
+                    continue
+
+                symbol = await self.trading_pair_associated_to_exchange_symbol(order_update.get("symbol", ""))
+                status = order_update.get("status", "NEW")
+                
+                new_order_update: OrderUpdate = OrderUpdate(
+                    trading_pair=symbol,
+                    update_timestamp=order_update.get("updateTime", order_update.get("updatedAt", time.time() * 1000)) * 1e-3,
+                    new_state=CONSTANTS.ORDER_STATE.get(status, OrderState.OPEN),
+                    client_order_id=order_update.get("clientOrderId", client_order_id),
+                    exchange_order_id=order_update.get("orderId"),
+                )
+
+                self._order_tracker.process_order_update(new_order_update)
+
+    async def _get_position_mode(self) -> Optional[PositionMode]:
+        # To-do: ensure there's no active order or contract before changing position mode
+        if self._position_mode is None:
+            response = await self._api_get(
+                path_url=CONSTANTS.CHANGE_POSITION_MODE_URL,
+                is_auth_required=True,
+                return_err=True
+            )
+            
+            if isinstance(response, dict):
+                dual_position = response.get("dualSidePosition", response.get("dualPosition", False))
+                self._position_mode = PositionMode.HEDGE if dual_position else PositionMode.ONEWAY
+
+        return self._position_mode
+
+    async def _trading_pair_position_mode_set(self, mode: PositionMode, trading_pair: str) -> Tuple[bool, str]:
+        msg = ""
+        success = True
+        initial_mode = await self._get_position_mode()
+        
+        if initial_mode != mode:
+            params = {
+                "dualSidePosition": True if mode == PositionMode.HEDGE else False,
+            }
+            
+            response = await self._api_post(
+                path_url=CONSTANTS.CHANGE_POSITION_MODE_URL,
+                data=params,
+                is_auth_required=True,
+                return_err=True
+            )
+            
+            if isinstance(response, dict) and response.get("code") != 0:
+                success = False
+                return success, str(response)
+            
+            self._position_mode = mode
+        
+        return success, msg
+
+    async def _set_trading_pair_leverage(self, trading_pair: str, leverage: int) -> Tuple[bool, str]:
+        symbol = await self.exchange_symbol_associated_to_pair(trading_pair)
+        params = {"symbol": symbol, "leverage": leverage}
+        
+        set_leverage = await self._api_post(
+            path_url=CONSTANTS.SET_LEVERAGE_URL,
+            data=params,
+            is_auth_required=True,
+        )
+        
+        success = False
+        msg = ""
+        
+        if isinstance(set_leverage, dict) and set_leverage.get("leverage") == leverage:
+            success = True
+        else:
+            msg = 'Unable to set leverage'
+        
+        return success, msg
+
+    async def _fetch_last_fee_payment(self, trading_pair: str) -> Tuple[int, Decimal, Decimal]:
+        exchange_symbol = await self.exchange_symbol_associated_to_pair(trading_pair)
+        
+        payment_response = await self._api_get(
+            path_url=CONSTANTS.GET_INCOME_HISTORY_URL,
+            params={
+                "symbol": exchange_symbol,
+                "incomeType": "FUNDING_FEE",
+            },
+            is_auth_required=True,
+        )
+        
+        funding_info_response = await self._api_get(
+            path_url=CONSTANTS.MARK_PRICE_URL,
+            params={
+                "symbol": exchange_symbol,
+            },
+        )
+        
+        payment_list = payment_response.get("list", payment_response.get("data", [])) if isinstance(payment_response, dict) else payment_response
+        
+        sorted_payment_response = sorted(payment_list, key=lambda a: a.get('time', 0), reverse=True)
+        
+        if len(sorted_payment_response) < 1:
+            timestamp, funding_rate, payment = 0, Decimal("-1"), Decimal("-1")
+            return timestamp, funding_rate, payment
+        
+        funding_payment = sorted_payment_response[0]
+        _payment = Decimal(funding_payment.get("income", "0"))
+        funding_rate = Decimal(funding_info_response.get("lastFundingRate", funding_info_response.get("fundingRate", "0")))
+        timestamp = funding_payment.get("time", 0)
+        
+        if _payment != Decimal("0"):
+            payment = _payment
+        else:
+            payment = Decimal("0")
+
+        return timestamp, funding_rate, payment

--- a/hummingbot/connector/derivative/grvt_perpetual/grvt_perpetual_utils.py
+++ b/hummingbot/connector/derivative/grvt_perpetual/grvt_perpetual_utils.py
@@ -1,0 +1,66 @@
+from decimal import Decimal
+
+from pydantic import Field, SecretStr
+
+from hummingbot.client.config.config_data_types import BaseConnectorConfigMap
+from hummingbot.core.data_type.trade_fee import TradeFeeSchema
+
+DEFAULT_FEES = TradeFeeSchema(
+    maker_percent_fee_decimal=Decimal("0.0002"),
+    taker_percent_fee_decimal=Decimal("0.0004"),
+    buy_percent_fee_deducted_from_returns=True
+)
+
+CENTRALIZED = True
+
+EXAMPLE_PAIR = "BTC-USDT"
+
+BROKER_ID = "hummingbot"
+
+
+class GRVTPerpetualConfigMap(BaseConnectorConfigMap):
+    connector: str = "grvt_perpetual"
+    grvt_perpetual_api_key: SecretStr = Field(
+        default=...,
+        json_schema_extra={
+            "prompt": "Enter your GRVT Perpetual API key",
+            "is_secure": True, "is_connect_key": True, "prompt_on_new": True}
+    )
+    grvt_perpetual_api_secret: SecretStr = Field(
+        default=...,
+        json_schema_extra={
+            "prompt": "Enter your GRVT Perpetual API secret",
+            "is_secure": True, "is_connect_key": True, "prompt_on_new": True}
+    )
+
+
+KEYS = GRVTPerpetualConfigMap.model_construct()
+
+OTHER_DOMAINS = ["grvt_perpetual_testnet"]
+OTHER_DOMAINS_PARAMETER = {"grvt_perpetual_testnet": "grvt_perpetual_testnet"}
+OTHER_DOMAINS_EXAMPLE_PAIR = {"grvt_perpetual_testnet": "BTC-USDT"}
+OTHER_DOMAINS_DEFAULT_FEES = {"grvt_perpetual_testnet": [0.02, 0.04]}
+
+
+class GRVTPerpetualTestnetConfigMap(BaseConnectorConfigMap):
+    connector: str = "grvt_perpetual_testnet"
+    grvt_perpetual_testnet_api_key: SecretStr = Field(
+        default=...,
+        json_schema_extra={
+            "prompt": "Enter your GRVT Perpetual testnet API key",
+            "is_secure": True, "is_connect_key": True, "prompt_on_new": True}
+    )
+    grvt_perpetual_testnet_api_secret: SecretStr = Field(
+        default=...,
+        json_schema_extra={
+            "prompt": "Enter your GRVT Perpetual testnet API secret",
+            "is_secure": True, "is_connect_key": True, "prompt_on_new": True}
+    )
+
+
+OTHER_DOMAINS_KEYS = {"grvt_perpetual_testnet": GRVTPerpetualTestnetConfigMap.model_construct()}
+
+KEY_TO_ALLOWLIST = {
+    "grvt_perpetual_api_key",
+    "grvt_perpetual_api_secret",
+}

--- a/hummingbot/connector/derivative/grvt_perpetual/grvt_perpetual_web_utils.py
+++ b/hummingbot/connector/derivative/grvt_perpetual/grvt_perpetual_web_utils.py
@@ -1,0 +1,103 @@
+from typing import Any, Callable, Dict, Optional
+
+import hummingbot.connector.derivative.grvt_perpetual.grvt_perpetual_constants as CONSTANTS
+from hummingbot.connector.time_synchronizer import TimeSynchronizer
+from hummingbot.connector.utils import TimeSynchronizerRESTPreProcessor
+from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from hummingbot.core.web_assistant.auth import AuthBase
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod, RESTRequest
+from hummingbot.core.web_assistant.rest_pre_processors import RESTPreProcessorBase
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+
+
+class GRVTPerpetualRESTPreProcessor(RESTPreProcessorBase):
+
+    async def pre_process(self, request: RESTRequest) -> RESTRequest:
+        if request.headers is None:
+            request.headers = {}
+        request.headers["Content-Type"] = "application/json"
+        request.headers["Accept"] = "application/json"
+        return request
+
+
+def public_rest_url(path_url: str, domain: str = "grvt_perpetual"):
+    base_url = CONSTANTS.PERPETUAL_BASE_URL if domain == "grvt_perpetual" else CONSTANTS.TESTNET_BASE_URL
+    return base_url + path_url
+
+
+def private_rest_url(path_url: str, domain: str = "grvt_perpetual"):
+    base_url = CONSTANTS.PERPETUAL_BASE_URL if domain == "grvt_perpetual" else CONSTANTS.TESTNET_BASE_URL
+    return base_url + path_url
+
+
+def wss_url(endpoint: str, domain: str = "grvt_perpetual"):
+    base_ws_url = CONSTANTS.PERPETUAL_WS_URL if domain == "grvt_perpetual" else CONSTANTS.TESTNET_WS_URL
+    return base_ws_url + endpoint
+
+
+def build_api_factory(
+        throttler: Optional[AsyncThrottler] = None,
+        time_synchronizer: Optional[TimeSynchronizer] = None,
+        domain: str = CONSTANTS.DOMAIN,
+        time_provider: Optional[Callable] = None,
+        auth: Optional[AuthBase] = None) -> WebAssistantsFactory:
+    throttler = throttler or create_throttler()
+    time_synchronizer = time_synchronizer or TimeSynchronizer()
+    time_provider = time_provider or (lambda: get_current_server_time(
+        throttler=throttler,
+        domain=domain,
+    ))
+    api_factory = WebAssistantsFactory(
+        throttler=throttler,
+        auth=auth,
+        rest_pre_processors=[
+            TimeSynchronizerRESTPreProcessor(synchronizer=time_synchronizer, time_provider=time_provider),
+            GRVTPerpetualRESTPreProcessor(),
+        ])
+    return api_factory
+
+
+def build_api_factory_without_time_synchronizer_pre_processor(throttler: AsyncThrottler) -> WebAssistantsFactory:
+    api_factory = WebAssistantsFactory(
+        throttler=throttler,
+        rest_pre_processors=[GRVTPerpetualRESTPreProcessor()])
+    return api_factory
+
+
+def create_throttler() -> AsyncThrottler:
+    return AsyncThrottler(CONSTANTS.RATE_LIMITS)
+
+
+async def get_current_server_time(
+        throttler: Optional[AsyncThrottler] = None,
+        domain: str = CONSTANTS.DOMAIN,
+) -> float:
+    throttler = throttler or create_throttler()
+    api_factory = build_api_factory_without_time_synchronizer_pre_processor(throttler=throttler)
+    rest_assistant = await api_factory.get_rest_assistant()
+    response = await rest_assistant.execute_request(
+        url=public_rest_url(path_url=CONSTANTS.SERVER_TIME_PATH_URL, domain=domain),
+        method=RESTMethod.GET,
+        throttler_limit_id=CONSTANTS.SERVER_TIME_PATH_URL,
+    )
+    server_time = int(response.get("serverTime", response.get("timestamp", 0)))
+    return server_time
+
+
+def is_exchange_information_valid(rule: Dict[str, Any]) -> bool:
+    """
+    Verifies if a trading pair is enabled to operate with based on its exchange information
+
+    :param exchange_info: the exchange information for a trading pair
+
+    :return: True if the trading pair is enabled, False otherwise
+    """
+    # GRVT-specific validation
+    status = rule.get("status", "")
+    contract_type = rule.get("contractType", "")
+    
+    if status == "TRADING" and contract_type in ("PERPETUAL", "PERP"):
+        valid = True
+    else:
+        valid = False
+    return valid

--- a/test/hummingbot/connector/derivative/grvt_perpetual/test_grvt_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/grvt_perpetual/test_grvt_perpetual_api_order_book_data_source.py
@@ -1,0 +1,161 @@
+import asyncio
+from decimal import Decimal
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+from unittest import TestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import hummingbot.connector.derivative.grvt_perpetual.grvt_perpetual_constants as CONSTANTS
+from hummingbot.connector.derivative.grvt_perpetual.grvt_perpetual_api_order_book_data_source import (
+    GRVTPerpetualAPIOrderBookDataSource,
+)
+from hummingbot.core.data_type.common import TradeType
+from hummingbot.core.data_type.funding_info import FundingInfo
+from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
+
+
+class GRVTPerpetualAPIOrderBookDataSourceTests(TestCase):
+    def setUp(self):
+        self.connector = MagicMock()
+        self.connector.get_last_traded_prices = AsyncMock(return_value={"BTC-USDT": 50000.0})
+        
+        self.data_source = GRVTPerpetualAPIOrderBookDataSource(
+            trading_pairs=["BTC-USDT"],
+            connector=self.connector,
+            api_factory=MagicMock(),
+            domain="grvt_perpetual",
+        )
+
+    def async_run_with_timeout(self, coroutine, timeout: int = 1):
+        return asyncio.get_event_loop().run_until_complete(asyncio.wait_for(coroutine, timeout))
+
+    def test_get_last_traded_prices(self):
+        prices = self.async_run_with_timeout(
+            self.data_source.get_last_traded_prices(["BTC-USDT"])
+        )
+        self.assertEqual({"BTC-USDT": 50000.0}, prices)
+
+
+class GRVTPerpetualAPIOrderBookDataSourceAsyncTests(IsolatedAsyncioWrapperTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.base_asset = "BTC"
+        cls.quote_asset = "USDT"
+        cls.trading_pair = f"{cls.base_asset}-{cls.quote_asset}"
+        cls.ex_trading_pair = f"{cls.base_asset}-{cls.quote_asset}"
+
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+        
+        self.connector = MagicMock()
+        self.connector.exchange_symbol_associated_to_pair = AsyncMock(return_value=self.ex_trading_pair)
+        self.connector.trading_pair_associated_to_exchange_symbol = MagicMock(return_value=self.trading_pair)
+        self.connector.get_last_traded_prices = AsyncMock(return_value={self.trading_pair: 50000.0})
+        
+        self.data_source = GRVTPerpetualAPIOrderBookDataSource(
+            trading_pairs=[self.trading_pair],
+            connector=self.connector,
+            api_factory=MagicMock(),
+            domain="grvt_perpetual",
+        )
+
+    async def test_get_funding_info(self):
+        self.connector._api_get = AsyncMock(return_value={
+            "symbol": "BTC-USDT",
+            "markPrice": "50000.0",
+            "indexPrice": "49900.0",
+            "lastFundingRate": "0.0001",
+            "nextFundingTime": "1700000000000",
+        })
+        
+        funding_info = await self.data_source.get_funding_info(self.trading_pair)
+        
+        self.assertIsInstance(funding_info, FundingInfo)
+        self.assertEqual(self.trading_pair, funding_info.trading_pair)
+        self.assertEqual(Decimal("49900"), funding_info.index_price)
+        self.assertEqual(Decimal("50000"), funding_info.mark_price)
+
+    async def test_order_book_snapshot(self):
+        self.connector._api_get = AsyncMock(return_value={
+            "lastUpdateId": 12345,
+            "bids": [["50000", "1.0"], ["49999", "2.0"]],
+            "asks": [["50001", "1.5"], ["50002", "3.0"]],
+        })
+        
+        snapshot = await self.data_source._order_book_snapshot(self.trading_pair)
+        
+        self.assertEqual(OrderBookMessageType.SNAPSHOT, snapshot.type)
+        self.assertEqual(self.trading_pair, snapshot.content["trading_pair"])
+        self.assertEqual(2, len(snapshot.content["bids"]))
+        self.assertEqual(2, len(snapshot.content["asks"]))
+
+    async def test_parse_order_book_diff_message(self):
+        raw_message = {
+            "stream": "btc-usdt:depth",
+            "data": {
+                "s": "BTC-USDT",
+                "u": 12345,
+                "b": [["50000", "1.0"]],
+                "a": [["50001", "1.5"]],
+            }
+        }
+        
+        message_queue = asyncio.Queue()
+        await self.data_source._parse_order_book_diff_message(raw_message, message_queue)
+        
+        self.assertFalse(message_queue.empty())
+        diff_message = await message_queue.get()
+        self.assertEqual(OrderBookMessageType.DIFF, diff_message.type)
+
+    async def test_parse_trade_message(self):
+        raw_message = {
+            "stream": "btc-usdt:trade",
+            "data": {
+                "s": "BTC-USDT",
+                "t": 12345,
+                "p": "50000",
+                "q": "1.0",
+                "m": False,  # false = buy
+                "E": 1700000000000,
+            }
+        }
+        
+        message_queue = asyncio.Queue()
+        await self.data_source._parse_trade_message(raw_message, message_queue)
+        
+        self.assertFalse(message_queue.empty())
+        trade_message = await message_queue.get()
+        self.assertEqual(OrderBookMessageType.TRADE, trade_message.type)
+
+    async def test_parse_funding_info_message(self):
+        raw_message = {
+            "stream": "btc-usdt:mark_price",
+            "data": {
+                "s": "BTC-USDT",
+                "i": "49900",
+                "p": "50000",
+                "r": "0.0001",
+                "T": 1700000000000,
+            }
+        }
+        
+        message_queue = asyncio.Queue()
+        await self.data_source._parse_funding_info_message(raw_message, message_queue)
+        
+        self.assertFalse(message_queue.empty())
+
+    async def test_channel_originating_message(self):
+        # Test depth channel
+        depth_message = {"stream": "btc-usdt:depth", "data": {}}
+        channel = self.data_source._channel_originating_message(depth_message)
+        self.assertEqual(str(CONSTANTS.DIFF_STREAM_ID), channel)
+        
+        # Test trade channel
+        trade_message = {"stream": "btc-usdt:trade", "data": {}}
+        channel = self.data_source._channel_originating_message(trade_message)
+        self.assertEqual(str(CONSTANTS.TRADE_STREAM_ID), channel)
+        
+        # Test funding channel
+        funding_message = {"stream": "btc-usdt:mark_price", "data": {}}
+        channel = self.data_source._channel_originating_message(funding_message)
+        self.assertEqual(str(CONSTANTS.FUNDING_INFO_STREAM_ID), channel)

--- a/test/hummingbot/connector/derivative/grvt_perpetual/test_grvt_perpetual_api_user_stream_data_source.py
+++ b/test/hummingbot/connector/derivative/grvt_perpetual/test_grvt_perpetual_api_user_stream_data_source.py
@@ -1,0 +1,74 @@
+import asyncio
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+from unittest import TestCase
+from unittest.mock import AsyncMock, MagicMock
+
+import hummingbot.connector.derivative.grvt_perpetual.grvt_perpetual_constants as CONSTANTS
+from hummingbot.connector.derivative.grvt_perpetual.grvt_perpetual_api_user_stream_data_source import (
+    GRVTPerpetualUserStreamDataSource,
+)
+
+
+class GRVTPerpetualUserStreamDataSourceTests(TestCase):
+    def setUp(self):
+        self.auth = MagicMock()
+        self.auth.get_auth_headers = MagicMock(return_value={"GRVT-API-KEY": "test_key"})
+        
+        self.connector = MagicMock()
+        
+        self.data_source = GRVTPerpetualUserStreamDataSource(
+            auth=self.auth,
+            connector=self.connector,
+            api_factory=MagicMock(),
+            domain="grvt_perpetual",
+        )
+
+
+class GRVTPerpetualUserStreamDataSourceAsyncTests(IsolatedAsyncioWrapperTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.trading_pair = "BTC-USDT"
+
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+        
+        self.auth = MagicMock()
+        self.auth.get_auth_headers = MagicMock(return_value={"GRVT-API-KEY": "test_key"})
+        
+        self.connector = MagicMock()
+        
+        self.data_source = GRVTPerpetualUserStreamDataSource(
+            auth=self.auth,
+            connector=self.connector,
+            api_factory=MagicMock(),
+            domain="grvt_perpetual",
+        )
+
+    async def test_subscribe_channels(self):
+        ws_assistant = AsyncMock()
+        
+        await self.data_source._subscribe_channels(ws_assistant)
+        
+        # Verify that send was called
+        ws_assistant.send.assert_called_once()
+
+    async def test_on_user_stream_interruption(self):
+        ws_assistant = AsyncMock()
+        
+        await self.data_source._on_user_stream_interruption(ws_assistant)
+        
+        # Verify disconnect was called
+        ws_assistant.disconnect.assert_called_once()
+
+    async def test_connected_websocket_assistant(self):
+        api_factory = AsyncMock()
+        ws_assistant = AsyncMock()
+        api_factory.get_ws_assistant = AsyncMock(return_value=ws_assistant)
+        
+        self.data_source._api_factory = api_factory
+        
+        result = await self.data_source._connected_websocket_assistant()
+        
+        # Verify connection was attempted
+        ws_assistant.connect.assert_called_once()

--- a/test/hummingbot/connector/derivative/grvt_perpetual/test_grvt_perpetual_auth.py
+++ b/test/hummingbot/connector/derivative/grvt_perpetual/test_grvt_perpetual_auth.py
@@ -1,0 +1,80 @@
+import asyncio
+from decimal import Decimal
+from unittest import TestCase
+from unittest.mock import AsyncMock, MagicMock
+
+import hummingbot.connector.derivative.grvt_perpetual.grvt_perpetual_constants as CONSTANTS
+from hummingbot.connector.derivative.grvt_perpetual.grvt_perpetual_auth import GRVTPerpetualAuth
+
+
+class GRVTPerpetualAuthTests(TestCase):
+    def setUp(self):
+        self.auth = GRVTPerpetualAuth(
+            api_key="test_api_key",
+            api_secret="test_api_secret"
+        )
+
+    def test_header_for_authentication(self):
+        headers = self.auth.header_for_authentication()
+        self.assertEqual("test_api_key", headers.get("GRVT-API-KEY"))
+
+    def test_get_auth_headers(self):
+        headers = self.auth.get_auth_headers()
+        self.assertIn("GRVT-API-KEY", headers)
+        self.assertIn("GRVT-TIMESTAMP", headers)
+        self.assertIn("GRVT-SIGNATURE", headers)
+
+    def test_generate_signature(self):
+        signature = self.auth.generate_signature(
+            method="GET",
+            path="/test",
+            params={"key": "value"}
+        )
+        self.assertIsNotNone(signature)
+        self.assertIsInstance(signature, str)
+        self.assertEqual(64, len(signature))  # SHA256 hex digest is 64 chars
+
+    def test_generate_signature_with_empty_params(self):
+        signature = self.auth.generate_signature(
+            method="GET",
+            path="/test",
+            params=None
+        )
+        self.assertIsNotNone(signature)
+        self.assertIsInstance(signature, str)
+
+
+class GRVTPerpetualAuthAsyncTests(TestCase):
+    def setUp(self):
+        self.auth = GRVTPerpetualAuth(
+            api_key="test_api_key",
+            api_secret="test_api_secret"
+        )
+
+    def async_run_with_timeout(self, coroutine, timeout: int = 1):
+        return asyncio.get_event_loop().run_until_complete(asyncio.wait_for(coroutine, timeout))
+
+    def test_rest_authenticate(self):
+        from hummingbot.core.web_assistant.connections.data_types import RESTMethod, RESTRequest
+        
+        request = RESTRequest(
+            url="https://api.grvt.io/test",
+            method=RESTMethod.GET,
+        )
+        
+        authenticated_request = self.async_run_with_timeout(self.auth.rest_authenticate(request))
+        
+        self.assertIn("GRVT-API-KEY", authenticated_request.headers)
+        self.assertIn("GRVT-TIMESTAMP", authenticated_request.headers)
+        self.assertIn("GRVT-SIGNATURE", authenticated_request.headers)
+
+    def test_ws_authenticate(self):
+        from hummingbot.core.web_assistant.connections.data_types import WSRequest
+        
+        request = WSRequest()
+        
+        # WebSocket auth should return the request as-is (handled differently)
+        authenticated_request = self.async_run_with_timeout(self.auth.ws_authenticate(request))
+        
+        # No additional headers added for WS (handled via URL params)
+        self.assertEqual(request, authenticated_request)

--- a/test/hummingbot/connector/derivative/grvt_perpetual/test_grvt_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/grvt_perpetual/test_grvt_perpetual_derivative.py
@@ -1,0 +1,351 @@
+import asyncio
+from decimal import Decimal
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+from unittest import TestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from bidict import bidict
+
+import hummingbot.connector.derivative.grvt_perpetual.grvt_perpetual_constants as CONSTANTS
+import hummingbot.connector.derivative.grvt_perpetual.grvt_perpetual_web_utils as web_utils
+from hummingbot.connector.derivative.grvt_perpetual.grvt_perpetual_derivative import GRVTPerpetualDerivative
+from hummingbot.connector.derivative.position import Position
+from hummingbot.connector.trading_rule import TradingRule
+from hummingbot.core.data_type.common import OrderType, PositionAction, PositionMode, PositionSide, PriceType, TradeType
+from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState
+from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
+from hummingbot.core.data_type.trade_fee import TokenAmount
+
+
+class GRVTPerpetualDerivativeTests(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.connector = GRVTPerpetualDerivative(
+            grvt_perpetual_api_key="",
+            grvt_perpetual_api_secret="",
+            trading_pairs=[],
+            trading_required=False,
+        )
+
+    def async_run_with_timeout(self, coroutine, timeout: int = 1):
+        return asyncio.get_event_loop().run_until_complete(asyncio.wait_for(coroutine, timeout))
+
+    def test_format_trading_rules_filters_perpetual(self):
+        markets = [
+            {
+                "symbol": "BTC-USDT",
+                "pair": "BTC-USDT",
+                "baseAsset": "BTC",
+                "quoteAsset": "USDT",
+                "status": "TRADING",
+                "contractType": "PERPETUAL",
+                "filters": [
+                    {
+                        "filterType": "LOT_SIZE",
+                        "minQty": "0.001",
+                        "stepSize": "0.001",
+                    },
+                    {
+                        "filterType": "PRICE_FILTER",
+                        "tickSize": "0.01",
+                    },
+                    {
+                        "filterType": "MIN_NOTIONAL",
+                        "notional": "5",
+                    }
+                ],
+                "marginAsset": "USDT",
+            },
+            {
+                "symbol": "ETH-USDT",
+                "pair": "ETH-USDT",
+                "baseAsset": "ETH",
+                "quoteAsset": "USDT",
+                "status": "TRADING",
+                "contractType": "PERPETUAL",
+                "filters": [
+                    {
+                        "filterType": "LOT_SIZE",
+                        "minQty": "0.01",
+                        "stepSize": "0.01",
+                    },
+                    {
+                        "filterType": "PRICE_FILTER",
+                        "tickSize": "0.01",
+                    },
+                ],
+                "marginAsset": "USDT",
+            },
+        ]
+
+        rules = self.async_run_with_timeout(self.connector._format_trading_rules(markets))
+        self.assertEqual(2, len(rules))
+
+    def test_initialize_trading_pair_symbols_from_exchange_info(self):
+        markets = [
+            {
+                "symbol": "BTC-USDT",
+                "pair": "BTC-USDT",
+                "baseAsset": "BTC",
+                "quoteAsset": "USDT",
+                "status": "TRADING",
+                "contractType": "PERPETUAL",
+            },
+        ]
+        self.connector._initialize_trading_pair_symbols_from_exchange_info(markets)
+        mapping = self.connector._trading_pair_symbol_map
+        self.assertEqual("BTC-USDT", mapping.get("BTC-USDT"))
+
+
+class GRVTPerpetualDerivativeAsyncTests(IsolatedAsyncioWrapperTestCase):
+    level = 0
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls.base_asset = "BTC"
+        cls.quote_asset = "USDT"
+        cls.trading_pair = f"{cls.base_asset}-{cls.quote_asset}"
+        cls.ex_trading_pair = f"{cls.base_asset}-{cls.quote_asset}"
+
+    async def asyncSetUp(self) -> None:
+        await super().asyncSetUp()
+        self.log_records = []
+
+        self.connector = GRVTPerpetualDerivative(
+            grvt_perpetual_api_key="",
+            grvt_perpetual_api_secret="",
+            trading_pairs=[self.trading_pair],
+            trading_required=False,
+        )
+        self.connector.logger().setLevel(1)
+        self.connector.logger().addHandler(self)
+
+        self.connector._auth = MagicMock()
+        self.connector._account_balances = {"USDT": Decimal("1000")}
+        self.connector._account_available_balances = {"USDT": Decimal("1000")}
+        self.connector._set_trading_pair_symbol_map(bidict({self.ex_trading_pair: self.trading_pair}))
+
+    def handle(self, record):
+        self.log_records.append(record)
+
+    def _is_logged(self, log_level: str, message: str) -> bool:
+        return any(record.levelname == log_level and record.getMessage() == message for record in self.log_records)
+
+    async def test_supported_order_types(self):
+        self.assertEqual(
+            [OrderType.LIMIT, OrderType.MARKET, OrderType.LIMIT_MAKER],
+            self.connector.supported_order_types()
+        )
+
+    async def test_supported_position_modes(self):
+        self.assertEqual(
+            [PositionMode.ONEWAY, PositionMode.HEDGE],
+            self.connector.supported_position_modes()
+        )
+
+    async def test_place_order_market(self):
+        self.connector._api_post = AsyncMock(return_value={
+            "orderId": "12345",
+            "symbol": "BTC-USDT",
+            "side": "BUY",
+            "quantity": "0.1",
+            "type": "MARKET",
+            "status": "FILLED",
+            "price": "0",
+            "clientOrderId": "test_order_id",
+            "updateTime": 1234567890,
+        })
+
+        o_id, txn_time = await self.connector._place_order(
+            order_id="test_order_id",
+            trading_pair=self.trading_pair,
+            amount=Decimal("0.1"),
+            trade_type=TradeType.BUY,
+            order_type=OrderType.MARKET,
+            price=Decimal("50000"),
+        )
+
+        self.assertEqual("12345", o_id)
+        self.assertEqual(1234567890, txn_time)
+
+    async def test_place_order_limit(self):
+        self.connector._api_post = AsyncMock(return_value={
+            "orderId": "12345",
+            "symbol": "BTC-USDT",
+            "side": "BUY",
+            "quantity": "0.1",
+            "type": "LIMIT",
+            "status": "NEW",
+            "price": "50000",
+            "clientOrderId": "test_order_id",
+            "updateTime": 1234567890,
+        })
+
+        o_id, txn_time = await self.connector._place_order(
+            order_id="test_order_id",
+            trading_pair=self.trading_pair,
+            amount=Decimal("0.1"),
+            trade_type=TradeType.BUY,
+            order_type=OrderType.LIMIT,
+            price=Decimal("50000"),
+        )
+
+        self.assertEqual("12345", o_id)
+
+    async def test_cancel_order(self):
+        tracked_order = InFlightOrder(
+            client_order_id="test_order_id",
+            exchange_order_id="exchange_12345",
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            trade_type=TradeType.BUY,
+            amount=Decimal("0.1"),
+            price=Decimal("50000"),
+        )
+        tracked_order.update_state(OrderState.OPEN, 1234567890)
+
+        self.connector._api_delete = AsyncMock(return_value={
+            "orderId": "exchange_12345",
+            "symbol": "BTC-USDT",
+            "status": "CANCELED",
+        })
+
+        result = await self.connector._place_cancel("test_order_id", tracked_order)
+        self.assertTrue(result)
+
+    async def test_cancel_order_not_found(self):
+        tracked_order = InFlightOrder(
+            client_order_id="test_order_id",
+            exchange_order_id="exchange_12345",
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            trade_type=TradeType.BUY,
+            amount=Decimal("0.1"),
+            price=Decimal("50000"),
+        )
+
+        self.connector._api_delete = AsyncMock(return_value={
+            "code": -1,
+            "msg": "Order not found",
+        })
+
+        with self.assertRaises(IOError):
+            await self.connector._place_cancel("test_order_id", tracked_order)
+
+    async def test_update_balances(self):
+        self.connector._api_get = AsyncMock(return_value={
+            "assets": [
+                {
+                    "asset": "USDT",
+                    "walletBalance": "1000.0",
+                    "availableBalance": "900.0",
+                },
+                {
+                    "asset": "BTC",
+                    "walletBalance": "0.5",
+                    "availableBalance": "0.4",
+                }
+            ]
+        })
+
+        await self.connector._update_balances()
+
+        self.assertEqual(Decimal("1000"), self.connector._account_balances.get("USDT"))
+        self.assertEqual(Decimal("900"), self.connector._account_available_balances.get("USDT"))
+        self.assertEqual(Decimal("0.5"), self.connector._account_balances.get("BTC"))
+
+    async def test_update_positions(self):
+        self.connector._api_get = AsyncMock(return_value=[
+            {
+                "symbol": "BTC-USDT",
+                "positionSide": "LONG",
+                "positionAmt": "0.5",
+                "entryPrice": "50000.0",
+                "unRealizedProfit": "100.0",
+                "leverage": "10",
+            }
+        ])
+
+        await self.connector._update_positions()
+
+        position = self.connector._perpetual_trading.get_position(self.trading_pair, PositionSide.LONG)
+        self.assertIsNotNone(position)
+        self.assertEqual(Decimal("0.5"), position.amount)
+        self.assertEqual(Decimal("50000"), position.entry_price)
+
+    async def test_request_order_status(self):
+        self.connector._api_get = AsyncMock(return_value={
+            "orderId": "exchange_12345",
+            "symbol": "BTC-USDT",
+            "clientOrderId": "test_order_id",
+            "status": "FILLED",
+            "price": "50000",
+            "updateTime": 1234567890,
+        })
+
+        tracked_order = InFlightOrder(
+            client_order_id="test_order_id",
+            exchange_order_id="exchange_12345",
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            trade_type=TradeType.BUY,
+            amount=Decimal("0.1"),
+            price=Decimal("50000"),
+        )
+
+        order_update = await self.connector._request_order_status(tracked_order)
+        self.assertEqual(OrderState.FILLED, order_update.new_state)
+
+    async def test_get_last_traded_price(self):
+        self.connector._api_get = AsyncMock(return_value={
+            "lastPrice": "50000.0",
+        })
+
+        price = await self.connector._get_last_traded_price(self.trading_pair)
+        self.assertEqual(50000.0, price)
+
+    async def test_set_leverage(self):
+        self.connector._api_post = AsyncMock(return_value={
+            "symbol": "BTC-USDT",
+            "leverage": 10,
+        })
+
+        success, msg = await self.connector._set_trading_pair_leverage(self.trading_pair, 10)
+        self.assertTrue(success)
+
+    async def test_format_trading_rules(self):
+        exchange_info = {
+            "symbols": [
+                {
+                    "symbol": "BTC-USDT",
+                    "baseAsset": "BTC",
+                    "quoteAsset": "USDT",
+                    "status": "TRADING",
+                    "contractType": "PERPETUAL",
+                    "filters": [
+                        {
+                            "filterType": "LOT_SIZE",
+                            "minQty": "0.001",
+                            "stepSize": "0.001",
+                        },
+                        {
+                            "filterType": "PRICE_FILTER",
+                            "tickSize": "0.01",
+                        },
+                        {
+                            "filterType": "MIN_NOTIONAL",
+                            "notional": "5",
+                        }
+                    ],
+                    "marginAsset": "USDT",
+                }
+            ]
+        }
+
+        rules = await self.connector._format_trading_rules(exchange_info)
+        self.assertEqual(1, len(rules))
+        rule = rules[0]
+        self.assertEqual("BTC-USDT", rule.trading_pair)
+        self.assertEqual(Decimal("0.001"), rule.min_order_size)
+        self.assertEqual(Decimal("0.01"), rule.min_price_increment)

--- a/test/hummingbot/connector/derivative/grvt_perpetual/test_grvt_perpetual_web_utils.py
+++ b/test/hummingbot/connector/derivative/grvt_perpetual/test_grvt_perpetual_web_utils.py
@@ -1,0 +1,59 @@
+from unittest import TestCase
+
+from hummingbot.connector.derivative.grvt_perpetual import grvt_perpetual_web_utils as web_utils
+import hummingbot.connector.derivative.grvt_perpetual.grvt_perpetual_constants as CONSTANTS
+
+
+class GRVTPerpetualWebUtilsTests(TestCase):
+    def test_public_rest_url(self):
+        url = web_utils.public_rest_url("test/path", "grvt_perpetual")
+        self.assertEqual("https://api.grvt.io/test/path", url)
+
+    def test_public_rest_url_testnet(self):
+        url = web_utils.public_rest_url("test/path", "grvt_perpetual_testnet")
+        self.assertEqual("https://api-testnet.grvt.io/test/path", url)
+
+    def test_private_rest_url(self):
+        url = web_utils.private_rest_url("test/path", "grvt_perpetual")
+        self.assertEqual("https://api.grvt.io/test/path", url)
+
+    def test_private_rest_url_testnet(self):
+        url = web_utils.private_rest_url("test/path", "grvt_perpetual_testnet")
+        self.assertEqual("https://api-testnet.grvt.io/test/path", url)
+
+    def test_wss_url(self):
+        url = web_utils.wss_url("ws", "grvt_perpetual")
+        self.assertEqual("wss://ws.grvt.io/ws", url)
+
+    def test_wss_url_testnet(self):
+        url = web_utils.wss_url("ws", "grvt_perpetual_testnet")
+        self.assertEqual("wss://ws-testnet.grvt.io/ws", url)
+
+    def test_build_api_factory(self):
+        api_factory = web_utils.build_api_factory()
+        self.assertIsNotNone(api_factory)
+
+    def test_create_throttler(self):
+        throttler = web_utils.create_throttler()
+        self.assertIsNotNone(throttler)
+
+    def test_is_exchange_information_valid_true(self):
+        rule = {
+            "status": "TRADING",
+            "contractType": "PERPETUAL",
+        }
+        self.assertTrue(web_utils.is_exchange_information_valid(rule))
+
+    def test_is_exchange_information_valid_false_status(self):
+        rule = {
+            "status": "BREAK",
+            "contractType": "PERPETUAL",
+        }
+        self.assertFalse(web_utils.is_exchange_information_valid(rule))
+
+    def test_is_exchange_information_valid_false_contract_type(self):
+        rule = {
+            "status": "TRADING",
+            "contractType": "OPTION",
+        }
+        self.assertFalse(web_utils.is_exchange_information_valid(rule))


### PR DESCRIPTION
## Summary
Add GRVT (Gravita) perpetual futures connector to Hummingbot.

## Features
- REST API integration for trading
- WebSocket support for real-time data
- HMAC-SHA256 authentication
- Support for perpetual futures trading
- Order, position, and balance management

## Files Added
- `grvt_perpetual_constants.py` - API endpoints and constants
- `grvt_perpetual_utils.py` - Utility functions
- `grvt_perpetual_auth.py` - Authentication
- `grvt_perpetual_web_utils.py` - WebSocket tools
- `grvt_perpetual_api_order_book_data_source.py` - Order book data
- `grvt_perpetual_api_user_stream_data_source.py` - User stream
- `grvt_perpetual_config.py` - Configuration
- `grvt_perpetual_derivative.py` - Main connector

## Note
API endpoints need to be verified with GRVT API credentials before production use.

---
Submitted by Atlas (OpenClaw AI)