### PR TITLE
feat: add Bithumb (빗썸) exchange connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Currently, the master branch of Hummingbot also includes the following exchange 
 | [BingX](https://hummingbot.org/exchanges/bing_x/) | CLOB CEX | Spot | `bing_x` | - |
 | [Bitget](https://hummingbot.org/exchanges/bitget-perpetual/) | CLOB CEX | Perpetual | `bitget_perpetual` | - |
 | [Bitrue](https://hummingbot.org/exchanges/bitrue/) | CLOB CEX | Spot | `bitrue` | - |
+| [Bithumb](https://www.bithumb.com) | CLOB CEX | Spot | `bithumb` | - |
 | [Bitstamp](https://hummingbot.org/exchanges/bitstamp/) | CLOB CEX | Spot | `bitstamp` | - |
 | [BTC Markets](https://hummingbot.org/exchanges/btc-markets/) | CLOB CEX | Spot | `btc_markets` | - |
 | [Bybit](https://hummingbot.org/exchanges/bybit/) | CLOB CEX | Spot, Perpetual | `bybit`, `bybit_perpetual` | - |

--- a/hummingbot/connector/exchange/bithumb/README.md
+++ b/hummingbot/connector/exchange/bithumb/README.md
@@ -1,0 +1,203 @@
+# Bithumb Exchange Connector
+
+This connector integrates [Bithumb](https://www.bithumb.com) — South Korea's largest cryptocurrency exchange — with Hummingbot.
+
+## Overview
+
+| Property | Value |
+|---|---|
+| Exchange | Bithumb |
+| Exchange type | Centralized (CEX) |
+| Country | South Korea 🇰🇷 |
+| API version | v1 |
+| Supported order types | Limit, Market |
+| Default payment currency | KRW |
+| Default fees | 0.25% maker / 0.25% taker |
+| REST API | `https://api.bithumb.com` |
+| Public WebSocket | `wss://pubwss.bithumb.com/pub/ws` |
+| API documentation | [Bithumb API Docs](https://apidocs.bithumb.com) |
+
+---
+
+## Features
+
+- **Real-time order book** via Bithumb public WebSocket
+- **Real-time trade feed** via Bithumb public WebSocket
+- **Limit and market orders** (buy/sell)
+- **Order cancellation**
+- **Balance tracking** via REST polling
+- **Order status tracking** via REST polling
+- **Trade fill history** per order
+
+> **Note:** Bithumb does not provide a private WebSocket API. Order and balance updates are handled through Hummingbot's built-in REST polling loop (every ~10 seconds).
+
+---
+
+## Prerequisites
+
+1. Create an account at [bithumb.com](https://www.bithumb.com)
+2. Go to **My Page → API Management** and create an API key pair
+3. Enable the following permissions on your API key:
+   - Order inquiry
+   - Order placement
+   - Order cancellation
+   - Balance inquiry
+
+---
+
+## Configuration
+
+### Step 1: Connect via Hummingbot CLI
+
+```
+>>> connect bithumb
+```
+
+You will be prompted to enter:
+
+| Field | Description |
+|---|---|
+| `bithumb_api_key` | Your Bithumb API key |
+| `bithumb_secret_key` | Your Bithumb secret key |
+
+### Step 2: Verify connection
+
+```
+>>> balance
+>>> status
+```
+
+---
+
+## Supported Trading Pairs
+
+All KRW and BTC base pairs listed on Bithumb are supported. Examples:
+
+- `BTC-KRW`
+- `ETH-KRW`
+- `XRP-KRW`
+- `SOL-KRW`
+- `DOGE-KRW`
+
+To use BTC-denominated pairs (e.g., `ETH-BTC`), configure `payment_currency="BTC"` when instantiating the connector programmatically.
+
+---
+
+## Using in a Strategy Script
+
+```python
+from hummingbot.connector.exchange.bithumb import BithumbExchange
+from decimal import Decimal
+
+connector = BithumbExchange(
+    bithumb_api_key="YOUR_API_KEY",
+    bithumb_secret_key="YOUR_SECRET_KEY",
+    trading_pairs=["BTC-KRW", "ETH-KRW"],
+    trading_required=True,
+)
+```
+
+---
+
+## Authentication Details
+
+Bithumb uses **HMAC-SHA512** authentication for all private REST endpoints.
+
+Each private request requires three HTTP headers:
+
+| Header | Value |
+|---|---|
+| `Api-Key` | Your API key |
+| `Api-Nonce` | Current timestamp in milliseconds |
+| `Api-Sign` | `Base64(HMAC-SHA512(secret, endpoint + \0 + body + \0 + nonce))` |
+
+All private endpoints use `POST` with `Content-Type: application/x-www-form-urlencoded`.
+
+---
+
+## API Endpoints Used
+
+### Public (no authentication)
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /public/ticker/ALL_KRW` | Fetch all KRW trading pairs and prices |
+| `GET /public/orderbook/{symbol}` | Order book snapshot |
+| `GET /public/transaction_history/{symbol}` | Recent trade history |
+
+### Private (HMAC-SHA512 required)
+
+| Endpoint | Purpose |
+|---|---|
+| `POST /info/balance` | Account balances |
+| `POST /info/order_detail` | Order status and fill details |
+| `POST /trade/place` | Place a limit order |
+| `POST /trade/cancel` | Cancel an order |
+| `POST /trade/market_buy` | Place a market buy order |
+| `POST /trade/market_sell` | Place a market sell order |
+
+---
+
+## WebSocket Channels
+
+| Channel | Event type | Description |
+|---|---|---|
+| `orderbooksnapshot` | `orderbooksnapshot` | Full order book snapshot |
+| `transaction` | `transaction` | Real-time trade feed |
+
+Subscribe example payload:
+```json
+{"type": "orderbooksnapshot", "symbols": ["BTC_KRW", "ETH_KRW"]}
+{"type": "transaction", "symbols": ["BTC_KRW", "ETH_KRW"]}
+```
+
+---
+
+## Trading Rules
+
+Bithumb does not expose per-pair min/max size constraints via its public API. The connector uses the following conservative defaults:
+
+| Rule | Default |
+|---|---|
+| Min price increment | 1 KRW |
+| Min base amount increment | 0.00000001 |
+| Min notional size | 1,000 KRW |
+
+---
+
+## Known Limitations
+
+| Limitation | Reason |
+|---|---|
+| No private WebSocket | Bithumb does not offer a private WebSocket stream; state is updated via REST polling |
+| Polling interval | Order and balance state reflects approximately every 10 seconds |
+| KRW-only by default | Other payment currencies (BTC) require explicit `payment_currency` configuration |
+
+---
+
+## File Structure
+
+```
+hummingbot/connector/exchange/bithumb/
+├── __init__.py                           # Package export
+├── bithumb_constants.py                  # API URLs, endpoints, rate limits, order states
+├── bithumb_utils.py                      # Pydantic config model, default fees
+├── bithumb_auth.py                       # HMAC-SHA512 authentication handler
+├── bithumb_web_utils.py                  # URL builders, WebAssistantsFactory
+├── bithumb_api_order_book_data_source.py # Order book REST + WebSocket handling
+├── bithumb_api_user_stream_data_source.py# User stream (heartbeat / REST polling)
+├── bithumb_exchange.py                   # Main exchange connector class
+└── README.md                             # This file
+```
+
+---
+
+## Contributing
+
+Bug reports and pull requests are welcome. Please open an issue before submitting a large PR.
+
+---
+
+## Disclaimer
+
+This connector is provided for informational and educational purposes. Cryptocurrency trading carries significant financial risk. Always test with small amounts before deploying any automated strategy with real funds.

--- a/hummingbot/connector/exchange/bithumb/__init__.py
+++ b/hummingbot/connector/exchange/bithumb/__init__.py
@@ -1,0 +1,3 @@
+from .bithumb_exchange import BithumbExchange
+
+__all__ = ["BithumbExchange"]

--- a/hummingbot/connector/exchange/bithumb/bithumb_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/bithumb/bithumb_api_order_book_data_source.py
@@ -1,0 +1,186 @@
+import asyncio
+import json
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from hummingbot.connector.exchange.bithumb import bithumb_constants as CONSTANTS, bithumb_web_utils as web_utils
+from hummingbot.core.data_type.common import TradeType
+from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
+from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+from hummingbot.core.web_assistant.ws_assistant import WSAssistant
+from hummingbot.logger import HummingbotLogger
+
+if TYPE_CHECKING:
+    from hummingbot.connector.exchange.bithumb.bithumb_exchange import BithumbExchange
+
+
+class BithumbAPIOrderBookDataSource(OrderBookTrackerDataSource):
+    _logger: Optional[HummingbotLogger] = None
+
+    def __init__(
+        self,
+        trading_pairs: List[str],
+        connector: "BithumbExchange",
+        api_factory: WebAssistantsFactory,
+    ):
+        super().__init__(trading_pairs)
+        self._connector = connector
+        self._api_factory = api_factory
+
+    async def get_last_traded_prices(
+        self, trading_pairs: List[str], domain: Optional[str] = None
+    ) -> Dict[str, float]:
+        return await self._connector.get_last_traded_prices(trading_pairs=trading_pairs)
+
+    async def _order_book_snapshot(self, trading_pair: str) -> OrderBookMessage:
+        symbol = await self._connector.exchange_symbol_associated_to_pair(trading_pair=trading_pair)
+        # symbol is like "BTC_KRW" → split to order_currency and payment_currency
+        parts = symbol.split("_")
+        order_currency = parts[0]
+        payment_currency = parts[1] if len(parts) > 1 else CONSTANTS.DEFAULT_PAYMENT_CURRENCY
+
+        path = CONSTANTS.ORDERBOOK_PATH_URL.format(
+            order_currency=order_currency,
+            payment_currency=payment_currency,
+        )
+        rest_assistant = await self._api_factory.get_rest_assistant()
+        response = await rest_assistant.execute_request(
+            url=web_utils.public_rest_url(path),
+            method=RESTMethod.GET,
+            throttler_limit_id=CONSTANTS.ORDERBOOK_PATH_URL,
+        )
+
+        data = response.get("data", {})
+        timestamp = int(data.get("timestamp", 0)) * 1e-3
+
+        bids = [
+            (float(level["price"]), float(level["quantity"]))
+            for level in data.get("bids", [])
+        ]
+        asks = [
+            (float(level["price"]), float(level["quantity"]))
+            for level in data.get("asks", [])
+        ]
+
+        content = {
+            "trading_pair": trading_pair,
+            "update_id": int(data.get("timestamp", 0)),
+            "bids": bids,
+            "asks": asks,
+        }
+        return OrderBookMessage(OrderBookMessageType.SNAPSHOT, content, timestamp)
+
+    async def _parse_trade_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
+        content_list = raw_message.get("content", {}).get("list", [])
+        for item in content_list:
+            symbol = item.get("symbol", "")
+            try:
+                trading_pair = await self._connector.trading_pair_associated_to_exchange_symbol(symbol=symbol)
+            except Exception:
+                continue
+
+            # buySellGb: "1" = sell, "2" = buy
+            buy_sell_gb = item.get("buySellGb", "1")
+            trade_type = TradeType.BUY if buy_sell_gb == "2" else TradeType.SELL
+
+            # contDtm: "2023-01-01 00:00:00.000000" - parse to timestamp
+            cont_dtm = item.get("contDtm", "")
+            try:
+                from datetime import datetime
+                ts = datetime.strptime(cont_dtm, "%Y-%m-%d %H:%M:%S.%f").timestamp()
+            except Exception:
+                ts = self._time()
+
+            content = {
+                "trade_id": f"{symbol}_{cont_dtm}",
+                "trading_pair": trading_pair,
+                "trade_type": float(trade_type.value),
+                "amount": float(item.get("contQty", 0)),
+                "price": float(item.get("contPrice", 0)),
+            }
+            message = OrderBookMessage(OrderBookMessageType.TRADE, content, ts)
+            message_queue.put_nowait(message)
+
+    async def _parse_order_book_diff_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
+        # Bithumb sends full snapshots; treat as SNAPSHOT
+        content_list = raw_message.get("content", {}).get("list", [])
+        if not content_list:
+            return
+
+        symbol = content_list[0].get("symbol", "")
+        try:
+            trading_pair = await self._connector.trading_pair_associated_to_exchange_symbol(symbol=symbol)
+        except Exception:
+            return
+
+        datetime_str = raw_message.get("content", {}).get("datetime", "0")
+        try:
+            update_id = int(datetime_str)
+            timestamp = update_id * 1e-3
+        except (ValueError, TypeError):
+            update_id = 0
+            timestamp = self._time()
+
+        bids = [
+            (float(item["price"]), float(item["quantity"]))
+            for item in content_list
+            if item.get("orderType") == "bid"
+        ]
+        asks = [
+            (float(item["price"]), float(item["quantity"]))
+            for item in content_list
+            if item.get("orderType") == "ask"
+        ]
+
+        content = {
+            "trading_pair": trading_pair,
+            "update_id": update_id,
+            "first_update_id": update_id,
+            "bids": bids,
+            "asks": asks,
+        }
+        message = OrderBookMessage(OrderBookMessageType.SNAPSHOT, content, timestamp)
+        message_queue.put_nowait(message)
+
+    async def _subscribe_channels(self, ws: WSAssistant):
+        symbols = [
+            await self._connector.exchange_symbol_associated_to_pair(trading_pair=pair)
+            for pair in self._trading_pairs
+        ]
+        # Subscribe to order book snapshots
+        await ws.send(WSJSONRequest(payload={
+            "type": CONSTANTS.WS_ORDERBOOK_EVENT_TYPE,
+            "symbols": symbols,
+        }))
+        # Subscribe to trades
+        await ws.send(WSJSONRequest(payload={
+            "type": CONSTANTS.WS_TRADE_EVENT_TYPE,
+            "symbols": symbols,
+        }))
+        self.logger().info("Subscribed to Bithumb public order book and trade streams.")
+
+    async def _process_websocket_messages(self, websocket_assistant: WSAssistant):
+        async for ws_response in websocket_assistant.iter_messages():
+            raw = ws_response.data
+            if isinstance(raw, bytes):
+                raw = raw.decode()
+            try:
+                message = json.loads(raw)
+            except Exception:
+                self.logger().warning("Received non-JSON Bithumb WebSocket payload: %s", raw)
+                continue
+
+            msg_type = message.get("type")
+            if msg_type == CONSTANTS.WS_TRADE_EVENT_TYPE:
+                self._message_queue[self._trade_messages_queue_key].put_nowait(message)
+            elif msg_type == CONSTANTS.WS_ORDERBOOK_EVENT_TYPE:
+                self._message_queue[self._diff_messages_queue_key].put_nowait(message)
+
+    def _channel_originating_message(self, event_message: Dict[str, Any]) -> str:
+        return event_message.get("type", "")
+
+    async def _connected_websocket_assistant(self) -> WSAssistant:
+        ws = await self._api_factory.get_ws_assistant()
+        await ws.connect(ws_url=CONSTANTS.WS_URL, ping_timeout=CONSTANTS.PING_INTERVAL)
+        return ws

--- a/hummingbot/connector/exchange/bithumb/bithumb_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/bithumb/bithumb_api_user_stream_data_source.py
@@ -1,0 +1,59 @@
+import asyncio
+import time
+from typing import TYPE_CHECKING, Optional
+
+from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+from hummingbot.core.web_assistant.ws_assistant import WSAssistant
+from hummingbot.logger import HummingbotLogger
+
+if TYPE_CHECKING:
+    from hummingbot.connector.exchange.bithumb.bithumb_auth import BithumbAuth
+    from hummingbot.connector.exchange.bithumb.bithumb_exchange import BithumbExchange
+
+
+class BithumbAPIUserStreamDataSource(UserStreamTrackerDataSource):
+    """
+    Bithumb does not provide a private WebSocket API.
+    This data source uses a heartbeat loop to satisfy the interface while order
+    and balance updates are handled via the exchange's periodic REST polling.
+    """
+
+    _logger: Optional[HummingbotLogger] = None
+
+    @classmethod
+    def logger(cls) -> HummingbotLogger:
+        if cls._logger is None:
+            cls._logger = HummingbotLogger(name=__name__)
+        return cls._logger
+
+    def __init__(
+        self,
+        auth: "BithumbAuth",
+        connector: "BithumbExchange",
+        api_factory: WebAssistantsFactory,
+    ):
+        super().__init__()
+        self._auth = auth
+        self._connector = connector
+        self._api_factory = api_factory
+
+    async def _connected_websocket_assistant(self) -> WSAssistant:
+        raise NotImplementedError("Bithumb does not support a private WebSocket stream.")
+
+    async def listen_for_user_stream(self, output: asyncio.Queue):
+        """
+        Keeps the user stream tracker alive by emitting periodic heartbeat events.
+        Actual order/balance state is refreshed by the exchange's polling loop via
+        _update_balances() and _request_order_status().
+        """
+        while True:
+            try:
+                await asyncio.sleep(5)
+                output.put_nowait({"type": "heartbeat", "timestamp": time.time()})
+                self._last_recv_time = time.time()
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                self.logger().warning("Bithumb user stream heartbeat error: %s", e)
+                await asyncio.sleep(5)

--- a/hummingbot/connector/exchange/bithumb/bithumb_auth.py
+++ b/hummingbot/connector/exchange/bithumb/bithumb_auth.py
@@ -1,0 +1,60 @@
+import base64
+import hashlib
+import hmac
+import time
+import urllib.parse
+from urllib.parse import urlparse
+
+from hummingbot.core.web_assistant.auth import AuthBase
+from hummingbot.core.web_assistant.connections.data_types import RESTRequest, WSRequest
+
+
+class BithumbAuth(AuthBase):
+    """
+    Bithumb v1 API authentication.
+    Private endpoints require:
+      Api-Key   : API key
+      Api-Sign  : Base64( HMAC-SHA512( secret, endpoint + chr(0) + query_string + chr(0) + nonce ) )
+      Api-Nonce : current timestamp in milliseconds (string)
+    Content-Type must be application/x-www-form-urlencoded for POST requests.
+    """
+
+    def __init__(self, api_key: str, secret_key: str):
+        self._api_key = api_key
+        self._secret_key = secret_key
+
+    async def rest_authenticate(self, request: RESTRequest) -> RESTRequest:
+        nonce = str(int(time.time() * 1000))
+
+        path = urlparse(request.url).path
+
+        data = request.data or {}
+        if isinstance(data, dict):
+            query_string = urllib.parse.urlencode(sorted(data.items()))
+        elif isinstance(data, str):
+            query_string = data
+        else:
+            query_string = ""
+
+        api_sign = self._generate_signature(path, query_string, nonce)
+
+        headers = dict(request.headers or {})
+        headers["Api-Key"] = self._api_key
+        headers["Api-Sign"] = api_sign
+        headers["Api-Nonce"] = nonce
+        headers["Content-Type"] = "application/x-www-form-urlencoded"
+        request.headers = headers
+        return request
+
+    async def ws_authenticate(self, request: WSRequest) -> WSRequest:
+        # Bithumb public WebSocket does not require authentication
+        return request
+
+    def _generate_signature(self, endpoint: str, query_string: str, nonce: str) -> str:
+        message = endpoint + chr(0) + query_string + chr(0) + nonce
+        hmac_sig = hmac.new(
+            self._secret_key.encode("utf-8"),
+            message.encode("utf-8"),
+            hashlib.sha512,
+        ).hexdigest()
+        return base64.b64encode(hmac_sig.encode("utf-8")).decode("utf-8")

--- a/hummingbot/connector/exchange/bithumb/bithumb_constants.py
+++ b/hummingbot/connector/exchange/bithumb/bithumb_constants.py
@@ -1,0 +1,122 @@
+from hummingbot.connector.constants import SECOND
+from hummingbot.core.api_throttler.data_types import LinkedLimitWeightPair, RateLimit
+from hummingbot.core.data_type.in_flight_order import OrderState
+
+DEFAULT_DOMAIN = "bithumb"
+DEFAULT_PAYMENT_CURRENCY = "KRW"
+
+REST_URL = "https://api.bithumb.com"
+WS_URL = "wss://pubwss.bithumb.com/pub/ws"
+
+MAX_ORDER_ID_LEN = 36
+HBOT_ORDER_ID_PREFIX = "HBOT"
+
+# Public REST endpoints
+TICKER_ALL_PATH_URL = "/public/ticker/ALL_KRW"
+TICKER_PATH_URL = "/public/ticker/{order_currency}_{payment_currency}"
+ORDERBOOK_PATH_URL = "/public/orderbook/{order_currency}_{payment_currency}"
+TRANSACTION_HISTORY_PATH_URL = "/public/transaction_history/{order_currency}_{payment_currency}"
+
+# Private REST endpoints
+BALANCE_PATH_URL = "/info/balance"
+ORDER_DETAIL_PATH_URL = "/info/order_detail"
+ORDERS_PATH_URL = "/info/orders"
+USER_TRANSACTIONS_PATH_URL = "/info/user_transactions"
+TRADE_PLACE_PATH_URL = "/trade/place"
+TRADE_CANCEL_PATH_URL = "/trade/cancel"
+TRADE_MARKET_BUY_PATH_URL = "/trade/market_buy"
+TRADE_MARKET_SELL_PATH_URL = "/trade/market_sell"
+
+# Rate limit IDs
+PUBLIC_REST_LIMIT_ID = "bithumb_public_rest"
+PRIVATE_REST_LIMIT_ID = "bithumb_private_rest"
+
+# WebSocket event types
+WS_ORDERBOOK_EVENT_TYPE = "orderbooksnapshot"
+WS_TRADE_EVENT_TYPE = "transaction"
+
+PING_INTERVAL = 30.0
+
+ORDER_STATE = {
+    "placed": OrderState.OPEN,
+    "completed": OrderState.FILLED,
+    "cancel": OrderState.CANCELED,
+    "cancelled": OrderState.CANCELED,
+}
+
+RATE_LIMITS = [
+    RateLimit(limit_id=PUBLIC_REST_LIMIT_ID, limit=10, time_interval=SECOND),
+    RateLimit(limit_id=PRIVATE_REST_LIMIT_ID, limit=1, time_interval=SECOND),
+    RateLimit(
+        limit_id=TICKER_ALL_PATH_URL,
+        limit=10,
+        time_interval=SECOND,
+        linked_limits=[LinkedLimitWeightPair(PUBLIC_REST_LIMIT_ID)],
+    ),
+    RateLimit(
+        limit_id=TICKER_PATH_URL,
+        limit=10,
+        time_interval=SECOND,
+        linked_limits=[LinkedLimitWeightPair(PUBLIC_REST_LIMIT_ID)],
+    ),
+    RateLimit(
+        limit_id=ORDERBOOK_PATH_URL,
+        limit=10,
+        time_interval=SECOND,
+        linked_limits=[LinkedLimitWeightPair(PUBLIC_REST_LIMIT_ID)],
+    ),
+    RateLimit(
+        limit_id=TRANSACTION_HISTORY_PATH_URL,
+        limit=10,
+        time_interval=SECOND,
+        linked_limits=[LinkedLimitWeightPair(PUBLIC_REST_LIMIT_ID)],
+    ),
+    RateLimit(
+        limit_id=BALANCE_PATH_URL,
+        limit=1,
+        time_interval=SECOND,
+        linked_limits=[LinkedLimitWeightPair(PRIVATE_REST_LIMIT_ID)],
+    ),
+    RateLimit(
+        limit_id=ORDER_DETAIL_PATH_URL,
+        limit=1,
+        time_interval=SECOND,
+        linked_limits=[LinkedLimitWeightPair(PRIVATE_REST_LIMIT_ID)],
+    ),
+    RateLimit(
+        limit_id=ORDERS_PATH_URL,
+        limit=1,
+        time_interval=SECOND,
+        linked_limits=[LinkedLimitWeightPair(PRIVATE_REST_LIMIT_ID)],
+    ),
+    RateLimit(
+        limit_id=USER_TRANSACTIONS_PATH_URL,
+        limit=1,
+        time_interval=SECOND,
+        linked_limits=[LinkedLimitWeightPair(PRIVATE_REST_LIMIT_ID)],
+    ),
+    RateLimit(
+        limit_id=TRADE_PLACE_PATH_URL,
+        limit=1,
+        time_interval=SECOND,
+        linked_limits=[LinkedLimitWeightPair(PRIVATE_REST_LIMIT_ID)],
+    ),
+    RateLimit(
+        limit_id=TRADE_CANCEL_PATH_URL,
+        limit=1,
+        time_interval=SECOND,
+        linked_limits=[LinkedLimitWeightPair(PRIVATE_REST_LIMIT_ID)],
+    ),
+    RateLimit(
+        limit_id=TRADE_MARKET_BUY_PATH_URL,
+        limit=1,
+        time_interval=SECOND,
+        linked_limits=[LinkedLimitWeightPair(PRIVATE_REST_LIMIT_ID)],
+    ),
+    RateLimit(
+        limit_id=TRADE_MARKET_SELL_PATH_URL,
+        limit=1,
+        time_interval=SECOND,
+        linked_limits=[LinkedLimitWeightPair(PRIVATE_REST_LIMIT_ID)],
+    ),
+]

--- a/hummingbot/connector/exchange/bithumb/bithumb_exchange.py
+++ b/hummingbot/connector/exchange/bithumb/bithumb_exchange.py
@@ -1,0 +1,503 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any, Dict, List, Optional, Tuple
+
+from bidict import bidict
+
+import hummingbot.core.utils.estimate_fee as fee_utils
+from hummingbot.connector.exchange.bithumb import (
+    bithumb_auth as bithumb_auth_module,
+    bithumb_constants as CONSTANTS,
+    bithumb_web_utils as web_utils,
+)
+from hummingbot.connector.exchange.bithumb.bithumb_api_order_book_data_source import BithumbAPIOrderBookDataSource
+from hummingbot.connector.exchange.bithumb.bithumb_api_user_stream_data_source import BithumbAPIUserStreamDataSource
+from hummingbot.connector.exchange_py_base import ExchangePyBase
+from hummingbot.connector.trading_rule import TradingRule
+from hummingbot.connector.utils import combine_to_hb_trading_pair
+from hummingbot.core.data_type.common import OrderType, PositionAction, TradeType
+from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderUpdate, TradeUpdate
+from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
+from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee, TokenAmount, TradeFeeBase
+from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+
+
+class BithumbExchange(ExchangePyBase):
+    UPDATE_ORDER_STATUS_MIN_INTERVAL = 10.0
+    web_utils = web_utils
+
+    def __init__(
+        self,
+        bithumb_api_key: str,
+        bithumb_secret_key: str,
+        payment_currency: str = CONSTANTS.DEFAULT_PAYMENT_CURRENCY,
+        balance_asset_limit: Optional[Dict[str, Dict[str, Decimal]]] = None,
+        rate_limits_share_pct: Decimal = Decimal("100"),
+        trading_pairs: Optional[List[str]] = None,
+        trading_required: bool = True,
+        domain: str = CONSTANTS.DEFAULT_DOMAIN,
+    ):
+        self._api_key = bithumb_api_key
+        self._secret_key = bithumb_secret_key
+        self._payment_currency = payment_currency.upper()
+        self._trading_pairs = trading_pairs
+        self._trading_required = trading_required
+        self._domain = domain
+
+        super().__init__(balance_asset_limit=balance_asset_limit, rate_limits_share_pct=rate_limits_share_pct)
+
+        self._real_time_balance_update = False
+
+    # -------------------------------------------------------------------------
+    # Required properties
+    # -------------------------------------------------------------------------
+
+    @property
+    def authenticator(self):
+        return bithumb_auth_module.BithumbAuth(self._api_key, self._secret_key)
+
+    @property
+    def name(self) -> str:
+        return "bithumb"
+
+    @property
+    def rate_limits_rules(self):
+        return CONSTANTS.RATE_LIMITS
+
+    @property
+    def domain(self):
+        return self._domain
+
+    @property
+    def client_order_id_max_length(self):
+        return CONSTANTS.MAX_ORDER_ID_LEN
+
+    @property
+    def client_order_id_prefix(self):
+        return CONSTANTS.HBOT_ORDER_ID_PREFIX
+
+    @property
+    def trading_rules_request_path(self) -> str:
+        return f"/public/ticker/ALL_{self._payment_currency}"
+
+    @property
+    def trading_pairs_request_path(self) -> str:
+        return f"/public/ticker/ALL_{self._payment_currency}"
+
+    @property
+    def check_network_request_path(self) -> str:
+        return f"/public/ticker/ALL_{self._payment_currency}"
+
+    @property
+    def trading_pairs(self):
+        return self._trading_pairs
+
+    @property
+    def is_cancel_request_in_exchange_synchronous(self) -> bool:
+        return True
+
+    @property
+    def is_trading_required(self) -> bool:
+        return self._trading_required
+
+    def supported_order_types(self):
+        return [OrderType.LIMIT, OrderType.MARKET]
+
+    # -------------------------------------------------------------------------
+    # Factory methods
+    # -------------------------------------------------------------------------
+
+    def _create_web_assistants_factory(self) -> WebAssistantsFactory:
+        return web_utils.build_api_factory(throttler=self._throttler, auth=self._auth)
+
+    def _create_order_book_data_source(self) -> OrderBookTrackerDataSource:
+        return BithumbAPIOrderBookDataSource(
+            trading_pairs=self._trading_pairs or [],
+            connector=self,
+            api_factory=self._web_assistants_factory,
+        )
+
+    def _create_user_stream_data_source(self) -> UserStreamTrackerDataSource:
+        return BithumbAPIUserStreamDataSource(
+            auth=self._auth,
+            connector=self,
+            api_factory=self._web_assistants_factory,
+        )
+
+    # -------------------------------------------------------------------------
+    # Trading pair symbol mapping
+    # -------------------------------------------------------------------------
+
+    def _initialize_trading_pair_symbols_from_exchange_info(self, exchange_info: Dict[str, Any]):
+        """
+        Bithumb /public/ticker/ALL_KRW response:
+          { "status": "0000", "data": { "BTC": {...}, "ETH": {...}, "date": "..." } }
+        """
+        mapping = bidict()
+        data = exchange_info.get("data", {})
+        for key, value in data.items():
+            if key == "date":
+                continue
+            bithumb_symbol = f"{key}_{self._payment_currency}"
+            hb_pair = combine_to_hb_trading_pair(key, self._payment_currency)
+            mapping[bithumb_symbol] = hb_pair
+        self._set_trading_pair_symbol_map(mapping)
+
+    # -------------------------------------------------------------------------
+    # Trading rules
+    # -------------------------------------------------------------------------
+
+    async def _format_trading_rules(self, exchange_info: Dict[str, Any]) -> List[TradingRule]:
+        """
+        Bithumb does not expose per-pair min/max size rules via public API.
+        Use conservative defaults:
+          - min_notional_size = 1000 KRW
+          - min increments = 1 (KRW) for price, 0.00000001 for base amount
+        """
+        rules: List[TradingRule] = []
+        data = exchange_info.get("data", {})
+        for key in data:
+            if key == "date":
+                continue
+            hb_pair = combine_to_hb_trading_pair(key, self._payment_currency)
+            rules.append(
+                TradingRule(
+                    trading_pair=hb_pair,
+                    min_price_increment=Decimal("1"),
+                    min_base_amount_increment=Decimal("0.00000001"),
+                    min_notional_size=Decimal("1000"),
+                    supports_market_orders=True,
+                )
+            )
+        return rules
+
+    # -------------------------------------------------------------------------
+    # Last traded prices
+    # -------------------------------------------------------------------------
+
+    async def get_all_pairs_prices(self) -> List[Dict[str, Any]]:
+        rest_assistant = await self._web_assistants_factory.get_rest_assistant()
+        response = await rest_assistant.execute_request(
+            url=web_utils.public_rest_url(f"/public/ticker/ALL_{self._payment_currency}"),
+            method=RESTMethod.GET,
+            throttler_limit_id=CONSTANTS.TICKER_ALL_PATH_URL,
+        )
+        results = []
+        data = response.get("data", {})
+        for key, value in data.items():
+            if key == "date":
+                continue
+            results.append({
+                "symbol": f"{key}_{self._payment_currency}",
+                "closing_price": value.get("closing_price", "0"),
+            })
+        return results
+
+    # -------------------------------------------------------------------------
+    # Error classification helpers
+    # -------------------------------------------------------------------------
+
+    def _is_request_exception_related_to_time_synchronizer(self, request_exception: Exception) -> bool:
+        return False
+
+    def _is_order_not_found_during_status_update_error(self, status_update_exception: Exception) -> bool:
+        return "order_not_found" in str(status_update_exception).lower()
+
+    def _is_order_not_found_during_cancelation_error(self, cancelation_exception: Exception) -> bool:
+        return "order_not_found" in str(cancelation_exception).lower()
+
+    # -------------------------------------------------------------------------
+    # Balance
+    # -------------------------------------------------------------------------
+
+    async def _update_balances(self):
+        rest_assistant = await self._web_assistants_factory.get_rest_assistant()
+        response = await rest_assistant.execute_request(
+            url=web_utils.private_rest_url(CONSTANTS.BALANCE_PATH_URL),
+            data={"currency": "ALL"},
+            method=RESTMethod.POST,
+            is_auth_required=True,
+            throttler_limit_id=CONSTANTS.BALANCE_PATH_URL,
+        )
+        if response.get("status") != "0000":
+            raise IOError(f"Bithumb balance error: {response}")
+
+        local_asset_names = set(self._account_balances.keys())
+        remote_asset_names = set()
+
+        data = response.get("data", {})
+        for key, raw_value in data.items():
+            if not key.startswith("available_"):
+                continue
+            currency = key[len("available_"):].upper()
+            available = Decimal(str(raw_value))
+            total_key = f"total_{currency.lower()}"
+            total = Decimal(str(data.get(total_key, raw_value)))
+            self._account_available_balances[currency] = available
+            self._account_balances[currency] = total
+            remote_asset_names.add(currency)
+
+        for stale in local_asset_names - remote_asset_names:
+            del self._account_available_balances[stale]
+            del self._account_balances[stale]
+
+    # -------------------------------------------------------------------------
+    # Order placement
+    # -------------------------------------------------------------------------
+
+    async def _place_order(
+        self,
+        order_id: str,
+        trading_pair: str,
+        amount: Decimal,
+        trade_type: TradeType,
+        order_type: OrderType,
+        price: Optional[Decimal] = None,
+        position_action: Optional[PositionAction] = None,
+    ) -> Tuple[str, float]:
+        symbol = await self.exchange_symbol_associated_to_pair(trading_pair=trading_pair)
+        parts = symbol.split("_")
+        order_currency = parts[0]
+        payment_currency = parts[1] if len(parts) > 1 else self._payment_currency
+        order_side = "bid" if trade_type == TradeType.BUY else "ask"
+
+        rest_assistant = await self._web_assistants_factory.get_rest_assistant()
+
+        if order_type == OrderType.MARKET:
+            if trade_type == TradeType.BUY:
+                # Market buy: units = KRW amount to spend
+                path = CONSTANTS.TRADE_MARKET_BUY_PATH_URL
+                data = {
+                    "order_currency": order_currency,
+                    "payment_currency": payment_currency,
+                    "units": str(amount),
+                }
+            else:
+                # Market sell: units = base quantity to sell
+                path = CONSTANTS.TRADE_MARKET_SELL_PATH_URL
+                data = {
+                    "order_currency": order_currency,
+                    "payment_currency": payment_currency,
+                    "units": str(amount),
+                }
+        else:
+            path = CONSTANTS.TRADE_PLACE_PATH_URL
+            data = {
+                "order_currency": order_currency,
+                "payment_currency": payment_currency,
+                "units": str(amount),
+                "price": str(price),
+                "type": order_side,
+            }
+
+        response = await rest_assistant.execute_request(
+            url=web_utils.private_rest_url(path),
+            data=data,
+            method=RESTMethod.POST,
+            is_auth_required=True,
+            throttler_limit_id=path,
+        )
+
+        if response.get("status") != "0000":
+            raise IOError(f"Bithumb place order error [{response.get('status')}]: {response.get('message', response)}")
+
+        resp_data = response.get("data", {})
+        exchange_order_id = str(resp_data.get("order_id", ""))
+        try:
+            order_date_ms = int(resp_data.get("order_date", 0))
+            timestamp = order_date_ms * 1e-3
+        except (TypeError, ValueError):
+            timestamp = self.current_timestamp
+
+        return exchange_order_id, timestamp
+
+    # -------------------------------------------------------------------------
+    # Order cancellation
+    # -------------------------------------------------------------------------
+
+    async def _place_cancel(self, order_id: str, tracked_order: InFlightOrder) -> Tuple[bool, str]:
+        symbol = await self.exchange_symbol_associated_to_pair(trading_pair=tracked_order.trading_pair)
+        parts = symbol.split("_")
+        order_currency = parts[0]
+        payment_currency = parts[1] if len(parts) > 1 else self._payment_currency
+        order_side = "bid" if tracked_order.trade_type == TradeType.BUY else "ask"
+
+        rest_assistant = await self._web_assistants_factory.get_rest_assistant()
+        response = await rest_assistant.execute_request(
+            url=web_utils.private_rest_url(CONSTANTS.TRADE_CANCEL_PATH_URL),
+            data={
+                "order_id": tracked_order.exchange_order_id,
+                "order_currency": order_currency,
+                "payment_currency": payment_currency,
+                "type": order_side,
+            },
+            method=RESTMethod.POST,
+            is_auth_required=True,
+            throttler_limit_id=CONSTANTS.TRADE_CANCEL_PATH_URL,
+        )
+
+        if response.get("status") != "0000":
+            raise IOError(
+                f"Bithumb cancel error [{response.get('status')}]: {response.get('message', response)}"
+            )
+
+        return True, tracked_order.exchange_order_id
+
+    # -------------------------------------------------------------------------
+    # Order status
+    # -------------------------------------------------------------------------
+
+    async def _request_order_status(self, tracked_order: InFlightOrder) -> OrderUpdate:
+        symbol = await self.exchange_symbol_associated_to_pair(trading_pair=tracked_order.trading_pair)
+        parts = symbol.split("_")
+        order_currency = parts[0]
+        payment_currency = parts[1] if len(parts) > 1 else self._payment_currency
+
+        rest_assistant = await self._web_assistants_factory.get_rest_assistant()
+        response = await rest_assistant.execute_request(
+            url=web_utils.private_rest_url(CONSTANTS.ORDER_DETAIL_PATH_URL),
+            data={
+                "order_id": tracked_order.exchange_order_id,
+                "order_currency": order_currency,
+                "payment_currency": payment_currency,
+            },
+            method=RESTMethod.POST,
+            is_auth_required=True,
+            throttler_limit_id=CONSTANTS.ORDER_DETAIL_PATH_URL,
+        )
+
+        if response.get("status") == "5100":
+            raise IOError("order_not_found")
+        if response.get("status") != "0000":
+            raise IOError(
+                f"Bithumb order detail error [{response.get('status')}]: {response.get('message', response)}"
+            )
+
+        data = response.get("data", {})
+        order_status_str = data.get("order_status", "placed")
+        new_state = CONSTANTS.ORDER_STATE.get(order_status_str, tracked_order.current_state)
+
+        try:
+            transaction_date_ms = int(data.get("transaction_date", 0))
+            update_timestamp = transaction_date_ms * 1e-3
+        except (TypeError, ValueError):
+            update_timestamp = self.current_timestamp
+
+        return OrderUpdate(
+            client_order_id=tracked_order.client_order_id,
+            exchange_order_id=tracked_order.exchange_order_id,
+            trading_pair=tracked_order.trading_pair,
+            update_timestamp=update_timestamp,
+            new_state=new_state,
+        )
+
+    # -------------------------------------------------------------------------
+    # Trade fills
+    # -------------------------------------------------------------------------
+
+    async def _all_trade_updates_for_order(self, order: InFlightOrder) -> List[TradeUpdate]:
+        symbol = await self.exchange_symbol_associated_to_pair(trading_pair=order.trading_pair)
+        parts = symbol.split("_")
+        order_currency = parts[0]
+        payment_currency = parts[1] if len(parts) > 1 else self._payment_currency
+
+        rest_assistant = await self._web_assistants_factory.get_rest_assistant()
+        response = await rest_assistant.execute_request(
+            url=web_utils.private_rest_url(CONSTANTS.ORDER_DETAIL_PATH_URL),
+            data={
+                "order_id": order.exchange_order_id,
+                "order_currency": order_currency,
+                "payment_currency": payment_currency,
+            },
+            method=RESTMethod.POST,
+            is_auth_required=True,
+            throttler_limit_id=CONSTANTS.ORDER_DETAIL_PATH_URL,
+        )
+
+        if response.get("status") != "0000":
+            return []
+
+        data = response.get("data", {})
+        contracts = data.get("contract", [])
+        trade_updates = []
+
+        for idx, contract in enumerate(contracts):
+            try:
+                fill_price = Decimal(str(contract.get("price", "0")))
+                fill_amount = Decimal(str(contract.get("units", "0")))
+                fee_amount = Decimal(str(contract.get("fee", "0")))
+                fee_currency = str(contract.get("fee_currency", payment_currency)).upper()
+                tx_date = contract.get("transaction_date", "0")
+                fill_timestamp = int(tx_date) * 1e-3
+            except (ValueError, TypeError):
+                continue
+
+            trade_id = f"{order.exchange_order_id}_{idx}"
+
+            fee = AddedToCostTradeFee(
+                flat_fees=[TokenAmount(token=fee_currency, amount=fee_amount)]
+            )
+
+            trade_updates.append(
+                TradeUpdate(
+                    trade_id=trade_id,
+                    client_order_id=order.client_order_id,
+                    exchange_order_id=order.exchange_order_id,
+                    trading_pair=order.trading_pair,
+                    fill_timestamp=fill_timestamp,
+                    fill_price=fill_price,
+                    fill_base_amount=fill_amount,
+                    fill_quote_amount=fill_price * fill_amount,
+                    fee=fee,
+                )
+            )
+
+        return trade_updates
+
+    # -------------------------------------------------------------------------
+    # Fee calculation
+    # -------------------------------------------------------------------------
+
+    async def _update_trading_fees(self):
+        pass
+
+    def _get_fee(
+        self,
+        base_currency: str,
+        quote_currency: str,
+        order_type: OrderType,
+        order_side: TradeType,
+        position_action: Optional[PositionAction] = None,
+        amount: Optional[Decimal] = None,
+        price: Optional[Decimal] = None,
+        is_maker: Optional[bool] = None,
+    ) -> TradeFeeBase:
+        is_maker_val = is_maker if is_maker is not None else (order_type == OrderType.LIMIT_MAKER)
+        return fee_utils.build_trade_fee(
+            exchange=self.name,
+            is_maker=is_maker_val,
+            base_currency=base_currency,
+            quote_currency=quote_currency,
+            order_type=order_type,
+            order_side=order_side,
+            amount=amount or Decimal("0"),
+            price=price or Decimal("0"),
+        )
+
+    # -------------------------------------------------------------------------
+    # User stream event listener
+    # -------------------------------------------------------------------------
+
+    async def _user_stream_event_listener(self):
+        """
+        Bithumb has no private WebSocket.
+        Heartbeat events from BithumbAPIUserStreamDataSource are silently discarded.
+        All state updates occur through the exchange's REST polling loop.
+        """
+        async for event_message in self._iter_user_event_queue():
+            # Ignore heartbeats; real updates come from polling
+            if event_message.get("type") == "heartbeat":
+                continue

--- a/hummingbot/connector/exchange/bithumb/bithumb_utils.py
+++ b/hummingbot/connector/exchange/bithumb/bithumb_utils.py
@@ -1,0 +1,40 @@
+from decimal import Decimal
+
+from pydantic import ConfigDict, Field, SecretStr
+
+from hummingbot.client.config.config_data_types import BaseConnectorConfigMap
+from hummingbot.core.data_type.trade_fee import TradeFeeSchema
+
+CENTRALIZED = True
+EXAMPLE_PAIR = "BTC-KRW"
+
+DEFAULT_FEES = TradeFeeSchema(
+    maker_percent_fee_decimal=Decimal("0.0025"),
+    taker_percent_fee_decimal=Decimal("0.0025"),
+)
+
+
+class BithumbConfigMap(BaseConnectorConfigMap):
+    connector: str = "bithumb"
+    bithumb_api_key: SecretStr = Field(
+        default=...,
+        json_schema_extra={
+            "prompt": "Enter your Bithumb API key",
+            "is_secure": True,
+            "is_connect_key": True,
+            "prompt_on_new": True,
+        },
+    )
+    bithumb_secret_key: SecretStr = Field(
+        default=...,
+        json_schema_extra={
+            "prompt": "Enter your Bithumb secret key",
+            "is_secure": True,
+            "is_connect_key": True,
+            "prompt_on_new": True,
+        },
+    )
+    model_config = ConfigDict(title="bithumb")
+
+
+KEYS = BithumbConfigMap.model_construct()

--- a/hummingbot/connector/exchange/bithumb/bithumb_web_utils.py
+++ b/hummingbot/connector/exchange/bithumb/bithumb_web_utils.py
@@ -1,0 +1,26 @@
+from typing import Optional
+
+from hummingbot.connector.exchange.bithumb import bithumb_constants as CONSTANTS
+from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from hummingbot.core.web_assistant.auth import AuthBase
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+
+
+def public_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:
+    return f"{CONSTANTS.REST_URL}{path_url}"
+
+
+def private_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:
+    return f"{CONSTANTS.REST_URL}{path_url}"
+
+
+def create_throttler() -> AsyncThrottler:
+    return AsyncThrottler(CONSTANTS.RATE_LIMITS)
+
+
+def build_api_factory(
+    throttler: Optional[AsyncThrottler] = None,
+    auth: Optional[AuthBase] = None,
+) -> WebAssistantsFactory:
+    throttler = throttler or create_throttler()
+    return WebAssistantsFactory(throttler=throttler, auth=auth)

--- a/hummingbot/templates/conf_fee_overrides_TEMPLATE.yml
+++ b/hummingbot/templates/conf_fee_overrides_TEMPLATE.yml
@@ -56,6 +56,12 @@ bitmart_maker_percent_fee:
 bitmart_percent_fee_token:
 bitmart_taker_fixed_fees:
 bitmart_taker_percent_fee:
+bithumb_buy_percent_fee_deducted_from_returns:
+bithumb_maker_fixed_fees:
+bithumb_maker_percent_fee:
+bithumb_percent_fee_token:
+bithumb_taker_fixed_fees:
+bithumb_taker_percent_fee:
 bitstamp_buy_percent_fee_deducted_from_returns:
 bitstamp_maker_fixed_fees:
 bitstamp_maker_percent_fee:
@@ -63,9 +69,9 @@ bitstamp_percent_fee_token:
 bitstamp_taker_fixed_fees:
 bitstamp_taker_percent_fee:
 btc_markets_percent_fee_token:
-btc_markets_maker_percent_fee:  
-btc_markets_taker_percent_fee:  
-btc_markets_buy_percent_fee_deducted_from_returns: 
+btc_markets_maker_percent_fee:
+btc_markets_taker_percent_fee:
+btc_markets_buy_percent_fee_deducted_from_returns:
 bybit_perpetual_buy_percent_fee_deducted_from_returns:
 bybit_perpetual_maker_fixed_fees:
 bybit_perpetual_maker_percent_fee:


### PR DESCRIPTION
## Summary

This PR adds a native Hummingbot connector for **Bithumb (빗썸)**, South Korea's largest cryptocurrency exchange by trading volume.

- New connector at `hummingbot/connector/exchange/bithumb/`
- Supports **KRW and BTC** denominated trading pairs (e.g. `BTC-KRW`, `ETH-KRW`)
- Adds Bithumb to the exchange connectors table in `README.md`
- Adds Bithumb fee override entries to `conf_fee_overrides_TEMPLATE.yml`

## Features

| Feature | Status |
|---|---|
| Limit orders (buy/sell) | ✅ |
| Market orders (buy/sell) | ✅ |
| Order cancellation | ✅ |
| Real-time order book (WebSocket) | ✅ |
| Real-time trade feed (WebSocket) | ✅ |
| Balance updates | ✅ (REST polling) |
| Order status updates | ✅ (REST polling) |
| Trade fill history | ✅ |
| Private WebSocket | ❌ (not available on Bithumb) |

## Architecture

| File | Description |
|---|---|
| `bithumb_constants.py` | API URLs, endpoints, rate limits, order state mapping |
| `bithumb_utils.py` | Pydantic config map, default fees (0.25% maker/taker) |
| `bithumb_auth.py` | HMAC-SHA512 authentication (`Api-Key`, `Api-Sign`, `Api-Nonce`) |
| `bithumb_web_utils.py` | URL builders, `WebAssistantsFactory` |
| `bithumb_api_order_book_data_source.py` | Order book REST snapshot + WebSocket subscription |
| `bithumb_api_user_stream_data_source.py` | Heartbeat loop (Bithumb has no private WebSocket) |
| `bithumb_exchange.py` | Main connector — orders, balances, fills, trading rules |
| `README.md` | Connector-level documentation |

## Authentication

Bithumb v1 private API uses **HMAC-SHA512**:

```
Api-Sign = Base64( HMAC-SHA512( secret, endpoint + \0 + body + \0 + nonce ) )
```

Headers required on all private requests:
- `Api-Key`
- `Api-Sign`
- `Api-Nonce` (millisecond timestamp)
- `Content-Type: application/x-www-form-urlencoded`

## Notes

- Bithumb does **not** offer a private WebSocket API. Order and balance state is refreshed via Hummingbot's built-in REST polling loop (~10s interval).
- The connector defaults to **KRW** as the payment currency. Other currencies can be configured via the `payment_currency` constructor parameter.

## Test plan

- [ ] `connect bithumb` prompt works and stores credentials
- [ ] `balance` command returns correct KRW and crypto balances
- [ ] Order book and trade feed are populated for `BTC-KRW`
- [ ] Limit buy/sell orders are placed and tracked
- [ ] Order cancellation works
- [ ] Market buy/sell orders work
- [ ] Fills are correctly attributed after an order completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)