### PR TITLE
fix/handle empty candle deque after websocket interruption

### DIFF
--- a/hummingbot/data_feed/candles_feed/candles_base.py
+++ b/hummingbot/data_feed/candles_feed/candles_base.py
@@ -325,6 +325,10 @@ class CandlesBase(NetworkBase):
         """
         while not self.ready:
             await self._ws_candle_available.wait()
+            # WS disconnect can clear _candles without clearing _ws_candle_available; avoid IndexError on [0].
+            if len(self._candles) == 0:
+                self._ws_candle_available.clear()
+                continue
             try:
                 end_time = self._round_timestamp_to_interval_multiple(self._candles[0][0])
                 missing_records = self._candles.maxlen - len(self._candles)
@@ -472,6 +476,7 @@ class CandlesBase(NetworkBase):
     async def _on_order_stream_interruption(self, websocket_assistant: Optional[WSAssistant] = None):
         websocket_assistant and await websocket_assistant.disconnect()
         self._candles.clear()
+        self._ws_candle_available.clear()
 
     def get_seconds_from_interval(self, interval: str) -> int:
         """

--- a/test/hummingbot/data_feed/candles_feed/test_candles_base_ws_interruption.py
+++ b/test/hummingbot/data_feed/candles_feed/test_candles_base_ws_interruption.py
@@ -1,0 +1,36 @@
+import asyncio
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+
+import numpy as np
+
+from hummingbot.data_feed.candles_feed.binance_perpetual_candles import BinancePerpetualCandles
+
+
+class TestCandlesBaseWsInterruption(IsolatedAsyncioWrapperTestCase):
+    __test__ = True
+
+    def setUp(self):
+        super().setUp()
+        self.trading_pair = "BTC-USDT"
+        self.interval = "1h"
+
+    async def test_on_order_stream_interruption_clears_ws_candle_available(self):
+        feed = BinancePerpetualCandles(
+            trading_pair=self.trading_pair, interval=self.interval, max_records=10
+        )
+        row = np.array([1000.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0], dtype=float)
+        feed._candles.append(row)
+        feed._ws_candle_available.set()
+        await feed._on_order_stream_interruption(None)
+        self.assertEqual(len(feed._candles), 0)
+        self.assertFalse(feed._ws_candle_available.is_set())
+
+    async def test_fill_historical_waits_when_ws_event_set_but_deque_empty(self):
+        """If _candles was cleared without clearing the event, do not index _candles[0]."""
+        feed = BinancePerpetualCandles(
+            trading_pair=self.trading_pair, interval=self.interval, max_records=10
+        )
+        feed._ws_candle_available.set()
+        self.assertEqual(len(feed._candles), 0)
+        with self.assertRaises(asyncio.TimeoutError):
+            await asyncio.wait_for(feed.fill_historical_candles(), timeout=0.05)


### PR DESCRIPTION
On WebSocket disconnect, `_on_order_stream_interruption` cleared `_candles` but not `_ws_candle_available`. `fill_historical_candles` could then wake from `await self._ws_candle_available.wait()` with an empty deque and hit **`IndexError`** on `_candles[0]`, often in a tight retry loop.

This PR fixes the race and adds tests for it. No exchange-specific or strategy behaviour change.

Made-with: Cursor

**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] Tests all pass — *`pytest test/hummingbot/data_feed/candles_feed/test_candles_base.py test/hummingbot/data_feed/candles_feed/test_candles_base_ws_interruption.py`: all pass. Diff coverage on changed lines in `candles_base.py`: 100%.*
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/") — *Branch: `fix/candles-ws-interruption-fill-historical`.*

**A description of the changes proposed in the pull request**:

**Problem:**  
On WebSocket interruption, `_on_order_stream_interruption` clears `_candles` but did not clear `_ws_candle_available`. Another coroutine (e.g. `fill_historical_candles`) can be waiting on `_ws_candle_available.wait()`. When the event is still set from before the clear, it wakes, sees an empty `_candles`, and indexes `_candles[0]` → **`IndexError`**. In practice this can cause a tight retry loop and noisy logs.

**Changes:**

1. **`fill_historical_candles`** — After `await self._ws_candle_available.wait()`, if `len(self._candles) == 0`, clear the event and `continue` so the loop blocks again until a real first candle is available. This avoids indexing an empty deque.
2. **`_on_order_stream_interruption`** — After clearing `_candles`, call `self._ws_candle_available.clear()` so the event state matches `_reset_candles()` and waiters don’t wake with empty data.

**Tests:**  
New file `test/hummingbot/data_feed/candles_feed/test_candles_base_ws_interruption.py`:

- `test_on_order_stream_interruption_clears_ws_candle_available` — Ensures the interruption handler clears both `_candles` and the event.
- `test_fill_historical_waits_when_ws_event_set_but_deque_empty` — Ensures that when the event is set but `_candles` is empty, `fill_historical_candles` does not index `_candles[0]` and instead keeps waiting (tested via short timeout).

**Tests performed by the developer**:

- `pytest test/hummingbot/data_feed/candles_feed/`: 717 passed (including the 2 new tests).
- `make development-diff-cover` for changed file: **100%** coverage on the modified lines in `hummingbot/data_feed/candles_feed/candles_base.py`.

**Tips for QA testing**:

1. Run any strategy or flow that uses candles (e.g. candle-based indicators or historical fill). Trigger a WebSocket disconnect (e.g. brief network drop or restart the feed) and confirm no `IndexError` in logs and no tight retry loop; the feed should recover when the connection is back and candles are refilled.
2. Optionally run the new tests:  
   `pytest test/hummingbot/data_feed/candles_feed/test_candles_base_ws_interruption.py -v`