### PR TITLE
Feat/trading core clock task observability

### DIFF
--- a/hummingbot/core/trading_core.py
+++ b/hummingbot/core/trading_core.py
@@ -98,6 +98,7 @@ class TradingCore:
         self.strategy_config_map: Optional[BaseStrategyConfigMap] = None
         self.strategy_task: Optional[asyncio.Task] = None
         self._strategy_file_name: Optional[str] = None
+        self._clock_task: Optional[asyncio.Task] = None
 
         # Supporting components
         self.notifiers: List[NotifierBase] = []
@@ -188,6 +189,7 @@ class TradingCore:
 
             # Start the clock
             self._clock_task = asyncio.create_task(self._run_clock())
+            self._clock_task.add_done_callback(self._on_clock_task_done)
             self._is_running = True
             self.start_time = time.time() * 1e3
 
@@ -213,6 +215,7 @@ class TradingCore:
                     pass
 
             self.clock = None
+            self._clock_task = None
             self._is_running = False
 
             self.logger().info("Clock stopped successfully")
@@ -555,9 +558,39 @@ class TradingCore:
             raise
 
     async def _run_clock(self):
-        """Run the clock system."""
-        with self.clock as clock:
-            await clock.run()
+        """Run the clock system.
+
+        Logs any unhandled exception before re-raising so that clock task
+        failures are visible in logs instead of being stored silently on
+        the Task (which can make the bot appear to hang with no output).
+        """
+        try:
+            with self.clock as clock:
+                await clock.run()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self.logger().error(
+                "Clock coroutine died with an unhandled exception. "
+                "The bot will appear to hang — no further ticks will fire.",
+                exc_info=True,
+            )
+            raise
+
+    def _on_clock_task_done(self, task: asyncio.Task):
+        """Callback when the clock task finishes.
+
+        Logs any exception stored on the task so that clock failures are
+        visible in logs even if the task is never awaited.
+        """
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            self.logger().error(
+                f"Clock task terminated with {type(exc).__name__}: {exc}",
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )
 
     async def _wait_till_ready(self, func: Callable, *args, **kwargs):
         """Wait until all markets are ready before executing function."""

--- a/test/hummingbot/core/test_trading_core.py
+++ b/test/hummingbot/core/test_trading_core.py
@@ -816,7 +816,8 @@ class TradingCoreTest(IsolatedAsyncioWrapperTestCase):
         # Set up state
         self.trading_core._strategy_running = False
         self.trading_core._is_running = True
-        self.trading_core.clock = Mock()
+        clock_mock = Mock()
+        self.trading_core.clock = clock_mock
 
         # Add metrics collectors
         mock_collector1 = Mock(spec=MetricsCollector)
@@ -827,13 +828,12 @@ class TradingCoreTest(IsolatedAsyncioWrapperTestCase):
         }
 
         # Set up to raise exception on one collector (to test error handling)
-        self.trading_core.clock.remove_iterator.side_effect = [Exception("Test error"), None]
+        clock_mock.remove_iterator.side_effect = [Exception("Test error"), None]
 
         # Shutdown
         result = await self.trading_core.shutdown(skip_order_cancellation=True)
 
-        # Verify
+        # Verify (use clock_mock: shutdown() calls stop_clock() which sets self.clock = None)
         self.assertTrue(result)
         self.assertEqual(len(self.trading_core._metrics_collectors), 0)
-        # Verify both collectors were attempted to be removed
-        self.assertEqual(self.trading_core.clock.remove_iterator.call_count, 2)
+        self.assertEqual(clock_mock.remove_iterator.call_count, 2)


### PR DESCRIPTION
Store _clock_task in __init__ and reset in stop_clock; add _on_clock_task_done so clock task exceptions are logged when the task dies. Wrap _run_clock in try/except to log before re-raise. Includes a test fix for test_shutdown_with_metrics_collectors_cleanup (assert on clock mock ref after shutdown). No strategy semantics change.

**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings — *Verified: module imports; full `make build` (Docker) not run.*
- [x] Tests all pass — *`pytest test/hummingbot/core/test_trading_core.py`: 38 passed. Also fixed `test_shutdown_with_metrics_collectors_cleanup`, which asserted on `self.trading_core.clock` after `shutdown()`; `stop_clock()` sets `self.clock = None`, so the test now keeps a ref to the clock mock and asserts on that.*
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/") — *Branch: `feat/trading-core-clock-task-observability`.*

**A description of the changes proposed in the pull request**:

When the clock task (`_run_clock`) dies with an unhandled exception, asyncio stores it on the Task and nothing logs it, so the bot can appear to hang with no log output. This PR adds observability so those failures are visible in logs, and fixes one test that broke under that behaviour.

**Code changes:**

1. **`__init__`** — Add `self._clock_task: Optional[asyncio.Task] = None` so the attribute always exists (e.g. before any `stop_clock` call).
2. **`start_clock`** — Register `_on_clock_task_done` on the clock task via `add_done_callback` so that if the task finishes with an exception and is never awaited, it is still logged.
3. **`stop_clock`** — Set `self._clock_task = None` after cancelling the task.
4. **`_run_clock`** — Wrap the body in try/except: log any non-`CancelledError` exception (with `exc_info=True`) then re-raise.
5. **`_on_clock_task_done`** — New callback: if the task finished with an exception (and was not cancelled), log it; skip when the task was cancelled to avoid noise on normal shutdown.

**Test change:**

- **`test_shutdown_with_metrics_collectors_cleanup`** — Keep a reference to the clock mock (`clock_mock`) and use it for `side_effect` and for the final `remove_iterator.call_count` assertion. After `shutdown()`, `self.clock` is `None` (set in `stop_clock()`), so asserting on `self.trading_core.clock` was invalid; the test now asserts on the mock that was used during shutdown.

No change to strategy behaviour or clock semantics; only logging, lifecycle bookkeeping, and the test fix above.

**Tests performed by the developer**:

- `from hummingbot.core.trading_core import TradingCore` runs without errors.
- `pytest test/hummingbot/core/test_trading_core.py`: **38 passed** (including `test_shutdown_with_metrics_collectors_cleanup` after the fix).
- Full suite (`make test`): 6121 passed; 77 failures are existing Gateway/pydantic config issues, unrelated to this change.

**Tips for QA testing**:

1. **Normal run** — Start and stop the bot cleanly; confirm no extra error logs from the clock task (cancellation should not be logged).
2. **Clock failure** — In a dev build, force an exception inside the clock (e.g. in a strategy’s `start()`). Check logs for “Clock coroutine died with an unhandled exception” and/or “Clock task terminated with …” with traceback, instead of a silent hang.