### PR TITLE
feat / improve rate oracle + update binance perp ws

### DIFF
--- a/controllers/generic/grid_strike.py
+++ b/controllers/generic/grid_strike.py
@@ -150,11 +150,11 @@ class GridStrike(ControllerBase):
             status.append(header_line)
             # Data for the three columns
             level_dist_data = [
-                f"NOT_ACTIVE: {len(level.custom_info['levels_by_state'].get('NOT_ACTIVE', []))}",
-                f"OPEN_ORDER_PLACED: {len(level.custom_info['levels_by_state'].get('OPEN_ORDER_PLACED', []))}",
-                f"OPEN_ORDER_FILLED: {len(level.custom_info['levels_by_state'].get('OPEN_ORDER_FILLED', []))}",
-                f"CLOSE_ORDER_PLACED: {len(level.custom_info['levels_by_state'].get('CLOSE_ORDER_PLACED', []))}",
-                f"COMPLETE: {len(level.custom_info['levels_by_state'].get('COMPLETE', []))}"
+                f"NOT_ACTIVE: {level.custom_info['levels_by_state'].get('NOT_ACTIVE', 0)}",
+                f"OPEN_ORDER_PLACED: {level.custom_info['levels_by_state'].get('OPEN_ORDER_PLACED', 0)}",
+                f"OPEN_ORDER_FILLED: {level.custom_info['levels_by_state'].get('OPEN_ORDER_FILLED', 0)}",
+                f"CLOSE_ORDER_PLACED: {level.custom_info['levels_by_state'].get('CLOSE_ORDER_PLACED', 0)}",
+                f"COMPLETE: {level.custom_info['levels_by_state'].get('COMPLETE', 0)}"
             ]
             order_stats_data = [
                 f"Total: {sum(len(level.custom_info[k]) for k in ['filled_orders', 'failed_orders', 'canceled_orders'])}",

--- a/controllers/generic/multi_grid_strike.py
+++ b/controllers/generic/multi_grid_strike.py
@@ -241,11 +241,11 @@ class MultiGridStrike(ControllerBase):
 
                 # Data columns
                 level_dist_data = [
-                    f"NOT_ACTIVE: {len(executor.custom_info.get('levels_by_state', {}).get('NOT_ACTIVE', []))}",
-                    f"OPEN_ORDER_PLACED: {len(executor.custom_info.get('levels_by_state', {}).get('OPEN_ORDER_PLACED', []))}",
-                    f"OPEN_ORDER_FILLED: {len(executor.custom_info.get('levels_by_state', {}).get('OPEN_ORDER_FILLED', []))}",
-                    f"CLOSE_ORDER_PLACED: {len(executor.custom_info.get('levels_by_state', {}).get('CLOSE_ORDER_PLACED', []))}",
-                    f"COMPLETE: {len(executor.custom_info.get('levels_by_state', {}).get('COMPLETE', []))}"
+                    f"NOT_ACTIVE: {executor.custom_info.get('levels_by_state', {}).get('NOT_ACTIVE', 0)}",
+                    f"OPEN_ORDER_PLACED: {executor.custom_info.get('levels_by_state', {}).get('OPEN_ORDER_PLACED', 0)}",
+                    f"OPEN_ORDER_FILLED: {executor.custom_info.get('levels_by_state', {}).get('OPEN_ORDER_FILLED', 0)}",
+                    f"CLOSE_ORDER_PLACED: {executor.custom_info.get('levels_by_state', {}).get('CLOSE_ORDER_PLACED', 0)}",
+                    f"COMPLETE: {executor.custom_info.get('levels_by_state', {}).get('COMPLETE', 0)}"
                 ]
 
                 order_stats_data = [

--- a/hummingbot/connector/derivative/binance_perpetual/binance_perpetual_api_order_book_data_source.py
+++ b/hummingbot/connector/derivative/binance_perpetual/binance_perpetual_api_order_book_data_source.py
@@ -45,6 +45,7 @@ class BinancePerpetualAPIOrderBookDataSource(PerpetualAPIOrderBookDataSource):
         self._diff_messages_queue_key = CONSTANTS.DIFF_STREAM_ID
         self._funding_info_messages_queue_key = CONSTANTS.FUNDING_INFO_STREAM_ID
         self._snapshot_messages_queue_key = "order_book_snapshot"
+        self._market_ws_assistant: Optional[WSAssistant] = None
 
     async def get_last_traded_prices(self,
                                      trading_pairs: List[str],
@@ -93,18 +94,38 @@ class BinancePerpetualAPIOrderBookDataSource(PerpetualAPIOrderBookDataSource):
         await ws.connect(ws_url=url, ping_timeout=CONSTANTS.HEARTBEAT_TIME_INTERVAL)
         return ws
 
-    async def _subscribe_channels(self, ws: WSAssistant):
-        """
-        Subscribes to the trade events and diff orders events through the provided websocket connection.
-        :param ws: the websocket assistant used to connect to the exchange
-        """
+    async def _connected_market_websocket_assistant(self) -> WSAssistant:
+        url = f"{web_utils.wss_url(CONSTANTS.MARKET_WS_ENDPOINT, self._domain)}"
+        ws: WSAssistant = await self._api_factory.get_ws_assistant()
+        await ws.connect(ws_url=url, ping_timeout=CONSTANTS.HEARTBEAT_TIME_INTERVAL)
+        return ws
+
+    async def _subscribe_public_channels(self, ws: WSAssistant):
         try:
-            stream_id_channel_pairs = [
-                (CONSTANTS.DIFF_STREAM_ID, "@depth"),
+            params = []
+            for trading_pair in self._trading_pairs:
+                symbol = await self._connector.exchange_symbol_associated_to_pair(trading_pair=trading_pair)
+                params.append(f"{symbol.lower()}@depth")
+            payload = {
+                "method": "SUBSCRIBE",
+                "params": params,
+                "id": CONSTANTS.DIFF_STREAM_ID,
+            }
+            subscribe_request: WSJSONRequest = WSJSONRequest(payload)
+            await ws.send(subscribe_request)
+            self.logger().info("Subscribed to public order book channels...")
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self.logger().exception("Unexpected error occurred subscribing to order book streams...")
+            raise
+
+    async def _subscribe_market_channels(self, ws: WSAssistant):
+        try:
+            for stream_id, channel in [
                 (CONSTANTS.TRADE_STREAM_ID, "@aggTrade"),
                 (CONSTANTS.FUNDING_INFO_STREAM_ID, "@markPrice"),
-            ]
-            for stream_id, channel in stream_id_channel_pairs:
+            ]:
                 params = []
                 for trading_pair in self._trading_pairs:
                     symbol = await self._connector.exchange_symbol_associated_to_pair(trading_pair=trading_pair)
@@ -116,12 +137,19 @@ class BinancePerpetualAPIOrderBookDataSource(PerpetualAPIOrderBookDataSource):
                 }
                 subscribe_request: WSJSONRequest = WSJSONRequest(payload)
                 await ws.send(subscribe_request)
-            self.logger().info("Subscribed to public order book, trade and funding info channels...")
+            self.logger().info("Subscribed to market trade and funding info channels...")
         except asyncio.CancelledError:
             raise
         except Exception:
-            self.logger().exception("Unexpected error occurred subscribing to order book trading and delta streams...")
+            self.logger().exception("Unexpected error occurred subscribing to market streams...")
             raise
+
+    async def _subscribe_channels(self, ws: WSAssistant):
+        """
+        Subscribes to depth channels on the public WS connection.
+        :param ws: the websocket assistant used to connect to the exchange
+        """
+        await self._subscribe_public_channels(ws)
 
     def _channel_originating_message(self, event_message: Dict[str, Any]) -> str:
         channel = ""
@@ -134,6 +162,48 @@ class BinancePerpetualAPIOrderBookDataSource(PerpetualAPIOrderBookDataSource):
             elif "@markPrice" in stream_name:
                 channel = self._funding_info_messages_queue_key
         return channel
+
+    async def listen_for_subscriptions(self):
+        public_ws: Optional[WSAssistant] = None
+        market_ws: Optional[WSAssistant] = None
+        while True:
+            try:
+                public_ws = await self._connected_websocket_assistant()
+                self._ws_assistant = public_ws
+                await self._subscribe_public_channels(public_ws)
+
+                market_ws = await self._connected_market_websocket_assistant()
+                self._market_ws_assistant = market_ws
+                await self._subscribe_market_channels(market_ws)
+
+                public_task = asyncio.ensure_future(
+                    self._process_websocket_messages(websocket_assistant=public_ws))
+                market_task = asyncio.ensure_future(
+                    self._process_websocket_messages(websocket_assistant=market_ws))
+
+                done, pending = await asyncio.wait(
+                    [public_task, market_task],
+                    return_when=asyncio.FIRST_EXCEPTION,
+                )
+                for task in pending:
+                    task.cancel()
+                for task in done:
+                    task.result()
+            except asyncio.CancelledError:
+                raise
+            except ConnectionError as connection_exception:
+                self.logger().warning(f"The websocket connection was closed ({connection_exception})")
+            except Exception:
+                self.logger().exception(
+                    "Unexpected error occurred when listening to order book streams. Retrying in 5 seconds...",
+                )
+                await self._sleep(1.0)
+            finally:
+                self._ws_assistant = None
+                self._market_ws_assistant = None
+                await self._on_order_stream_interruption(websocket_assistant=public_ws)
+                if market_ws is not None:
+                    await market_ws.disconnect()
 
     async def _parse_order_book_diff_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
         timestamp: float = time.time()
@@ -208,12 +278,12 @@ class BinancePerpetualAPIOrderBookDataSource(PerpetualAPIOrderBookDataSource):
     async def subscribe_to_trading_pair(self, trading_pair: str) -> bool:
         """
         Subscribes to order book, trade, and funding info channels for a single trading pair
-        on the existing WebSocket connection.
+        on the existing WebSocket connections.
 
         :param trading_pair: the trading pair to subscribe to
         :return: True if subscription was successful, False otherwise
         """
-        if self._ws_assistant is None:
+        if self._ws_assistant is None or self._market_ws_assistant is None:
             self.logger().warning(
                 f"Cannot subscribe to {trading_pair}: WebSocket not connected"
             )
@@ -222,20 +292,22 @@ class BinancePerpetualAPIOrderBookDataSource(PerpetualAPIOrderBookDataSource):
         try:
             symbol = await self._connector.exchange_symbol_associated_to_pair(trading_pair=trading_pair)
 
-            stream_id_channel_pairs = [
-                (self._get_next_subscribe_id(), "@depth"),
-                (self._get_next_subscribe_id(), "@aggTrade"),
-                (self._get_next_subscribe_id(), "@markPrice"),
-            ]
+            # Subscribe to @depth on public WS
+            depth_payload = {
+                "method": "SUBSCRIBE",
+                "params": [f"{symbol.lower()}@depth"],
+                "id": self._get_next_subscribe_id(),
+            }
+            await self._ws_assistant.send(WSJSONRequest(depth_payload))
 
-            for stream_id, channel in stream_id_channel_pairs:
-                payload = {
+            # Subscribe to @aggTrade and @markPrice on market WS
+            for channel in ["@aggTrade", "@markPrice"]:
+                market_payload = {
                     "method": "SUBSCRIBE",
                     "params": [f"{symbol.lower()}{channel}"],
-                    "id": stream_id,
+                    "id": self._get_next_subscribe_id(),
                 }
-                subscribe_request: WSJSONRequest = WSJSONRequest(payload)
-                await self._ws_assistant.send(subscribe_request)
+                await self._market_ws_assistant.send(WSJSONRequest(market_payload))
 
             self.add_trading_pair(trading_pair)
             self.logger().info(f"Subscribed to {trading_pair} order book, trade and funding info channels")
@@ -250,12 +322,12 @@ class BinancePerpetualAPIOrderBookDataSource(PerpetualAPIOrderBookDataSource):
     async def unsubscribe_from_trading_pair(self, trading_pair: str) -> bool:
         """
         Unsubscribes from order book, trade, and funding info channels for a single trading pair
-        on the existing WebSocket connection.
+        on the existing WebSocket connections.
 
         :param trading_pair: the trading pair to unsubscribe from
         :return: True if unsubscription was successful, False otherwise
         """
-        if self._ws_assistant is None:
+        if self._ws_assistant is None or self._market_ws_assistant is None:
             self.logger().warning(
                 f"Cannot unsubscribe from {trading_pair}: WebSocket not connected"
             )
@@ -264,19 +336,24 @@ class BinancePerpetualAPIOrderBookDataSource(PerpetualAPIOrderBookDataSource):
         try:
             symbol = await self._connector.exchange_symbol_associated_to_pair(trading_pair=trading_pair)
 
-            unsubscribe_params = [
-                f"{symbol.lower()}@depth",
-                f"{symbol.lower()}@aggTrade",
-                f"{symbol.lower()}@markPrice",
-            ]
-
-            payload = {
+            # Unsubscribe @depth from public WS
+            depth_payload = {
                 "method": "UNSUBSCRIBE",
-                "params": unsubscribe_params,
+                "params": [f"{symbol.lower()}@depth"],
                 "id": self._get_next_subscribe_id(),
             }
-            unsubscribe_request: WSJSONRequest = WSJSONRequest(payload)
-            await self._ws_assistant.send(unsubscribe_request)
+            await self._ws_assistant.send(WSJSONRequest(depth_payload))
+
+            # Unsubscribe @aggTrade and @markPrice from market WS
+            market_payload = {
+                "method": "UNSUBSCRIBE",
+                "params": [
+                    f"{symbol.lower()}@aggTrade",
+                    f"{symbol.lower()}@markPrice",
+                ],
+                "id": self._get_next_subscribe_id(),
+            }
+            await self._market_ws_assistant.send(WSJSONRequest(market_payload))
 
             self.remove_trading_pair(trading_pair)
             self.logger().info(f"Unsubscribed from {trading_pair} order book, trade and funding info channels")

--- a/hummingbot/connector/derivative/binance_perpetual/binance_perpetual_constants.py
+++ b/hummingbot/connector/derivative/binance_perpetual/binance_perpetual_constants.py
@@ -14,8 +14,9 @@ TESTNET_BASE_URL = "https://testnet.binancefuture.com/fapi/"
 PERPETUAL_WS_URL = "wss://fstream.binance.com/"
 TESTNET_WS_URL = "wss://stream.binancefuture.com/"
 
-PUBLIC_WS_ENDPOINT = "stream"
-PRIVATE_WS_ENDPOINT = "ws"
+PUBLIC_WS_ENDPOINT = "public/stream"   # For @depth (combined stream, wrapped {stream,data} messages)
+MARKET_WS_ENDPOINT = "market/stream"   # For @aggTrade, @markPrice (combined stream)
+PRIVATE_WS_ENDPOINT = "private/ws"     # For user stream; listenKey is passed as ?listenKey= query param
 
 TIME_IN_FORCE_GTC = "GTC"  # Good till cancelled
 TIME_IN_FORCE_GTX = "GTX"  # Good Till Crossing

--- a/hummingbot/connector/derivative/binance_perpetual/binance_perpetual_user_stream_data_source.py
+++ b/hummingbot/connector/derivative/binance_perpetual/binance_perpetual_user_stream_data_source.py
@@ -180,7 +180,7 @@ class BinancePerpetualUserStreamDataSource(UserStreamTrackerDataSource):
 
         # Get a websocket assistant and connect it
         ws = await self._get_ws_assistant()
-        url = f"{web_utils.wss_url(CONSTANTS.PRIVATE_WS_ENDPOINT, self._domain)}/{self._current_listen_key}"
+        url = f"{web_utils.wss_url(CONSTANTS.PRIVATE_WS_ENDPOINT, self._domain)}?listenKey={self._current_listen_key}"
 
         self.logger().info(f"Connecting to user stream with listen key {self._current_listen_key}")
         await ws.connect(ws_url=url, ping_timeout=self.HEARTBEAT_TIME_INTERVAL)

--- a/hummingbot/connector/markets_recorder.py
+++ b/hummingbot/connector/markets_recorder.py
@@ -429,7 +429,6 @@ class MarketsRecorder:
                         price=evt.price,
                         order_amount=evt.amount,
                         token=quote_asset,
-                        exchange=market
                     )
                 except Exception as e:
                     self.logger().error(f"Error calculating fee in quote: {e}, will be stored in the DB as 0.")
@@ -597,7 +596,6 @@ class MarketsRecorder:
                     price=mid_price,
                     order_amount=base_amount,
                     token=quote_asset,
-                    exchange=connector
                 )
             except Exception as e:
                 self.logger().error(f"Error calculating fee in quote for LP position: {e}, will be stored as 0.")

--- a/hummingbot/core/connector_manager.py
+++ b/hummingbot/core/connector_manager.py
@@ -6,6 +6,7 @@ from hummingbot.client.config.security import Security
 from hummingbot.client.settings import AllConnectorSettings
 from hummingbot.connector.exchange.paper_trade import create_paper_trade_market
 from hummingbot.connector.exchange_base import ExchangeBase
+from hummingbot.core.rate_oracle.rate_oracle import RateOracle
 
 
 class ConnectorManager:
@@ -99,6 +100,7 @@ class ConnectorManager:
 
             # Add to active connectors
             self.connectors[connector_name] = connector
+            RateOracle.get_instance().register_connector(connector)
 
             self._logger.info(f"Created connector: {connector_name}")
 
@@ -123,6 +125,7 @@ class ConnectorManager:
             return False
 
         del self.connectors[connector_name]
+        RateOracle.get_instance().unregister_connector(connector_name)
         self._logger.info(f"Removed connector: {connector_name}")
         return True
 

--- a/hummingbot/core/data_type/in_flight_order.py
+++ b/hummingbot/core/data_type/in_flight_order.py
@@ -2,7 +2,6 @@ import asyncio
 import copy
 import logging
 import math
-import typing
 from decimal import Decimal
 from enum import Enum
 from typing import Any, Dict, NamedTuple, Optional, Tuple
@@ -13,9 +12,6 @@ from hummingbot.core.data_type.common import OrderType, PositionAction, TradeTyp
 from hummingbot.core.data_type.limit_order import LimitOrder
 from hummingbot.core.data_type.trade_fee import TradeFeeBase
 from hummingbot.logger import HummingbotLogger
-
-if typing.TYPE_CHECKING:  # avoid circular import problems
-    from hummingbot.connector.exchange_base import ExchangeBase
 
 s_decimal_0 = Decimal("0")
 
@@ -306,11 +302,13 @@ class InFlightOrder:
                 await self.exchange_order_id_update_event.wait()
         return self.exchange_order_id
 
-    def cumulative_fee_paid(self, token: str, exchange: Optional['ExchangeBase'] = None) -> Decimal:
+    def cumulative_fee_paid(self, token: str) -> Decimal:
         """
-        Returns the total amount of fee paid for each trade update, expressed in the specified token
+        Returns the total amount of fee paid for each trade update, expressed in the specified token.
+        Rate conversions are resolved through :class:`RateOracle`, which transparently falls back to
+        live order books of registered connectors when the configured rate source lacks a pair.
+
         :param token: The token all partial fills' fees should be transformed to before summing them
-        :param exchange: The exchange being used. If specified the logic will try to use the order book to get the rate
         :return: the cumulative fee paid for all partial fills in the specified token
         """
         total_fee_in_token = Decimal("0")
@@ -321,7 +319,6 @@ class InFlightOrder:
                     price=trade_update.fill_price,
                     order_amount=trade_update.fill_base_amount,
                     token=token,
-                    exchange=exchange
                 )
         except Exception:
             self.logger().exception(f"Error calculating fee paid in {token}.")

--- a/hummingbot/core/data_type/trade_fee.py
+++ b/hummingbot/core/data_type/trade_fee.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 from typing import Any, Dict, List, Optional, Type
 
 from hummingbot.connector.utils import combine_to_hb_trading_pair, split_hb_trading_pair
-from hummingbot.core.data_type.common import PositionAction, PriceType, TradeType
+from hummingbot.core.data_type.common import PositionAction, TradeType
 
 if typing.TYPE_CHECKING:  # avoid circular import problems
     from hummingbot.connector.exchange_base import ExchangeBase
@@ -179,32 +179,13 @@ class TradeFeeBase(ABC):
     @staticmethod
     def _get_exchange_rate(
             trading_pair: str,
-            exchange: Optional["ExchangeBase"] = None,
             rate_source: Optional["RateOracle"] = None      # noqa: F821
     ) -> Decimal:
         from hummingbot.core.rate_oracle.rate_oracle import RateOracle
 
-        if exchange is not None and hasattr(exchange, "order_books") and exchange.order_books is not None:
-            if trading_pair in exchange.order_books:
-                rate = exchange.get_price_by_type(trading_pair, PriceType.MidPrice)
-                return rate
-            # Check the reverse pair (e.g. "USDT-SIREN" → try "SIREN-USDT")
-            base, quote = split_hb_trading_pair(trading_pair)
-            reverse_pair = combine_to_hb_trading_pair(base=quote, quote=base)
-            if reverse_pair in exchange.order_books:
-                reverse_rate = exchange.get_price_by_type(reverse_pair, PriceType.MidPrice)
-                if reverse_rate and reverse_rate > Decimal("0"):
-                    return Decimal("1") / reverse_rate
-
         local_rate_source: Optional[RateOracle] = rate_source or RateOracle.get_instance()
-        rate: Decimal = local_rate_source.get_pair_rate(trading_pair)
+        rate: Optional[Decimal] = local_rate_source.get_pair_rate(trading_pair)
         if rate is None:
-            # Try the reverse pair on the rate oracle (e.g. "USDT-BASED" → "BASED-USDT")
-            base, quote = split_hb_trading_pair(trading_pair)
-            reverse_pair = combine_to_hb_trading_pair(base=quote, quote=base)
-            reverse_rate: Decimal = local_rate_source.get_pair_rate(reverse_pair)
-            if reverse_rate is not None and reverse_rate > Decimal("0"):
-                return Decimal("1") / reverse_rate
             raise ValueError(f"Could not find the exchange rate for {trading_pair} using the rate source "
                              f"{local_rate_source} (please verify it has been correctly configured)")
         return rate
@@ -215,7 +196,6 @@ class TradeFeeBase(ABC):
             price: Decimal,
             order_amount: Decimal,
             token: str,
-            exchange: Optional["ExchangeBase"] = None,
             rate_source: Optional["RateOracle"] = None      # noqa: F821
     ) -> Decimal:
         base, quote = split_hb_trading_pair(trading_pair)
@@ -225,7 +205,7 @@ class TradeFeeBase(ABC):
             if self._are_tokens_interchangeable(quote, token):
                 fee_amount += amount_from_percentage
             else:
-                conversion_rate: Decimal = self._get_exchange_rate(trading_pair, exchange, rate_source)
+                conversion_rate: Decimal = self._get_exchange_rate(trading_pair, rate_source)
                 # Protect against division by zero - use trade price as fallback if rate is 0
                 if conversion_rate == S_DECIMAL_0:
                     conversion_rate = price if price > S_DECIMAL_0 else Decimal("1")
@@ -240,7 +220,7 @@ class TradeFeeBase(ABC):
                 fee_amount += flat_fee.amount * price
             else:
                 conversion_pair: str = combine_to_hb_trading_pair(base=flat_fee.token, quote=token)
-                conversion_rate: Decimal = self._get_exchange_rate(conversion_pair, exchange, rate_source)
+                conversion_rate: Decimal = self._get_exchange_rate(conversion_pair, rate_source)
                 fee_amount += flat_fee.amount * conversion_rate
         return fee_amount
 

--- a/hummingbot/core/data_type/trade_fee.py
+++ b/hummingbot/core/data_type/trade_fee.py
@@ -184,15 +184,23 @@ class TradeFeeBase(ABC):
     ) -> Decimal:
         from hummingbot.core.rate_oracle.rate_oracle import RateOracle
 
-        if (exchange is not None and hasattr(exchange, "order_books") and exchange.order_books is not None and
-                trading_pair in exchange.order_books):
-            rate = exchange.get_price_by_type(trading_pair, PriceType.MidPrice)
-        else:
-            local_rate_source: Optional[RateOracle] = rate_source or RateOracle.get_instance()
-            rate: Decimal = local_rate_source.get_pair_rate(trading_pair)
-            if rate is None:
-                raise ValueError(f"Could not find the exchange rate for {trading_pair} using the rate source "
-                                 f"{local_rate_source} (please verify it has been correctly configured)")
+        if exchange is not None and hasattr(exchange, "order_books") and exchange.order_books is not None:
+            if trading_pair in exchange.order_books:
+                rate = exchange.get_price_by_type(trading_pair, PriceType.MidPrice)
+                return rate
+            # Check the reverse pair (e.g. "USDT-SIREN" → try "SIREN-USDT")
+            base, quote = split_hb_trading_pair(trading_pair)
+            reverse_pair = combine_to_hb_trading_pair(base=quote, quote=base)
+            if reverse_pair in exchange.order_books:
+                reverse_rate = exchange.get_price_by_type(reverse_pair, PriceType.MidPrice)
+                if reverse_rate and reverse_rate > Decimal("0"):
+                    return Decimal("1") / reverse_rate
+
+        local_rate_source: Optional[RateOracle] = rate_source or RateOracle.get_instance()
+        rate: Decimal = local_rate_source.get_pair_rate(trading_pair)
+        if rate is None:
+            raise ValueError(f"Could not find the exchange rate for {trading_pair} using the rate source "
+                             f"{local_rate_source} (please verify it has been correctly configured)")
         return rate
 
     def fee_amount_in_token(

--- a/hummingbot/core/data_type/trade_fee.py
+++ b/hummingbot/core/data_type/trade_fee.py
@@ -199,6 +199,12 @@ class TradeFeeBase(ABC):
         local_rate_source: Optional[RateOracle] = rate_source or RateOracle.get_instance()
         rate: Decimal = local_rate_source.get_pair_rate(trading_pair)
         if rate is None:
+            # Try the reverse pair on the rate oracle (e.g. "USDT-BASED" → "BASED-USDT")
+            base, quote = split_hb_trading_pair(trading_pair)
+            reverse_pair = combine_to_hb_trading_pair(base=quote, quote=base)
+            reverse_rate: Decimal = local_rate_source.get_pair_rate(reverse_pair)
+            if reverse_rate is not None and reverse_rate > Decimal("0"):
+                return Decimal("1") / reverse_rate
             raise ValueError(f"Could not find the exchange rate for {trading_pair} using the rate source "
                              f"{local_rate_source} (please verify it has been correctly configured)")
         return rate

--- a/hummingbot/core/rate_oracle/rate_oracle.py
+++ b/hummingbot/core/rate_oracle/rate_oracle.py
@@ -1,11 +1,16 @@
 import asyncio
 import logging
+import typing
 from decimal import Decimal
 from typing import Dict, Optional
 
 import hummingbot.client.settings  # noqa
-from hummingbot.connector.utils import combine_to_hb_trading_pair
+from hummingbot.connector.utils import combine_to_hb_trading_pair, split_hb_trading_pair
+from hummingbot.core.data_type.common import PriceType
 from hummingbot.core.network_base import NetworkBase
+
+if typing.TYPE_CHECKING:  # avoid circular import problems
+    from hummingbot.connector.connector_base import ConnectorBase
 from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.core.rate_oracle.sources.aevo_rate_source import AevoRateSource
 from hummingbot.core.rate_oracle.sources.architect_perpetual_rate_source import ArchitectPerpetualRateSource
@@ -76,6 +81,41 @@ class RateOracle(NetworkBase):
         self._fetch_price_task: Optional[asyncio.Task] = None
         self._ready_event = asyncio.Event()
         self._quote_token = quote_token if quote_token is not None else "USD"
+        self._connectors: Dict[str, "ConnectorBase"] = {}
+
+    def register_connector(self, connector: "ConnectorBase") -> None:
+        """
+        Registers a live connector so that its order books can be used as a fallback
+        price source when the configured rate source does not have a given pair.
+        """
+        self._connectors[connector.name] = connector
+
+    def unregister_connector(self, connector_name: str) -> None:
+        """
+        Removes a previously registered connector from the fallback pool.
+        """
+        self._connectors.pop(connector_name, None)
+
+    def _get_rate_from_connectors(self, pair: str) -> Optional[Decimal]:
+        """
+        Iterates over registered connectors (sorted by name for determinism) and returns
+        the first positive mid price found for the requested pair, trying the reverse pair
+        on each connector when the direct one is unavailable.
+        """
+        base, quote = split_hb_trading_pair(pair)
+        reverse_pair = combine_to_hb_trading_pair(base=quote, quote=base)
+        for name in sorted(self._connectors):
+            connector = self._connectors[name]
+            order_books = getattr(connector, "order_books", None) or {}
+            if pair in order_books:
+                rate = connector.get_price_by_type(pair, PriceType.MidPrice)
+                if rate is not None and rate > Decimal("0"):
+                    return rate
+            if reverse_pair in order_books:
+                reverse_rate = connector.get_price_by_type(reverse_pair, PriceType.MidPrice)
+                if reverse_rate is not None and reverse_rate > Decimal("0"):
+                    return Decimal("1") / reverse_rate
+        return None
 
     def __str__(self):
         return f"{self._source.name} rate oracle"
@@ -165,15 +205,29 @@ class RateOracle(NetworkBase):
         pair = combine_to_hb_trading_pair(base=base_token, quote=self._quote_token)
         return find_rate(prices, pair)
 
-    def get_pair_rate(self, pair: str) -> Decimal:
+    def get_pair_rate(self, pair: str) -> Optional[Decimal]:
         """
-        Finds a conversion rate for a given trading pair, this can be direct or indirect prices as
-        long as it can find a route to achieve this.
+        Finds a conversion rate for a given trading pair. The lookup tries, in order:
+          1. the configured rate source cache (direct pair)
+          2. registered connectors' live order books (direct and reverse pair)
+          3. the configured rate source cache (reverse pair, inverted)
+        Returns ``None`` when no rate can be resolved.
 
         :param pair: A trading pair, e.g. BTC-USDT
-        :return A conversion rate
+        :return A conversion rate, or ``None`` if no rate is available
         """
-        return find_rate(self._prices, pair)
+        rate = find_rate(self._prices, pair)
+        if rate is not None and rate > Decimal("0"):
+            return rate
+        connector_rate = self._get_rate_from_connectors(pair)
+        if connector_rate is not None:
+            return connector_rate
+        base, quote = split_hb_trading_pair(pair)
+        reverse_pair = combine_to_hb_trading_pair(base=quote, quote=base)
+        reverse_rate = find_rate(self._prices, reverse_pair)
+        if reverse_rate is not None and reverse_rate > Decimal("0"):
+            return Decimal("1") / reverse_rate
+        return None
 
     async def stored_or_live_rate(self, pair: str) -> Decimal:
         """

--- a/hummingbot/strategy_v2/executors/arbitrage_executor/arbitrage_executor.py
+++ b/hummingbot/strategy_v2/executors/arbitrage_executor/arbitrage_executor.py
@@ -299,7 +299,6 @@ class ArbitrageExecutor(ExecutorBase):
                 price=price,
                 order_amount=order_amount,
                 token=asset,
-                exchange=connector,
             )
 
     def process_order_created_event(self, _, market, event: Union[BuyOrderCreatedEvent, SellOrderCreatedEvent]):

--- a/hummingbot/strategy_v2/executors/grid_executor/grid_executor.py
+++ b/hummingbot/strategy_v2/executors/grid_executor/grid_executor.py
@@ -678,7 +678,7 @@ class GridExecutor(ExecutorBase):
 
         return {
             "side": self.config.side,
-            "levels_by_state": {key.name: value for key, value in self.levels_by_state.items()},
+            "levels_by_state": {key.name: len(value) for key, value in self.levels_by_state.items()},
             "filled_orders": self._filled_orders,
             "held_position_orders": self._held_position_orders,
             "held_position_value": held_position_value,

--- a/hummingbot/strategy_v2/executors/xemm_executor/xemm_executor.py
+++ b/hummingbot/strategy_v2/executors/xemm_executor/xemm_executor.py
@@ -207,7 +207,6 @@ class XEMMExecutor(ExecutorBase):
                 price=self._taker_result_price,
                 order_amount=order_amount,
                 token=asset,
-                exchange=connector,
             )
 
     async def get_resulting_price_for_amount(self, connector: str, trading_pair: str, is_buy: bool,

--- a/hummingbot/strategy_v2/models/executors.py
+++ b/hummingbot/strategy_v2/models/executors.py
@@ -90,23 +90,15 @@ class TrackedOrder:
 
     @property
     def cum_fees_base(self):
-        return self.get_cum_fees_base()
-
-    def get_cum_fees_base(self, exchange=None):
         if self.order:
-            return self.order.cumulative_fee_paid(token=self.order.base_asset, exchange=exchange)
-        else:
-            return Decimal("0")
+            return self.order.cumulative_fee_paid(token=self.order.base_asset)
+        return Decimal("0")
 
     @property
     def cum_fees_quote(self):
-        return self.get_cum_fees_quote()
-
-    def get_cum_fees_quote(self, exchange=None):
         if self.order:
-            return self.order.cumulative_fee_paid(token=self.order.quote_asset, exchange=exchange)
-        else:
-            return Decimal("0")
+            return self.order.cumulative_fee_paid(token=self.order.quote_asset)
+        return Decimal("0")
 
     @property
     def is_done(self):

--- a/hummingbot/strategy_v2/models/executors.py
+++ b/hummingbot/strategy_v2/models/executors.py
@@ -90,15 +90,21 @@ class TrackedOrder:
 
     @property
     def cum_fees_base(self):
+        return self.get_cum_fees_base()
+
+    def get_cum_fees_base(self, exchange=None):
         if self.order:
-            return self.order.cumulative_fee_paid(token=self.order.base_asset)
+            return self.order.cumulative_fee_paid(token=self.order.base_asset, exchange=exchange)
         else:
             return Decimal("0")
 
     @property
     def cum_fees_quote(self):
+        return self.get_cum_fees_quote()
+
+    def get_cum_fees_quote(self, exchange=None):
         if self.order:
-            return self.order.cumulative_fee_paid(token=self.order.quote_asset)
+            return self.order.cumulative_fee_paid(token=self.order.quote_asset, exchange=exchange)
         else:
             return Decimal("0")
 

--- a/test/hummingbot/connector/derivative/binance_perpetual/test_binance_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/binance_perpetual/test_binance_perpetual_api_order_book_data_source.py
@@ -271,22 +271,40 @@ class BinancePerpetualAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTest
                             "Unexpected error occurred when listening to order book streams. Retrying in 5 seconds...")
         )
 
-    async def test_subscribe_to_channels_raises_cancel_exception(self):
+    async def test_subscribe_public_channels_raises_cancel_exception(self):
         mock_ws = MagicMock()
         mock_ws.send.side_effect = asyncio.CancelledError
 
         with self.assertRaises(asyncio.CancelledError):
-            await self.data_source._subscribe_channels(mock_ws)
+            await self.data_source._subscribe_public_channels(mock_ws)
 
-    async def test_subscribe_to_channels_raises_exception_and_logs_error(self):
+    async def test_subscribe_public_channels_raises_exception_and_logs_error(self):
         mock_ws = MagicMock()
         mock_ws.send.side_effect = Exception("Test Error")
 
         with self.assertRaises(Exception):
-            await self.data_source._subscribe_channels(mock_ws)
+            await self.data_source._subscribe_public_channels(mock_ws)
 
         self.assertTrue(
-            self._is_logged("ERROR", "Unexpected error occurred subscribing to order book trading and delta streams...")
+            self._is_logged("ERROR", "Unexpected error occurred subscribing to order book streams...")
+        )
+
+    async def test_subscribe_market_channels_raises_cancel_exception(self):
+        mock_ws = MagicMock()
+        mock_ws.send.side_effect = asyncio.CancelledError
+
+        with self.assertRaises(asyncio.CancelledError):
+            await self.data_source._subscribe_market_channels(mock_ws)
+
+    async def test_subscribe_market_channels_raises_exception_and_logs_error(self):
+        mock_ws = MagicMock()
+        mock_ws.send.side_effect = Exception("Test Error")
+
+        with self.assertRaises(Exception):
+            await self.data_source._subscribe_market_channels(mock_ws)
+
+        self.assertTrue(
+            self._is_logged("ERROR", "Unexpected error occurred subscribing to market streams...")
         )
 
     async def test_channel_originating_message_returns_correct(self):
@@ -307,9 +325,12 @@ class BinancePerpetualAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTest
         msg_queue_diffs: asyncio.Queue = asyncio.Queue()
         msg_queue_trades: asyncio.Queue = asyncio.Queue()
         msg_queue_funding: asyncio.Queue = asyncio.Queue()
+
+        # Both public and market WS connections use the same mock
         mock_ws.return_value = self.mocking_assistant.create_websocket_mock()
         mock_ws.close.return_value = None
 
+        # Feed messages through the mocked websocket (both connections share same mock)
         self.mocking_assistant.add_websocket_aiohttp_message(
             mock_ws.return_value, json.dumps(self._orderbook_update_event())
         )
@@ -432,15 +453,19 @@ class BinancePerpetualAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTest
             bidict({self.ex_trading_pair: self.trading_pair, ex_new_pair: new_pair})
         )
 
-        # Create a mock WebSocket assistant
+        # Create mock WebSocket assistants for both public and market connections
         mock_ws = AsyncMock()
+        mock_market_ws = AsyncMock()
         self.data_source._ws_assistant = mock_ws
+        self.data_source._market_ws_assistant = mock_market_ws
 
         result = await self.data_source.subscribe_to_trading_pair(new_pair)
 
         self.assertTrue(result)
-        # Binance perpetual subscribes to 3 channels: depth, aggTrade, markPrice
-        self.assertEqual(3, mock_ws.send.call_count)
+        # 1 send to public WS (@depth)
+        self.assertEqual(1, mock_ws.send.call_count)
+        # 2 sends to market WS (@aggTrade, @markPrice)
+        self.assertEqual(2, mock_market_ws.send.call_count)
 
         # Verify pair was added to trading pairs
         self.assertIn(new_pair, self.data_source._trading_pairs)
@@ -455,6 +480,21 @@ class BinancePerpetualAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTest
 
         # Ensure ws_assistant is None
         self.data_source._ws_assistant = None
+        self.data_source._market_ws_assistant = None
+
+        result = await self.data_source.subscribe_to_trading_pair(new_pair)
+
+        self.assertFalse(result)
+        self.assertTrue(
+            self._is_logged("WARNING", f"Cannot subscribe to {new_pair}: WebSocket not connected")
+        )
+
+    async def test_subscribe_to_trading_pair_market_ws_not_connected(self):
+        """Test subscription fails when market WebSocket is not connected."""
+        new_pair = "ETH-USDT"
+
+        self.data_source._ws_assistant = AsyncMock()
+        self.data_source._market_ws_assistant = None
 
         result = await self.data_source.subscribe_to_trading_pair(new_pair)
 
@@ -475,6 +515,7 @@ class BinancePerpetualAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTest
         mock_ws = AsyncMock()
         mock_ws.send.side_effect = asyncio.CancelledError
         self.data_source._ws_assistant = mock_ws
+        self.data_source._market_ws_assistant = AsyncMock()
 
         with self.assertRaises(asyncio.CancelledError):
             await self.data_source.subscribe_to_trading_pair(new_pair)
@@ -491,6 +532,7 @@ class BinancePerpetualAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTest
         mock_ws = AsyncMock()
         mock_ws.send.side_effect = Exception("Test Error")
         self.data_source._ws_assistant = mock_ws
+        self.data_source._market_ws_assistant = AsyncMock()
 
         result = await self.data_source.subscribe_to_trading_pair(new_pair)
 
@@ -505,13 +547,17 @@ class BinancePerpetualAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTest
         self.assertIn(self.trading_pair, self.data_source._trading_pairs)
 
         mock_ws = AsyncMock()
+        mock_market_ws = AsyncMock()
         self.data_source._ws_assistant = mock_ws
+        self.data_source._market_ws_assistant = mock_market_ws
 
         result = await self.data_source.unsubscribe_from_trading_pair(self.trading_pair)
 
         self.assertTrue(result)
-        # Binance perpetual sends 1 unsubscribe message for all channels
+        # 1 unsubscribe to public WS (@depth)
         self.assertEqual(1, mock_ws.send.call_count)
+        # 1 unsubscribe to market WS (@aggTrade + @markPrice in one message)
+        self.assertEqual(1, mock_market_ws.send.call_count)
 
         # Verify pair was removed from trading pairs
         self.assertNotIn(self.trading_pair, self.data_source._trading_pairs)
@@ -523,6 +569,7 @@ class BinancePerpetualAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTest
     async def test_unsubscribe_from_trading_pair_websocket_not_connected(self):
         """Test unsubscription fails when WebSocket is not connected."""
         self.data_source._ws_assistant = None
+        self.data_source._market_ws_assistant = None
 
         result = await self.data_source.unsubscribe_from_trading_pair(self.trading_pair)
 
@@ -536,6 +583,7 @@ class BinancePerpetualAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTest
         mock_ws = AsyncMock()
         mock_ws.send.side_effect = asyncio.CancelledError
         self.data_source._ws_assistant = mock_ws
+        self.data_source._market_ws_assistant = AsyncMock()
 
         with self.assertRaises(asyncio.CancelledError):
             await self.data_source.unsubscribe_from_trading_pair(self.trading_pair)
@@ -545,6 +593,7 @@ class BinancePerpetualAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTest
         mock_ws = AsyncMock()
         mock_ws.send.side_effect = Exception("Test Error")
         self.data_source._ws_assistant = mock_ws
+        self.data_source._market_ws_assistant = AsyncMock()
 
         result = await self.data_source.unsubscribe_from_trading_pair(self.trading_pair)
 
@@ -552,3 +601,18 @@ class BinancePerpetualAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTest
         self.assertTrue(
             self._is_logged("ERROR", f"Error unsubscribing from {self.trading_pair}")
         )
+
+    async def test_connected_websocket_assistant_uses_public_endpoint(self):
+        """Test that the public WS connects to the /public endpoint."""
+        expected_url = web_utils.wss_url(CONSTANTS.PUBLIC_WS_ENDPOINT, self.domain)
+        self.assertIn("public", expected_url)
+        self.assertNotIn("stream", expected_url)
+
+    async def test_connected_market_websocket_assistant_uses_market_endpoint(self):
+        """Test that the market WS connects to the /market endpoint."""
+        expected_url = web_utils.wss_url(CONSTANTS.MARKET_WS_ENDPOINT, self.domain)
+        self.assertIn("market", expected_url)
+
+    async def test_market_ws_assistant_initialized_to_none(self):
+        """Test that the market WS assistant is initialized to None."""
+        self.assertIsNone(self.data_source._market_ws_assistant)

--- a/test/hummingbot/connector/derivative/binance_perpetual/test_binance_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/binance_perpetual/test_binance_perpetual_api_order_book_data_source.py
@@ -605,8 +605,7 @@ class BinancePerpetualAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTest
     async def test_connected_websocket_assistant_uses_public_endpoint(self):
         """Test that the public WS connects to the /public endpoint."""
         expected_url = web_utils.wss_url(CONSTANTS.PUBLIC_WS_ENDPOINT, self.domain)
-        self.assertIn("public", expected_url)
-        self.assertNotIn("stream", expected_url)
+        self.assertIn("public/stream", expected_url)
 
     async def test_connected_market_websocket_assistant_uses_market_endpoint(self):
         """Test that the market WS connects to the /market endpoint."""

--- a/test/hummingbot/core/data_type/test_trade_fee.py
+++ b/test/hummingbot/core/data_type/test_trade_fee.py
@@ -2,7 +2,7 @@ from decimal import Decimal
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
-from hummingbot.core.data_type.common import PositionAction, PriceType, TradeType
+from hummingbot.core.data_type.common import PositionAction, TradeType
 from hummingbot.core.data_type.in_flight_order import TradeUpdate
 from hummingbot.core.data_type.trade_fee import (
     AddedToCostTradeFee,
@@ -252,47 +252,24 @@ class TradeFeeTests(TestCase):
 
 class GetExchangeRateTests(TestCase):
 
-    def test_get_exchange_rate_from_exchange_order_books(self):
-        mock_exchange = MagicMock()
-        mock_exchange.order_books = {"HBOT-USDT": MagicMock()}
-        mock_exchange.get_price_by_type.return_value = Decimal("10.5")
+    def test_get_exchange_rate_from_rate_source(self):
+        mock_rate_source = MagicMock()
+        mock_rate_source.get_pair_rate.return_value = Decimal("10.5")
 
-        rate = TradeFeeBase._get_exchange_rate("HBOT-USDT", exchange=mock_exchange)
+        rate = TradeFeeBase._get_exchange_rate("HBOT-USDT", rate_source=mock_rate_source)
 
         self.assertEqual(Decimal("10.5"), rate)
-        mock_exchange.get_price_by_type.assert_called_once_with("HBOT-USDT", PriceType.MidPrice)
+        mock_rate_source.get_pair_rate.assert_called_once_with("HBOT-USDT")
 
-    def test_get_exchange_rate_uses_reverse_pair_when_direct_not_found(self):
-        mock_exchange = MagicMock()
-        mock_exchange.order_books = {"USDT-HBOT": MagicMock()}
-        mock_exchange.get_price_by_type.return_value = Decimal("0.1")
-
-        rate = TradeFeeBase._get_exchange_rate("HBOT-USDT", exchange=mock_exchange)
-
-        self.assertEqual(Decimal("1") / Decimal("0.1"), rate)
-        mock_exchange.get_price_by_type.assert_called_once_with("USDT-HBOT", PriceType.MidPrice)
-
-    def test_get_exchange_rate_reverse_pair_zero_falls_through_to_rate_oracle(self):
-        mock_exchange = MagicMock()
-        mock_exchange.order_books = {"USDT-HBOT": MagicMock()}
-        mock_exchange.get_price_by_type.return_value = Decimal("0")
-
+    def test_get_exchange_rate_uses_default_rate_oracle_instance(self):
         with patch("hummingbot.core.rate_oracle.rate_oracle.RateOracle") as mock_oracle_cls:
             mock_oracle = MagicMock()
             mock_oracle.get_pair_rate.return_value = Decimal("10")
             mock_oracle_cls.get_instance.return_value = mock_oracle
 
-            rate = TradeFeeBase._get_exchange_rate("HBOT-USDT", exchange=mock_exchange)
+            rate = TradeFeeBase._get_exchange_rate("HBOT-USDT")
 
             self.assertEqual(Decimal("10"), rate)
-
-    def test_get_exchange_rate_rate_oracle_uses_reverse_pair_when_direct_not_found(self):
-        mock_rate_source = MagicMock()
-        mock_rate_source.get_pair_rate.side_effect = lambda pair: Decimal("0.1") if pair == "USDT-HBOT" else None
-
-        rate = TradeFeeBase._get_exchange_rate("HBOT-USDT", rate_source=mock_rate_source)
-
-        self.assertEqual(Decimal("1") / Decimal("0.1"), rate)
 
     def test_get_exchange_rate_raises_when_rate_source_returns_none(self):
         mock_rate_source = MagicMock()

--- a/test/hummingbot/core/data_type/test_trade_fee.py
+++ b/test/hummingbot/core/data_type/test_trade_fee.py
@@ -1,7 +1,8 @@
 from decimal import Decimal
 from unittest import TestCase
+from unittest.mock import MagicMock, patch
 
-from hummingbot.core.data_type.common import PositionAction, TradeType
+from hummingbot.core.data_type.common import PositionAction, PriceType, TradeType
 from hummingbot.core.data_type.in_flight_order import TradeUpdate
 from hummingbot.core.data_type.trade_fee import (
     AddedToCostTradeFee,
@@ -247,6 +248,50 @@ class TradeFeeTests(TestCase):
             token="BNB")
 
         self.assertEqual(Decimal("0"), fee_amount)
+
+
+class GetExchangeRateTests(TestCase):
+
+    def test_get_exchange_rate_from_exchange_order_books(self):
+        mock_exchange = MagicMock()
+        mock_exchange.order_books = {"HBOT-USDT": MagicMock()}
+        mock_exchange.get_price_by_type.return_value = Decimal("10.5")
+
+        rate = TradeFeeBase._get_exchange_rate("HBOT-USDT", exchange=mock_exchange)
+
+        self.assertEqual(Decimal("10.5"), rate)
+        mock_exchange.get_price_by_type.assert_called_once_with("HBOT-USDT", PriceType.MidPrice)
+
+    def test_get_exchange_rate_uses_reverse_pair_when_direct_not_found(self):
+        mock_exchange = MagicMock()
+        mock_exchange.order_books = {"USDT-HBOT": MagicMock()}
+        mock_exchange.get_price_by_type.return_value = Decimal("0.1")
+
+        rate = TradeFeeBase._get_exchange_rate("HBOT-USDT", exchange=mock_exchange)
+
+        self.assertEqual(Decimal("1") / Decimal("0.1"), rate)
+        mock_exchange.get_price_by_type.assert_called_once_with("USDT-HBOT", PriceType.MidPrice)
+
+    def test_get_exchange_rate_reverse_pair_zero_falls_through_to_rate_oracle(self):
+        mock_exchange = MagicMock()
+        mock_exchange.order_books = {"USDT-HBOT": MagicMock()}
+        mock_exchange.get_price_by_type.return_value = Decimal("0")
+
+        with patch("hummingbot.core.rate_oracle.rate_oracle.RateOracle") as mock_oracle_cls:
+            mock_oracle = MagicMock()
+            mock_oracle.get_pair_rate.return_value = Decimal("10")
+            mock_oracle_cls.get_instance.return_value = mock_oracle
+
+            rate = TradeFeeBase._get_exchange_rate("HBOT-USDT", exchange=mock_exchange)
+
+            self.assertEqual(Decimal("10"), rate)
+
+    def test_get_exchange_rate_raises_when_rate_source_returns_none(self):
+        mock_rate_source = MagicMock()
+        mock_rate_source.get_pair_rate.return_value = None
+
+        with self.assertRaises(ValueError):
+            TradeFeeBase._get_exchange_rate("HBOT-USDT", rate_source=mock_rate_source)
 
 
 class TokenAmountTests(TestCase):

--- a/test/hummingbot/core/data_type/test_trade_fee.py
+++ b/test/hummingbot/core/data_type/test_trade_fee.py
@@ -286,6 +286,14 @@ class GetExchangeRateTests(TestCase):
 
             self.assertEqual(Decimal("10"), rate)
 
+    def test_get_exchange_rate_rate_oracle_uses_reverse_pair_when_direct_not_found(self):
+        mock_rate_source = MagicMock()
+        mock_rate_source.get_pair_rate.side_effect = lambda pair: Decimal("0.1") if pair == "USDT-HBOT" else None
+
+        rate = TradeFeeBase._get_exchange_rate("HBOT-USDT", rate_source=mock_rate_source)
+
+        self.assertEqual(Decimal("1") / Decimal("0.1"), rate)
+
     def test_get_exchange_rate_raises_when_rate_source_returns_none(self):
         mock_rate_source = MagicMock()
         mock_rate_source.get_pair_rate.return_value = None

--- a/test/hummingbot/core/rate_oracle/test_rate_oracle.py
+++ b/test/hummingbot/core/rate_oracle/test_rate_oracle.py
@@ -2,10 +2,12 @@ from copy import deepcopy
 from decimal import Decimal
 from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from typing import Dict, Optional
+from unittest.mock import MagicMock
 
 from hummingbot.client.config.client_config_map import ClientConfigMap
 from hummingbot.client.config.config_helpers import ClientConfigAdapter
 from hummingbot.connector.utils import combine_to_hb_trading_pair
+from hummingbot.core.data_type.common import PriceType
 from hummingbot.core.rate_oracle.rate_oracle import RateOracle
 from hummingbot.core.rate_oracle.sources.coin_gecko_rate_source import CoinGeckoRateSource
 from hummingbot.core.rate_oracle.sources.rate_source_base import RateSourceBase
@@ -99,3 +101,66 @@ class RateOracleTest(IsolatedAsyncioWrapperTestCase):
         config_map.global_token.global_token_name = "EUR"
 
         self.assertEqual(0, len(rate_oracle.prices))
+
+    @staticmethod
+    def _make_connector(name: str, order_books: Dict[str, Decimal]) -> MagicMock:
+        connector = MagicMock()
+        connector.name = name
+        connector.order_books = {pair: MagicMock() for pair in order_books}
+        connector.get_price_by_type.side_effect = (
+            lambda pair, price_type: order_books.get(pair) if price_type == PriceType.MidPrice else None
+        )
+        return connector
+
+    def test_register_and_unregister_connector(self):
+        rate_oracle = RateOracle(source=DummyRateSource(price_dict={}))
+        connector = self._make_connector("binance", {"HBOT-USDT": Decimal("2")})
+
+        rate_oracle.register_connector(connector)
+        self.assertIn("binance", rate_oracle._connectors)
+
+        rate_oracle.unregister_connector("binance")
+        self.assertNotIn("binance", rate_oracle._connectors)
+
+    def test_get_pair_rate_falls_back_to_connector_order_book(self):
+        rate_oracle = RateOracle(source=DummyRateSource(price_dict={}))
+        connector = self._make_connector("binance", {"HBOT-USDT": Decimal("10.5")})
+        rate_oracle.register_connector(connector)
+
+        self.assertEqual(Decimal("10.5"), rate_oracle.get_pair_rate("HBOT-USDT"))
+
+    def test_get_pair_rate_connector_reverse_pair(self):
+        rate_oracle = RateOracle(source=DummyRateSource(price_dict={}))
+        connector = self._make_connector("binance", {"USDT-HBOT": Decimal("0.1")})
+        rate_oracle.register_connector(connector)
+
+        self.assertEqual(Decimal("1") / Decimal("0.1"), rate_oracle.get_pair_rate("HBOT-USDT"))
+
+    def test_get_pair_rate_prefers_configured_source_over_connector(self):
+        rate_oracle = RateOracle(source=DummyRateSource(price_dict={}))
+        rate_oracle._prices = {"HBOT-USDT": Decimal("100")}
+        connector = self._make_connector("binance", {"HBOT-USDT": Decimal("10")})
+        rate_oracle.register_connector(connector)
+
+        self.assertEqual(Decimal("100"), rate_oracle.get_pair_rate("HBOT-USDT"))
+
+    def test_get_pair_rate_reverse_on_source_after_connector_miss(self):
+        rate_oracle = RateOracle(source=DummyRateSource(price_dict={}))
+        rate_oracle._prices = {"USDT-HBOT": Decimal("0.5")}
+        connector = self._make_connector("binance", {"FOO-BAR": Decimal("1")})
+        rate_oracle.register_connector(connector)
+
+        self.assertEqual(Decimal("2"), rate_oracle.get_pair_rate("HBOT-USDT"))
+
+    def test_get_pair_rate_returns_none_when_no_route(self):
+        rate_oracle = RateOracle(source=DummyRateSource(price_dict={}))
+        self.assertIsNone(rate_oracle.get_pair_rate("HBOT-USDT"))
+
+    def test_get_pair_rate_connector_iteration_is_deterministic(self):
+        rate_oracle = RateOracle(source=DummyRateSource(price_dict={}))
+        connector_b = self._make_connector("b_connector", {"HBOT-USDT": Decimal("2")})
+        connector_a = self._make_connector("a_connector", {"HBOT-USDT": Decimal("1")})
+        rate_oracle.register_connector(connector_b)
+        rate_oracle.register_connector(connector_a)
+
+        self.assertEqual(Decimal("1"), rate_oracle.get_pair_rate("HBOT-USDT"))

--- a/test/hummingbot/strategy_v2/executors/grid_executor/test_grid_executor.py
+++ b/test/hummingbot/strategy_v2/executors/grid_executor/test_grid_executor.py
@@ -1068,7 +1068,7 @@ class TestGridExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         executor_info = executor.executor_info
         custom_info = executor_info.custom_info
         self.assertEqual(custom_info["levels_by_state"],
-                         {key.name: value for key, value in executor.levels_by_state.items()})
+                         {key.name: len(value) for key, value in executor.levels_by_state.items()})
         self.assertEqual(custom_info["filled_orders"], executor._filled_orders)
         self.assertEqual(custom_info["failed_orders"], executor._failed_orders)
         self.assertEqual(custom_info["canceled_orders"], executor._canceled_orders)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] Tests all pass
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
 Improve fee calculation for perpetuals via Rate Oracle                                                                                                                                   
   
  Refactors fee/PNL calculation to rely on the RateOracle for quote conversions instead of passing exchange instances around. Key changes:                                                 
                                                                             
  - Removes exchange argument from orders, fees, and MarketsRecorder — conversions now go through RateOracle.                                                                              
  - RateOracle is initialized with the connectors at creation time, and looks up inverse pairs when a direct pair isn't available.
  - Updates strategy_v2 executors to the new API.                                                                                                                                          
  - Applies a Binance WS upgrade fix and serialization fixes uncovered by the refactor.                                                                                                    
                                                                                                                                                                                           
  Suggested QA Tests                                                                                                                                                                       
                                                                                                                                                                                           
  - [x] Spot trading (Binance, Kucoin, Gate.io): place/fill a market + limit order; verify fees and PnL appear correctly in the trade history and history command.                            
  - [x] Perpetual trading (Binance Perp, Hyperliquid, etc.): open and close a position; confirm realized PnL and fees are recorded with correct quote conversion (e.g. fees in non-USD quote
  converted properly).                                                                                                                                                                     
  - [ ] Inverse pair lookup: trade a market where only the inverse pair exists in the rate oracle (e.g. fee asset where only QUOTE-BASE is listed); verify conversion still resolves.
  - [x] Binance WebSocket: run a Binance bot for an extended period and confirm the user stream stays connected after the WS upgrade and order updates flow through.                          
  - [x] MarketsRecorder persistence: restart the bot mid-strategy and verify orders/trades/fees load correctly from the SQLite DB (serialization fix).                                        
  - [x] Strategy V2 executors: run position_executor, twap_executor, and grid_executor end-to-end on a perp connector — verify fee accounting, net PnL, and early-stop behavior.              
  - [x] PMM / XEMM legacy strategies: regression run to confirm the recorder/fee changes didn't break v1 strategies.                                                                          
  - [x] Rate Oracle initialization: start bot with multiple connectors and verify the oracle picks up all of them; check logs for missing-pair warnings.                                      
  - [x] history and export CLI commands: confirm output formatting (quote conversions, totals) matches pre-refactor values within rounding.   