### PR TITLE
feat/lighter: add perpetual connector and tests

### DIFF
--- a/hummingbot/connector/derivative/lighter_perpetual/dummy.pxd
+++ b/hummingbot/connector/derivative/lighter_perpetual/dummy.pxd
@@ -1,0 +1,2 @@
+cdef class dummy():
+    pass

--- a/hummingbot/connector/derivative/lighter_perpetual/dummy.pyx
+++ b/hummingbot/connector/derivative/lighter_perpetual/dummy.pyx
@@ -1,0 +1,2 @@
+cdef class dummy():
+    pass

--- a/hummingbot/connector/derivative/lighter_perpetual/lighter_perpetual_api_order_book_data_source.py
+++ b/hummingbot/connector/derivative/lighter_perpetual/lighter_perpetual_api_order_book_data_source.py
@@ -1,0 +1,517 @@
+import asyncio
+import time
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from hummingbot.connector.derivative.lighter_perpetual import (
+    lighter_perpetual_constants as CONSTANTS,
+    lighter_perpetual_web_utils as web_utils,
+)
+from hummingbot.core.data_type.common import TradeType
+from hummingbot.core.data_type.funding_info import FundingInfo, FundingInfoUpdate
+from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
+from hummingbot.core.data_type.perpetual_api_order_book_data_source import PerpetualAPIOrderBookDataSource
+from hummingbot.core.utils.async_utils import safe_ensure_future
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+from hummingbot.core.web_assistant.ws_assistant import WSAssistant
+from hummingbot.logger import HummingbotLogger
+
+if TYPE_CHECKING:
+    from hummingbot.connector.derivative.lighter_perpetual.lighter_perpetual_derivative import (
+        LighterPerpetualDerivative,
+    )
+
+
+class LighterPerpetualAPIOrderBookDataSource(PerpetualAPIOrderBookDataSource):
+    _logger: Optional[HummingbotLogger] = None
+
+    def __init__(
+        self,
+        trading_pairs: List[str],
+        connector: "LighterPerpetualDerivative",
+        api_factory: WebAssistantsFactory,
+        domain: str = CONSTANTS.DEFAULT_DOMAIN,
+    ):
+        super().__init__(trading_pairs)
+        self._connector = connector
+        self._api_factory = api_factory
+        self._domain = domain
+        self._ping_task: Optional[asyncio.Task] = None
+
+    async def get_last_traded_prices(self, trading_pairs: List[str], domain: Optional[str] = None) -> Dict[str, float]:
+        return await self._connector.get_last_traded_prices(trading_pairs=trading_pairs)
+
+    def _get_headers(self) -> Dict[str, str]:
+        headers = {}
+        if self._connector.rest_api_key:
+            headers["X-Api-Key"] = self._connector.rest_api_key
+        return headers
+
+    async def _request_order_book_snapshot(self, trading_pair: str) -> Dict[str, Any]:
+        """
+        https://docs.LIGHTER.fi/api-documentation/api/rest-api/markets/get-orderbook
+
+        {
+            "success": true,
+            "data": {
+                "s": "BTC",
+                "l": [
+                [
+                    {
+                    "p": "106504",
+                    "a": "0.26203",
+                    "n": 1
+                    },
+                    {
+                    "p": "106498",
+                    "a": "0.29281",
+                    "n": 1
+                    }
+                ],
+                [
+                    {
+                    "p": "106559",
+                    "a": "0.26802",
+                    "n": 1
+                    },
+                    {
+                    "p": "106564",
+                    "a": "0.3002",
+                    "n": 1
+                    },
+                ]
+                ],
+                "t": 1751370536325
+            },
+            "error": null,
+            "code": null
+        }
+        """
+        rest_assistant = await self._api_factory.get_rest_assistant()
+        params = {"symbol": await self._connector.exchange_symbol_associated_to_pair(trading_pair=trading_pair)}
+
+        response = await rest_assistant.execute_request(
+            url=web_utils.public_rest_url(path_url=CONSTANTS.GET_MARKET_ORDER_BOOK_SNAPSHOT_PATH_URL, domain=self._domain),
+            params=params,
+            method=RESTMethod.GET,
+            throttler_limit_id=CONSTANTS.GET_MARKET_ORDER_BOOK_SNAPSHOT_PATH_URL,
+            headers=self._get_headers()
+        )
+
+        if not response.get("success") is True:
+            raise ValueError(f"[get_order_book_snapshot] Failed to get order book snapshot for {trading_pair}: {response}")
+
+        if not response.get("data", []):
+            raise ValueError(f"[get_order_book_snapshot] No data when requesting order book snapshot for {trading_pair}: {response}")
+
+        return response["data"]
+
+    async def _order_book_snapshot(self, trading_pair: str) -> OrderBookMessage:
+        order_book_snapshot_data = await self._request_order_book_snapshot(trading_pair)
+        order_book_snapshot_timestamp = order_book_snapshot_data["t"] / 1000
+
+        return OrderBookMessage(OrderBookMessageType.SNAPSHOT, {
+            "trading_pair": trading_pair,
+            "update_id": order_book_snapshot_timestamp,
+            "bids": [(bids["p"], bids["a"]) for bids in order_book_snapshot_data["l"][0]],
+            "asks": [(asks["p"], asks["a"]) for asks in order_book_snapshot_data["l"][1]]
+        }, timestamp=order_book_snapshot_timestamp)
+
+    async def get_funding_info(self, trading_pair: str) -> FundingInfo:
+        """
+        https://docs.LIGHTER.fi/api-documentation/api/rest-api/markets/get-prices
+
+        {
+            "success": true,
+            "data": [
+                {
+                "funding": "0.00010529",
+                "mark": "1.084819",
+                "mid": "1.08615",
+                "next_funding": "0.00011096",
+                "open_interest": "3634796",
+                "oracle": "1.084524",
+                "symbol": "XPL",
+                "timestamp": 1759222967974,
+                "volume_24h": "20896698.0672",
+                "yesterday_price": "1.3412"
+                }
+            ],
+            "error": null,
+            "code": null
+        }
+
+        Index price = Oracle price
+        Next funding timestamp = :00 of next hour
+        """
+        rest_assistant = await self._api_factory.get_rest_assistant()
+        symbol = await self._connector.exchange_symbol_associated_to_pair(trading_pair=trading_pair)
+
+        response = await rest_assistant.execute_request(
+            url=web_utils.public_rest_url(path_url=CONSTANTS.GET_PRICES_PATH_URL, domain=self._domain),
+            method=RESTMethod.GET,
+            throttler_limit_id=CONSTANTS.GET_PRICES_PATH_URL,
+            headers=self._get_headers()
+        )
+
+        if not response.get("success") is True:
+            raise ValueError(f"[get_funding_info] Failed to get price info for {trading_pair}: {response}")
+
+        if not response.get("data", []):
+            raise ValueError(f"[get_funding_info] No data when requesting price info for {trading_pair}: {response}")
+
+        for price_info in response["data"]:
+            if price_info["symbol"] == symbol:
+                break
+        else:
+            raise ValueError(f"[get_funding_info] Failed to get price info for {trading_pair}: {response}")
+
+        return FundingInfo(
+            trading_pair=trading_pair,
+            index_price=Decimal(price_info["oracle"]),
+            mark_price=Decimal(price_info["mark"]),
+            next_funding_utc_timestamp=int((time.time() // 3600 + 1) * 3600),
+            rate=Decimal(price_info["funding"]),
+        )
+
+    async def _connected_websocket_assistant(self) -> WSAssistant:
+        ws: WSAssistant = await self._api_factory.get_ws_assistant()
+
+        await ws.connect(ws_url=web_utils.wss_url(self._domain), ws_headers=self._get_headers())
+        self._ping_task = safe_ensure_future(self._ping_loop(ws))
+        return ws
+
+    async def _subscribe_channels(self, ws: WSAssistant):
+        try:
+            # OB snapshots
+            for trading_pair in self._trading_pairs:
+                payload = {
+                    "method": "subscribe",
+                    "params": {
+                        "source": "book",
+                        "symbol": await self._connector.exchange_symbol_associated_to_pair(trading_pair),
+                        "agg_level": 1,
+                    },
+                }
+                subscribe_request = WSJSONRequest(payload=payload)
+                await ws.send(subscribe_request)
+
+            # no OB diffs
+
+            # trades
+            for trading_pair in self._trading_pairs:
+                payload = {
+                    "method": "subscribe",
+                    "params": {
+                        "source": "trades",
+                        "symbol": await self._connector.exchange_symbol_associated_to_pair(trading_pair),
+                    },
+                }
+                subscribe_request = WSJSONRequest(payload=payload)
+                await ws.send(subscribe_request)
+
+            # funding info
+
+            payload = {
+                "method": "subscribe",
+                "params": {
+                    "source": "prices",
+                },
+            }
+            subscribe_request = WSJSONRequest(payload=payload)
+            await ws.send(subscribe_request)
+
+            self.logger().info("Subscribed to public order book and trade channels...")
+
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self.logger().exception("Unexpected error occurred subscribing to order book trading pairs.")
+            raise
+
+    async def _on_order_stream_interruption(self, websocket_assistant: Optional[WSAssistant] = None):
+        await super()._on_order_stream_interruption(websocket_assistant)
+        if self._ping_task is not None:
+            self._ping_task.cancel()
+            self._ping_task = None
+
+    async def _ping_loop(self, ws: WSAssistant):
+        while True:
+            try:
+                await asyncio.sleep(CONSTANTS.WS_PING_INTERVAL)
+                ping_request = WSJSONRequest(payload={"method": "ping"})
+                await ws.send(ping_request)
+            except asyncio.CancelledError:
+                raise
+            except RuntimeError as e:
+                if "WS is not connected" in str(e):
+                    return
+                raise
+            except Exception:
+                self.logger().warning("Error sending ping to LIGHTER WebSocket", exc_info=True)
+                await asyncio.sleep(5.0)  # Wait before retrying
+
+    async def _parse_order_book_snapshot_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
+        """
+        https://docs.LIGHTER.fi/api-documentation/api/websocket/subscriptions/orderbook
+
+        {
+            "channel": "book",
+            "data": {
+                "l": [
+                [
+                    {
+                    "a": "37.86",
+                    "n": 4,
+                    "p": "157.47"
+                    },
+                    // ... other aggegated bid levels
+                ],
+                [
+                    {
+                    "a": "12.7",
+                    "n": 2,
+                    "p": "157.49"
+                    },
+                    {
+                    "a": "44.45",
+                    "n": 3,
+                    "p": "157.5"
+                    },
+                    // ... other aggregated ask levels
+                ]
+                ],
+                "s": "SOL",
+                "t": 1749051881187,
+                "li": 1559885104
+            }
+        }
+        """
+        snapshot_data = raw_message["data"]
+        trading_pair = await self._connector.trading_pair_associated_to_exchange_symbol(symbol=snapshot_data["s"])
+        snapshot_timestamp = snapshot_data["t"] / 1000  # exchange provides time in ms
+        update_id = snapshot_data["li"]
+
+        order_book_message_content = {
+            "trading_pair": trading_pair,
+            "update_id": update_id,
+            "bids": [(bid["p"], bid["a"]) for bid in snapshot_data["l"][0]],
+            "asks": [(ask["p"], ask["a"]) for ask in snapshot_data["l"][1]],
+        }
+        snapshot_msg: OrderBookMessage = OrderBookMessage(
+            OrderBookMessageType.SNAPSHOT,
+            order_book_message_content,
+            snapshot_timestamp)
+
+        message_queue.put_nowait(snapshot_msg)
+
+    async def _parse_trade_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
+        """
+        https://docs.LIGHTER.fi/api-documentation/api/websocket/subscriptions/trades
+
+        {
+            "channel": "trades",
+            "data": [
+                {
+                "u": "42trU9A5...",
+                "h": 80062522,
+                "s": "BTC",
+                "a": "0.00001",
+                "p": "89471",
+                "d": "close_short",
+                "tc": "normal",
+                "t": 1765018379085,
+                "li": 1559885104
+                }
+            ]
+        }
+
+        Trade side:
+        (*) open_long
+        (*) open_short
+        (*) close_long
+        (*) close_short
+        """
+        trade_updates = raw_message["data"]
+
+        for trade_data in trade_updates:
+            trading_pair = await self._connector.trading_pair_associated_to_exchange_symbol(symbol=trade_data["s"])
+            message_content = {
+                "trade_id": trade_data["h"],  # we use history id as trade id
+                "update_id": trade_data["li"],
+                "trading_pair": trading_pair,
+                "trade_type": float(TradeType.BUY.value) if trade_data["d"] in ("open_long", "close_short") else float(TradeType.SELL.value),
+                "amount": trade_data["a"],
+                "price": trade_data["p"]
+            }
+            trade_message: Optional[OrderBookMessage] = OrderBookMessage(
+                message_type=OrderBookMessageType.TRADE,
+                content=message_content,
+                timestamp=trade_data["t"] / 1000  # originally it's time in ms
+            )
+
+            message_queue.put_nowait(trade_message)
+
+    async def _parse_funding_info_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
+        """
+        https://docs.LIGHTER.fi/api-documentation/api/websocket/subscriptions/prices
+
+        {
+            "channel": "prices",
+            "data": [
+                {
+                    "funding": "0.0000125",
+                    "mark": "105473",
+                    "mid": "105476",
+                    "next_funding": "0.0000125",
+                    "open_interest": "0.00524",
+                    "oracle": "105473",
+                    "symbol": "BTC",
+                    "timestamp": 1749051612681,
+                    "volume_24h": "63265.87522",
+                    "yesterday_price": "955476"
+                }
+                // ... other symbol prices
+            ],
+        }
+
+        Index price = Oracle price
+        Next funding timestamp = :00 of next hour
+        """
+        for price_entry in raw_message["data"]:
+            trading_pair = await self._connector.trading_pair_associated_to_exchange_symbol(price_entry["symbol"])
+            if trading_pair not in self._trading_pairs:
+                continue
+
+            info_update = FundingInfoUpdate(
+                trading_pair=trading_pair,
+                index_price=Decimal(price_entry["oracle"]),
+                mark_price=Decimal(price_entry["mark"]),
+                next_funding_utc_timestamp=int((time.time() // 3600 + 1) * 3600),
+                rate=Decimal(price_entry["funding"])
+            )
+
+            message_queue.put_nowait(info_update)
+
+            self._connector.set_LIGHTER_price(
+                trading_pair,
+                timestamp=price_entry["timestamp"] / 1000,
+                index_price=Decimal(price_entry["oracle"]),
+                mark_price=Decimal(price_entry["mark"]),
+            )
+
+    def _channel_originating_message(self, event_message: Dict[str, Any]) -> str:
+        channel = ""
+        if "data" in event_message:
+            event_channel = event_message["channel"]
+            if event_channel == CONSTANTS.WS_ORDER_BOOK_SNAPSHOT_CHANNEL:
+                channel = self._snapshot_messages_queue_key
+            elif event_channel == CONSTANTS.WS_TRADES_CHANNEL:
+                channel = self._trade_messages_queue_key
+            elif event_channel == CONSTANTS.WS_PRICES_CHANNEL:
+                channel = self._funding_info_messages_queue_key
+        return channel
+
+    async def subscribe_to_trading_pair(self, trading_pair: str) -> bool:
+        """
+        Subscribes to order book and trade channels for a single trading pair
+        on the existing WebSocket connection.
+
+        :param trading_pair: the trading pair to subscribe to
+        :return: True if subscription was successful, False otherwise
+        """
+        if self._ws_assistant is None:
+            self.logger().warning(
+                f"Cannot subscribe to {trading_pair}: WebSocket not connected"
+            )
+            return False
+
+        try:
+            symbol = await self._connector.exchange_symbol_associated_to_pair(trading_pair=trading_pair)
+
+            # Subscribe to order book snapshots
+            book_payload = {
+                "method": "subscribe",
+                "params": {
+                    "source": "book",
+                    "symbol": symbol,
+                    "agg_level": 1,
+                },
+            }
+            subscribe_book_request = WSJSONRequest(payload=book_payload)
+
+            # Subscribe to trades
+            trades_payload = {
+                "method": "subscribe",
+                "params": {
+                    "source": "trades",
+                    "symbol": symbol,
+                },
+            }
+            subscribe_trades_request = WSJSONRequest(payload=trades_payload)
+
+            await self._ws_assistant.send(subscribe_book_request)
+            await self._ws_assistant.send(subscribe_trades_request)
+
+            self.add_trading_pair(trading_pair)
+            self.logger().info(f"Subscribed to {trading_pair} order book and trade channels")
+            return True
+
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self.logger().exception(f"Error subscribing to {trading_pair}")
+            return False
+
+    async def unsubscribe_from_trading_pair(self, trading_pair: str) -> bool:
+        """
+        Unsubscribes from order book and trade channels for a single trading pair
+        on the existing WebSocket connection.
+
+        :param trading_pair: the trading pair to unsubscribe from
+        :return: True if unsubscription was successful, False otherwise
+        """
+        if self._ws_assistant is None:
+            self.logger().warning(
+                f"Cannot unsubscribe from {trading_pair}: WebSocket not connected"
+            )
+            return False
+
+        try:
+            symbol = await self._connector.exchange_symbol_associated_to_pair(trading_pair=trading_pair)
+
+            # Unsubscribe from order book snapshots
+            book_payload = {
+                "method": "unsubscribe",
+                "params": {
+                    "source": "book",
+                    "symbol": symbol,
+                    "agg_level": 1,
+                },
+            }
+            unsubscribe_book_request = WSJSONRequest(payload=book_payload)
+
+            # Unsubscribe from trades
+            trades_payload = {
+                "method": "unsubscribe",
+                "params": {
+                    "source": "trades",
+                    "symbol": symbol,
+                },
+            }
+            unsubscribe_trades_request = WSJSONRequest(payload=trades_payload)
+
+            await self._ws_assistant.send(unsubscribe_book_request)
+            await self._ws_assistant.send(unsubscribe_trades_request)
+
+            self.remove_trading_pair(trading_pair)
+            self.logger().info(f"Unsubscribed from {trading_pair} order book and trade channels")
+
+            return True
+
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self.logger().exception(f"Error unsubscribing from {trading_pair}")
+            return False

--- a/hummingbot/connector/derivative/lighter_perpetual/lighter_perpetual_api_order_book_data_source.py
+++ b/hummingbot/connector/derivative/lighter_perpetual/lighter_perpetual_api_order_book_data_source.py
@@ -50,7 +50,7 @@ class LighterPerpetualAPIOrderBookDataSource(PerpetualAPIOrderBookDataSource):
 
     async def _request_order_book_snapshot(self, trading_pair: str) -> Dict[str, Any]:
         """
-        https://docs.LIGHTER.fi/api-documentation/api/rest-api/markets/get-orderbook
+        https://apidocs.lighter.xyz/reference/orderbooks
 
         {
             "success": true,
@@ -120,7 +120,7 @@ class LighterPerpetualAPIOrderBookDataSource(PerpetualAPIOrderBookDataSource):
 
     async def get_funding_info(self, trading_pair: str) -> FundingInfo:
         """
-        https://docs.LIGHTER.fi/api-documentation/api/rest-api/markets/get-prices
+        https://apidocs.lighter.xyz/reference/exchangestats
 
         {
             "success": true,
@@ -254,7 +254,7 @@ class LighterPerpetualAPIOrderBookDataSource(PerpetualAPIOrderBookDataSource):
 
     async def _parse_order_book_snapshot_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
         """
-        https://docs.LIGHTER.fi/api-documentation/api/websocket/subscriptions/orderbook
+        https://apidocs.lighter.xyz/docs/websocket-reference
 
         {
             "channel": "book",
@@ -308,7 +308,7 @@ class LighterPerpetualAPIOrderBookDataSource(PerpetualAPIOrderBookDataSource):
 
     async def _parse_trade_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
         """
-        https://docs.LIGHTER.fi/api-documentation/api/websocket/subscriptions/trades
+        https://apidocs.lighter.xyz/docs/websocket-reference
 
         {
             "channel": "trades",
@@ -355,7 +355,7 @@ class LighterPerpetualAPIOrderBookDataSource(PerpetualAPIOrderBookDataSource):
 
     async def _parse_funding_info_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
         """
-        https://docs.LIGHTER.fi/api-documentation/api/websocket/subscriptions/prices
+        https://apidocs.lighter.xyz/docs/websocket-reference
 
         {
             "channel": "prices",

--- a/hummingbot/connector/derivative/lighter_perpetual/lighter_perpetual_auth.py
+++ b/hummingbot/connector/derivative/lighter_perpetual/lighter_perpetual_auth.py
@@ -1,0 +1,22 @@
+from hummingbot.core.web_assistant.auth import AuthBase
+from hummingbot.core.web_assistant.connections.data_types import RESTRequest, WSRequest
+
+
+class LighterPerpetualAuth(AuthBase):
+    def __init__(self, api_key: str, api_secret: str = "", account_identifier: str = ""):
+        self.api_key = api_key
+        self.api_secret = api_secret
+        self.user_wallet_public_key = account_identifier
+
+    async def rest_authenticate(self, request: RESTRequest) -> RESTRequest:
+        headers = dict(request.headers or {})
+        headers["accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+        if self.api_key:
+            headers["X-Api-Key"] = self.api_key
+        request.headers = headers
+
+        return request
+
+    async def ws_authenticate(self, request: WSRequest) -> WSRequest:
+        return request

--- a/hummingbot/connector/derivative/lighter_perpetual/lighter_perpetual_constants.py
+++ b/hummingbot/connector/derivative/lighter_perpetual/lighter_perpetual_constants.py
@@ -1,0 +1,160 @@
+from hummingbot.core.api_throttler.data_types import LinkedLimitWeightPair, RateLimit
+from hummingbot.core.data_type.in_flight_order import OrderState
+
+EXCHANGE_NAME = "lighter_perpetual"
+DEFAULT_DOMAIN = "lighter_perpetual"
+HB_OT_ID_PREFIX = "HBOT"
+
+# Base URLs
+REST_URL = "https://mainnet.zklighter.elliot.ai/api/v1"
+WSS_URL = "wss://mainnet.zklighter.elliot.ai/stream"
+
+TESTNET_DOMAIN = "lighter_perpetual_testnet"
+TESTNET_REST_URL = "https://testnet.zklighter.elliot.ai/api/v1"
+TESTNET_WSS_URL = "wss://testnet.zklighter.elliot.ai/stream"
+
+# order status mapping
+ORDER_STATE = {
+    "open": OrderState.OPEN,
+    "filled": OrderState.FILLED,
+    "partially_filled": OrderState.PARTIALLY_FILLED,
+    "cancelled": OrderState.CANCELED,
+    "rejected": OrderState.FAILED,
+}
+
+GET_MARKET_ORDER_BOOK_SNAPSHOT_PATH_URL = "/orderbooks"
+GET_ORDER_HISTORY_PATH_URL = "/accountInactiveOrders"
+GET_CANDLES_PATH_URL = "/candles"
+GET_PRICES_PATH_URL = "/exchangeStats"
+GET_POSITIONS_PATH_URL = "/positions"
+GET_FUNDING_HISTORY_PATH_URL = "/fundings"
+SET_LEVERAGE_PATH_URL = "/changeAccountTier"
+CANCEL_ORDER_PATH_URL = "/sendTx"
+EXCHANGE_INFO_PATH_URL = "/orderBooks"
+GET_ACCOUNT_INFO_PATH_URL = "/account"
+GET_ACCOUNT_API_CONFIG_KEYS = "/apikeys"
+CREATE_ACCOUNT_API_CONFIG_KEY = "/tokens_create"
+GET_TRADE_HISTORY_PATH_URL = "/trades"
+GET_FEES_INFO_PATH_URL = "/leaseOptions"
+
+# the API endpoints for market / limit / stop orders are different
+# the support for stop orders is out of the scope for this integration
+CREATE_MARKET_ORDER_PATH_URL = "/sendTx"
+CREATE_LIMIT_ORDER_PATH_URL = "/sendTx"
+
+# Default maximum slippage tolerance for market orders (percentage string, e.g. "5" = 5%)
+MARKET_ORDER_MAX_SLIPPAGE = "5"
+
+# WebSocket Channels
+
+WS_ORDER_BOOK_SNAPSHOT_CHANNEL = "book"
+WS_TRADES_CHANNEL = "trades"
+WS_PRICES_CHANNEL = "prices"
+
+WS_ACCOUNT_ORDER_UPDATES_CHANNEL = "account_order_updates"
+WS_ACCOUNT_POSITIONS_CHANNEL = "account_positions"
+WS_ACCOUNT_INFO_CHANNEL = "account_info"
+WS_ACCOUNT_TRADES_CHANNEL = "account_trades"
+WS_ACCOUNT_ALL_CHANNEL = "account_all"
+
+WS_PING_INTERVAL = 30  # Keep connection alive
+
+# the exchange has different "costs" of the calls for every endpoint
+# plus there're exactly 2 tiers of rate limits: (1) Unidentified IP (2) Valid API Config Key
+# below you could find (in the comments) -- the costs (aka "weight") of each endpoints group
+
+LIGHTER_LIMIT_ID = "LIGHTER_LIMIT"
+
+# Default throttler limits derived from the documented Lighter request budget.
+LIGHTER_TIER_1_LIMIT = 24000
+LIGHTER_TIER_2_LIMIT = 24000
+LIGHTER_LIMIT_INTERVAL = 60
+
+FEE_TIER_LIMITS = {
+    0: 3000,     # doc: 300
+    1: 6000,     # doc: 600
+    2: 12000,    # doc: 1200
+    3: 24000,    # doc: 2400
+    4: 60000,    # doc: 6000
+    5: 120000,   # doc: 12000
+    6: 240000,   # doc: 24000
+    7: 300000,   # doc: 30000
+}
+
+# Costs (x10 of doc values)
+STANDARD_REQUEST_COST = 10       # doc: 1
+ORDER_CANCELLATION_COST = 5      # doc: 0.5
+HEAVY_GET_REQUEST_COST_TIER_1 = 120  # Unidentified IP (doc: 12)
+HEAVY_GET_REQUEST_COST_TIER_2 = 30   # Valid API Config Key (doc: 3)
+
+RATE_LIMITS = [
+    RateLimit(limit_id=LIGHTER_LIMIT_ID, limit=LIGHTER_TIER_1_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL),
+    RateLimit(limit_id=GET_MARKET_ORDER_BOOK_SNAPSHOT_PATH_URL, limit=LIGHTER_TIER_1_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL,
+              linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=HEAVY_GET_REQUEST_COST_TIER_1)]),
+    RateLimit(limit_id=CREATE_LIMIT_ORDER_PATH_URL, limit=LIGHTER_TIER_1_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL,
+              linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=STANDARD_REQUEST_COST)]),
+    RateLimit(limit_id=CREATE_MARKET_ORDER_PATH_URL, limit=LIGHTER_TIER_1_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL,
+              linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=STANDARD_REQUEST_COST)]),
+    RateLimit(limit_id=CANCEL_ORDER_PATH_URL, limit=LIGHTER_TIER_1_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL,
+              linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=ORDER_CANCELLATION_COST)]),
+    RateLimit(limit_id=SET_LEVERAGE_PATH_URL, limit=LIGHTER_TIER_1_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL,
+              linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=STANDARD_REQUEST_COST)]),
+    RateLimit(limit_id=GET_FUNDING_HISTORY_PATH_URL, limit=LIGHTER_TIER_1_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL,
+              linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=HEAVY_GET_REQUEST_COST_TIER_1)]),
+    RateLimit(limit_id=GET_POSITIONS_PATH_URL, limit=LIGHTER_TIER_1_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL,
+              linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=HEAVY_GET_REQUEST_COST_TIER_1)]),
+    RateLimit(limit_id=GET_ORDER_HISTORY_PATH_URL, limit=LIGHTER_TIER_1_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL,
+              linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=HEAVY_GET_REQUEST_COST_TIER_1)]),
+    RateLimit(limit_id=GET_CANDLES_PATH_URL, limit=LIGHTER_TIER_1_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL,
+              linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=HEAVY_GET_REQUEST_COST_TIER_1)]),
+    RateLimit(limit_id=EXCHANGE_INFO_PATH_URL, limit=LIGHTER_TIER_1_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL,
+              linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=HEAVY_GET_REQUEST_COST_TIER_1)]),
+    RateLimit(limit_id=GET_PRICES_PATH_URL, limit=LIGHTER_TIER_1_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL,
+              linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=HEAVY_GET_REQUEST_COST_TIER_1)]),
+    RateLimit(limit_id=GET_ACCOUNT_INFO_PATH_URL, limit=LIGHTER_TIER_1_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL,
+              linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=HEAVY_GET_REQUEST_COST_TIER_1)]),
+    RateLimit(limit_id=GET_ACCOUNT_API_CONFIG_KEYS, limit=LIGHTER_TIER_1_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL,
+              linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=HEAVY_GET_REQUEST_COST_TIER_1)]),
+    RateLimit(limit_id=CREATE_ACCOUNT_API_CONFIG_KEY, limit=LIGHTER_TIER_1_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL,
+              linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=HEAVY_GET_REQUEST_COST_TIER_1)]),
+    RateLimit(limit_id=GET_TRADE_HISTORY_PATH_URL, limit=LIGHTER_TIER_1_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL,
+              linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=HEAVY_GET_REQUEST_COST_TIER_1)]),
+    RateLimit(limit_id=GET_FEES_INFO_PATH_URL, limit=LIGHTER_TIER_1_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL,
+              linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=HEAVY_GET_REQUEST_COST_TIER_1)]),
+]
+
+RATE_LIMITS_TIER_2 = [
+    RateLimit(limit_id=LIGHTER_LIMIT_ID, limit=LIGHTER_TIER_2_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL),
+    RateLimit(limit_id=GET_MARKET_ORDER_BOOK_SNAPSHOT_PATH_URL, limit=LIGHTER_TIER_2_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL,
+              linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=HEAVY_GET_REQUEST_COST_TIER_2)]),
+    RateLimit(limit_id=CREATE_LIMIT_ORDER_PATH_URL, limit=LIGHTER_TIER_2_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL,
+              linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=STANDARD_REQUEST_COST)]),
+    RateLimit(limit_id=CREATE_MARKET_ORDER_PATH_URL, limit=LIGHTER_TIER_2_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL,
+              linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=STANDARD_REQUEST_COST)]),
+    RateLimit(limit_id=CANCEL_ORDER_PATH_URL, limit=LIGHTER_TIER_2_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL,
+              linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=ORDER_CANCELLATION_COST)]),
+    RateLimit(limit_id=SET_LEVERAGE_PATH_URL, limit=LIGHTER_TIER_2_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL,
+              linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=STANDARD_REQUEST_COST)]),
+    RateLimit(limit_id=GET_FUNDING_HISTORY_PATH_URL, limit=LIGHTER_TIER_2_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL,
+              linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=HEAVY_GET_REQUEST_COST_TIER_2)]),
+    RateLimit(limit_id=GET_POSITIONS_PATH_URL, limit=LIGHTER_TIER_2_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL,
+              linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=HEAVY_GET_REQUEST_COST_TIER_2)]),
+    RateLimit(limit_id=GET_ORDER_HISTORY_PATH_URL, limit=LIGHTER_TIER_2_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL,
+              linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=HEAVY_GET_REQUEST_COST_TIER_2)]),
+    RateLimit(limit_id=GET_CANDLES_PATH_URL, limit=LIGHTER_TIER_2_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL,
+              linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=HEAVY_GET_REQUEST_COST_TIER_2)]),
+    RateLimit(limit_id=EXCHANGE_INFO_PATH_URL, limit=LIGHTER_TIER_2_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL,
+              linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=HEAVY_GET_REQUEST_COST_TIER_2)]),
+    RateLimit(limit_id=GET_PRICES_PATH_URL, limit=LIGHTER_TIER_2_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL,
+              linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=HEAVY_GET_REQUEST_COST_TIER_2)]),
+    RateLimit(limit_id=GET_ACCOUNT_INFO_PATH_URL, limit=LIGHTER_TIER_2_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL,
+              linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=HEAVY_GET_REQUEST_COST_TIER_2)]),
+    RateLimit(limit_id=GET_ACCOUNT_API_CONFIG_KEYS, limit=LIGHTER_TIER_2_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL,
+              linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=HEAVY_GET_REQUEST_COST_TIER_2)]),
+    RateLimit(limit_id=CREATE_ACCOUNT_API_CONFIG_KEY, limit=LIGHTER_TIER_2_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL,
+              linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=HEAVY_GET_REQUEST_COST_TIER_2)]),
+    RateLimit(limit_id=GET_TRADE_HISTORY_PATH_URL, limit=LIGHTER_TIER_2_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL,
+              linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=HEAVY_GET_REQUEST_COST_TIER_2)]),
+    RateLimit(limit_id=GET_FEES_INFO_PATH_URL, limit=LIGHTER_TIER_2_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL,
+              linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=HEAVY_GET_REQUEST_COST_TIER_2)]),
+]

--- a/hummingbot/connector/derivative/lighter_perpetual/lighter_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/lighter_perpetual/lighter_perpetual_derivative.py
@@ -51,6 +51,7 @@ class LighterPerpetualDerivative(PerpetualDerivativePyBase):
     web_utils = web_utils
 
     TRADING_FEES_INTERVAL = DAY
+    LIQUIDATION_WARNING_THRESHOLD = Decimal("0.05")
 
     def __init__(
         self,
@@ -94,7 +95,8 @@ class LighterPerpetualDerivative(PerpetualDerivativePyBase):
     @staticmethod
     def _client_order_index_from_order_id(order_id: str) -> int:
         digest = hashlib.sha256(order_id.encode()).digest()
-        return int.from_bytes(digest[:8], byteorder="big", signed=False) & 0x7FFFFFFFFFFFFFFF
+        # Lighter API enforces client_order_index <= 2^48-1 (281474976710655)
+        return int.from_bytes(digest[:8], byteorder="big", signed=False) & ((1 << 48) - 1)
 
     @staticmethod
     def _is_int_string(value: str) -> bool:
@@ -613,6 +615,37 @@ class LighterPerpetualDerivative(PerpetualDerivativePyBase):
 
         return True
 
+    async def _modify_order(
+        self,
+        tracked_order: InFlightOrder,
+        new_price: Decimal,
+        new_amount: Decimal,
+    ) -> Tuple[str, float]:
+        """
+        Amend an open order in-place using the Lighter native modify_order transaction.
+        A single signed transaction is submitted; the exchange order index is preserved.
+        """
+        market_id, size_decimals, price_decimals, _ = await self._get_market_spec(tracked_order.trading_pair)
+        signer_client = self._get_lighter_signer_client()
+
+        base_amount_scaled = int((new_amount * Decimal(f"1e{size_decimals}")).to_integral_value())
+        price_scaled = int((new_price * Decimal(f"1e{price_decimals}")).to_integral_value())
+
+        _, tx_response, error = await signer_client.modify_order(
+            market_index=market_id,
+            order_index=int(tracked_order.exchange_order_id),
+            base_amount=base_amount_scaled,
+            price=price_scaled,
+            api_key_index=self._get_api_key_index(),
+        )
+
+        if error is not None:
+            raise IOError(f"Lighter modify_order signing/send failed: {error}")
+        if tx_response is None or getattr(tx_response, "code", None) != 200:
+            raise IOError(f"Lighter modify_order failed: {tx_response}")
+
+        return str(tracked_order.exchange_order_id), self.current_timestamp
+
     async def _update_balances(self):
         """
         https://docs.LIGHTER.fi/api-documentation/api/rest-api/account/get-account-info
@@ -782,6 +815,7 @@ class LighterPerpetualDerivative(PerpetualDerivativePyBase):
             position_key = self._perpetual_trading.position_key(hb_trading_pair, position_side)
             amount = Decimal(str(position_entry.get("amount") or position_entry.get("position") or "0"))
             entry_price = Decimal(str(position_entry.get("entry_price") or position_entry.get("avg_entry_price") or "0"))
+            liquidation_price = self._extract_liquidation_price(position_entry)
 
             price_record = self.get_LIGHTER_price(hb_trading_pair)
             if price_record is not None:
@@ -800,6 +834,13 @@ class LighterPerpetualDerivative(PerpetualDerivativePyBase):
                     unrealized_pnl = (mark_price - entry_price) * amount
                 else:
                     unrealized_pnl = (entry_price - mark_price) * amount
+
+            self._warn_if_position_near_liquidation(
+                trading_pair=hb_trading_pair,
+                position_side=position_side,
+                mark_price=mark_price,
+                liquidation_price=liquidation_price,
+            )
 
             position = Position(
                 trading_pair=hb_trading_pair,
@@ -1034,6 +1075,22 @@ class LighterPerpetualDerivative(PerpetualDerivativePyBase):
         ```
         """
         symbol = await self.exchange_symbol_associated_to_pair(trading_pair)
+
+        prices_response = await self._api_get(
+            path_url=CONSTANTS.GET_PRICES_PATH_URL,
+            return_err=True,
+        )
+
+        if self._is_ok_response(prices_response):
+            price_entries = prices_response.get("data") or prices_response.get("order_book_stats") or []
+            for price_entry in price_entries:
+                if price_entry.get("symbol") != symbol:
+                    continue
+
+                ticker_price = self._extract_ticker_price(price_entry)
+                if ticker_price is not None:
+                    return float(ticker_price)
+
         params = {
             "symbol": symbol,
             "interval": "1m",
@@ -1047,7 +1104,7 @@ class LighterPerpetualDerivative(PerpetualDerivativePyBase):
 
         candles = response.get("data") or []
         if not candles:
-            self.logger().warning(f"No candle data returned for {trading_pair}, returning 0.0")
+            self.logger().warning(f"No ticker/candle data returned for {trading_pair}, returning 0.0")
             return 0.0
         return float(candles[0]["c"])
 
@@ -1363,6 +1420,7 @@ class LighterPerpetualDerivative(PerpetualDerivativePyBase):
                 "a": str(abs(raw_amount)),
                 "p": str(position_entry.get("avg_entry_price") or "0"),
                 "upnl": str(position_entry.get("unrealized_pnl")) if position_entry.get("unrealized_pnl") is not None else None,
+                "l": position_entry.get("liquidation_price"),
             })
 
         return normalized_entries
@@ -1534,18 +1592,26 @@ class LighterPerpetualDerivative(PerpetualDerivativePyBase):
             position_key = self._perpetual_trading.position_key(hb_trading_pair, position_side)
             amount = Decimal(position_entry["a"])
             entry_price = Decimal(position_entry["p"])
+            liquidation_price = self._extract_liquidation_price(position_entry)
+
+            price_record = self.get_LIGHTER_price(hb_trading_pair)
+            mark_price = price_record.mark_price if price_record is not None else entry_price
 
             provided_unrealized_pnl = position_entry.get("upnl")
             if provided_unrealized_pnl is not None:
                 unrealized_pnl = Decimal(str(provided_unrealized_pnl))
             else:
-                price_record = self.get_LIGHTER_price(hb_trading_pair)
-                mark_price = price_record.mark_price if price_record is not None else entry_price
-
                 if position_side == PositionSide.LONG:
                     unrealized_pnl = (mark_price - entry_price) * amount
                 else:
                     unrealized_pnl = (entry_price - mark_price) * amount
+
+            self._warn_if_position_near_liquidation(
+                trading_pair=hb_trading_pair,
+                position_side=position_side,
+                mark_price=mark_price,
+                liquidation_price=liquidation_price,
+            )
 
             position = Position(
                 trading_pair=hb_trading_pair,
@@ -1695,6 +1761,64 @@ class LighterPerpetualDerivative(PerpetualDerivativePyBase):
         """
         return f"{order_id}_{timestamp}_{fill_base_amount}_{fill_price}"
 
+    @staticmethod
+    def _extract_ticker_price(price_entry: Dict[str, Any]) -> Optional[Decimal]:
+        for field in ("last_trade_price", "last", "mid", "mark", "oracle"):
+            value = price_entry.get(field)
+            if value is None:
+                continue
+            try:
+                return Decimal(str(value))
+            except Exception:
+                continue
+        return None
+
+    @staticmethod
+    def _extract_liquidation_price(position_entry: Dict[str, Any]) -> Optional[Decimal]:
+        raw_value = position_entry.get("liquidation_price")
+        if raw_value is None:
+            raw_value = position_entry.get("l")
+        if raw_value in (None, "", "null"):
+            return None
+
+        try:
+            return Decimal(str(raw_value))
+        except Exception:
+            return None
+
+    def _warn_if_position_near_liquidation(
+        self,
+        trading_pair: str,
+        position_side: PositionSide,
+        mark_price: Decimal,
+        liquidation_price: Optional[Decimal],
+    ):
+        if liquidation_price is None or mark_price <= s_decimal_0 or liquidation_price <= s_decimal_0:
+            return
+
+        if position_side == PositionSide.LONG:
+            if mark_price <= liquidation_price:
+                self.logger().warning(
+                    f"{trading_pair} long position reached liquidation level "
+                    f"(mark={mark_price}, liquidation={liquidation_price})"
+                )
+                return
+            distance = (mark_price - liquidation_price) / mark_price
+        else:
+            if mark_price >= liquidation_price:
+                self.logger().warning(
+                    f"{trading_pair} short position reached liquidation level "
+                    f"(mark={mark_price}, liquidation={liquidation_price})"
+                )
+                return
+            distance = (liquidation_price - mark_price) / mark_price
+
+        if distance <= self.LIQUIDATION_WARNING_THRESHOLD:
+            self.logger().warning(
+                f"{trading_pair} {position_side.name.lower()} position is near liquidation "
+                f"(mark={mark_price}, liquidation={liquidation_price}, buffer={distance:.4%})"
+            )
+
     def round_amount(self, trading_pair: str, amount: Decimal) -> Decimal:
         """
         Round the given amount to the lot size defined in the trading rules for the given symbol
@@ -1776,10 +1900,14 @@ class LighterPerpetualDerivative(PerpetualDerivativePyBase):
             return []
 
         results = []
-        for price_data in response.get("data", []):
+        price_entries = response.get("data") or response.get("order_book_stats") or []
+        for price_data in price_entries:
+            mark = price_data.get("mark") or price_data.get("mid") or price_data.get("last_trade_price")
+            if mark is None:
+                continue
             results.append({
                 "trading_pair": await self.trading_pair_associated_to_exchange_symbol(symbol=price_data["symbol"]),
-                "price": price_data["mark"]
+                "price": mark
             })
 
         return results

--- a/hummingbot/connector/derivative/lighter_perpetual/lighter_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/lighter_perpetual/lighter_perpetual_derivative.py
@@ -406,7 +406,7 @@ class LighterPerpetualDerivative(PerpetualDerivativePyBase):
         """
         e.g.
         {"success":false,"data":null,"error":"Failed to cancel order","code":5}
-        https://docs.LIGHTER.fi/api-documentation/api/error-codes
+        https://apidocs.lighter.xyz/docs/data-structures-constants-and-errors
 
         """
         return '"code":5' in str(cancelation_exception)
@@ -435,7 +435,7 @@ class LighterPerpetualDerivative(PerpetualDerivativePyBase):
 
     async def _format_trading_rules(self, exchange_info_dict: Dict[str, Any]) -> List[TradingRule]:
         """
-        https://docs.LIGHTER.fi/api-documentation/api/rest-api/markets/get-market-info
+        https://apidocs.lighter.xyz/reference/orderbooks
 
         {
             "success": true,
@@ -532,8 +532,8 @@ class LighterPerpetualDerivative(PerpetualDerivativePyBase):
         **kwargs,
     ) -> Tuple[str, float]:
         """
-        https://docs.LIGHTER.fi/api-documentation/api/rest-api/orders/create-market-order
-        https://docs.LIGHTER.fi/api-documentation/api/rest-api/orders/create-limit-order
+        https://apidocs.lighter.xyz/reference/sendtx
+        https://apidocs.lighter.xyz/reference/sendtx
         """
 
         if order_type not in self.supported_order_types():
@@ -597,7 +597,7 @@ class LighterPerpetualDerivative(PerpetualDerivativePyBase):
 
     async def _place_cancel(self, order_id: str, tracked_order: InFlightOrder) -> bool:
         """
-        https://docs.LIGHTER.fi/api-documentation/api/rest-api/orders/cancel-order
+        https://apidocs.lighter.xyz/reference/sendtx
         """
         market_id, _, _, _ = await self._get_market_spec(tracked_order.trading_pair)
         signer_client = self._get_lighter_signer_client()
@@ -648,7 +648,7 @@ class LighterPerpetualDerivative(PerpetualDerivativePyBase):
 
     async def _update_balances(self):
         """
-        https://docs.LIGHTER.fi/api-documentation/api/rest-api/account/get-account-info
+        https://apidocs.lighter.xyz/reference/account
         ```
         {
           "success": true,
@@ -707,7 +707,7 @@ class LighterPerpetualDerivative(PerpetualDerivativePyBase):
 
     async def _update_positions(self):
         """
-        https://docs.LIGHTER.fi/api-documentation/api/rest-api/account/get-positions
+        https://apidocs.lighter.xyz/reference/account
         Positions Info
         ```
           {
@@ -731,7 +731,7 @@ class LighterPerpetualDerivative(PerpetualDerivativePyBase):
         }
         ```
 
-        https://docs.LIGHTER.fi/api-documentation/api/rest-api/markets/get-prices
+        https://apidocs.lighter.xyz/reference/exchangestats
         Prices Info
         ```
          {
@@ -857,7 +857,7 @@ class LighterPerpetualDerivative(PerpetualDerivativePyBase):
         Retrieves trade updates for a specific order using the account trade history endpoint.
         Uses the order's creation timestamp as the start time to filter the trade history.
 
-        https://docs.LIGHTER.fi/api-documentation/api/rest-api/account/get-trade-history
+        https://apidocs.lighter.xyz/reference/trades
 
         Example API response:
         ```
@@ -971,7 +971,7 @@ class LighterPerpetualDerivative(PerpetualDerivativePyBase):
 
     async def _request_order_status(self, tracked_order: InFlightOrder) -> OrderUpdate:
         """
-        https://docs.LIGHTER.fi/api-documentation/api/rest-api/orders/get-order-history-by-id
+        https://apidocs.lighter.xyz/reference/accountinactiveorders
 
         Example API response:
         ```
@@ -1049,7 +1049,7 @@ class LighterPerpetualDerivative(PerpetualDerivativePyBase):
 
     async def _get_last_traded_price(self, trading_pair: str) -> float:
         """
-        https://docs.LIGHTER.fi/api-documentation/api/rest-api/markets/get-candle-data
+        https://apidocs.lighter.xyz/reference/candles
 
         Example API response:
         ```
@@ -1110,7 +1110,7 @@ class LighterPerpetualDerivative(PerpetualDerivativePyBase):
 
     async def _update_trading_fees(self):
         """
-        https://docs.LIGHTER.fi/api-documentation/api/rest-api/account/get-account-info
+        https://apidocs.lighter.xyz/reference/account
         ```
         {
           "success": true,
@@ -1172,7 +1172,7 @@ class LighterPerpetualDerivative(PerpetualDerivativePyBase):
 
     async def _fetch_last_fee_payment(self, trading_pair: str) -> Tuple[float, Decimal, Decimal]:
         """
-        https://docs.LIGHTER.fi/api-documentation/api/rest-api/account/get-funding-history
+        https://apidocs.lighter.xyz/reference/fundings
 
         Example API response:
             {
@@ -1479,7 +1479,7 @@ class LighterPerpetualDerivative(PerpetualDerivativePyBase):
 
     async def _process_account_order_updates_ws_event_message(self, event_message: Dict[str, Any]):
         """
-        https://docs.LIGHTER.fi/api-documentation/api/websocket/subscriptions/account-order-updates
+        https://apidocs.lighter.xyz/docs/websocket-reference
         {
             "channel": "account_order_updates",
             "data": [
@@ -1525,7 +1525,7 @@ class LighterPerpetualDerivative(PerpetualDerivativePyBase):
 
     async def _process_account_positions_ws_event_message(self, event_message: Dict[str, Any]):
         """
-        https://docs.LIGHTER.fi/api-documentation/api/websocket/subscriptions/account-positions
+        https://apidocs.lighter.xyz/docs/websocket-reference
         {
             "channel": "subscribe",
             "data": {
@@ -1625,7 +1625,7 @@ class LighterPerpetualDerivative(PerpetualDerivativePyBase):
 
     async def _process_account_info_ws_event_message(self, event_message: Dict[str, Any]):
         """
-        https://docs.LIGHTER.fi/api-documentation/api/websocket/subscriptions/account-info
+        https://apidocs.lighter.xyz/docs/websocket-reference
         {
             "channel": "account_info",
             "data": {
@@ -1652,7 +1652,7 @@ class LighterPerpetualDerivative(PerpetualDerivativePyBase):
 
     async def _process_account_trades_ws_event_message(self, event_message: Dict[str, Any]):
         """
-        https://docs.LIGHTER.fi/api-documentation/api/websocket/subscriptions/account-trades
+        https://apidocs.lighter.xyz/docs/websocket-reference
         {
             "channel": "account_trades",
             "data": [
@@ -1854,7 +1854,7 @@ class LighterPerpetualDerivative(PerpetualDerivativePyBase):
         Retrieves the prices (mark price) for all trading pairs.
         Required for Rate Oracle support.
 
-        https://docs.LIGHTER.fi/api-documentation/api/rest-api/markets/get-prices
+        https://apidocs.lighter.xyz/reference/exchangestats
         Prices Info
         ```
          {

--- a/hummingbot/connector/derivative/lighter_perpetual/lighter_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/lighter_perpetual/lighter_perpetual_derivative.py
@@ -1,0 +1,1785 @@
+import asyncio
+import hashlib
+import time
+from decimal import Decimal
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple
+
+from bidict import bidict
+
+import hummingbot.connector.derivative.lighter_perpetual.lighter_perpetual_constants as CONSTANTS
+import hummingbot.connector.derivative.lighter_perpetual.lighter_perpetual_web_utils as web_utils
+from hummingbot.connector.constants import DAY
+from hummingbot.connector.derivative.lighter_perpetual.lighter_perpetual_api_order_book_data_source import (
+    LighterPerpetualAPIOrderBookDataSource,
+)
+from hummingbot.connector.derivative.lighter_perpetual.lighter_perpetual_auth import LighterPerpetualAuth
+from hummingbot.connector.derivative.lighter_perpetual.lighter_perpetual_user_stream_data_source import (
+    LighterPerpetualUserStreamDataSource,
+)
+from hummingbot.connector.derivative.position import Position
+from hummingbot.connector.perpetual_derivative_py_base import PerpetualDerivativePyBase
+from hummingbot.connector.trading_rule import TradingRule
+from hummingbot.connector.utils import combine_to_hb_trading_pair
+from hummingbot.core.api_throttler.data_types import RateLimit
+from hummingbot.core.data_type.common import OrderType, PositionAction, PositionMode, PositionSide, TradeType
+from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderUpdate, TradeUpdate
+from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
+from hummingbot.core.data_type.trade_fee import TokenAmount, TradeFeeBase, TradeFeeSchema
+from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
+from hummingbot.core.utils.estimate_fee import build_trade_fee
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+
+s_decimal_0 = Decimal(0)
+
+
+class LighterPerpetualPriceRecord(NamedTuple):
+    """
+    Price record for the specific trading pair
+
+    :param timestamp: the timestamp of the price (in seconds)
+    :param index_price: the index price
+    :param mark_price: the mark price
+    """
+    timestamp: float
+    index_price: Decimal
+    mark_price: Decimal
+
+
+class LighterPerpetualDerivative(PerpetualDerivativePyBase):
+
+    web_utils = web_utils
+
+    TRADING_FEES_INTERVAL = DAY
+
+    def __init__(
+        self,
+        lighter_perpetual_api_key: str,
+        lighter_perpetual_api_secret: str,
+        lighter_perpetual_account_index: str,
+        lighter_perpetual_api_key_index: str = "",
+        lighter_perpetual_private_key: str = "",
+        trading_pairs: Optional[List[str]] = None,
+        trading_required: bool = True,
+        domain: str = CONSTANTS.DEFAULT_DOMAIN,
+        balance_asset_limit: Optional[Dict[str, Dict[str, Decimal]]] = None,
+        rate_limits_share_pct: Decimal = Decimal("100"),
+    ):
+        self.api_key = lighter_perpetual_api_key
+        self.api_secret = lighter_perpetual_api_secret
+        self.account_index = lighter_perpetual_account_index
+        self.api_key_index = lighter_perpetual_api_key_index
+        self.private_key = lighter_perpetual_private_key
+        self.api_config_key = self.api_key
+        self.user_wallet_public_key = self.account_index
+
+        self._domain = domain
+        self._trading_required = trading_required
+        self._trading_pairs = trading_pairs
+
+        self._prices: Dict[str, Optional[LighterPerpetualPriceRecord]] = {
+            trading_pair: None for trading_pair in trading_pairs
+        }
+
+        self._order_history_last_poll_timestamp: Dict[str, float] = {}
+        self._market_id_by_symbol: Dict[str, int] = {}
+        self._size_decimals_by_symbol: Dict[str, int] = {}
+        self._price_decimals_by_symbol: Dict[str, int] = {}
+        self._lighter_signer_client = None
+
+        self._fee_tier = 0
+
+        super().__init__(balance_asset_limit=balance_asset_limit, rate_limits_share_pct=rate_limits_share_pct)
+
+    @staticmethod
+    def _client_order_index_from_order_id(order_id: str) -> int:
+        digest = hashlib.sha256(order_id.encode()).digest()
+        return int.from_bytes(digest[:8], byteorder="big", signed=False) & 0x7FFFFFFFFFFFFFFF
+
+    @staticmethod
+    def _is_int_string(value: str) -> bool:
+        if value is None:
+            return False
+        try:
+            int(str(value))
+            return True
+        except Exception:
+            return False
+
+    def _get_rest_api_key(self) -> str:
+        if self._is_int_string(self.api_key):
+            return self.api_key
+        if self.api_secret:
+            return self.api_secret
+        return self.api_key
+
+    def _get_signer_private_key(self) -> str:
+        if self.private_key:
+            return self.private_key
+        if self.api_key and not self._is_int_string(self.api_key):
+            return self.api_key
+        if self.api_secret and not self._is_int_string(self.api_secret):
+            return self.api_secret
+        raise ValueError(
+            "Lighter signer private key is required for signed transactions. "
+            "Provide lighter_perpetual_private_key (or set lighter_perpetual_api_key to signer private key in compatibility mode)."
+        )
+
+    @property
+    def rest_api_key(self) -> str:
+        return self._get_rest_api_key()
+
+    def _api_host_for_signer(self) -> str:
+        return CONSTANTS.REST_URL.split("/api/v1")[0]
+
+    def _get_api_key_index(self) -> int:
+        if self._is_int_string(self.api_key_index):
+            return int(self.api_key_index)
+        if self._is_int_string(self.api_key):
+            return int(self.api_key)
+        if self._is_int_string(self.api_secret):
+            return int(self.api_secret)
+        raise ValueError(
+            "Lighter API key index must be provided as an integer string in lighter_perpetual_api_key "
+            "or lighter_perpetual_api_secret (compatibility mode)."
+        )
+
+    def _get_account_index(self) -> int:
+        try:
+            return int(self.account_index)
+        except Exception as e:
+            raise ValueError("Lighter account index must be an integer string") from e
+
+    @staticmethod
+    def _is_ok_response(response: Dict[str, Any]) -> bool:
+        if response.get("success") is True:
+            return True
+        code = response.get("code")
+        try:
+            return int(code) == 200
+        except Exception:
+            return False
+
+    def _account_query_params(self) -> Dict[str, Any]:
+        return {
+            "by": "index",
+            "value": str(self._get_account_index()),
+        }
+
+    @staticmethod
+    def _account_from_response(response: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        data = response.get("data")
+        if isinstance(data, dict):
+            return data
+        accounts = response.get("accounts")
+        if isinstance(accounts, list) and len(accounts) > 0:
+            return accounts[0]
+        return None
+
+    def _get_lighter_signer_client(self):
+        if self._lighter_signer_client is None:
+            import lighter
+
+            self._lighter_signer_client = lighter.signer_client.SignerClient(
+                url=self._api_host_for_signer(),
+                account_index=self._get_account_index(),
+                api_private_keys={self._get_api_key_index(): self._get_signer_private_key()},
+            )
+
+        return self._lighter_signer_client
+
+    async def _refresh_market_metadata(self):
+        response = await self._api_get(
+            path_url=CONSTANTS.EXCHANGE_INFO_PATH_URL,
+            return_err=True,
+        )
+
+        for market in response.get("order_books", []):
+            if market.get("market_type") != "perp":
+                continue
+
+            symbol = market["symbol"]
+            self._market_id_by_symbol[symbol] = int(market["market_id"])
+            self._size_decimals_by_symbol[symbol] = int(market.get("supported_size_decimals", 0))
+            self._price_decimals_by_symbol[symbol] = int(market.get("supported_price_decimals", 0))
+
+    async def _get_market_spec(self, trading_pair: str) -> Tuple[int, int, int, str]:
+        symbol = await self.exchange_symbol_associated_to_pair(trading_pair)
+
+        if symbol not in self._market_id_by_symbol:
+            await self._refresh_market_metadata()
+
+        if symbol not in self._market_id_by_symbol:
+            raise ValueError(f"Market metadata not found for symbol {symbol}")
+
+        return (
+            self._market_id_by_symbol[symbol],
+            self._size_decimals_by_symbol.get(symbol, 0),
+            self._price_decimals_by_symbol.get(symbol, 0),
+            symbol,
+        )
+
+    @property
+    def name(self) -> str:
+        return self._domain
+
+    @property
+    def authenticator(self) -> LighterPerpetualAuth:
+        return LighterPerpetualAuth(
+            api_key=self.rest_api_key,
+            api_secret=self.api_secret,
+            account_identifier=self.account_index,
+        )
+
+    @property
+    def rate_limits_rules(self):
+        if not self.api_key:
+            return CONSTANTS.RATE_LIMITS
+
+        tier2_limit = CONSTANTS.FEE_TIER_LIMITS.get(self._fee_tier, CONSTANTS.LIGHTER_TIER_2_LIMIT)
+
+        global_limit = RateLimit(
+            limit_id=CONSTANTS.LIGHTER_LIMIT_ID,
+            limit=tier2_limit,
+            time_interval=CONSTANTS.LIGHTER_LIMIT_INTERVAL
+        )
+
+        return [global_limit] + CONSTANTS.RATE_LIMITS_TIER_2[1:]
+
+    async def _api_request(
+        self,
+        path_url,
+        overwrite_url: Optional[str] = None,
+        method: RESTMethod = RESTMethod.GET,
+        params: Optional[Dict[str, Any]] = None,
+        data: Optional[Dict[str, Any]] = None,
+        is_auth_required: bool = False,
+        return_err: bool = False,
+        limit_id: Optional[str] = None,
+        headers: Optional[Dict[str, Any]] = None,
+        **kwargs
+    ) -> Dict[str, Any]:
+
+        if self.rest_api_key:
+            api_headers = {"X-Api-Key": self.rest_api_key}
+            if headers:
+                headers.update(api_headers)
+            else:
+                headers = api_headers
+
+        return await super()._api_request(
+            path_url=path_url,
+            overwrite_url=overwrite_url,
+            method=method,
+            params=params,
+            data=data,
+            is_auth_required=is_auth_required,
+            return_err=return_err,
+            limit_id=limit_id,
+            headers=headers,
+            **kwargs
+        )
+
+    async def _api_request_url(self, path_url: str, is_auth_required: bool = False) -> str:
+        return web_utils.private_rest_url(path_url, domain=self._domain)
+
+    async def _fetch_or_create_api_config_key(self):
+        if self.api_config_key and self._is_int_string(self.api_key_index):
+            return
+
+        if not self.account_index or not self.rest_api_key:
+            self.logger().warning("Lighter account index or REST API key is missing; skipping API key discovery")
+            return
+
+        response = await self._api_get(
+            path_url=CONSTANTS.GET_ACCOUNT_API_CONFIG_KEYS,
+            params={"account_index": self._get_account_index(), "api_key_index": 255},
+            is_auth_required=True,
+            return_err=True,
+        )
+
+        api_keys = response.get("api_keys") or []
+        matching_key = next(
+            (
+                api_key
+                for api_key in api_keys
+                if str(api_key.get("public_key", "")).lower() == str(self.rest_api_key).lower()
+            ),
+            None,
+        )
+
+        if matching_key is not None:
+            self.api_key_index = str(matching_key.get("api_key_index"))
+            self.api_config_key = self.rest_api_key
+            self.logger().info(f"Resolved Lighter API key index: {self.api_key_index}")
+            if self._throttler:
+                self._throttler.set_rate_limits(self.rate_limits_rules)
+            return
+
+        self.logger().warning(
+            "Configured Lighter REST API key was not found in /apikeys response. "
+            "Provide lighter_perpetual_api_key_index explicitly or onboard/register the API key on Lighter first."
+        )
+
+    def generate_api_key_pair(self) -> Tuple[str, str]:
+        try:
+            import lighter
+        except Exception as e:
+            raise ImportError("lighter SDK package is required for Lighter API key generation") from e
+
+        private_key, public_key, error = lighter.create_api_key()
+        if error:
+            raise ValueError(f"Failed to generate Lighter API key pair: {error}")
+        return private_key, public_key
+
+    @property
+    def domain(self):
+        return self._domain
+
+    @property
+    def client_order_id_max_length(self):
+        return 32
+
+    @property
+    def client_order_id_prefix(self):
+        return CONSTANTS.HB_OT_ID_PREFIX
+
+    @property
+    def trading_rules_request_path(self):
+        return CONSTANTS.EXCHANGE_INFO_PATH_URL
+
+    @property
+    def trading_pairs_request_path(self):
+        return CONSTANTS.EXCHANGE_INFO_PATH_URL
+
+    @property
+    def check_network_request_path(self):
+        # LIGHTER does not expose a dedicated ping or time endpoint.
+        # Use the lighter market-stats route instead of the full metadata payload.
+        return CONSTANTS.GET_PRICES_PATH_URL
+
+    @property
+    def trading_pairs(self) -> Optional[List[str]]:
+        return self._trading_pairs
+
+    @property
+    def is_cancel_request_in_exchange_synchronous(self) -> bool:
+        return True
+
+    @property
+    def is_trading_required(self) -> bool:
+        return self._trading_required
+
+    @property
+    def funding_fee_poll_interval(self) -> int:
+        # actually it updates every hour
+        # but there's a chance that the bot was started 5 minutes before update
+        # so we would wait extra hour
+        # so query every 2 minutes should work
+        return 120
+
+    def supported_order_types(self) -> List[OrderType]:
+        return [OrderType.LIMIT, OrderType.LIMIT_MAKER, OrderType.MARKET]
+
+    def supported_position_modes(self) -> List[PositionMode]:
+        return [PositionMode.ONEWAY]
+
+    def get_buy_collateral_token(self, trading_pair: str) -> str:
+        return "USDC"
+
+    def get_sell_collateral_token(self, trading_pair: str) -> str:
+        return "USDC"
+
+    def _is_request_exception_related_to_time_synchronizer(self, request_exception: Exception):
+        return False
+
+    def _is_order_not_found_during_status_update_error(self, status_update_exception: Exception) -> bool:
+        """
+        e.g.
+        {"success":false,"data":null,"error":"Order history not found for order ID: 28416222569","code":404}
+        """
+        return "not found" in str(status_update_exception)
+
+    def _is_order_not_found_during_cancelation_error(self, cancelation_exception: Exception) -> bool:
+        """
+        e.g.
+        {"success":false,"data":null,"error":"Failed to cancel order","code":5}
+        https://docs.LIGHTER.fi/api-documentation/api/error-codes
+
+        """
+        return '"code":5' in str(cancelation_exception)
+
+    def _create_web_assistants_factory(self) -> WebAssistantsFactory:
+        return web_utils.build_api_factory(
+            throttler=self._throttler,
+            auth=self._auth,
+        )
+
+    def _create_order_book_data_source(self) -> OrderBookTrackerDataSource:
+        return LighterPerpetualAPIOrderBookDataSource(
+            trading_pairs=self._trading_pairs,
+            connector=self,
+            api_factory=self._web_assistants_factory,
+            domain=self._domain,
+        )
+
+    def _create_user_stream_data_source(self) -> UserStreamTrackerDataSource:
+        return LighterPerpetualUserStreamDataSource(
+            connector=self,
+            api_factory=self._web_assistants_factory,
+            auth=self._auth,
+            domain=self._domain,
+        )
+
+    async def _format_trading_rules(self, exchange_info_dict: Dict[str, Any]) -> List[TradingRule]:
+        """
+        https://docs.LIGHTER.fi/api-documentation/api/rest-api/markets/get-market-info
+
+        {
+            "success": true,
+            "data": [
+                {
+                "symbol": "ETH",
+                "tick_size": "0.1",
+                "min_tick": "0",
+                "max_tick": "1000000",
+                "lot_size": "0.0001",
+                "max_leverage": 50,
+                "isolated_only": false,
+                "min_order_size": "10",
+                "max_order_size": "5000000",
+                "funding_rate": "0.0000125",
+                "next_funding_rate": "0.0000125",
+                "created_at": 1748881333944
+                },
+                {
+                "symbol": "BTC",
+                "tick_size": "1",
+                "min_tick": "0",
+                "max_tick": "1000000",
+                "lot_size": "0.00001",
+                "max_leverage": 50,
+                "isolated_only": false,
+                "min_order_size": "10",
+                "max_order_size": "5000000",
+                "funding_rate": "0.0000125",
+                "next_funding_rate": "0.0000125",
+                "created_at": 1748881333944
+                },
+                ....
+            ],
+            "error": null,
+            "code": null
+        }
+        """
+        rules = []
+
+        order_books = exchange_info_dict.get("order_books")
+        if order_books:
+            for pair_info in order_books:
+                if pair_info.get("market_type") != "perp":
+                    continue
+
+                symbol = pair_info["symbol"]
+                size_decimals = int(pair_info.get("supported_size_decimals", 0))
+                price_decimals = int(pair_info.get("supported_price_decimals", 0))
+                lot_size = Decimal(f"1e-{size_decimals}")
+                tick_size = Decimal(f"1e-{price_decimals}")
+                min_notional = Decimal(str(pair_info.get("min_quote_amount", "10")))
+
+                self._market_id_by_symbol[symbol] = int(pair_info["market_id"])
+                self._size_decimals_by_symbol[symbol] = size_decimals
+                self._price_decimals_by_symbol[symbol] = price_decimals
+
+                rules.append(
+                    TradingRule(
+                        trading_pair=await self.trading_pair_associated_to_exchange_symbol(symbol=symbol),
+                        min_order_size=lot_size,
+                        min_price_increment=tick_size,
+                        min_base_amount_increment=lot_size,
+                        min_notional_size=min_notional,
+                        min_order_value=min_notional,
+                    )
+                )
+
+            return rules
+
+        for pair_info in exchange_info_dict.get("data", []):
+            rules.append(
+                TradingRule(
+                    trading_pair=await self.trading_pair_associated_to_exchange_symbol(symbol=pair_info["symbol"]),
+                    min_order_size=Decimal(pair_info["lot_size"]),
+                    min_price_increment=Decimal(pair_info["tick_size"]),
+                    min_base_amount_increment=Decimal(pair_info["lot_size"]),
+                    min_notional_size=Decimal(pair_info["min_order_size"]),
+                    min_order_value=Decimal(pair_info["min_order_size"]),
+                )
+            )
+
+        return rules
+
+    async def _place_order(
+        self,
+        order_id: str,
+        trading_pair: str,
+        amount: Decimal,
+        trade_type: TradeType,
+        order_type: OrderType,
+        price: Decimal,
+        position_action: PositionAction = PositionAction.NIL,
+        **kwargs,
+    ) -> Tuple[str, float]:
+        """
+        https://docs.LIGHTER.fi/api-documentation/api/rest-api/orders/create-market-order
+        https://docs.LIGHTER.fi/api-documentation/api/rest-api/orders/create-limit-order
+        """
+
+        if order_type not in self.supported_order_types():
+            raise ValueError(f"Order type {order_type} is not supported by {self.name}.")
+
+        # the exchange APIs let you pass client order id, which must be a UUID string
+        # in order to do that, we should change the behaviour of
+        # hummingbot.connector.utils.py:get_new_client_order_id(...) function
+        # which is used to generate client order IDs in self.buy() / self.sell() functions
+
+        # Until Hummingbot client IDs can be emitted as UUID strings, the connector uses
+        # the exchange order id for follow-up status, fill, and cancellation operations.
+
+        market_id, size_decimals, price_decimals, _ = await self._get_market_spec(trading_pair)
+        signer_client = self._get_lighter_signer_client()
+
+        base_amount_scaled = int((amount * Decimal(f"1e{size_decimals}")).to_integral_value())
+        price_scaled = int((price * Decimal(f"1e{price_decimals}")).to_integral_value())
+
+        signer_order_type = signer_client.ORDER_TYPE_LIMIT
+        signer_tif = signer_client.ORDER_TIME_IN_FORCE_GOOD_TILL_TIME
+        order_expiry = signer_client.DEFAULT_28_DAY_ORDER_EXPIRY
+        if order_type == OrderType.MARKET:
+            signer_order_type = signer_client.ORDER_TYPE_MARKET
+            signer_tif = signer_client.ORDER_TIME_IN_FORCE_IMMEDIATE_OR_CANCEL
+            order_expiry = signer_client.DEFAULT_IOC_EXPIRY
+        elif order_type == OrderType.LIMIT_MAKER:
+            signer_tif = signer_client.ORDER_TIME_IN_FORCE_POST_ONLY
+
+        client_order_index = self._client_order_index_from_order_id(order_id)
+        _, tx_response, error = await signer_client.create_order(
+            market_index=market_id,
+            client_order_index=client_order_index,
+            base_amount=base_amount_scaled,
+            price=price_scaled,
+            is_ask=(trade_type == TradeType.SELL),
+            order_type=signer_order_type,
+            time_in_force=signer_tif,
+            reduce_only=position_action == PositionAction.CLOSE,
+            order_expiry=order_expiry,
+            api_key_index=self._get_api_key_index(),
+        )
+
+        if error is not None:
+            raise IOError(f"Lighter create_order signing/send failed: {error}")
+        if tx_response is None or getattr(tx_response, "code", None) != 200:
+            raise IOError(f"Lighter create_order failed: {tx_response}")
+
+        return str(client_order_index), self.current_timestamp
+
+    def _set_usdc_balances(self, total_balance: Decimal, available_balance: Decimal):
+        asset = "USDC"
+
+        self._account_balances[asset] = total_balance
+        self._account_available_balances[asset] = available_balance
+
+        for balances_dict in (self._account_balances, self._account_available_balances):
+            stale_assets = [tracked_asset for tracked_asset in balances_dict if tracked_asset != asset]
+            for stale_asset in stale_assets:
+                del balances_dict[stale_asset]
+
+    async def _place_cancel(self, order_id: str, tracked_order: InFlightOrder) -> bool:
+        """
+        https://docs.LIGHTER.fi/api-documentation/api/rest-api/orders/cancel-order
+        """
+        market_id, _, _, _ = await self._get_market_spec(tracked_order.trading_pair)
+        signer_client = self._get_lighter_signer_client()
+
+        _, tx_response, error = await signer_client.cancel_order(
+            market_index=market_id,
+            order_index=int(tracked_order.exchange_order_id),
+            api_key_index=self._get_api_key_index(),
+        )
+
+        if error is not None:
+            raise IOError(f"Lighter cancel_order signing/send failed: {error}")
+        if tx_response is None or getattr(tx_response, "code", None) != 200:
+            raise IOError(f"Lighter cancel_order failed: {tx_response}")
+
+        return True
+
+    async def _update_balances(self):
+        """
+        https://docs.LIGHTER.fi/api-documentation/api/rest-api/account/get-account-info
+        ```
+        {
+          "success": true,
+          "data": [{
+            "balance": "2000.000000",
+            "fee_level": 0,
+            "maker_fee": "0.00015",
+            "taker_fee": "0.0004",
+            "account_equity": "2150.250000",
+            "available_to_spend": "1800.750000",
+            "available_to_withdraw": "1500.850000",
+            "pending_balance": "0.000000",
+            "total_margin_used": "349.500000",
+            "cross_mmr": "420.690000",
+            "positions_count": 2,
+            "orders_count": 3,
+            "stop_orders_count": 1,
+            "updated_at": 1716200000000,
+            "use_ltp_for_stop_orders": false
+          }
+        ],
+          "error": null,
+          "code": null
+        }
+        ```
+        """
+        response = await self._api_get(
+            path_url=CONSTANTS.GET_ACCOUNT_INFO_PATH_URL,
+            params=self._account_query_params(),
+            return_err=True
+        )
+
+        if not self._is_ok_response(response):
+            self.logger().error(f"[_update_balances] Failed to update balances (api responded with failure): {response}")
+            return
+
+        data = self._account_from_response(response)
+        if not data:
+            self.logger().error(f"[_update_balances] Failed to update balances (no data): {response}")
+            return
+
+        total_balance = data.get("account_equity") or data.get("equity") or data.get("collateral") or "0"
+        available_balance = (
+            data.get("available_to_spend")
+            or data.get("availableForTrade")
+            or data.get("available_balance")
+            or data.get("availableCollateral")
+            or total_balance
+        )
+
+        self._set_usdc_balances(
+            total_balance=Decimal(str(total_balance)),
+            available_balance=Decimal(str(available_balance)),
+        )
+        self._fee_tier = data.get("fee_level", 0)
+
+    async def _update_positions(self):
+        """
+        https://docs.LIGHTER.fi/api-documentation/api/rest-api/account/get-positions
+        Positions Info
+        ```
+          {
+            "success": true,
+            "data": [
+                {
+                "symbol": "AAVE",
+                "side": "ask",
+                "amount": "223.72",
+                "entry_price": "279.283134",
+                "margin": "0", // only shown for isolated margin
+                "funding": "13.159593",
+                "isolated": false,
+                "created_at": 1754928414996,
+                "updated_at": 1759223365538
+                }
+            ],
+            "error": null,
+            "code": null,
+            "last_order_id": 1557431179
+        }
+        ```
+
+        https://docs.LIGHTER.fi/api-documentation/api/rest-api/markets/get-prices
+        Prices Info
+        ```
+         {
+            "success": true,
+            "data": [
+                {
+                "funding": "0.00010529",
+                "mark": "1.084819",
+                "mid": "1.08615",
+                "next_funding": "0.00011096",
+                "open_interest": "3634796",
+                "oracle": "1.084524",
+                "symbol": "XPL",
+                "timestamp": 1759222967974,
+                "volume_24h": "20896698.0672",
+                "yesterday_price": "1.3412"
+                }
+            ],
+            "error": null,
+            "code": null
+        }
+        ```
+        """
+        response = await self._api_get(
+            path_url=CONSTANTS.GET_ACCOUNT_INFO_PATH_URL,
+            params=self._account_query_params(),
+            return_err=True,
+        )
+
+        if not self._is_ok_response(response):
+            self.logger().error(f"[_update_positions] Failed to update positions (api responded with failure): {response}")
+            return
+
+        account_data = self._account_from_response(response)
+        if not account_data:
+            self.logger().error(f"[_update_positions] Failed to update positions (no account data): {response}")
+            return
+
+        position_entries = account_data.get("positions") or response.get("data") or []
+
+        position_symbols = [position_entry["symbol"] for position_entry in position_entries if position_entry.get("symbol")]
+        position_trading_pairs = [
+            await self.trading_pair_associated_to_exchange_symbol(position_symbol) for position_symbol in position_symbols
+        ]
+        if any([self.get_LIGHTER_price(position_trading_pair) is None for position_trading_pair in position_trading_pairs]):
+            self.logger().info("[_update_positions] Prices cache is empty. Going to fetch prices via HTTP.")
+            # we should update the cache
+            # in future we could also consider to add some cache invalidation rules (e.g. timestamp too old)
+            prices_response = await self._api_get(
+                path_url=CONSTANTS.GET_PRICES_PATH_URL,
+                return_err=True,
+            )
+            if not self._is_ok_response(prices_response):
+                self.logger().error(f"[_update_positions] Failed to update prices cache using HTTP API: {response}")
+                return
+            price_entries = prices_response.get("data") or prices_response.get("order_book_stats") or []
+            for price_entry in price_entries:
+                if price_entry["symbol"] not in position_symbols:
+                    continue
+                hb_trading_pair = await self.trading_pair_associated_to_exchange_symbol(price_entry["symbol"])
+                mark_price = price_entry.get("mark") or price_entry.get("mid") or price_entry.get("last_trade_price") or "0"
+                index_price = price_entry.get("oracle") or price_entry.get("mid") or price_entry.get("last_trade_price") or mark_price
+                timestamp = price_entry.get("timestamp") or int(time.time() * 1000)
+                self.set_LIGHTER_price(
+                    trading_pair=hb_trading_pair,
+                    timestamp=timestamp / 1000,
+                    index_price=Decimal(str(index_price)),
+                    mark_price=Decimal(str(mark_price)),
+                )
+
+        # if there're 2 positions available, it will only show those 2
+        # if one of those 2 positions is closed -- you will see only 1
+        # so it make sense to clear the storage of positions
+        # and fill it with the positions from the response
+        self._perpetual_trading.account_positions.clear()
+
+        for position_entry in position_entries:
+            hb_trading_pair = await self.trading_pair_associated_to_exchange_symbol(position_entry["symbol"])
+            sign = int(position_entry.get("sign", 1))
+            position_side = PositionSide.LONG if sign >= 0 else PositionSide.SHORT
+            position_key = self._perpetual_trading.position_key(hb_trading_pair, position_side)
+            amount = Decimal(str(position_entry.get("amount") or position_entry.get("position") or "0"))
+            entry_price = Decimal(str(position_entry.get("entry_price") or position_entry.get("avg_entry_price") or "0"))
+
+            price_record = self.get_LIGHTER_price(hb_trading_pair)
+            if price_record is not None:
+                mark_price = price_record.mark_price
+            else:
+                # Use the unrealized_pnl from the event if available, otherwise default to entry_price
+                upnl_str = position_entry.get("unrealized_pnl")
+                if upnl_str is not None:
+                    unrealized_pnl = Decimal(str(upnl_str))
+                else:
+                    unrealized_pnl = Decimal("0")
+                mark_price = entry_price  # fallback so PnL calc below yields zero if no event pnl
+
+            if price_record is not None:
+                if position_side == PositionSide.LONG:
+                    unrealized_pnl = (mark_price - entry_price) * amount
+                else:
+                    unrealized_pnl = (entry_price - mark_price) * amount
+
+            position = Position(
+                trading_pair=hb_trading_pair,
+                position_side=position_side,
+                unrealized_pnl=unrealized_pnl,
+                entry_price=entry_price,
+                amount=amount * (Decimal("-1.0") if position_side == PositionSide.SHORT else Decimal("1.0")),
+                leverage=Decimal(self.get_leverage(hb_trading_pair))
+            )
+            self._perpetual_trading.set_position(position_key, position)
+
+    async def _all_trade_updates_for_order(self, order: InFlightOrder) -> List[TradeUpdate]:
+        """
+        Retrieves trade updates for a specific order using the account trade history endpoint.
+        Uses the order's creation timestamp as the start time to filter the trade history.
+
+        https://docs.LIGHTER.fi/api-documentation/api/rest-api/account/get-trade-history
+
+        Example API response:
+        ```
+        {
+            "success": true,
+            "data": [
+                {
+                    "history_id": 19329801,
+                    "order_id": 315293920,
+                    "client_order_id": "acf...",
+                    "symbol": "LDO",
+                    "amount": "0.1",
+                    "price": "1.1904",
+                    "entry_price": "1.176247",
+                    "fee": "0",
+                    "pnl": "-0.001415",
+                    "event_type": "fulfill_maker",
+                    "side": "close_short",
+                    "created_at": 1759215599188,
+                    "cause": "normal"
+                }
+            ],
+            "next_cursor": "11111Z5RK",
+            "has_more": true
+        }
+        ```
+        """
+        trade_updates = []
+
+        # Use cached last poll timestamp or order creation time as start_time
+        last_poll_timestamp = self._order_history_last_poll_timestamp.get(order.exchange_order_id)
+        if last_poll_timestamp:
+            start_time = int(last_poll_timestamp * 1000)
+        else:
+            start_time = int(order.creation_timestamp * 1000)
+
+        current_time = self.current_timestamp
+        end_time = int(current_time * 1000)
+
+        params = {
+            "account": self.user_wallet_public_key,
+            "start_time": start_time,
+            "end_time": end_time,
+            "limit": 100,
+        }
+
+        while True:
+            response = await self._api_get(
+                path_url=CONSTANTS.GET_TRADE_HISTORY_PATH_URL,
+                params=params,
+            )
+
+            if not response.get("success") or not response.get("data"):
+                break
+
+            for trade_message in response["data"]:
+                exchange_order_id = str(trade_message["order_id"])
+
+                if exchange_order_id != order.exchange_order_id:
+                    continue
+
+                fill_timestamp = trade_message["created_at"] / 1000
+                fill_price = Decimal(trade_message["price"])
+                fill_base_amount = Decimal(trade_message["amount"])
+
+                trade_id = self.get_LIGHTER_finance_trade_id(
+                    order_id=trade_message["order_id"],
+                    timestamp=fill_timestamp,
+                    fill_base_amount=fill_base_amount,
+                    fill_price=fill_price,
+                )
+
+                fee_amount = Decimal(trade_message["fee"])
+                fee_asset = order.quote_asset
+
+                position_action = PositionAction.OPEN if trade_message["side"] in ("open_long", "open_short", ) else PositionAction.CLOSE
+
+                fee = TradeFeeBase.new_perpetual_fee(
+                    fee_schema=self.trade_fee_schema(),
+                    position_action=position_action,
+                    percent_token=fee_asset,
+                    flat_fees=[TokenAmount(
+                        amount=fee_amount,
+                        token=fee_asset
+                    )]
+                )
+
+                is_taker = trade_message["event_type"] == "fulfill_taker"
+
+                trade_updates.append(TradeUpdate(
+                    trade_id=trade_id,
+                    client_order_id=order.client_order_id,
+                    exchange_order_id=order.exchange_order_id,
+                    trading_pair=order.trading_pair,
+                    fill_timestamp=fill_timestamp,
+                    fill_price=fill_price,
+                    fill_base_amount=fill_base_amount,
+                    fill_quote_amount=fill_price * fill_base_amount,
+                    fee=fee,
+                    is_taker=is_taker,
+                ))
+
+            if response.get("has_more") and response.get("next_cursor"):
+                params["cursor"] = response["next_cursor"]
+            else:
+                break
+
+        self._order_history_last_poll_timestamp[order.exchange_order_id] = current_time
+
+        return trade_updates
+
+    async def _request_order_status(self, tracked_order: InFlightOrder) -> OrderUpdate:
+        """
+        https://docs.LIGHTER.fi/api-documentation/api/rest-api/orders/get-order-history-by-id
+
+        Example API response:
+        ```
+        {
+            "success": true,
+            "data": [
+                {
+                "history_id": 641452639,
+                "order_id": 315992721,
+                "client_order_id": "ade1aa6...",
+                "symbol": "XPL",
+                "side": "ask",
+                "price": "1.0865",
+                "initial_amount": "984",
+                "filled_amount": "0",
+                "cancelled_amount": "984",
+                "event_type": "cancel",
+                "order_type": "limit",
+                "order_status": "cancelled",
+                "stop_price": null,
+                "stop_parent_order_id": null,
+                "reduce_only": false,
+                "created_at": 1759224895038
+                },
+                {
+                "history_id": 641452513,
+                "order_id": 315992721,
+                "client_order_id": "ade1aa6...",
+                "symbol": "XPL",
+                "side": "ask",
+                "price": "1.0865",
+                "initial_amount": "984",
+                "filled_amount": "0",
+                "cancelled_amount": "0",
+                "event_type": "make",
+                "order_type": "limit",
+                "order_status": "open",
+                "stop_price": null,
+                "stop_parent_order_id": null,
+                "reduce_only": false,
+                "created_at": 1759224893638
+                }
+            ],
+            "error": null,
+            "code": null
+        }
+        ```
+        """
+        response = await self._api_get(
+            path_url=CONSTANTS.GET_ORDER_HISTORY_PATH_URL,
+            params={
+                "order_id": tracked_order.exchange_order_id,
+            },
+        )
+
+        data = response.get("data")
+        if not data:
+            raise IOError(
+                f"Order status query returned empty data for order {tracked_order.exchange_order_id}: {response}"
+            )
+
+        order_entry = data[0]
+        raw_status = order_entry.get("order_status", "")
+        order_status = CONSTANTS.ORDER_STATE.get(raw_status)
+        if order_status is None:
+            raise IOError(f"Unknown order status '{raw_status}' for order {tracked_order.exchange_order_id}")
+
+        return OrderUpdate(
+            trading_pair=tracked_order.trading_pair,
+            update_timestamp=order_entry.get("created_at", 0) / 1000,
+            new_state=order_status,
+            client_order_id=tracked_order.client_order_id,
+            exchange_order_id=tracked_order.exchange_order_id,
+        )
+
+    async def _get_last_traded_price(self, trading_pair: str) -> float:
+        """
+        https://docs.LIGHTER.fi/api-documentation/api/rest-api/markets/get-candle-data
+
+        Example API response:
+        ```
+        {
+            "success": true,
+            "data": [
+                {
+                "t": 1748954160000,
+                "T": 1748954220000,
+                "s": "BTC",
+                "i": "1m",
+                "o": "105376",
+                "c": "105376",
+                "h": "105376",
+                "l": "105376",
+                "v": "0.00022",
+                "n": 2
+                }
+            ],
+            "error": null,
+            "code": null
+        }
+        ```
+        """
+        symbol = await self.exchange_symbol_associated_to_pair(trading_pair)
+        params = {
+            "symbol": symbol,
+            "interval": "1m",
+            "start_time": int(time.time() * 1000) - 60 * 1000,
+        }
+
+        response = await self._api_get(
+            path_url=CONSTANTS.GET_CANDLES_PATH_URL,
+            params=params,
+        )
+
+        candles = response.get("data") or []
+        if not candles:
+            self.logger().warning(f"No candle data returned for {trading_pair}, returning 0.0")
+            return 0.0
+        return float(candles[0]["c"])
+
+    async def _update_trading_fees(self):
+        """
+        https://docs.LIGHTER.fi/api-documentation/api/rest-api/account/get-account-info
+        ```
+        {
+          "success": true,
+          "data": [{
+            "balance": "2000.000000",
+            "fee_level": 0,
+            "maker_fee": "0.00015",
+            "taker_fee": "0.0004",
+            "account_equity": "2150.250000",
+            "available_to_spend": "1800.750000",
+            "available_to_withdraw": "1500.850000",
+            "pending_balance": "0.000000",
+            "total_margin_used": "349.500000",
+            "cross_mmr": "420.690000",
+            "positions_count": 2,
+            "orders_count": 3,
+            "stop_orders_count": 1,
+            "updated_at": 1716200000000,
+            "use_ltp_for_stop_orders": false
+          }
+        ],
+          "error": null,
+          "code": null
+        }
+        ```
+        """
+        response = await self._api_get(
+            path_url=CONSTANTS.GET_ACCOUNT_INFO_PATH_URL,
+            params=self._account_query_params(),
+            return_err=True
+        )
+
+        # comparison with True is needed, bc we might expect a string to be there
+        # while the only indicator of success here is True boolean value
+        if not self._is_ok_response(response):
+            self.logger().error(f"[_update_trading_fees] Failed to update trading fees (api responded with failure): {response}")
+            return
+
+        data = self._account_from_response(response)
+        if not data:
+            self.logger().error(f"[_update_trading_fees] Failed to update trading fees (no data): {response}")
+            return
+
+        maker_fee = data.get("maker_fee")
+        taker_fee = data.get("taker_fee")
+        if maker_fee is None or taker_fee is None:
+            self.logger().debug("[_update_trading_fees] Live account response does not expose maker/taker fee rates; keeping existing/default fees")
+            return
+
+        trade_fee_schema = TradeFeeSchema(
+            maker_percent_fee_decimal=Decimal(data["maker_fee"]),
+            taker_percent_fee_decimal=Decimal(data["taker_fee"]),
+        )
+
+        for trading_pair in self._trading_pairs:
+            self._trading_fees[trading_pair] = trade_fee_schema
+
+        self.logger().info("Trading fees updated")
+
+    async def _fetch_last_fee_payment(self, trading_pair: str) -> Tuple[float, Decimal, Decimal]:
+        """
+        https://docs.LIGHTER.fi/api-documentation/api/rest-api/account/get-funding-history
+
+        Example API response:
+            {
+                "success": true,
+                "data": [
+                    {
+                        "history_id": 2287920,
+                        "symbol": "PUMP",
+                        "side": "ask",
+                        "amount": "39033804",
+                        "payout": "2.617479",
+                        "rate": "0.0000125",
+                        "created_at": 1759222804122
+                    },
+                    ...
+                ],
+                "next_cursor": "11114Lz77",
+                "has_more": true
+            }
+        """
+        symbol = await self.exchange_symbol_associated_to_pair(trading_pair)
+
+        response = await self._api_get(
+            path_url=CONSTANTS.GET_FUNDING_HISTORY_PATH_URL,
+            params={
+                "account": self.user_wallet_public_key,
+                "limit": 100,
+            },
+            return_err=True
+        )
+
+        if not response.get("success") is True:
+            self.logger().error(f"Failed to fetch last fee payment (api responded with failure): {response}")
+            return 0, Decimal("-1"), Decimal("-1")
+
+        data = response.get("data")
+        if not data:
+            self.logger().debug(f"Failed to fetch last fee payment (no data): {response}")
+            return 0, Decimal("-1"), Decimal("-1")
+
+        # check if the first page has the trading pair we need
+        for funding_history_item in data:
+            if funding_history_item["symbol"] == symbol:
+                return funding_history_item["created_at"], Decimal(funding_history_item["rate"]), Decimal(funding_history_item["payout"])
+
+        # so it's not presented on the first page
+        # we should check other pages, but no more than 1 hour back
+        # 1 hour back from the time of first item on first page
+        # has_more == True if there're more pages
+        # cursor is used to query next page (pass it to GET params)
+
+        timestamp_of_first_record_on_first_page = data[0]["created_at"]
+
+        # this is timestamp in ms
+        # let's calculate 1hr back from it
+        one_hour_back_timestamp = timestamp_of_first_record_on_first_page - 60 * 60 * 1000
+
+        # let's also extend it by 5 minutes
+        # in case the exchange the gap between entries is a bit bigger than 1hr
+        one_hour_back_timestamp -= 5 * 60 * 1000
+
+        # now let's query the pages one by one
+        # until we reach the page with the first record older than one hour back
+        has_more = response.get("has_more", False)
+        cursor = response.get("next_cursor")
+        while has_more:
+            response = await self._api_get(
+                path_url=CONSTANTS.GET_FUNDING_HISTORY_PATH_URL,
+                params={
+                    "account": self.user_wallet_public_key,
+                    "limit": 100,
+                    "cursor": cursor,
+                },
+                return_err=True
+            )
+
+            if not response.get("success") is True:
+                self.logger().error(f"Failed to fetch last fee payment (api responded with failure): {response}")
+                return 0, Decimal("-1"), Decimal("-1")
+
+            data = response.get("data")
+            if not data:
+                self.logger().debug(f"Failed to fetch last fee payment (no data): {response}")
+                return 0, Decimal("-1"), Decimal("-1")
+
+            if data[0]["created_at"] < one_hour_back_timestamp:
+                # this page doesn't have the record we need
+                # the timestamp of first record on this page is alrady behind the limit
+                return 0, Decimal("-1"), Decimal("-1")
+
+            for funding_history_item in data:
+                if funding_history_item["symbol"] == symbol:
+                    return funding_history_item["created_at"], Decimal(funding_history_item["rate"]), Decimal(funding_history_item["payout"])
+
+            has_more = response.get("has_more", False)
+            cursor = response.get("next_cursor")
+
+        return 0, Decimal("-1"), Decimal("-1")
+
+    async def _set_trading_pair_leverage(self, trading_pair: str, leverage: int) -> Tuple[bool, str]:
+        symbol = await self.exchange_symbol_associated_to_pair(trading_pair)
+
+        data = {
+            "symbol": symbol,
+            "leverage": leverage,
+            "type": "update_leverage",
+        }
+        response: Dict[str, Any] = await self._api_post(
+            path_url=CONSTANTS.SET_LEVERAGE_PATH_URL,
+            data=data,
+            return_err=True,
+            is_auth_required=True,
+        )
+
+        success = response.get("success") is True
+        msg = ""
+        if not success:
+            msg = (f"Error when setting leverage: "
+                   f"msg={response.get('error', 'error')}, "
+                   f"code={response.get('code', 'code')}")
+
+        return success, msg
+
+    async def _trading_pair_position_mode_set(self, mode: PositionMode, trading_pair: str) -> Tuple[bool, str]:
+        return True, ""
+
+    def _initialize_trading_pair_symbols_from_exchange_info(self, exchange_info: Dict[str, Any]):
+        mapping = bidict()
+        order_books = exchange_info.get("order_books")
+        if order_books:
+            for symbol_data in order_books:
+                if symbol_data.get("market_type") != "perp":
+                    continue
+
+                exchange_symbol = symbol_data["symbol"]
+                base = exchange_symbol
+                quote = "USDC"
+                trading_pair = combine_to_hb_trading_pair(base, quote)
+                mapping[exchange_symbol] = trading_pair
+
+                self._market_id_by_symbol[exchange_symbol] = int(symbol_data["market_id"])
+                self._size_decimals_by_symbol[exchange_symbol] = int(symbol_data.get("supported_size_decimals", 0))
+                self._price_decimals_by_symbol[exchange_symbol] = int(symbol_data.get("supported_price_decimals", 0))
+        else:
+            for symbol_data in exchange_info.get("data", []):
+                exchange_symbol = symbol_data["symbol"]
+                base = exchange_symbol
+                quote = "USDC"
+                trading_pair = combine_to_hb_trading_pair(base, quote)
+                mapping[exchange_symbol] = trading_pair
+
+        self._set_trading_pair_symbol_map(mapping)
+
+    def _get_fee(self,
+                 base_currency: str,
+                 quote_currency: str,
+                 order_type: OrderType,
+                 order_side: TradeType,
+                 position_action: PositionAction,
+                 amount: Decimal,
+                 price: Decimal = Decimal("nan"),
+                 is_maker: Optional[bool] = None) -> TradeFeeBase:
+        is_maker = is_maker or False
+        fee = build_trade_fee(
+            self.name,
+            is_maker,
+            base_currency=base_currency,
+            quote_currency=quote_currency,
+            order_type=order_type,
+            order_side=order_side,
+            amount=amount,
+            price=price,
+        )
+        return fee
+
+    async def _user_stream_event_listener(self):
+        """
+        Wait for new messages from _user_stream_tracker.user_stream queue and processes them according to their
+        message channels. The respective UserStreamDataSource queues these messages.
+        """
+        async for event_message in self._iter_user_event_queue():
+            try:
+                channel = event_message.get("channel")
+                event_type = event_message.get("type")
+                if channel == CONSTANTS.WS_ACCOUNT_ORDER_UPDATES_CHANNEL:
+                    await self._process_account_order_updates_ws_event_message(event_message)
+                elif channel == CONSTANTS.WS_ACCOUNT_POSITIONS_CHANNEL:
+                    await self._process_account_positions_ws_event_message(event_message)
+                elif channel == CONSTANTS.WS_ACCOUNT_INFO_CHANNEL:
+                    await self._process_account_info_ws_event_message(event_message)
+                elif channel == CONSTANTS.WS_ACCOUNT_TRADES_CHANNEL:
+                    await self._process_account_trades_ws_event_message(event_message)
+                elif (
+                    event_type in {"subscribed/account_all", "update/account_all"}
+                    or str(channel).startswith(f"{CONSTANTS.WS_ACCOUNT_ALL_CHANNEL}:")
+                ):
+                    await self._process_account_all_ws_event_message(event_message)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                self.logger().error(f"Unexpected error in user stream listener loop: {e}", exc_info=True)
+                await self._sleep(5.0)
+
+    async def _process_account_all_ws_event_message(self, event_message: Dict[str, Any]):
+        await self._process_account_trades_ws_event_message(event_message)
+        await self._process_account_positions_ws_event_message(event_message)
+        # Extract balance info from account_all assets payload (USDC asset)
+        assets = event_message.get("assets")
+        if isinstance(assets, dict):
+            for asset_entry in assets.values():
+                if str(asset_entry.get("symbol", "")).upper() == "USDC":
+                    total_balance = Decimal(str(asset_entry.get("balance", "0")))
+                    locked = Decimal(str(asset_entry.get("locked_balance", "0")))
+                    self._set_usdc_balances(
+                        total_balance=total_balance,
+                        available_balance=total_balance - locked,
+                    )
+                    break
+
+    @staticmethod
+    def _normalized_position_entries_from_event(event_message: Dict[str, Any]) -> List[Dict[str, Any]]:
+        raw_entries = event_message.get("data")
+        if raw_entries is None:
+            positions = event_message.get("positions") or {}
+            raw_entries = list(positions.values()) if isinstance(positions, dict) else positions
+
+        normalized_entries: List[Dict[str, Any]] = []
+        for position_entry in raw_entries or []:
+            if "s" in position_entry:
+                normalized_entries.append(position_entry)
+                continue
+
+            symbol = position_entry.get("symbol")
+            if not symbol:
+                continue
+
+            raw_amount = Decimal(str(position_entry.get("position") or "0"))
+            if raw_amount == s_decimal_0:
+                continue
+
+            sign = int(position_entry.get("sign", 1) or 1)
+            normalized_entries.append({
+                "s": symbol,
+                "d": "bid" if sign >= 0 else "ask",
+                "a": str(abs(raw_amount)),
+                "p": str(position_entry.get("avg_entry_price") or "0"),
+                "upnl": str(position_entry.get("unrealized_pnl")) if position_entry.get("unrealized_pnl") is not None else None,
+            })
+
+        return normalized_entries
+
+    def _normalized_trade_entries_from_event(self, event_message: Dict[str, Any]) -> List[Dict[str, Any]]:
+        raw_entries = event_message.get("data")
+        if raw_entries is not None:
+            return list(raw_entries or [])
+
+        trades = event_message.get("trades") or {}
+        if isinstance(trades, dict):
+            trade_buckets = trades.values()
+        elif isinstance(trades, list):
+            trade_buckets = trades
+        else:
+            trade_buckets = []
+
+        normalized_entries: List[Dict[str, Any]] = []
+        for trade_bucket in trade_buckets:
+            entries = trade_bucket if isinstance(trade_bucket, list) else [trade_bucket]
+            for trade_entry in entries:
+                if not isinstance(trade_entry, dict):
+                    continue
+                if "i" in trade_entry:
+                    normalized_entries.append(trade_entry)
+                    continue
+
+                own_bid = str(trade_entry.get("bid_account_id")) == str(self._get_account_index())
+                own_ask = str(trade_entry.get("ask_account_id")) == str(self._get_account_index())
+                if not own_bid and not own_ask:
+                    continue
+
+                exchange_order_id = (
+                    str(trade_entry.get("bid_client_id_str") or trade_entry.get("bid_client_id") or "")
+                    if own_bid
+                    else str(trade_entry.get("ask_client_id_str") or trade_entry.get("ask_client_id") or "")
+                )
+                if not exchange_order_id:
+                    continue
+
+                is_taker = (own_bid and bool(trade_entry.get("is_maker_ask"))) or (own_ask and not bool(trade_entry.get("is_maker_ask")))
+                fee_rate_ppm = Decimal(str(trade_entry.get("taker_fee") if is_taker else trade_entry.get("maker_fee") or 0))
+                fee_amount = Decimal(str(trade_entry.get("usd_amount") or "0")) * fee_rate_ppm / Decimal("1000000")
+
+                normalized_entries.append({
+                    "i": exchange_order_id,
+                    "p": str(trade_entry.get("price") or "0"),
+                    "a": str(trade_entry.get("size") or "0"),
+                    "f": str(fee_amount),
+                    "t": trade_entry.get("timestamp") or trade_entry.get("transaction_time") or 0,
+                    "ts": "open_long" if own_bid else "open_short",
+                    "trade_id": trade_entry.get("trade_id_str") or trade_entry.get("trade_id"),
+                })
+
+        return normalized_entries
+
+    async def _process_account_order_updates_ws_event_message(self, event_message: Dict[str, Any]):
+        """
+        https://docs.LIGHTER.fi/api-documentation/api/websocket/subscriptions/account-order-updates
+        {
+            "channel": "account_order_updates",
+            "data": [
+                {
+                "i": 1559665358,
+                "I": null,
+                "u": "BrZp5bidJ3WUvceSq7X78bhjTfZXeezzGvGEV4hAYKTa",
+                "s": "BTC",
+                "d": "bid",
+                "p": "89501",
+                "ip": "89501",
+                "lp": "89501",
+                "a": "0.00012",
+                "f": "0.00012",
+                "oe": "fulfill_limit",
+                "os": "filled",
+                "ot": "limit",
+                "sp": null,
+                "si": null,
+                "r": false,
+                "ct": 1765017049008,
+                "ut": 1765017219639,
+                "li": 1559696133
+                }
+            ]
+        }
+        """
+        tracked_orders = {order.exchange_order_id: order for order in self._order_tracker.all_updatable_orders.values()}
+
+        for order_update_message in event_message["data"]:
+            exchange_order_id = str(order_update_message["i"])
+            tracked_order = tracked_orders.get(exchange_order_id)
+            if tracked_order:
+                order_status = CONSTANTS.ORDER_STATE[order_update_message["os"]]
+                order_update = OrderUpdate(
+                    trading_pair=tracked_order.trading_pair,
+                    update_timestamp=order_update_message["ut"] / 1000,
+                    new_state=order_status,
+                    client_order_id=tracked_order.client_order_id,
+                    exchange_order_id=tracked_order.exchange_order_id,
+                )
+                self._order_tracker.process_order_update(order_update)
+
+    async def _process_account_positions_ws_event_message(self, event_message: Dict[str, Any]):
+        """
+        https://docs.LIGHTER.fi/api-documentation/api/websocket/subscriptions/account-positions
+        {
+            "channel": "subscribe",
+            "data": {
+                "source": "account_positions",
+                "account": "BrZp5..."
+            }
+            }
+            // this is the initialization snapshot
+            {
+            "channel": "account_positions",
+            "data": [
+                {
+                "s": "BTC",
+                "d": "bid",
+                "a": "0.00022",
+                "p": "87185",
+                "m": "0",
+                "f": "-0.00023989",
+                "i": false,
+                "l": null,
+                "t": 1764133203991
+                }
+            ],
+            "li": 1559395580
+            }
+            // this shows the position being increased by an order filling
+            {
+            "channel": "account_positions",
+            "data": [
+                {
+                "s": "BTC",
+                "d": "bid",
+                "a": "0.00044",
+                "p": "87285.5",
+                "m": "0",
+                "f": "-0.00023989",
+                "i": false,
+                "l": "-95166.79231",
+                "t": 1764133656974
+                }
+            ],
+            "li": 1559412952
+            }
+            // this shows the position being closed
+            {
+            "channel": "account_positions",
+            "data": [],
+            "li": 1559438203
+        }
+        """
+        # LIGHTER provides full snapshot of positions
+        # if there're 2 positions available, it will only show those 2
+        # if one of those 2 positions is closed -- you will see only 1
+        # so it make sense to clear the storage of positions
+        # and fill it with the positions from the response
+
+        # the implementation is actually the same as the one for
+        # HTTP calls self._update_positions()
+        self._perpetual_trading.account_positions.clear()
+
+        for position_entry in self._normalized_position_entries_from_event(event_message):
+            hb_trading_pair = await self.trading_pair_associated_to_exchange_symbol(position_entry["s"])
+            position_side = PositionSide.LONG if position_entry["d"] == "bid" else PositionSide.SHORT
+            position_key = self._perpetual_trading.position_key(hb_trading_pair, position_side)
+            amount = Decimal(position_entry["a"])
+            entry_price = Decimal(position_entry["p"])
+
+            provided_unrealized_pnl = position_entry.get("upnl")
+            if provided_unrealized_pnl is not None:
+                unrealized_pnl = Decimal(str(provided_unrealized_pnl))
+            else:
+                price_record = self.get_LIGHTER_price(hb_trading_pair)
+                mark_price = price_record.mark_price if price_record is not None else entry_price
+
+                if position_side == PositionSide.LONG:
+                    unrealized_pnl = (mark_price - entry_price) * amount
+                else:
+                    unrealized_pnl = (entry_price - mark_price) * amount
+
+            position = Position(
+                trading_pair=hb_trading_pair,
+                position_side=position_side,
+                unrealized_pnl=unrealized_pnl,
+                entry_price=entry_price,
+                amount=amount * (Decimal("-1.0") if position_side == PositionSide.SHORT else Decimal("1.0")),
+                leverage=Decimal(self.get_leverage(hb_trading_pair))
+            )
+            self._perpetual_trading.set_position(position_key, position)
+
+    async def _process_account_info_ws_event_message(self, event_message: Dict[str, Any]):
+        """
+        https://docs.LIGHTER.fi/api-documentation/api/websocket/subscriptions/account-info
+        {
+            "channel": "account_info",
+            "data": {
+                "ae": "2000",
+                "as": "1500",
+                "aw": "1400",
+                "b": "2000",
+                "f": 1,
+                "mu": "500",
+                "cm": "400",
+                "oc": 10,
+                "pb": "0",
+                "pc": 2,
+                "sc": 2,
+                "t": 1234567890
+            }
+        }
+        """
+        self._set_usdc_balances(
+            total_balance=Decimal(event_message["data"]["ae"]),
+            available_balance=Decimal(event_message["data"]["as"]),
+        )
+        self._fee_tier = int(event_message["data"].get("f", self._fee_tier))
+
+    async def _process_account_trades_ws_event_message(self, event_message: Dict[str, Any]):
+        """
+        https://docs.LIGHTER.fi/api-documentation/api/websocket/subscriptions/account-trades
+        {
+            "channel": "account_trades",
+            "data": [
+                {
+                "h": 80063441,
+                "i": 1559912767,
+                "I": null,
+                "u": "BrZp5bidJ3WUvceSq7X78bhjTfZXeezzGvGEV4hAYKTa",
+                "s": "BTC",
+                "p": "89477",
+                "o": "89505",
+                "a": "0.00036",
+                "te": "fulfill_taker",
+                "ts": "close_long",
+                "tc": "normal",
+                "f": "0.012885",
+                "n": "-0.022965",
+                "t": 1765018588190,
+                "li": 1559912767
+                }
+            ]
+        }
+        """
+        tracked_orders = {order.exchange_order_id: order for order in self._order_tracker.all_fillable_orders.values()}
+
+        for trade_message in self._normalized_trade_entries_from_event(event_message):
+            exchange_order_id = str(trade_message["i"])
+            tracked_order = tracked_orders.get(exchange_order_id)
+            if not tracked_order:
+                continue
+
+            trade_timestamp = Decimal(str(trade_message["t"]))
+            fill_timestamp = float(trade_timestamp / Decimal("1000")) if trade_timestamp > Decimal("1000000000000") else float(trade_timestamp)
+
+            trade_id = trade_message.get("trade_id") or self.get_LIGHTER_finance_trade_id(
+                order_id=trade_message["i"],
+                timestamp=fill_timestamp,
+                fill_base_amount=Decimal(trade_message["a"]),
+                fill_price=Decimal(trade_message["p"]),
+            )
+
+            # it would always be USDC
+            fee_asset = tracked_order.quote_asset
+
+            fee = TradeFeeBase.new_perpetual_fee(
+                fee_schema=self.trade_fee_schema(),
+                position_action=tracked_order.position,
+                percent_token=fee_asset,
+                flat_fees=[TokenAmount(
+                    amount=Decimal(trade_message["f"]),
+                    token=fee_asset
+                )]
+            )
+
+            trade_update = TradeUpdate(
+                trade_id=trade_id,
+                client_order_id=tracked_order.client_order_id,
+                exchange_order_id=exchange_order_id,
+                trading_pair=tracked_order.trading_pair,
+                fee=fee,
+                fill_base_amount=Decimal(trade_message["a"]),
+                fill_quote_amount=Decimal(trade_message["p"]) * Decimal(trade_message["a"]),
+                fill_price=Decimal(trade_message["p"]),
+                fill_timestamp=fill_timestamp,
+            )
+
+            self._order_tracker.process_trade_update(trade_update)
+
+    def set_LIGHTER_price(self, trading_pair: str, timestamp: float, index_price: Decimal, mark_price: Decimal):
+        """
+        Set the price information for the given trading pair
+
+        :param trading_pair: the trading pair
+        :param timestamp: the timestamp of the price (in seconds)
+        :param index_price: the index price
+        :param mark_price: the mark price
+        """
+        existing = self._prices.get(trading_pair)
+        if existing is None or timestamp >= existing.timestamp:
+            self._prices[trading_pair] = LighterPerpetualPriceRecord(
+                timestamp=timestamp,
+                index_price=index_price,
+                mark_price=mark_price
+            )
+
+    def get_LIGHTER_price(self, trading_pair: str) -> Optional[LighterPerpetualPriceRecord]:
+        """
+        Get the price information for the given trading pair
+
+        :param trading_pair: the trading pair
+
+        :return: the price information for the given trading pair or None if the trading pair is not found
+        """
+        return self._prices.get(trading_pair)
+
+    def get_LIGHTER_finance_trade_id(self, order_id: int, timestamp: float, fill_base_amount: Decimal, fill_price: Decimal) -> str:
+        """
+        Generate a trade ID for the given order ID, timestamp, base amount, and price
+
+        :param order_id: the order ID
+        :param timestamp: the timestamp of the trade (in seconds)
+        :param fill_base_amount: the base amount of the trade
+        :param fill_price: the price of the trade
+
+        :return: the trade ID
+        """
+        return f"{order_id}_{timestamp}_{fill_base_amount}_{fill_price}"
+
+    def round_amount(self, trading_pair: str, amount: Decimal) -> Decimal:
+        """
+        Round the given amount to the lot size defined in the trading rules for the given symbol
+        Sample lot size is 0.001
+
+        :param trading_pair: the trading pair
+        :param amount: the amount to round
+
+        :return: the rounded amount
+        """
+        return amount.quantize(self._trading_rules[trading_pair].min_base_amount_increment)
+
+    def round_fee(self, fee_amount: Decimal) -> Decimal:
+        """
+        Round the given fee amount to the lot size defined in the trading rules for the given symbol
+
+        :param fee_amount: the fee amount to round
+
+        :return: the rounded fee amount
+        """
+        return round(fee_amount, 6)
+
+    async def start_network(self):
+        await self._fetch_or_create_api_config_key()
+        # status polling is already started in super().start_network() -> _status_polling_loop()
+        # but we need to ensure fee tier is fetched immediately
+        # we call it before super() so that the rate limits are correctly set before the periodic loops start
+        await self._update_balances()
+        await super().start_network()
+
+    async def get_all_pairs_prices(self) -> List[Dict[str, Any]]:
+        """
+        Retrieves the prices (mark price) for all trading pairs.
+        Required for Rate Oracle support.
+
+        https://docs.LIGHTER.fi/api-documentation/api/rest-api/markets/get-prices
+        Prices Info
+        ```
+         {
+            "success": true,
+            "data": [
+                {
+                "funding": "0.00010529",
+                "mark": "1.084819",
+                "mid": "1.08615",
+                "next_funding": "0.00011096",
+                "open_interest": "3634796",
+                "oracle": "1.084524",
+                "symbol": "XPL",
+                "timestamp": 1759222967974,
+                "volume_24h": "20896698.0672",
+                "yesterday_price": "1.3412"
+                }
+            ],
+            "error": null,
+            "code": null
+        }
+        ```
+
+        Sample output:
+        ```
+        [
+            {
+            "symbol": "XPL",
+            "price": "1.084819"
+            },
+        ]
+        ```
+
+        :return: A list of dictionaries containing symbol and a price
+        """
+        response = await self._api_get(
+            path_url=CONSTANTS.GET_PRICES_PATH_URL,
+            return_err=True,
+        )
+
+        if not response.get("success") is True:
+            self.logger().error(f"[get_all_pairs_prices] Failed to fetch all pairs prices: {response}")
+            return []
+
+        results = []
+        for price_data in response.get("data", []):
+            results.append({
+                "trading_pair": await self.trading_pair_associated_to_exchange_symbol(symbol=price_data["symbol"]),
+                "price": price_data["mark"]
+            })
+
+        return results

--- a/hummingbot/connector/derivative/lighter_perpetual/lighter_perpetual_user_stream_data_source.py
+++ b/hummingbot/connector/derivative/lighter_perpetual/lighter_perpetual_user_stream_data_source.py
@@ -1,0 +1,104 @@
+import asyncio
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+from hummingbot.connector.derivative.lighter_perpetual import (
+    lighter_perpetual_constants as CONSTANTS,
+    lighter_perpetual_web_utils as web_utils,
+)
+from hummingbot.connector.derivative.lighter_perpetual.lighter_perpetual_auth import LighterPerpetualAuth
+from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
+from hummingbot.core.utils.async_utils import safe_ensure_future
+from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest, WSResponse
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+from hummingbot.core.web_assistant.ws_assistant import WSAssistant
+from hummingbot.logger import HummingbotLogger
+
+if TYPE_CHECKING:
+    from hummingbot.connector.derivative.lighter_perpetual.lighter_perpetual_derivative import (
+        LighterPerpetualDerivative,
+    )
+
+
+class LighterPerpetualUserStreamDataSource(UserStreamTrackerDataSource):
+    _logger: Optional[HummingbotLogger] = None
+
+    def __init__(
+        self,
+        connector: "LighterPerpetualDerivative",
+        api_factory: WebAssistantsFactory,
+        auth: LighterPerpetualAuth,
+        domain: str = CONSTANTS.DEFAULT_DOMAIN,
+    ):
+        super().__init__()
+        self._connector = connector
+        self._api_factory = api_factory
+        self._auth = auth
+        self._domain = domain
+        self._ping_task: Optional[asyncio.Task] = None
+
+    async def _connected_websocket_assistant(self) -> WSAssistant:
+        ws: WSAssistant = await self._api_factory.get_ws_assistant()
+
+        ws_headers = {}
+        if self._connector.rest_api_key:
+            ws_headers["X-Api-Key"] = self._connector.rest_api_key
+
+        await ws.connect(ws_url=web_utils.wss_url(self._domain), ws_headers=ws_headers)
+        self._ping_task = safe_ensure_future(self._ping_loop(ws))
+        return ws
+
+    async def _subscribe_channels(self, websocket_assistant: WSAssistant) -> None:
+        try:
+            response: Optional[WSResponse] = await websocket_assistant.receive()
+            message: Dict[str, Any] = response.data if response is not None else {}
+            if message.get("type") != "connected":
+                raise IOError("Private websocket connection did not acknowledge the session")
+
+            account_all_payload = {
+                "type": "subscribe",
+                "channel": f"{CONSTANTS.WS_ACCOUNT_ALL_CHANNEL}/{self._auth.user_wallet_public_key}",
+            }
+
+            await websocket_assistant.send(WSJSONRequest(account_all_payload))
+
+            self.logger().info("Subscribed to private account channel")
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self.logger().exception("Unexpected error occurred subscribing to order book trading and delta streams")
+            raise
+
+    async def _process_websocket_messages(self, websocket_assistant: WSAssistant, queue: asyncio.Queue):
+        async for ws_response in websocket_assistant.iter_messages():
+            data = ws_response.data
+            if data.get("type") == "ping":
+                await websocket_assistant.send(WSJSONRequest(payload={"type": "pong"}))
+                continue
+            await self._process_event_message(event_message=data, queue=queue)
+
+    async def _process_event_message(self, event_message: Dict[str, Any], queue: asyncio.Queue):
+        message_type = event_message.get("type")
+        channel = str(event_message.get("channel", ""))
+        if message_type in {"subscribed/account_all", "update/account_all"} or channel.startswith(f"{CONSTANTS.WS_ACCOUNT_ALL_CHANNEL}:"):
+            queue.put_nowait(event_message)
+
+    async def _on_user_stream_interruption(self, websocket_assistant: Optional[WSAssistant]):
+        await super()._on_user_stream_interruption(websocket_assistant)
+        if self._ping_task is not None:
+            self._ping_task.cancel()
+            self._ping_task = None
+
+    async def _ping_loop(self, ws: WSAssistant):
+        while True:
+            try:
+                await asyncio.sleep(CONSTANTS.WS_PING_INTERVAL)
+                await ws.send(WSJSONRequest(payload={"type": "ping"}))
+            except asyncio.CancelledError:
+                raise
+            except RuntimeError as e:
+                if "WS is not connected" in str(e):
+                    return
+                raise
+            except Exception:
+                self.logger().warning("Error sending ping to LIGHTER WebSocket", exc_info=True)
+                await asyncio.sleep(5.0)

--- a/hummingbot/connector/derivative/lighter_perpetual/lighter_perpetual_utils.py
+++ b/hummingbot/connector/derivative/lighter_perpetual/lighter_perpetual_utils.py
@@ -1,0 +1,158 @@
+from decimal import Decimal
+
+from pydantic import AliasChoices, ConfigDict, Field, SecretStr
+
+from hummingbot.client.config.config_data_types import BaseConnectorConfigMap
+from hummingbot.core.data_type.trade_fee import TradeFeeSchema
+
+CENTRALIZED = True
+EXAMPLE_PAIR = "BTC-USD"
+
+# Default fee values aligned with the currently observed base tier.
+DEFAULT_FEES = TradeFeeSchema(
+    maker_percent_fee_decimal=Decimal("0.00015"),
+    taker_percent_fee_decimal=Decimal("0.0004"),
+)
+
+
+class LighterPerpetualConfigMap(BaseConnectorConfigMap):
+    connector: str = "lighter_perpetual"
+
+    lighter_perpetual_api_key: SecretStr = Field(
+        default=...,
+        validation_alias=AliasChoices(
+            "lighter_perpetual_api_key",
+            "lighter_api_key",
+        ),
+        json_schema_extra={
+            "prompt": "Enter your Lighter API key",
+            "is_secure": True,
+            "is_connect_key": True,
+            "prompt_on_new": True
+        }
+    )
+
+    lighter_perpetual_api_secret: SecretStr = Field(
+        default=...,
+        validation_alias=AliasChoices(
+            "lighter_perpetual_api_secret",
+            "lighter_api_secret",
+            "lighter_perpetual_api_key_index",
+            "lighter_api_key_index",
+        ),
+        json_schema_extra={
+            "prompt": "Enter your Lighter API secret or API key index",
+            "is_secure": True,
+            "is_connect_key": True,
+            "prompt_on_new": True
+        }
+    )
+
+    lighter_perpetual_account_index: SecretStr = Field(
+        default=...,
+        validation_alias=AliasChoices(
+            "lighter_perpetual_account_index",
+            "lighter_account_index",
+        ),
+        json_schema_extra={
+            "prompt": "Enter your Lighter account index",
+            "is_secure": True,
+            "is_connect_key": True,
+            "prompt_on_new": True
+        }
+    )
+
+    lighter_perpetual_private_key: SecretStr = Field(
+        default=SecretStr(""),
+        validation_alias=AliasChoices(
+            "lighter_perpetual_private_key",
+            "lighter_private_key",
+            "lighter_signer_private_key",
+            "lighter_eoa_private_key",
+        ),
+        json_schema_extra={
+            "prompt": "Enter your Lighter signer private key (optional for data streams/read-only; required for signed order placement/cancel)",
+            "is_secure": True,
+            "is_connect_key": True,
+            "prompt_on_new": False
+        }
+    )
+
+    model_config = ConfigDict(title="lighter_perpetual")
+
+
+KEYS = LighterPerpetualConfigMap.model_construct()
+
+OTHER_DOMAINS = ["lighter_perpetual_testnet"]
+OTHER_DOMAINS_PARAMETER = {"lighter_perpetual_testnet": "lighter_perpetual_testnet"}
+OTHER_DOMAINS_EXAMPLE_PAIR = {"lighter_perpetual_testnet": "BTC-USD"}
+OTHER_DOMAINS_DEFAULT_FEES = {"lighter_perpetual_testnet": [0.00015, 0.0004]}
+
+
+class LighterPerpetualTestnetConfigMap(BaseConnectorConfigMap):
+    connector: str = "lighter_perpetual_testnet"
+
+    lighter_perpetual_testnet_api_key: SecretStr = Field(
+        default=...,
+        validation_alias=AliasChoices(
+            "lighter_perpetual_testnet_api_key",
+            "lighter_testnet_api_key",
+        ),
+        json_schema_extra={
+            "prompt": "Enter your Lighter testnet API key",
+            "is_secure": True,
+            "is_connect_key": True,
+            "prompt_on_new": True
+        }
+    )
+
+    lighter_perpetual_testnet_api_secret: SecretStr = Field(
+        default=...,
+        validation_alias=AliasChoices(
+            "lighter_perpetual_testnet_api_secret",
+            "lighter_testnet_api_secret",
+        ),
+        json_schema_extra={
+            "prompt": "Enter your Lighter testnet API secret",
+            "is_secure": True,
+            "is_connect_key": True,
+            "prompt_on_new": True
+        }
+    )
+
+    lighter_perpetual_testnet_account_index: SecretStr = Field(
+        default=...,
+        validation_alias=AliasChoices(
+            "lighter_perpetual_testnet_account_index",
+            "lighter_testnet_account_index",
+        ),
+        json_schema_extra={
+            "prompt": "Enter your Lighter testnet account index",
+            "is_secure": True,
+            "is_connect_key": True,
+            "prompt_on_new": True
+        }
+    )
+
+    lighter_perpetual_testnet_private_key: SecretStr = Field(
+        default=SecretStr(""),
+        validation_alias=AliasChoices(
+            "lighter_perpetual_testnet_private_key",
+            "lighter_testnet_private_key",
+            "lighter_testnet_signer_private_key",
+            "lighter_testnet_eoa_private_key",
+        ),
+        json_schema_extra={
+            "prompt": "Enter your Lighter testnet signer private key (optional for data streams/read-only; required for signed order placement/cancel)",
+            "is_secure": True,
+            "is_connect_key": True,
+            "prompt_on_new": False
+        }
+    )
+
+    model_config = ConfigDict(title="lighter_perpetual_testnet")
+
+
+OTHER_DOMAINS_KEYS = {
+    "lighter_perpetual_testnet": LighterPerpetualTestnetConfigMap.model_construct()
+}

--- a/hummingbot/connector/derivative/lighter_perpetual/lighter_perpetual_web_utils.py
+++ b/hummingbot/connector/derivative/lighter_perpetual/lighter_perpetual_web_utils.py
@@ -1,0 +1,39 @@
+import time
+from typing import Optional
+
+from hummingbot.connector.derivative.lighter_perpetual import lighter_perpetual_constants as CONSTANTS
+from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from hummingbot.core.web_assistant.auth import AuthBase
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+
+
+def public_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:
+    base_url = CONSTANTS.REST_URL if domain == CONSTANTS.DEFAULT_DOMAIN else CONSTANTS.TESTNET_REST_URL
+    return base_url + path_url
+
+
+def private_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:
+    return public_rest_url(path_url, domain)
+
+
+def wss_url(domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:
+    return CONSTANTS.WSS_URL if domain == CONSTANTS.DEFAULT_DOMAIN else CONSTANTS.TESTNET_WSS_URL
+
+
+def build_api_factory(
+    throttler: Optional[AsyncThrottler] = None,
+    auth: Optional[AuthBase] = None,
+) -> WebAssistantsFactory:
+    throttler = throttler or AsyncThrottler(CONSTANTS.RATE_LIMITS)
+    api_factory = WebAssistantsFactory(
+        throttler=throttler,
+        auth=auth,
+    )
+    return api_factory
+
+
+async def get_current_server_time(
+        throttler: Optional[AsyncThrottler] = None,
+        domain: str = CONSTANTS.DEFAULT_DOMAIN,
+) -> float:
+    return time.time()

--- a/scripts/lighter_perp_integration_report.json
+++ b/scripts/lighter_perp_integration_report.json
@@ -1,0 +1,47 @@
+{
+  "timestamp": 1775208134,
+  "results": [
+    {
+      "step": "REST /orderBooks",
+      "status": "PASS",
+      "details": "status=200",
+      "tx_hash": ""
+    },
+    {
+      "step": "REST /account",
+      "status": "PASS",
+      "details": "status=200",
+      "tx_hash": ""
+    },
+    {
+      "step": "REST /exchangeStats",
+      "status": "PASS",
+      "details": "status=200",
+      "tx_hash": ""
+    },
+    {
+      "step": "Market selection",
+      "status": "PASS",
+      "details": "AMD mark=219.55",
+      "tx_hash": ""
+    },
+    {
+      "step": "Signer init",
+      "status": "PASS",
+      "details": "SignerClient initialized",
+      "tx_hash": ""
+    },
+    {
+      "step": "Perp place limit order",
+      "status": "PASS",
+      "details": "symbol=AMD code=200 error=None",
+      "tx_hash": "165d1d08ad39fc3b51499b288f2a073f856375a2917e0ff1953274a710bbe24be226f49f989c9077"
+    },
+    {
+      "step": "Perp cancel order",
+      "status": "PASS",
+      "details": "order_index=173721163198631 code=200 error=None",
+      "tx_hash": "78e8d841b41a6f93ad83a0a7c4952473fcad4b9c267aab843f0f265d274102c0902d5ce3ac4d9ab6"
+    }
+  ]
+}

--- a/scripts/lighter_perp_integration_report.json
+++ b/scripts/lighter_perp_integration_report.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": 1775208134,
+  "timestamp": 1775208752,
   "results": [
     {
       "step": "REST /orderBooks",
@@ -22,7 +22,7 @@
     {
       "step": "Market selection",
       "status": "PASS",
-      "details": "AMD mark=219.55",
+      "details": "HYUNDAI mark=487565",
       "tx_hash": ""
     },
     {
@@ -34,14 +34,14 @@
     {
       "step": "Perp place limit order",
       "status": "PASS",
-      "details": "symbol=AMD code=200 error=None",
-      "tx_hash": "165d1d08ad39fc3b51499b288f2a073f856375a2917e0ff1953274a710bbe24be226f49f989c9077"
+      "details": "symbol=HYUNDAI code=200 error=None",
+      "tx_hash": "3ca8e6015795e290a74cb50c358a7f70f61ff867134515cc450c5f3774d83c23db9cdba696a7017a"
     },
     {
       "step": "Perp cancel order",
       "status": "PASS",
-      "details": "order_index=173721163198631 code=200 error=None",
-      "tx_hash": "78e8d841b41a6f93ad83a0a7c4952473fcad4b9c267aab843f0f265d274102c0902d5ce3ac4d9ab6"
+      "details": "order_index=132940077622643 code=200 error=None",
+      "tx_hash": "893c9c198f59792ff2e390e81dd861dbea382a4987d053440d39ce2304173e2be4cacb4deac035d7"
     }
   ]
 }

--- a/scripts/lighter_perp_mainnet_validation.py
+++ b/scripts/lighter_perp_mainnet_validation.py
@@ -1,0 +1,394 @@
+import asyncio
+import hashlib
+import json
+import os
+import sys
+import time
+from decimal import Decimal, ROUND_DOWN
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import lighter
+import requests
+
+ROOT = Path(__file__).resolve().parents[1]
+
+if sys.platform.startswith("win"):
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
+
+def parse_env_file(path: Path) -> Dict[str, str]:
+    values: Dict[str, str] = {}
+    if not path.exists():
+        return values
+
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key.strip()] = value.strip().strip('"').strip("'")
+    return values
+
+
+def first_non_empty(env: Dict[str, str], *keys: str) -> Optional[str]:
+    for key in keys:
+        value = os.environ.get(key) or env.get(key)
+        if value:
+            return value
+    return None
+
+
+def quantize_down(value: Decimal, decimals: int) -> Decimal:
+    quantum = Decimal(f"1e-{decimals}")
+    return value.quantize(quantum, rounding=ROUND_DOWN)
+
+
+def extract_tx_hash(tx_response: Any) -> Optional[str]:
+    if tx_response is None:
+        return None
+
+    for attr in ("tx_hash", "transaction_hash", "hash"):
+        if hasattr(tx_response, attr):
+            value = getattr(tx_response, attr)
+            if value:
+                return str(value)
+
+    response_obj = getattr(tx_response, "response", None)
+    if isinstance(response_obj, dict):
+        for key in ("tx_hash", "transaction_hash", "hash"):
+            value = response_obj.get(key)
+            if value:
+                return str(value)
+
+    return None
+
+
+def is_int_string(value: Optional[str]) -> bool:
+    if value is None:
+        return False
+    try:
+        int(str(value))
+        return True
+    except Exception:
+        return False
+
+
+def get_rest_api_key(api_key: str, api_secret: str) -> str:
+    if is_int_string(api_key):
+        return api_key
+    if api_secret:
+        return api_secret
+    return api_key
+
+
+def get_api_key_index(api_key_index: Optional[str], api_key: str, api_secret: str) -> int:
+    if is_int_string(api_key_index):
+        return int(api_key_index)
+    if is_int_string(api_key):
+        return int(api_key)
+    if is_int_string(api_secret):
+        return int(api_secret)
+    raise ValueError("Unable to resolve numeric Lighter API key index")
+
+
+def get_signer_private_key(private_key: Optional[str], api_key: str, api_secret: str) -> str:
+    if private_key:
+        return private_key
+    if api_key and not is_int_string(api_key):
+        return api_key
+    if api_secret and not is_int_string(api_secret):
+        return api_secret
+    raise ValueError("Unable to resolve signer private key")
+
+
+def client_order_index_from_id(order_id: str) -> int:
+    digest = hashlib.sha256(order_id.encode()).digest()
+    # Lighter expects client_order_index <= 2^48-1.
+    return int.from_bytes(digest[:8], byteorder="big", signed=False) & ((1 << 48) - 1)
+
+
+def run() -> int:
+    env_path = ROOT.parent / "hummingbot" / ".env"
+    env = parse_env_file(env_path)
+
+    api_key = first_non_empty(
+        env,
+        "LIGHTER_PERPETUAL_API_KEY",
+        "LIGHTER_API_KEY",
+        "lighter_perpetual_api_key",
+        "lighter_api_key",
+    )
+    api_secret = first_non_empty(
+        env,
+        "LIGHTER_PERPETUAL_API_SECRET",
+        "LIGHTER_API_SECRET",
+        "lighter_perpetual_api_secret",
+        "lighter_api_secret",
+    )
+    api_key_index_raw = first_non_empty(
+        env,
+        "LIGHTER_PERPETUAL_API_KEY_INDEX",
+        "LIGHTER_API_KEY_INDEX",
+        "lighter_perpetual_api_key_index",
+        "lighter_api_key_index",
+    )
+    account_index = first_non_empty(
+        env,
+        "LIGHTER_PERPETUAL_ACCOUNT_INDEX",
+        "LIGHTER_ACCOUNT_INDEX",
+        "lighter_perpetual_account_index",
+        "lighter_account_index",
+    )
+    private_key = first_non_empty(
+        env,
+        "LIGHTER_PERPETUAL_PRIVATE_KEY",
+        "LIGHTER_PRIVATE_KEY",
+        "LIGHTER_SIGNER_PRIVATE_KEY",
+        "lighter_perpetual_private_key",
+        "lighter_private_key",
+        "lighter_signer_private_key",
+    ) or ""
+
+    steps = []
+
+    def record(step: str, passed: bool, details: str = "", tx_hash: str = ""):
+        steps.append({
+            "step": step,
+            "status": "PASS" if passed else "FAIL",
+            "details": details,
+            "tx_hash": tx_hash,
+        })
+
+    if not api_key or not account_index:
+        record("config", False, "Missing lighter perp credentials in .env")
+        print_table(steps)
+        return 1
+
+    if not api_secret and api_key_index_raw:
+        api_secret = api_key_index_raw
+
+    base_url = "https://mainnet.zklighter.elliot.ai/api/v1"
+
+    # REST health checks
+    try:
+        order_books = requests.get(f"{base_url}/orderBooks", timeout=20)
+        record("REST /orderBooks", order_books.status_code == 200, f"status={order_books.status_code}")
+    except Exception as e:
+        order_books = None
+        record("REST /orderBooks", False, str(e))
+
+    try:
+        rest_api_key = get_rest_api_key(api_key, api_secret)
+        signer_private_key = get_signer_private_key(private_key, api_key, api_secret)
+        api_key_index = get_api_key_index(api_key_index_raw, api_key, api_secret)
+    except Exception as e:
+        record("config", False, f"Credential resolution failed: {e}")
+        print_table(steps)
+        return 1
+
+    headers = {"X-Api-Key": rest_api_key}
+    try:
+        account_res = requests.get(
+            f"{base_url}/account",
+            params={"by": "index", "value": account_index},
+            headers=headers,
+            timeout=20,
+        )
+        account_json = account_res.json() if account_res.ok else {}
+        ok = account_res.status_code == 200 and bool(account_json.get("data") or account_json.get("accounts"))
+        record("REST /account", ok, f"status={account_res.status_code}")
+    except Exception as e:
+        account_json = {}
+        record("REST /account", False, str(e))
+
+    try:
+        stats_res = requests.get(f"{base_url}/exchangeStats", timeout=20)
+        stats_json = stats_res.json() if stats_res.ok else {}
+        record("REST /exchangeStats", stats_res.status_code == 200, f"status={stats_res.status_code}")
+    except Exception as e:
+        stats_json = {}
+        record("REST /exchangeStats", False, str(e))
+
+    signer = None
+
+    async def close_signer_sessions() -> None:
+        if signer is None:
+            return
+
+        close_calls = []
+        if hasattr(signer, "close"):
+            close_calls.append(getattr(signer, "close"))
+
+        for attr_name in ("api_client", "_api_client", "session", "client_session"):
+            holder = getattr(signer, attr_name, None)
+            if holder is not None and hasattr(holder, "close"):
+                close_calls.append(getattr(holder, "close"))
+
+        for close_fn in close_calls:
+            try:
+                result = close_fn()
+                if asyncio.iscoroutine(result):
+                    await result
+            except Exception:
+                pass
+
+    # Select a perp market with available pricing.
+    selected = None
+    try:
+        ob_data = order_books.json() if order_books is not None and order_books.ok else {}
+        perp_books = [b for b in (ob_data.get("order_books") or []) if b.get("market_type") == "perp"]
+        prices_map = {entry.get("symbol"): entry for entry in (stats_json.get("order_book_stats") or []) if entry.get("symbol")}
+
+        for book in perp_books:
+            symbol = book.get("symbol")
+            price_entry = prices_map.get(symbol)
+            if not price_entry:
+                continue
+
+            mark = Decimal(str(price_entry.get("mark") or price_entry.get("mid") or price_entry.get("last_trade_price") or "0"))
+            if mark <= 0:
+                continue
+
+            selected = {
+                "symbol": symbol,
+                "market_id": int(book.get("market_id")),
+                "size_decimals": int(book.get("supported_size_decimals", 0)),
+                "price_decimals": int(book.get("supported_price_decimals", 0)),
+                "min_quote": Decimal(str(book.get("min_quote_amount") or "10")),
+                "min_base": Decimal(str(book.get("min_base_amount") or "0")),
+                "mark": mark,
+            }
+            break
+
+        if selected is None:
+            record("Market selection", False, "No perp market with valid mark price found")
+            print_table(steps)
+            write_report(steps)
+            return 1
+
+        record("Market selection", True, f"{selected['symbol']} mark={selected['mark']}")
+    except Exception as e:
+        record("Market selection", False, str(e))
+        print_table(steps)
+        write_report(steps)
+        return 1
+
+    # Prepare and execute a post-only sell order above mark to avoid immediate fills.
+    async def execute_mainnet_trade_flow() -> None:
+        nonlocal signer
+
+        limit_price = quantize_down(selected["mark"] * Decimal("1.10"), selected["price_decimals"])
+        if limit_price <= 0:
+            raise ValueError("Rounded limit price is zero")
+
+        notional = max(Decimal("12"), selected["min_quote"])
+        raw_amount = notional / limit_price
+        amount = quantize_down(raw_amount, selected["size_decimals"])
+
+        if amount < selected["min_base"]:
+            amount = quantize_down(selected["min_base"], selected["size_decimals"])
+
+        if amount * limit_price < selected["min_quote"]:
+            required = selected["min_quote"] / limit_price
+            amount = quantize_down(required, selected["size_decimals"])
+
+        if amount < selected["min_base"]:
+            amount = quantize_down(selected["min_base"], selected["size_decimals"])
+
+        if amount <= 0:
+            raise ValueError("Rounded amount is zero")
+
+        base_amount_scaled = int((amount * Decimal(f"1e{selected['size_decimals']}")))
+        price_scaled = int((limit_price * Decimal(f"1e{selected['price_decimals']}")))
+
+        if base_amount_scaled <= 0 or price_scaled <= 0:
+            raise ValueError("Scaled amount/price are non-positive")
+        signer = lighter.signer_client.SignerClient(
+            url="https://mainnet.zklighter.elliot.ai",
+            account_index=int(account_index),
+            api_private_keys={api_key_index: signer_private_key},
+        )
+        record("Signer init", True, "SignerClient initialized")
+
+        client_order_id = f"HBOT-LP-{int(time.time())}"
+        client_order_index = client_order_index_from_id(client_order_id)
+
+        _, create_resp, create_err = await signer.create_order(
+            market_index=selected["market_id"],
+            client_order_index=client_order_index,
+            base_amount=base_amount_scaled,
+            price=price_scaled,
+            is_ask=True,
+            order_type=signer.ORDER_TYPE_LIMIT,
+            time_in_force=signer.ORDER_TIME_IN_FORCE_POST_ONLY,
+            reduce_only=False,
+            order_expiry=signer.DEFAULT_28_DAY_ORDER_EXPIRY,
+            api_key_index=api_key_index,
+        )
+
+        create_code = getattr(create_resp, "code", None)
+        create_hash = extract_tx_hash(create_resp) or ""
+        create_ok = create_err is None and create_code == 200
+        record(
+            "Perp place limit order",
+            create_ok,
+            f"symbol={selected['symbol']} code={create_code} error={create_err}",
+            create_hash,
+        )
+
+        if create_ok:
+            _, cancel_resp, cancel_err = await signer.cancel_order(
+                market_index=selected["market_id"],
+                order_index=client_order_index,
+                api_key_index=api_key_index,
+            )
+            cancel_code = getattr(cancel_resp, "code", None)
+            cancel_hash = extract_tx_hash(cancel_resp) or ""
+            cancel_ok = cancel_err is None and cancel_code == 200
+            record(
+                "Perp cancel order",
+                cancel_ok,
+                f"order_index={client_order_index} code={cancel_code} error={cancel_err}",
+                cancel_hash,
+            )
+
+    try:
+        asyncio.run(execute_mainnet_trade_flow())
+    except Exception as e:
+        if "SignerClient initialized" not in [s["details"] for s in steps if s["step"] == "Signer init"]:
+            record("Signer init", False, str(e))
+        else:
+            record("Perp trading flow", False, str(e))
+    finally:
+        try:
+            asyncio.run(close_signer_sessions())
+        except Exception:
+            pass
+
+    print_table(steps)
+    write_report(steps)
+
+    return 0 if all(step["status"] == "PASS" for step in steps) else 1
+
+
+def print_table(steps: list[Dict[str, str]]):
+    print("\n| Step | Status | Details | Tx Hash |")
+    print("|---|---|---|---|")
+    for step in steps:
+        details = step["details"].replace("|", "/")
+        tx = step["tx_hash"] or "-"
+        print(f"| {step['step']} | {step['status']} | {details} | {tx} |")
+
+
+def write_report(steps: list[Dict[str, str]]):
+    out_path = ROOT / "scripts" / "lighter_perp_integration_report.json"
+    payload = {
+        "timestamp": int(time.time()),
+        "results": steps,
+    }
+    out_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    raise SystemExit(run())

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ def main():
         "cryptography>=41.0.2",
         "eth-account>=0.13.0",
         "injective-py",
+        "lighter-sdk==1.0.6",
         "msgpack-python",
         "numba>=0.61.2",
         "numpy>=2.2.6",

--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -66,3 +66,4 @@ dependencies:
   - zlib>=1.2.13
   - pip:
     - injective-py==1.13.*
+    - lighter-sdk==1.0.6  # Pin the tested signer package until connector compatibility is revalidated against newer binaries

--- a/test/hummingbot/connector/derivative/lighter_perpetual/test_lighter_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/lighter_perpetual/test_lighter_perpetual_api_order_book_data_source.py
@@ -1,0 +1,289 @@
+import asyncio
+import sys
+import types
+import unittest
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def _ensure_limit_order_stub():
+    module_name = "hummingbot.core.data_type.limit_order"
+    if module_name in sys.modules:
+        return
+    stub_module = types.ModuleType(module_name)
+
+    class LimitOrder:
+        pass
+
+    stub_module.LimitOrder = LimitOrder
+    sys.modules[module_name] = stub_module
+
+
+def _ensure_order_book_stub():
+    module_name = "hummingbot.core.data_type.order_book"
+    if module_name in sys.modules:
+        return
+    stub_module = types.ModuleType(module_name)
+
+    class OrderBook:
+        pass
+
+    stub_module.OrderBook = OrderBook
+    sys.modules[module_name] = stub_module
+
+
+class LighterPerpetualAPIOrderBookDataSourceTests(unittest.IsolatedAsyncioTestCase):
+
+    data_source_cls = None
+    constants = None
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        _ensure_limit_order_stub()
+        _ensure_order_book_stub()
+        try:
+            from hummingbot.connector.derivative.lighter_perpetual import lighter_perpetual_constants as CONSTANTS
+            from hummingbot.connector.derivative.lighter_perpetual.lighter_perpetual_api_order_book_data_source import (
+                LighterPerpetualAPIOrderBookDataSource,
+            )
+
+            cls.constants = CONSTANTS
+            cls.data_source_cls = LighterPerpetualAPIOrderBookDataSource
+        except ModuleNotFoundError:
+            cls.data_source_cls = None
+
+    def setUp(self):
+        super().setUp()
+        if self.data_source_cls is None:
+            self.skipTest("Compiled hummingbot core modules are unavailable in this environment")
+
+        self.connector = MagicMock()
+        self.connector.rest_api_key = "api-key"
+        self.connector.exchange_symbol_associated_to_pair = AsyncMock(return_value="BTC")
+        self.connector.trading_pair_associated_to_exchange_symbol = AsyncMock(
+            side_effect=lambda symbol: {"BTC": "BTC-USDC", "ETH": "ETH-USDC"}[symbol]
+        )
+        self.connector.get_last_traded_prices = AsyncMock(return_value={"BTC-USDC": 101.2})
+        self.connector.set_LIGHTER_price = MagicMock()
+
+        self.rest_assistant = AsyncMock()
+        self.ws_assistant = AsyncMock()
+        self.api_factory = MagicMock()
+        self.api_factory.get_rest_assistant = AsyncMock(return_value=self.rest_assistant)
+        self.api_factory.get_ws_assistant = AsyncMock(return_value=self.ws_assistant)
+
+        self.data_source = self.data_source_cls(
+            trading_pairs=["BTC-USDC"],
+            connector=self.connector,
+            api_factory=self.api_factory,
+        )
+
+    async def test_request_order_book_snapshot_uses_expected_rest_request(self):
+        self.rest_assistant.execute_request = AsyncMock(return_value={
+            "success": True,
+            "data": {
+                "s": "BTC",
+                "l": [[{"p": "100", "a": "1"}], [{"p": "101", "a": "2"}]],
+                "t": 1700000000000,
+            },
+        })
+
+        result = await self.data_source._request_order_book_snapshot("BTC-USDC")
+
+        self.assertEqual("BTC", result["s"])
+        self.rest_assistant.execute_request.assert_awaited_once()
+        call_kwargs = self.rest_assistant.execute_request.call_args.kwargs
+        self.assertEqual({"symbol": "BTC"}, call_kwargs["params"])
+        self.assertEqual({"X-Api-Key": "api-key"}, call_kwargs["headers"])
+        self.assertEqual(self.constants.GET_MARKET_ORDER_BOOK_SNAPSHOT_PATH_URL, call_kwargs["throttler_limit_id"])
+
+    async def test_order_book_snapshot_builds_snapshot_message(self):
+        self.data_source._request_order_book_snapshot = AsyncMock(return_value={
+            "s": "BTC",
+            "l": [[{"p": "100", "a": "1.5"}], [{"p": "101", "a": "2.5"}]],
+            "t": 1700000000000,
+        })
+
+        message = await self.data_source._order_book_snapshot("BTC-USDC")
+
+        self.assertEqual("BTC-USDC", message.content["trading_pair"])
+        self.assertEqual([("100", "1.5")], message.content["bids"])
+        self.assertEqual([("101", "2.5")], message.content["asks"])
+        self.assertEqual(1700000000.0, message.timestamp)
+
+    async def test_get_funding_info_parses_price_entry(self):
+        self.rest_assistant.execute_request = AsyncMock(return_value={
+            "success": True,
+            "data": [{
+                "symbol": "BTC",
+                "oracle": "100",
+                "mark": "101",
+                "funding": "0.0001",
+            }],
+        })
+
+        funding_info = await self.data_source.get_funding_info("BTC-USDC")
+
+        self.assertEqual("BTC-USDC", funding_info.trading_pair)
+        self.assertEqual(Decimal("100"), funding_info.index_price)
+        self.assertEqual(Decimal("101"), funding_info.mark_price)
+        self.assertEqual(Decimal("0.0001"), funding_info.rate)
+
+    @patch("hummingbot.connector.derivative.lighter_perpetual.lighter_perpetual_api_order_book_data_source.safe_ensure_future")
+    async def test_connected_websocket_assistant_connects_and_starts_ping(self, safe_future_mock):
+        safe_future_mock.side_effect = lambda coro: (coro.close(), MagicMock())[1]
+
+        ws = await self.data_source._connected_websocket_assistant()
+
+        self.assertIs(self.ws_assistant, ws)
+        self.ws_assistant.connect.assert_awaited_once()
+        connect_kwargs = self.ws_assistant.connect.call_args.kwargs
+        self.assertEqual({"X-Api-Key": "api-key"}, connect_kwargs["ws_headers"])
+        self.assertEqual(1, safe_future_mock.call_count)
+
+    async def test_subscribe_channels_sends_book_trade_and_prices_requests(self):
+        await self.data_source._subscribe_channels(self.ws_assistant)
+
+        self.assertEqual(3, self.ws_assistant.send.await_count)
+        payloads = [call.args[0].payload for call in self.ws_assistant.send.call_args_list]
+        self.assertEqual(
+            {
+                "method": "subscribe",
+                "params": {"source": "book", "symbol": "BTC", "agg_level": 1},
+            },
+            payloads[0],
+        )
+        self.assertEqual(
+            {
+                "method": "subscribe",
+                "params": {"source": "trades", "symbol": "BTC"},
+            },
+            payloads[1],
+        )
+        self.assertEqual(
+            {
+                "method": "subscribe",
+                "params": {"source": "prices"},
+            },
+            payloads[2],
+        )
+
+    async def test_parse_order_book_snapshot_message_emits_snapshot(self):
+        queue = asyncio.Queue()
+
+        await self.data_source._parse_order_book_snapshot_message(
+            {
+                "data": {
+                    "l": [[{"p": "100", "a": "1"}], [{"p": "101", "a": "2"}]],
+                    "s": "BTC",
+                    "t": 1700000000000,
+                    "li": 123,
+                }
+            },
+            queue,
+        )
+
+        message = queue.get_nowait()
+        self.assertEqual("BTC-USDC", message.content["trading_pair"])
+        self.assertEqual(123, message.update_id)
+        self.assertEqual([("100", "1")], message.content["bids"])
+        self.assertEqual([("101", "2")], message.content["asks"])
+
+    async def test_parse_trade_message_emits_buy_and_sell_messages(self):
+        queue = asyncio.Queue()
+
+        await self.data_source._parse_trade_message(
+            {
+                "data": [
+                    {"h": 1, "li": 11, "s": "BTC", "d": "open_long", "a": "0.1", "p": "100", "t": 1700000000000},
+                    {"h": 2, "li": 12, "s": "BTC", "d": "open_short", "a": "0.2", "p": "99", "t": 1700000001000},
+                ]
+            },
+            queue,
+        )
+
+        buy_message = queue.get_nowait()
+        sell_message = queue.get_nowait()
+        self.assertEqual(1.0, buy_message.content["trade_type"])
+        self.assertEqual(2.0, sell_message.content["trade_type"])
+        self.assertEqual("0.1", buy_message.content["amount"])
+        self.assertEqual("99", sell_message.content["price"])
+
+    async def test_parse_funding_info_message_updates_queue_and_cached_prices(self):
+        queue = asyncio.Queue()
+
+        await self.data_source._parse_funding_info_message(
+            {
+                "data": [
+                    {"symbol": "BTC", "oracle": "100", "mark": "101", "funding": "0.0001", "timestamp": 1700000000000},
+                    {"symbol": "ETH", "oracle": "200", "mark": "201", "funding": "0.0002", "timestamp": 1700000000000},
+                ]
+            },
+            queue,
+        )
+
+        update = queue.get_nowait()
+        self.assertEqual("BTC-USDC", update.trading_pair)
+        self.assertEqual(Decimal("100"), update.index_price)
+        self.assertEqual(Decimal("101"), update.mark_price)
+        self.connector.set_LIGHTER_price.assert_called_once_with(
+            "BTC-USDC",
+            timestamp=1700000000.0,
+            index_price=Decimal("100"),
+            mark_price=Decimal("101"),
+        )
+
+    def test_channel_originating_message_routes_known_channels(self):
+        self.assertEqual(
+            self.data_source._snapshot_messages_queue_key,
+            self.data_source._channel_originating_message({"channel": "book", "data": {}}),
+        )
+        self.assertEqual(
+            self.data_source._trade_messages_queue_key,
+            self.data_source._channel_originating_message({"channel": "trades", "data": {}}),
+        )
+        self.assertEqual(
+            self.data_source._funding_info_messages_queue_key,
+            self.data_source._channel_originating_message({"channel": "prices", "data": {}}),
+        )
+        self.assertEqual("", self.data_source._channel_originating_message({"channel": "other"}))
+
+    async def test_subscribe_and_unsubscribe_trading_pair_send_expected_messages(self):
+        self.data_source._ws_assistant = self.ws_assistant
+
+        subscribed = await self.data_source.subscribe_to_trading_pair("BTC-USDC")
+        unsubscribed = await self.data_source.unsubscribe_from_trading_pair("BTC-USDC")
+
+        self.assertTrue(subscribed)
+        self.assertTrue(unsubscribed)
+        payloads = [call.args[0].payload for call in self.ws_assistant.send.call_args_list]
+        self.assertEqual("subscribe", payloads[0]["method"])
+        self.assertEqual("unsubscribe", payloads[2]["method"])
+        self.assertEqual("book", payloads[0]["params"]["source"])
+        self.assertEqual("trades", payloads[1]["params"]["source"])
+        self.assertEqual("book", payloads[2]["params"]["source"])
+        self.assertEqual("trades", payloads[3]["params"]["source"])
+
+    async def test_on_order_stream_interruption_cancels_ping_task(self):
+        ping_task = MagicMock()
+        self.data_source._ping_task = ping_task
+
+        await self.data_source._on_order_stream_interruption()
+
+        ping_task.cancel.assert_called_once()
+        self.assertIsNone(self.data_source._ping_task)
+
+    async def test_ping_loop_returns_when_ws_disconnects(self):
+        self.ws_assistant.send.side_effect = RuntimeError("WS is not connected")
+
+        with patch("hummingbot.connector.derivative.lighter_perpetual.lighter_perpetual_api_order_book_data_source.asyncio.sleep", new=AsyncMock()):
+            result = await self.data_source._ping_loop(self.ws_assistant)
+
+        self.assertIsNone(result)
+
+    async def test_subscribe_channels_raises_on_send_error(self):
+        self.ws_assistant.send.side_effect = Exception("boom")
+
+        with self.assertRaises(Exception):
+            await self.data_source._subscribe_channels(self.ws_assistant)

--- a/test/hummingbot/connector/derivative/lighter_perpetual/test_lighter_perpetual_auth.py
+++ b/test/hummingbot/connector/derivative/lighter_perpetual/test_lighter_perpetual_auth.py
@@ -1,0 +1,48 @@
+import unittest
+from unittest.mock import AsyncMock
+
+from hummingbot.connector.derivative.lighter_perpetual.lighter_perpetual_auth import LighterPerpetualAuth
+
+
+class LighterPerpetualAuthTests(unittest.IsolatedAsyncioTestCase):
+
+    async def test_rest_auth_adds_headers(self):
+        auth = LighterPerpetualAuth(
+            api_key="api-key",
+            api_secret="api-secret",
+        )
+
+        request = AsyncMock()
+        request.headers = {}
+        result = await auth.rest_authenticate(request)
+
+        self.assertIs(request, result)
+        self.assertEqual("application/json", request.headers["accept"])
+        self.assertEqual("application/json", request.headers["Content-Type"])
+        self.assertEqual("api-key", request.headers["X-Api-Key"])
+
+    async def test_rest_auth_preserves_existing_headers(self):
+        auth = LighterPerpetualAuth(
+            api_key="api-key",
+            api_secret="api-secret",
+        )
+
+        request = AsyncMock()
+        request.headers = {"X-Test": "1"}
+
+        result = await auth.rest_authenticate(request)
+
+        self.assertIs(request, result)
+        self.assertEqual("1", request.headers["X-Test"])
+        self.assertEqual("api-key", request.headers["X-Api-Key"])
+
+    async def test_ws_auth_does_not_mutate_request(self):
+        auth = LighterPerpetualAuth(
+            api_key="api-key",
+            api_secret="api-secret",
+        )
+
+        request = AsyncMock()
+        result = await auth.ws_authenticate(request)
+
+        self.assertIs(request, result)

--- a/test/hummingbot/connector/derivative/lighter_perpetual/test_lighter_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/lighter_perpetual/test_lighter_perpetual_derivative.py
@@ -4,7 +4,7 @@ import unittest
 from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
-from hummingbot.core.data_type.common import PositionAction
+from hummingbot.core.data_type.common import PositionAction, TradeType
 
 
 def _ensure_limit_order_stub():
@@ -924,17 +924,113 @@ class LighterPerpetualDerivativeTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_get_last_traded_price_returns_close_price(self):
         self.connector.exchange_symbol_associated_to_pair = AsyncMock(return_value="BTC")
-        self.connector._api_get = AsyncMock(return_value={"data": [{"c": "50123.5", "o": "50000"}]})
+        self.connector._api_get = AsyncMock(return_value={
+            "success": True,
+            "data": [{"symbol": "BTC", "mid": "50123.5", "mark": "50000"}],
+        })
 
         result = await self.connector._get_last_traded_price("BTC-USDC")
         self.assertAlmostEqual(50123.5, result)
 
+    async def test_get_last_traded_price_falls_back_to_candles_when_prices_endpoint_has_no_symbol(self):
+        self.connector.exchange_symbol_associated_to_pair = AsyncMock(return_value="BTC")
+        self.connector._api_get = AsyncMock(side_effect=[
+            {"success": True, "data": [{"symbol": "ETH", "mid": "3000"}]},
+            {"data": [{"c": "50123.5", "o": "50000"}]},
+        ])
+
+        result = await self.connector._get_last_traded_price("BTC-USDC")
+
+        self.assertAlmostEqual(50123.5, result)
+
     async def test_get_last_traded_price_returns_zero_for_empty_candles(self):
         self.connector.exchange_symbol_associated_to_pair = AsyncMock(return_value="BTC")
-        self.connector._api_get = AsyncMock(return_value={"data": []})
+        self.connector._api_get = AsyncMock(side_effect=[
+            {"success": True, "data": []},
+            {"data": []},
+        ])
 
         result = await self.connector._get_last_traded_price("BTC-USDC")
         self.assertEqual(0.0, result)
+
+    async def test_modify_order_uses_native_sdk(self):
+        tracked_order = MagicMock()
+        tracked_order.exchange_order_id = "1234"
+        tracked_order.trading_pair = "BTC-USDC"
+        tracked_order.current_timestamp = 1700000000.0
+
+        mock_tx_response = MagicMock()
+        mock_tx_response.code = 200
+
+        mock_signer = MagicMock()
+        mock_signer.modify_order = AsyncMock(return_value=(MagicMock(), mock_tx_response, None))
+        self.connector._get_lighter_signer_client = MagicMock(return_value=mock_signer)
+        self.connector._get_market_spec = AsyncMock(return_value=(0, 2, 2, None))
+        self.connector._get_api_key_index = MagicMock(return_value=2)
+
+        exchange_id, ts = await self.connector._modify_order(
+            tracked_order=tracked_order,
+            new_price=Decimal("50000"),
+            new_amount=Decimal("0.1"),
+        )
+
+        self.assertEqual("1234", exchange_id)
+        mock_signer.modify_order.assert_awaited_once_with(
+            market_index=0,
+            order_index=1234,
+            base_amount=10,
+            price=5000000,
+            api_key_index=2,
+        )
+
+    async def test_modify_order_raises_when_sdk_returns_error(self):
+        tracked_order = MagicMock()
+        tracked_order.exchange_order_id = "1234"
+        tracked_order.trading_pair = "BTC-USDC"
+
+        mock_signer = MagicMock()
+        mock_signer.modify_order = AsyncMock(return_value=(None, None, "sign error"))
+        self.connector._get_lighter_signer_client = MagicMock(return_value=mock_signer)
+        self.connector._get_market_spec = AsyncMock(return_value=(0, 2, 2, None))
+        self.connector._get_api_key_index = MagicMock(return_value=2)
+
+        with self.assertRaises(IOError):
+            await self.connector._modify_order(
+                tracked_order=tracked_order,
+                new_price=Decimal("50000"),
+                new_amount=Decimal("0.1"),
+            )
+
+    def test_extract_ticker_price_prefers_last_trade_then_mid_mark_oracle(self):
+        extractor = self.connector_cls._extract_ticker_price
+
+        self.assertEqual(Decimal("12.3"), extractor({"last_trade_price": "12.3", "mid": "11"}))
+        self.assertEqual(Decimal("11"), extractor({"mid": "11", "mark": "10"}))
+        self.assertEqual(Decimal("10"), extractor({"mark": "10", "oracle": "9"}))
+        self.assertEqual(Decimal("9"), extractor({"oracle": "9"}))
+        self.assertIsNone(extractor({}))
+
+    def test_extract_liquidation_price_reads_rest_and_ws_shapes(self):
+        extractor = self.connector_cls._extract_liquidation_price
+
+        self.assertEqual(Decimal("100"), extractor({"liquidation_price": "100"}))
+        self.assertEqual(Decimal("200"), extractor({"l": "200"}))
+        self.assertIsNone(extractor({"l": ""}))
+        self.assertIsNone(extractor({}))
+
+    def test_warn_if_position_near_liquidation_emits_warning(self):
+        mock_logger = MagicMock()
+        with patch.object(self.connector, "logger", return_value=mock_logger):
+            from hummingbot.core.data_type.common import PositionSide
+
+            self.connector._warn_if_position_near_liquidation(
+                trading_pair="BTC-USDC",
+                position_side=PositionSide.LONG,
+                mark_price=Decimal("100"),
+                liquidation_price=Decimal("96"),
+            )
+
+        mock_logger.warning.assert_called()
 
     async def test_update_trading_fees_updates_maker_and_taker_fee(self):
         self.connector._api_get = AsyncMock(return_value={

--- a/test/hummingbot/connector/derivative/lighter_perpetual/test_lighter_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/lighter_perpetual/test_lighter_perpetual_derivative.py
@@ -1,0 +1,1259 @@
+import sys
+import types
+import unittest
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+
+from hummingbot.core.data_type.common import PositionAction
+
+
+def _ensure_limit_order_stub():
+    module_name = "hummingbot.core.data_type.limit_order"
+    if module_name in sys.modules:
+        return
+    stub_module = types.ModuleType(module_name)
+
+    class LimitOrder:
+        pass
+
+    stub_module.LimitOrder = LimitOrder
+    sys.modules[module_name] = stub_module
+
+
+def _ensure_order_book_stub():
+    module_name = "hummingbot.core.data_type.order_book"
+    if module_name in sys.modules:
+        return
+    stub_module = types.ModuleType(module_name)
+
+    class OrderBook:
+        pass
+
+    stub_module.OrderBook = OrderBook
+    sys.modules[module_name] = stub_module
+
+
+class LighterPerpetualDerivativeTests(unittest.IsolatedAsyncioTestCase):
+
+    connector_cls = None
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        _ensure_limit_order_stub()
+        _ensure_order_book_stub()
+        try:
+            from hummingbot.connector.derivative.lighter_perpetual.lighter_perpetual_derivative import (
+                LighterPerpetualDerivative,
+            )
+            cls.connector_cls = LighterPerpetualDerivative
+        except ModuleNotFoundError:
+            cls.connector_cls = None
+
+    def setUp(self) -> None:
+        super().setUp()
+        if self.connector_cls is None:
+            self.skipTest("Compiled hummingbot core modules are unavailable in this environment")
+
+        self.connector = self.connector_cls(
+            lighter_perpetual_api_key="1",
+            lighter_perpetual_api_secret="0xabc",
+            lighter_perpetual_account_index="237600",
+            trading_pairs=["BTC-USDC"],
+            trading_required=False,
+        )
+
+    async def test_update_balances_parses_collateral(self):
+        self.connector._api_get = AsyncMock(return_value={
+            "success": True,
+            "data": {
+                "collateral": "123.45",
+                "availableCollateral": "120.11",
+                "fee_level": 2,
+            },
+        })
+
+        await self.connector._update_balances()
+
+        self.assertEqual(Decimal("123.45"), self.connector._account_balances["USDC"])
+        self.assertEqual(Decimal("120.11"), self.connector._account_available_balances["USDC"])
+        self.assertEqual(2, self.connector._fee_tier)
+
+    def test_set_usdc_balances_replaces_stale_assets(self):
+        self.connector._account_balances["BTC"] = Decimal("1")
+        self.connector._account_available_balances["BTC"] = Decimal("0.5")
+
+        self.connector._set_usdc_balances(Decimal("10"), Decimal("7"))
+
+        self.assertEqual({"USDC": Decimal("10")}, self.connector._account_balances)
+        self.assertEqual({"USDC": Decimal("7")}, self.connector._account_available_balances)
+
+    def test_check_network_request_path_uses_exchange_stats(self):
+        self.assertEqual("/exchangeStats", self.connector.check_network_request_path)
+
+    def test_get_api_key_index_prefers_numeric_api_key(self):
+        self.connector.api_key = "12"
+        self.assertEqual(12, self.connector._get_api_key_index())
+
+    def test_get_api_key_index_uses_numeric_api_secret_fallback(self):
+        self.connector.api_key = "not-a-number"
+        self.connector.api_secret = "34"
+        self.connector.api_key_index = ""
+
+        self.assertEqual(34, self.connector._get_api_key_index())
+
+    def test_get_api_key_index_raises_for_non_numeric_config(self):
+        self.connector.api_key = "not-a-number"
+        self.connector.api_secret = "not-a-number"
+        self.connector.api_key_index = ""
+
+        with self.assertRaises(ValueError):
+            self.connector._get_api_key_index()
+
+    async def test_fetch_or_create_api_config_key_resolves_index_from_api_keys(self):
+        self.connector.api_key = "abc_public_key"
+        self.connector.api_secret = ""
+        self.connector.api_config_key = "abc_public_key"
+        self.connector.api_key_index = ""
+        self.connector.account_index = "237600"
+        self.connector._api_get = AsyncMock(return_value={
+            "api_keys": [
+                {"api_key_index": 3, "public_key": "other_key"},
+                {"api_key_index": 5, "public_key": "abc_public_key"},
+            ]
+        })
+
+        await self.connector._fetch_or_create_api_config_key()
+
+        self.assertEqual("5", self.connector.api_key_index)
+
+    async def test_fetch_or_create_api_config_key_skips_when_index_already_configured(self):
+        self.connector.api_config_key = "configured"
+        self.connector.api_key_index = "4"
+        self.connector._api_get = AsyncMock()
+
+        await self.connector._fetch_or_create_api_config_key()
+
+        self.connector._api_get.assert_not_called()
+
+    async def test_fetch_or_create_api_config_key_warns_when_key_not_found(self):
+        mock_logger = MagicMock()
+        self.connector.api_key = "my_public_key"
+        self.connector.api_secret = ""
+        self.connector.api_config_key = "my_public_key"
+        self.connector.api_key_index = ""
+        self.connector.account_index = "237600"
+        self.connector._api_get = AsyncMock(return_value={
+            "api_keys": [{"api_key_index": 1, "public_key": "other_key"}]
+        })
+
+        with patch.object(self.connector, "logger", return_value=mock_logger):
+            await self.connector._fetch_or_create_api_config_key()
+
+        self.assertEqual("", self.connector.api_key_index)
+        mock_logger.warning.assert_called_once()
+
+    async def test_fetch_or_create_api_config_key_skips_when_credentials_missing(self):
+        mock_logger = MagicMock()
+        self.connector.account_index = ""
+        self.connector.api_key = ""
+        self.connector.api_secret = ""
+        self.connector.api_config_key = ""
+        self.connector._api_get = AsyncMock()
+
+        with patch.object(self.connector, "logger", return_value=mock_logger):
+            await self.connector._fetch_or_create_api_config_key()
+
+        self.connector._api_get.assert_not_called()
+        mock_logger.warning.assert_called_once()
+
+    def test_get_signer_private_key_prefers_explicit_private_key(self):
+        self.connector.private_key = "0xsigner"
+        self.connector.api_key = "public"
+        self.connector.api_secret = "secret"
+
+        self.assertEqual("0xsigner", self.connector._get_signer_private_key())
+
+    def test_get_signer_private_key_uses_non_numeric_api_key(self):
+        self.connector.private_key = ""
+        self.connector.api_key = "0xapi_key_private"
+        self.connector.api_secret = "123"
+
+        self.assertEqual("0xapi_key_private", self.connector._get_signer_private_key())
+
+    def test_get_signer_private_key_uses_non_numeric_api_secret(self):
+        self.connector.private_key = ""
+        self.connector.api_key = "123"
+        self.connector.api_secret = "0xapi_secret_private"
+
+        self.assertEqual("0xapi_secret_private", self.connector._get_signer_private_key())
+
+    def test_get_signer_private_key_raises_when_not_available(self):
+        self.connector.private_key = ""
+        self.connector.api_key = "123"
+        self.connector.api_secret = "456"
+
+        with self.assertRaises(ValueError):
+            self.connector._get_signer_private_key()
+
+    def test_generate_api_key_pair_returns_private_and_public_keys(self):
+        fake_lighter_module = types.SimpleNamespace(create_api_key=lambda: ("priv", "pub", None))
+        with patch.dict(sys.modules, {"lighter": fake_lighter_module}):
+            private_key, public_key = self.connector.generate_api_key_pair()
+
+        self.assertEqual("priv", private_key)
+        self.assertEqual("pub", public_key)
+
+    def test_generate_api_key_pair_raises_when_sdk_returns_error(self):
+        fake_lighter_module = types.SimpleNamespace(create_api_key=lambda: (None, None, "boom"))
+        with patch.dict(sys.modules, {"lighter": fake_lighter_module}):
+            with self.assertRaises(ValueError):
+                self.connector.generate_api_key_pair()
+
+    def test_authenticator_uses_rest_api_key_and_account_identifier(self):
+        self.connector.api_key = "public"
+        self.connector.api_secret = "secret"
+        self.connector.account_index = "237600"
+
+        auth = self.connector.authenticator
+
+        self.assertEqual("secret", auth.api_key)
+        self.assertEqual("secret", auth.api_secret)
+        self.assertEqual("237600", auth.user_wallet_public_key)
+
+    def test_rate_limits_rules_returns_default_limits_without_api_key(self):
+        import hummingbot.connector.derivative.lighter_perpetual.lighter_perpetual_constants as C
+
+        self.connector.api_key = ""
+
+        limits = self.connector.rate_limits_rules
+
+        self.assertEqual(C.RATE_LIMITS, limits)
+
+    def test_rate_limits_rules_uses_fee_tier_when_api_key_present(self):
+        import hummingbot.connector.derivative.lighter_perpetual.lighter_perpetual_constants as C
+
+        self.connector.api_key = "configured-key"
+        self.connector._fee_tier = 4
+
+        limits = self.connector.rate_limits_rules
+
+        self.assertEqual(C.LIGHTER_LIMIT_ID, limits[0].limit_id)
+        self.assertEqual(C.FEE_TIER_LIMITS[4], limits[0].limit)
+
+    def test_rate_limits_rules_uses_default_tier_2_limit_for_unknown_fee_tier(self):
+        import hummingbot.connector.derivative.lighter_perpetual.lighter_perpetual_constants as C
+
+        self.connector.api_key = "configured-key"
+        self.connector._fee_tier = 999
+
+        limits = self.connector.rate_limits_rules
+
+        self.assertEqual(C.LIGHTER_TIER_2_LIMIT, limits[0].limit)
+
+    def test_get_lighter_signer_client_is_cached(self):
+        captured_kwargs = {}
+
+        class MockSignerClient:
+            def __init__(self, **kwargs):
+                captured_kwargs.update(kwargs)
+
+        fake_lighter_module = types.SimpleNamespace(
+            signer_client=types.SimpleNamespace(SignerClient=MockSignerClient)
+        )
+        self.connector.api_key = "7"
+        self.connector.api_secret = "0xabc"
+        self.connector.account_index = "237600"
+        self.connector._lighter_signer_client = None
+
+        with patch.dict(sys.modules, {"lighter": fake_lighter_module}):
+            client_first = self.connector._get_lighter_signer_client()
+            client_second = self.connector._get_lighter_signer_client()
+
+        self.assertIs(client_first, client_second)
+        self.assertEqual(237600, captured_kwargs["account_index"])
+        self.assertIn(7, captured_kwargs["api_private_keys"])
+
+    def test_create_web_assistants_factory_returns_factory(self):
+        factory = self.connector._create_web_assistants_factory()
+
+        self.assertIsNotNone(factory)
+
+    def test_create_order_book_data_source_uses_connector_and_domain(self):
+        data_source = self.connector._create_order_book_data_source()
+
+        self.assertEqual(self.connector, data_source._connector)
+        self.assertEqual(self.connector.domain, data_source._domain)
+
+    def test_create_user_stream_data_source_uses_connector_and_auth(self):
+        data_source = self.connector._create_user_stream_data_source()
+
+        self.assertEqual(self.connector, data_source._connector)
+        self.assertEqual(self.connector.domain, data_source._domain)
+        self.assertEqual(self.connector.account_index, data_source._auth.user_wallet_public_key)
+
+    def test_get_rest_api_key_returns_non_numeric_api_key_when_secret_missing(self):
+        self.connector.api_key = "public-key"
+        self.connector.api_secret = ""
+
+        self.assertEqual("public-key", self.connector._get_rest_api_key())
+
+    def test_set_lighter_price_keeps_latest_timestamp(self):
+        self.connector.set_LIGHTER_price("BTC-USDC", 200.0, Decimal("101"), Decimal("102"))
+        self.connector.set_LIGHTER_price("BTC-USDC", 199.0, Decimal("99"), Decimal("100"))
+
+        price_record = self.connector.get_LIGHTER_price("BTC-USDC")
+        self.assertEqual(200.0, price_record.timestamp)
+        self.assertEqual(Decimal("101"), price_record.index_price)
+        self.assertEqual(Decimal("102"), price_record.mark_price)
+
+    async def test_api_request_adds_x_api_key_header(self):
+        from hummingbot.connector.perpetual_derivative_py_base import PerpetualDerivativePyBase
+
+        self.connector.api_key = "123"
+        with patch.object(
+            PerpetualDerivativePyBase,
+            "_api_request",
+            new_callable=AsyncMock,
+            return_value={"ok": True},
+        ) as super_api_request:
+            response = await self.connector._api_request(path_url="/test", headers={"Existing": "value"})
+
+        self.assertEqual({"ok": True}, response)
+        called_headers = super_api_request.call_args.kwargs["headers"]
+        self.assertEqual("123", called_headers["X-Api-Key"])
+        self.assertEqual("value", called_headers["Existing"])
+
+    async def test_api_request_without_rest_api_key_leaves_headers_unchanged(self):
+        from hummingbot.connector.perpetual_derivative_py_base import PerpetualDerivativePyBase
+
+        self.connector.api_key = ""
+        self.connector.api_secret = ""
+        with patch.object(
+            PerpetualDerivativePyBase,
+            "_api_request",
+            new_callable=AsyncMock,
+            return_value={"ok": True},
+        ) as super_api_request:
+            await self.connector._api_request(path_url="/test", headers={"Existing": "value"})
+
+        called_headers = super_api_request.call_args.kwargs["headers"]
+        self.assertEqual({"Existing": "value"}, called_headers)
+
+    async def test_api_request_without_headers_passes_api_key_header(self):
+        from hummingbot.connector.perpetual_derivative_py_base import PerpetualDerivativePyBase
+
+        self.connector.api_key = "55"
+        with patch.object(
+            PerpetualDerivativePyBase,
+            "_api_request",
+            new_callable=AsyncMock,
+            return_value={"ok": True},
+        ) as super_api_request:
+            await self.connector._api_request(path_url="/test", headers=None)
+
+        called_headers = super_api_request.call_args.kwargs["headers"]
+        self.assertEqual({"X-Api-Key": "55"}, called_headers)
+
+    async def test_process_account_order_updates_ws_event_message_updates_tracked_order(self):
+        tracked_order = MagicMock()
+        tracked_order.exchange_order_id = "123"
+        tracked_order.client_order_id = "HBOT-1"
+        tracked_order.trading_pair = "BTC-USDC"
+        self.connector._order_tracker.process_order_update = MagicMock()
+
+        with patch.object(
+            type(self.connector._order_tracker),
+            "all_updatable_orders",
+            new_callable=PropertyMock,
+            return_value={"HBOT-1": tracked_order},
+        ):
+            await self.connector._process_account_order_updates_ws_event_message({
+                "data": [{"i": 123, "os": "filled", "ut": 1700000000000}],
+            })
+
+        self.connector._order_tracker.process_order_update.assert_called_once()
+        order_update = self.connector._order_tracker.process_order_update.call_args.args[0]
+        self.assertEqual("HBOT-1", order_update.client_order_id)
+        self.assertEqual("123", order_update.exchange_order_id)
+
+    async def test_process_account_order_updates_ws_event_message_ignores_unknown_order(self):
+        self.connector._order_tracker.process_order_update = MagicMock()
+
+        with patch.object(
+            type(self.connector._order_tracker),
+            "all_updatable_orders",
+            new_callable=PropertyMock,
+            return_value={},
+        ):
+            await self.connector._process_account_order_updates_ws_event_message({
+                "data": [{"i": 123, "os": "filled", "ut": 1700000000000}],
+            })
+
+        self.connector._order_tracker.process_order_update.assert_not_called()
+
+    async def test_process_account_info_ws_event_message_updates_balances_and_fee_tier(self):
+        await self.connector._process_account_info_ws_event_message({
+            "data": {"ae": "12.5", "as": "10.2", "f": 3},
+        })
+
+        self.assertEqual(Decimal("12.5"), self.connector._account_balances["USDC"])
+        self.assertEqual(Decimal("10.2"), self.connector._account_available_balances["USDC"])
+        self.assertEqual(3, self.connector._fee_tier)
+
+    async def test_process_account_positions_ws_event_message_replaces_snapshot_with_long_and_short(self):
+        class FakePerpetualTrading:
+            def __init__(self):
+                self.account_positions = {"stale": "position"}
+
+            def position_key(self, trading_pair, position_side):
+                return f"{trading_pair}-{position_side.name}"
+
+            def set_position(self, key, position):
+                self.account_positions[key] = position
+
+        self.connector._perpetual_trading = FakePerpetualTrading()
+        self.connector.trading_pair_associated_to_exchange_symbol = AsyncMock(
+            side_effect=lambda symbol: {"BTC": "BTC-USDC", "ETH": "ETH-USDC"}[symbol]
+        )
+        self.connector.get_leverage = MagicMock(return_value="10")
+        self.connector.set_LIGHTER_price("BTC-USDC", 100.0, Decimal("100"), Decimal("105"))
+        self.connector.set_LIGHTER_price("ETH-USDC", 100.0, Decimal("200"), Decimal("190"))
+
+        await self.connector._process_account_positions_ws_event_message({
+            "data": [
+                {"s": "BTC", "d": "bid", "a": "0.5", "p": "100"},
+                {"s": "ETH", "d": "ask", "a": "1.2", "p": "200"},
+            ]
+        })
+
+        positions = self.connector._perpetual_trading.account_positions
+        self.assertEqual(2, len(positions))
+        btc_position = positions["BTC-USDC-LONG"]
+        eth_position = positions["ETH-USDC-SHORT"]
+        self.assertEqual(Decimal("0.5"), btc_position.amount)
+        self.assertEqual(Decimal("2.5"), btc_position.unrealized_pnl)
+        self.assertEqual(Decimal("-1.2"), eth_position.amount)
+        self.assertEqual(Decimal("12.0"), eth_position.unrealized_pnl)
+
+    async def test_process_account_positions_ws_event_message_clears_snapshot_when_empty(self):
+        class FakePerpetualTrading:
+            def __init__(self):
+                self.account_positions = {"BTC-USDC-LONG": "existing"}
+
+            def position_key(self, trading_pair, position_side):
+                return f"{trading_pair}-{position_side.name}"
+
+            def set_position(self, key, position):
+                self.account_positions[key] = position
+
+        self.connector._perpetual_trading = FakePerpetualTrading()
+
+        await self.connector._process_account_positions_ws_event_message({"data": []})
+
+        self.assertEqual({}, self.connector._perpetual_trading.account_positions)
+
+    async def test_process_account_positions_ws_event_message_handles_account_all_snapshot(self):
+        class FakePerpetualTrading:
+            def __init__(self):
+                self.account_positions = {"stale": "position"}
+
+            def position_key(self, trading_pair, position_side):
+                return f"{trading_pair}-{position_side.name}"
+
+            def set_position(self, key, position):
+                self.account_positions[key] = position
+
+        self.connector._perpetual_trading = FakePerpetualTrading()
+        self.connector.trading_pair_associated_to_exchange_symbol = AsyncMock(return_value="ETH-USDC")
+        self.connector.get_leverage = MagicMock(return_value="5")
+
+        await self.connector._process_account_positions_ws_event_message({
+            "type": "update/account_all",
+            "positions": {
+                "0": {
+                    "symbol": "ETH",
+                    "sign": -1,
+                    "position": "1.25",
+                    "avg_entry_price": "2000",
+                    "unrealized_pnl": "7.5",
+                }
+            },
+        })
+
+        positions = self.connector._perpetual_trading.account_positions
+        self.assertEqual(1, len(positions))
+        eth_position = positions["ETH-USDC-SHORT"]
+        self.assertEqual(Decimal("-1.25"), eth_position.amount)
+        self.assertEqual(Decimal("7.5"), eth_position.unrealized_pnl)
+
+    async def test_process_account_trades_ws_event_message_processes_tracked_trade(self):
+        tracked_order = MagicMock()
+        tracked_order.exchange_order_id = "123"
+        tracked_order.client_order_id = "HBOT-1"
+        tracked_order.trading_pair = "BTC-USDC"
+        tracked_order.quote_asset = "USDC"
+        self.connector._order_tracker.process_trade_update = MagicMock()
+
+        with patch.object(
+            type(self.connector._order_tracker),
+            "all_fillable_orders",
+            new_callable=PropertyMock,
+            return_value={"HBOT-1": tracked_order},
+        ):
+            await self.connector._process_account_trades_ws_event_message({
+                "data": [{
+                    "i": 123,
+                    "s": "BTC",
+                    "p": "100",
+                    "a": "0.2",
+                    "f": "0.01",
+                    "ts": "open_long",
+                    "t": 1700000000000,
+                }],
+            })
+
+        self.connector._order_tracker.process_trade_update.assert_called_once()
+        trade_update = self.connector._order_tracker.process_trade_update.call_args.args[0]
+        self.assertEqual("HBOT-1", trade_update.client_order_id)
+        self.assertEqual("123", trade_update.exchange_order_id)
+        self.assertEqual(Decimal("0.2"), trade_update.fill_base_amount)
+
+    async def test_process_account_trades_ws_event_message_ignores_unknown_trade(self):
+        self.connector._order_tracker.process_trade_update = MagicMock()
+
+        with patch.object(
+            type(self.connector._order_tracker),
+            "all_fillable_orders",
+            new_callable=PropertyMock,
+            return_value={},
+        ):
+            await self.connector._process_account_trades_ws_event_message({
+                "data": [{"i": 123, "p": "100", "a": "0.2", "f": "0.01", "ts": "open_long", "t": 1700000000000}],
+            })
+
+        self.connector._order_tracker.process_trade_update.assert_not_called()
+
+    async def test_process_account_trades_ws_event_message_handles_account_all_trade_update(self):
+        tracked_order = MagicMock()
+        tracked_order.exchange_order_id = "1774621023"
+        tracked_order.client_order_id = "HBOT-1"
+        tracked_order.trading_pair = "ETH-USDC"
+        tracked_order.quote_asset = "USDC"
+        tracked_order.position = PositionAction.OPEN
+        self.connector.account_index = "361816"
+        self.connector._order_tracker.process_trade_update = MagicMock()
+
+        with patch.object(
+            type(self.connector._order_tracker),
+            "all_fillable_orders",
+            new_callable=PropertyMock,
+            return_value={"HBOT-1": tracked_order},
+        ):
+            await self.connector._process_account_trades_ws_event_message({
+                "type": "update/account_all",
+                "trades": {
+                    "0": [{
+                        "trade_id_str": "16734837600",
+                        "market_id": 0,
+                        "size": "0.0051",
+                        "price": "1983.11",
+                        "usd_amount": "10.113861",
+                        "bid_client_id_str": "1774621023",
+                        "bid_account_id": 361816,
+                        "ask_account_id": 702389,
+                        "is_maker_ask": True,
+                        "taker_fee": 280,
+                        "maker_fee": 28,
+                        "timestamp": 1774621024363,
+                    }]
+                },
+            })
+
+        self.connector._order_tracker.process_trade_update.assert_called_once()
+        trade_update = self.connector._order_tracker.process_trade_update.call_args.args[0]
+        self.assertEqual("HBOT-1", trade_update.client_order_id)
+        self.assertEqual("1774621023", trade_update.exchange_order_id)
+        self.assertEqual(Decimal("0.0051"), trade_update.fill_base_amount)
+        self.assertEqual("16734837600", trade_update.trade_id)
+
+    async def test_user_stream_event_listener_routes_known_channels(self):
+        async def event_iter():
+            for event in [
+                {"channel": "account_order_updates", "data": []},
+                {"channel": "account_positions", "data": []},
+                {"channel": "account_info", "data": {"ae": "1", "as": "1"}},
+                {"channel": "account_trades", "data": []},
+            ]:
+                yield event
+
+        self.connector._iter_user_event_queue = event_iter
+        self.connector._process_account_order_updates_ws_event_message = AsyncMock()
+        self.connector._process_account_positions_ws_event_message = AsyncMock()
+        self.connector._process_account_info_ws_event_message = AsyncMock()
+        self.connector._process_account_trades_ws_event_message = AsyncMock()
+
+        await self.connector._user_stream_event_listener()
+
+        self.connector._process_account_order_updates_ws_event_message.assert_awaited_once()
+        self.connector._process_account_positions_ws_event_message.assert_awaited_once()
+        self.connector._process_account_info_ws_event_message.assert_awaited_once()
+        self.connector._process_account_trades_ws_event_message.assert_awaited_once()
+
+    async def test_user_stream_event_listener_routes_account_all_events(self):
+        async def event_iter():
+            yield {"type": "update/account_all", "channel": "account_all:237600", "positions": {}}
+
+        self.connector._iter_user_event_queue = event_iter
+        self.connector._process_account_all_ws_event_message = AsyncMock()
+
+        await self.connector._user_stream_event_listener()
+
+        self.connector._process_account_all_ws_event_message.assert_awaited_once()
+
+    async def test_process_account_all_ws_event_message_routes_trades_and_positions(self):
+        self.connector._process_account_trades_ws_event_message = AsyncMock()
+        self.connector._process_account_positions_ws_event_message = AsyncMock()
+
+        event = {"type": "update/account_all", "channel": "account_all:237600", "positions": {}, "trades": {}}
+        await self.connector._process_account_all_ws_event_message(event)
+
+        self.connector._process_account_trades_ws_event_message.assert_awaited_once_with(event)
+        self.connector._process_account_positions_ws_event_message.assert_awaited_once_with(event)
+
+    async def test_process_account_all_ws_event_message_extracts_usdc_balance(self):
+        event = {
+            "type": "update/account_all",
+            "channel": "account_all:237600",
+            "positions": {},
+            "trades": {},
+            "assets": {
+                "3": {"symbol": "USDC", "asset_id": 3, "balance": "100.50", "locked_balance": "10.25"},
+                "1": {"symbol": "ETH", "asset_id": 1, "balance": "0.001", "locked_balance": "0.0"},
+            },
+        }
+        self.connector._process_account_trades_ws_event_message = AsyncMock()
+        self.connector._process_account_positions_ws_event_message = AsyncMock()
+
+        await self.connector._process_account_all_ws_event_message(event)
+
+        self.assertEqual(Decimal("100.50"), self.connector._account_balances["USDC"])
+        self.assertEqual(Decimal("90.25"), self.connector._account_available_balances["USDC"])
+
+    async def test_process_account_all_ws_event_message_no_assets_key_skips_balance(self):
+        event = {"type": "update/account_all", "channel": "account_all:237600", "positions": {}, "trades": {}}
+        self.connector._process_account_trades_ws_event_message = AsyncMock()
+        self.connector._process_account_positions_ws_event_message = AsyncMock()
+
+        await self.connector._process_account_all_ws_event_message(event)
+
+        # Should not error; balances remain at their defaults
+        self.assertEqual({}, self.connector._account_balances)
+
+    async def test_user_stream_event_listener_sleeps_after_processing_error(self):
+        async def event_iter():
+            yield {"channel": "account_info", "data": {"ae": "1", "as": "1"}}
+
+        self.connector._iter_user_event_queue = event_iter
+        self.connector._process_account_info_ws_event_message = AsyncMock(side_effect=Exception("boom"))
+        self.connector._sleep = AsyncMock()
+
+        await self.connector._user_stream_event_listener()
+
+        self.connector._sleep.assert_awaited_once_with(5.0)
+
+    async def test_user_stream_event_listener_ignores_unknown_channel(self):
+        async def event_iter():
+            yield {"channel": "unknown_channel", "data": {}}
+
+        self.connector._iter_user_event_queue = event_iter
+        self.connector._sleep = AsyncMock()
+        self.connector._process_account_order_updates_ws_event_message = AsyncMock()
+        self.connector._process_account_positions_ws_event_message = AsyncMock()
+        self.connector._process_account_info_ws_event_message = AsyncMock()
+        self.connector._process_account_trades_ws_event_message = AsyncMock()
+
+        await self.connector._user_stream_event_listener()
+
+        self.connector._sleep.assert_not_awaited()
+        self.connector._process_account_order_updates_ws_event_message.assert_not_awaited()
+        self.connector._process_account_positions_ws_event_message.assert_not_awaited()
+        self.connector._process_account_info_ws_event_message.assert_not_awaited()
+        self.connector._process_account_trades_ws_event_message.assert_not_awaited()
+
+    # ---------------------------------------------------------------------------
+    # Static / class-level utility method tests
+    # ---------------------------------------------------------------------------
+
+    def test_is_int_string_returns_true_for_numeric_strings(self):
+        cls = self.connector_cls
+        self.assertTrue(cls._is_int_string("0"))
+        self.assertTrue(cls._is_int_string("123"))
+        self.assertTrue(cls._is_int_string("-5"))
+
+    def test_is_int_string_returns_false_for_non_numeric(self):
+        cls = self.connector_cls
+        self.assertFalse(cls._is_int_string("abc"))
+        self.assertFalse(cls._is_int_string(""))
+        self.assertFalse(cls._is_int_string(None))
+
+    def test_is_ok_response_true_for_success_flag(self):
+        cls = self.connector_cls
+        self.assertTrue(cls._is_ok_response({"success": True}))
+        self.assertFalse(cls._is_ok_response({"success": False}))
+        self.assertFalse(cls._is_ok_response({}))
+
+    def test_is_ok_response_true_for_code_200(self):
+        cls = self.connector_cls
+        self.assertTrue(cls._is_ok_response({"code": "200"}))
+        self.assertTrue(cls._is_ok_response({"code": 200}))
+        self.assertFalse(cls._is_ok_response({"code": "404"}))
+
+    def test_account_from_response_with_data_dict(self):
+        cls = self.connector_cls
+        result = cls._account_from_response({"data": {"balance": "100"}})
+        self.assertEqual({"balance": "100"}, result)
+
+    def test_account_from_response_with_accounts_list(self):
+        cls = self.connector_cls
+        result = cls._account_from_response({"accounts": [{"id": 1}]})
+        self.assertEqual({"id": 1}, result)
+
+    def test_account_from_response_returns_none_for_missing_keys(self):
+        cls = self.connector_cls
+        self.assertIsNone(cls._account_from_response({}))
+        self.assertIsNone(cls._account_from_response({"accounts": []}))
+
+    def test_client_order_index_from_order_id_is_deterministic_and_non_negative(self):
+        cls = self.connector_cls
+        idx1 = cls._client_order_index_from_order_id("HBOT-1234")
+        idx2 = cls._client_order_index_from_order_id("HBOT-1234")
+        self.assertEqual(idx1, idx2)
+        self.assertIsInstance(idx1, int)
+        self.assertGreaterEqual(idx1, 0)
+
+    # ---------------------------------------------------------------------------
+    # Simple property accessor tests
+    # ---------------------------------------------------------------------------
+
+    def test_name_and_domain_return_domain_string(self):
+        self.assertEqual("lighter_perpetual", self.connector.name)
+        self.assertEqual("lighter_perpetual", self.connector.domain)
+
+    def test_client_order_id_max_length_is_32(self):
+        self.assertEqual(32, self.connector.client_order_id_max_length)
+
+    def test_client_order_id_prefix_is_hbot(self):
+        self.assertEqual("HBOT", self.connector.client_order_id_prefix)
+
+    def test_request_path_properties(self):
+        import hummingbot.connector.derivative.lighter_perpetual.lighter_perpetual_constants as C
+
+        self.assertEqual(C.EXCHANGE_INFO_PATH_URL, self.connector.trading_rules_request_path)
+        self.assertEqual(C.EXCHANGE_INFO_PATH_URL, self.connector.trading_pairs_request_path)
+        self.assertEqual(C.GET_PRICES_PATH_URL, self.connector.check_network_request_path)
+
+    def test_trading_pairs_returns_initialized_list(self):
+        self.assertEqual(["BTC-USDC"], self.connector.trading_pairs)
+
+    def test_is_cancel_synchronous_is_true(self):
+        self.assertTrue(self.connector.is_cancel_request_in_exchange_synchronous)
+
+    def test_is_trading_required_returns_flag(self):
+        self.assertFalse(self.connector.is_trading_required)
+
+    def test_funding_fee_poll_interval_is_120(self):
+        self.assertEqual(120, self.connector.funding_fee_poll_interval)
+
+    def test_supported_order_types_includes_limit_limit_maker_and_market(self):
+        from hummingbot.core.data_type.common import OrderType
+
+        order_types = self.connector.supported_order_types()
+        self.assertIn(OrderType.LIMIT, order_types)
+        self.assertIn(OrderType.MARKET, order_types)
+        self.assertIn(OrderType.LIMIT_MAKER, order_types)
+
+    def test_supported_position_modes_is_oneway(self):
+        from hummingbot.core.data_type.common import PositionMode
+
+        modes = self.connector.supported_position_modes()
+        self.assertEqual([PositionMode.ONEWAY], modes)
+
+    def test_collateral_tokens_are_usdc(self):
+        self.assertEqual("USDC", self.connector.get_buy_collateral_token("BTC-USDC"))
+        self.assertEqual("USDC", self.connector.get_sell_collateral_token("BTC-USDC"))
+
+    # ---------------------------------------------------------------------------
+    # API key / account index helpers
+    # ---------------------------------------------------------------------------
+
+    def test_rest_api_key_returns_api_secret_when_api_key_non_numeric_and_secret_set(self):
+        self.connector.api_key = "pub_key_text"
+        self.connector.api_secret = "secret_string"
+        self.assertEqual("secret_string", self.connector.rest_api_key)
+
+    def test_rest_api_key_returns_api_key_when_numeric(self):
+        self.connector.api_key = "42"
+        self.assertEqual("42", self.connector.rest_api_key)
+
+    def test_rest_api_key_returns_api_key_when_secret_empty(self):
+        self.connector.api_key = "public_key"
+        self.connector.api_secret = ""
+        self.assertEqual("public_key", self.connector.rest_api_key)
+
+    def test_api_host_for_signer_strips_api_path(self):
+        host = self.connector._api_host_for_signer()
+        self.assertIn("mainnet.zklighter.elliot.ai", host)
+        self.assertNotIn("/api/v1", host)
+
+    def test_get_account_index_returns_int(self):
+        self.connector.account_index = "237600"
+        self.assertEqual(237600, self.connector._get_account_index())
+
+    def test_get_account_index_raises_for_invalid_string(self):
+        self.connector.account_index = "not_a_number"
+        with self.assertRaises(ValueError):
+            self.connector._get_account_index()
+
+    def test_account_query_params_returns_expected_dict(self):
+        self.connector.account_index = "237600"
+        params = self.connector._account_query_params()
+        self.assertEqual({"by": "index", "value": "237600"}, params)
+
+    async def test_refresh_market_metadata_updates_maps_for_perp_only(self):
+        self.connector._api_get = AsyncMock(return_value={
+            "order_books": [
+                {
+                    "market_type": "spot",
+                    "symbol": "BTC",
+                    "market_id": 1,
+                    "supported_size_decimals": 3,
+                    "supported_price_decimals": 2,
+                },
+                {
+                    "market_type": "perp",
+                    "symbol": "ETH",
+                    "market_id": 2,
+                    "supported_size_decimals": 4,
+                    "supported_price_decimals": 1,
+                },
+            ]
+        })
+
+        await self.connector._refresh_market_metadata()
+
+        self.assertNotIn("BTC", self.connector._market_id_by_symbol)
+        self.assertEqual(2, self.connector._market_id_by_symbol["ETH"])
+        self.assertEqual(4, self.connector._size_decimals_by_symbol["ETH"])
+        self.assertEqual(1, self.connector._price_decimals_by_symbol["ETH"])
+
+    async def test_get_market_spec_uses_cache_without_refresh(self):
+        self.connector.exchange_symbol_associated_to_pair = AsyncMock(return_value="BTC")
+        self.connector._market_id_by_symbol["BTC"] = 11
+        self.connector._size_decimals_by_symbol["BTC"] = 3
+        self.connector._price_decimals_by_symbol["BTC"] = 2
+        self.connector._refresh_market_metadata = AsyncMock()
+
+        market_id, size_decimals, price_decimals, symbol = await self.connector._get_market_spec("BTC-USDC")
+
+        self.assertEqual(11, market_id)
+        self.assertEqual(3, size_decimals)
+        self.assertEqual(2, price_decimals)
+        self.assertEqual("BTC", symbol)
+        self.connector._refresh_market_metadata.assert_not_awaited()
+
+    async def test_get_market_spec_raises_when_symbol_missing_after_refresh(self):
+        self.connector.exchange_symbol_associated_to_pair = AsyncMock(return_value="DOGE")
+        self.connector._refresh_market_metadata = AsyncMock()
+
+        with self.assertRaises(ValueError):
+            await self.connector._get_market_spec("DOGE-USDC")
+
+        self.connector._refresh_market_metadata.assert_awaited_once()
+
+    async def test_api_request_url_uses_private_rest_url(self):
+        import hummingbot.connector.derivative.lighter_perpetual.lighter_perpetual_web_utils as web_utils
+
+        path = "/api/v1/test"
+        expected = web_utils.private_rest_url(path, domain=self.connector.domain)
+
+        result = await self.connector._api_request_url(path)
+
+        self.assertEqual(expected, result)
+
+    def test_is_request_exception_not_related_to_time_synchronizer(self):
+        result = self.connector._is_request_exception_related_to_time_synchronizer(Exception("any error"))
+        self.assertFalse(result)
+
+    def test_is_order_not_found_during_status_update_error_matches(self):
+        self.assertTrue(self.connector._is_order_not_found_during_status_update_error(Exception("Order not found")))
+        self.assertFalse(self.connector._is_order_not_found_during_status_update_error(Exception("Network error")))
+
+    def test_is_order_not_found_during_cancelation_error_matches(self):
+        self.assertTrue(self.connector._is_order_not_found_during_cancelation_error(Exception('{"code":5}')))
+        self.assertFalse(self.connector._is_order_not_found_during_cancelation_error(Exception("network timeout")))
+
+    # ---------------------------------------------------------------------------
+    # Price record helpers
+    # ---------------------------------------------------------------------------
+
+    def test_get_lighter_price_returns_none_for_unknown_pair(self):
+        result = self.connector.get_LIGHTER_price("ETH-USDC")
+        self.assertIsNone(result)
+
+    def test_get_lighter_price_returns_none_for_unset_btc(self):
+        result = self.connector.get_LIGHTER_price("BTC-USDC")
+        self.assertIsNone(result)
+
+    def test_get_lighter_finance_trade_id_builds_expected_string(self):
+        trade_id = self.connector.get_LIGHTER_finance_trade_id(
+            order_id=123456,
+            timestamp=1700000000.0,
+            fill_base_amount=Decimal("0.5"),
+            fill_price=Decimal("50000"),
+        )
+        self.assertEqual("123456_1700000000.0_0.5_50000", trade_id)
+
+    def test_round_fee_rounds_to_6_decimal_places(self):
+        result = self.connector.round_fee(Decimal("0.123456789"))
+        self.assertAlmostEqual(0.123457, float(result), places=5)
+
+    # ---------------------------------------------------------------------------
+    # Async method tests (safe mocked paths)
+    # ---------------------------------------------------------------------------
+
+    async def test_get_last_traded_price_returns_close_price(self):
+        self.connector.exchange_symbol_associated_to_pair = AsyncMock(return_value="BTC")
+        self.connector._api_get = AsyncMock(return_value={"data": [{"c": "50123.5", "o": "50000"}]})
+
+        result = await self.connector._get_last_traded_price("BTC-USDC")
+        self.assertAlmostEqual(50123.5, result)
+
+    async def test_get_last_traded_price_returns_zero_for_empty_candles(self):
+        self.connector.exchange_symbol_associated_to_pair = AsyncMock(return_value="BTC")
+        self.connector._api_get = AsyncMock(return_value={"data": []})
+
+        result = await self.connector._get_last_traded_price("BTC-USDC")
+        self.assertEqual(0.0, result)
+
+    async def test_update_trading_fees_updates_maker_and_taker_fee(self):
+        self.connector._api_get = AsyncMock(return_value={
+            "success": True,
+            "data": {"fee_level": 1, "maker_fee": "0.0002", "taker_fee": "0.0005"},
+        })
+
+        await self.connector._update_trading_fees()
+
+        self.assertIn("BTC-USDC", self.connector._trading_fees)
+        schema = self.connector._trading_fees["BTC-USDC"]
+        self.assertEqual(Decimal("0.0002"), schema.maker_percent_fee_decimal)
+        self.assertEqual(Decimal("0.0005"), schema.taker_percent_fee_decimal)
+
+    async def test_update_trading_fees_skips_on_api_failure(self):
+        self.connector._api_get = AsyncMock(return_value={"success": False})
+
+        await self.connector._update_trading_fees()
+
+        self.assertEqual({}, self.connector._trading_fees)
+
+    async def test_update_trading_fees_skips_when_fees_absent_from_data(self):
+        self.connector._api_get = AsyncMock(return_value={"success": True, "data": {"fee_level": 0}})
+
+        await self.connector._update_trading_fees()
+
+        self.assertEqual({}, self.connector._trading_fees)
+
+    async def test_request_order_status_returns_order_update_for_filled(self):
+        tracked_order = MagicMock()
+        tracked_order.exchange_order_id = "315293920"
+        tracked_order.client_order_id = "HBOT-1"
+        tracked_order.trading_pair = "BTC-USDC"
+        self.connector._api_get = AsyncMock(return_value={"data": [{"order_status": "filled", "created_at": 1700000000000}]})
+
+        from hummingbot.core.data_type.in_flight_order import OrderState
+
+        order_update = await self.connector._request_order_status(tracked_order)
+
+        self.assertEqual("HBOT-1", order_update.client_order_id)
+        self.assertEqual("315293920", order_update.exchange_order_id)
+        self.assertEqual(OrderState.FILLED, order_update.new_state)
+
+    async def test_request_order_status_raises_on_empty_data(self):
+        tracked_order = MagicMock()
+        tracked_order.exchange_order_id = "999"
+        self.connector._api_get = AsyncMock(return_value={"data": []})
+
+        with self.assertRaises(IOError):
+            await self.connector._request_order_status(tracked_order)
+
+    async def test_request_order_status_raises_on_unknown_status(self):
+        tracked_order = MagicMock()
+        tracked_order.exchange_order_id = "999"
+        self.connector._api_get = AsyncMock(return_value={"data": [{"order_status": "unknown_xyz", "created_at": 0}]})
+
+        with self.assertRaises(IOError):
+            await self.connector._request_order_status(tracked_order)
+
+    async def test_set_trading_pair_leverage_returns_success(self):
+        self.connector.exchange_symbol_associated_to_pair = AsyncMock(return_value="BTC")
+        self.connector._api_post = AsyncMock(return_value={"success": True})
+
+        success, msg = await self.connector._set_trading_pair_leverage("BTC-USDC", 10)
+
+        self.assertTrue(success)
+        self.assertEqual("", msg)
+
+    async def test_set_trading_pair_leverage_returns_error_message_on_failure(self):
+        self.connector.exchange_symbol_associated_to_pair = AsyncMock(return_value="BTC")
+        self.connector._api_post = AsyncMock(return_value={"success": False, "error": "leverage too high", "code": 429})
+
+        success, msg = await self.connector._set_trading_pair_leverage("BTC-USDC", 1000)
+
+        self.assertFalse(success)
+        self.assertIn("leverage too high", msg)
+
+    async def test_trading_pair_position_mode_set_always_returns_true(self):
+        from hummingbot.core.data_type.common import PositionMode
+
+        success, msg = await self.connector._trading_pair_position_mode_set(PositionMode.ONEWAY, "BTC-USDC")
+        self.assertTrue(success)
+        self.assertEqual("", msg)
+
+    async def test_get_all_pairs_prices_returns_list(self):
+        self.connector.trading_pair_associated_to_exchange_symbol = AsyncMock(side_effect=lambda symbol: f"{symbol}-USDC")
+        self.connector._api_get = AsyncMock(return_value={
+            "success": True,
+            "data": [
+                {"symbol": "BTC", "mark": "50000"},
+                {"symbol": "ETH", "mark": "3000"},
+            ],
+        })
+
+        results = await self.connector.get_all_pairs_prices()
+
+        self.assertEqual(2, len(results))
+        self.assertEqual("BTC-USDC", results[0]["trading_pair"])
+        self.assertEqual("50000", results[0]["price"])
+
+    async def test_get_all_pairs_prices_returns_empty_on_api_failure(self):
+        self.connector._api_get = AsyncMock(return_value={"success": False})
+
+        results = await self.connector.get_all_pairs_prices()
+
+        self.assertEqual([], results)
+
+    # ---------------------------------------------------------------------------
+    # Trading rules + symbol map
+    # ---------------------------------------------------------------------------
+
+    async def test_format_trading_rules_from_order_books(self):
+        self.connector.trading_pair_associated_to_exchange_symbol = AsyncMock(side_effect=lambda symbol: f"{symbol}-USDC")
+        exchange_info = {
+            "order_books": [
+                {
+                    "market_type": "perp",
+                    "symbol": "BTC",
+                    "market_id": "0",
+                    "supported_size_decimals": 5,
+                    "supported_price_decimals": 1,
+                    "min_quote_amount": "10",
+                },
+                {
+                    "market_type": "spot",
+                    "symbol": "ETH",
+                    "market_id": "1",
+                    "supported_size_decimals": 4,
+                    "supported_price_decimals": 2,
+                    "min_quote_amount": "5",
+                },
+            ]
+        }
+
+        rules = await self.connector._format_trading_rules(exchange_info)
+
+        self.assertEqual(1, len(rules))
+        self.assertEqual("BTC-USDC", rules[0].trading_pair)
+        self.assertEqual(Decimal("1e-5"), rules[0].min_order_size)
+        self.assertEqual(Decimal("1e-1"), rules[0].min_price_increment)
+
+    async def test_format_trading_rules_from_data_list(self):
+        self.connector.trading_pair_associated_to_exchange_symbol = AsyncMock(side_effect=lambda symbol: f"{symbol}-USDC")
+        exchange_info = {
+            "data": [
+                {
+                    "symbol": "ETH",
+                    "lot_size": "0.001",
+                    "tick_size": "0.01",
+                    "min_order_size": "5",
+                }
+            ]
+        }
+
+        rules = await self.connector._format_trading_rules(exchange_info)
+
+        self.assertEqual(1, len(rules))
+        self.assertEqual("ETH-USDC", rules[0].trading_pair)
+        self.assertEqual(Decimal("0.001"), rules[0].min_order_size)
+        self.assertEqual(Decimal("0.01"), rules[0].min_price_increment)
+
+    def test_initialize_trading_pair_symbols_from_order_books_populates_market_map(self):
+        self.connector._set_trading_pair_symbol_map = MagicMock()
+        exchange_info = {
+            "order_books": [
+                {
+                    "market_type": "perp",
+                    "symbol": "BTC",
+                    "market_id": "1",
+                    "supported_size_decimals": 5,
+                    "supported_price_decimals": 1,
+                },
+                {
+                    "market_type": "spot",
+                    "symbol": "ETH",
+                    "market_id": "2",
+                    "supported_size_decimals": 4,
+                    "supported_price_decimals": 2,
+                },
+            ]
+        }
+
+        self.connector._initialize_trading_pair_symbols_from_exchange_info(exchange_info)
+
+        self.assertEqual(1, self.connector._market_id_by_symbol.get("BTC"))
+        self.assertNotIn("ETH", self.connector._market_id_by_symbol)
+        self.connector._set_trading_pair_symbol_map.assert_called_once()
+
+    def test_initialize_trading_pair_symbols_from_data_list(self):
+        self.connector._set_trading_pair_symbol_map = MagicMock()
+        exchange_info = {"data": [{"symbol": "ETH"}]}
+
+        self.connector._initialize_trading_pair_symbols_from_exchange_info(exchange_info)
+
+        self.connector._set_trading_pair_symbol_map.assert_called_once()
+
+    # ---------------------------------------------------------------------------
+    # Position / trade normalization helper tests
+    # ---------------------------------------------------------------------------
+
+    def test_normalized_position_entries_passthrough_for_short_form_data(self):
+        event = {"data": [{"s": "BTC", "d": "bid", "a": "0.5", "p": "50000"}]}
+
+        result = self.connector_cls._normalized_position_entries_from_event(event)
+
+        self.assertEqual(1, len(result))
+        self.assertEqual("BTC", result[0]["s"])
+
+    def test_normalized_position_entries_converts_positions_dict(self):
+        event = {
+            "positions": {
+                "0": {
+                    "symbol": "ETH",
+                    "sign": -1,
+                    "position": "1.0",
+                    "avg_entry_price": "2000",
+                    "unrealized_pnl": "5.0",
+                }
+            }
+        }
+
+        result = self.connector_cls._normalized_position_entries_from_event(event)
+
+        self.assertEqual(1, len(result))
+        self.assertEqual("ETH", result[0]["s"])
+        self.assertEqual("ask", result[0]["d"])
+
+    def test_normalized_position_entries_skips_zero_amount(self):
+        event = {
+            "positions": {
+                "0": {
+                    "symbol": "BTC",
+                    "sign": 1,
+                    "position": "0",
+                    "avg_entry_price": "50000",
+                }
+            }
+        }
+
+        result = self.connector_cls._normalized_position_entries_from_event(event)
+
+        self.assertEqual(0, len(result))
+
+    def test_normalized_trade_entries_passthrough_for_short_form_data(self):
+        event = {"data": [{"i": "123", "p": "100", "a": "0.5"}]}
+
+        result = self.connector._normalized_trade_entries_from_event(event)
+
+        self.assertEqual(1, len(result))
+        self.assertEqual("123", result[0]["i"])
+
+    def test_normalized_trade_entries_from_account_all_own_bid(self):
+        self.connector.account_index = "237600"
+        event = {
+            "trades": {
+                "0": [{
+                    "bid_client_id_str": "1774621023",
+                    "bid_account_id": 237600,
+                    "ask_account_id": 702389,
+                    "is_maker_ask": True,
+                    "taker_fee": 280,
+                    "maker_fee": 28,
+                    "price": "1983.11",
+                    "size": "0.0051",
+                    "usd_amount": "10.1",
+                    "trade_id_str": "16734837600",
+                    "timestamp": 1774621024363,
+                }]
+            }
+        }
+
+        result = self.connector._normalized_trade_entries_from_event(event)
+
+        self.assertEqual(1, len(result))
+        self.assertEqual("1774621023", result[0]["i"])
+
+    def test_normalized_trade_entries_skips_unrelated_trades(self):
+        self.connector.account_index = "237600"
+        event = {
+            "trades": {
+                "0": [{
+                    "bid_client_id_str": "999",
+                    "bid_account_id": 111111,
+                    "ask_account_id": 222222,
+                    "is_maker_ask": False,
+                    "taker_fee": 100,
+                    "maker_fee": 10,
+                    "price": "100",
+                    "size": "1.0",
+                    "usd_amount": "100",
+                    "timestamp": 1700000000000,
+                }]
+            }
+        }
+
+        result = self.connector._normalized_trade_entries_from_event(event)
+
+        self.assertEqual(0, len(result))
+
+    def test_round_amount_rounds_to_lot_size(self):
+        """Test that round_amount quantizes to the min_base_amount_increment from trading rules"""
+        from hummingbot.connector.trading_rule import TradingRule
+
+        # Setup trading rules with a specific lot size
+        trading_pair = "BTC-USDC"
+        self.connector._trading_rules = {
+            trading_pair: TradingRule(
+                trading_pair=trading_pair,
+                min_order_size=Decimal("0.001"),
+                max_order_size=Decimal("100"),
+                min_price_increment=Decimal("0.01"),
+                min_base_amount_increment=Decimal("0.001"),
+            )
+        }
+
+        # Test rounding up
+        result = self.connector.round_amount(trading_pair, Decimal("1.2345"))
+        self.assertEqual(Decimal("1.234"), result)
+
+        # Test rounding down
+        result = self.connector.round_amount(trading_pair, Decimal("0.9994"))
+        self.assertEqual(Decimal("0.999"), result)

--- a/test/hummingbot/connector/derivative/lighter_perpetual/test_lighter_perpetual_user_stream_data_source.py
+++ b/test/hummingbot/connector/derivative/lighter_perpetual/test_lighter_perpetual_user_stream_data_source.py
@@ -1,0 +1,165 @@
+import asyncio
+import sys
+import types
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def _ensure_limit_order_stub():
+    module_name = "hummingbot.core.data_type.limit_order"
+    if module_name in sys.modules:
+        return
+    stub_module = types.ModuleType(module_name)
+
+    class LimitOrder:
+        pass
+
+    stub_module.LimitOrder = LimitOrder
+    sys.modules[module_name] = stub_module
+
+
+def _ensure_order_book_stub():
+    module_name = "hummingbot.core.data_type.order_book"
+    if module_name in sys.modules:
+        return
+    stub_module = types.ModuleType(module_name)
+
+    class OrderBook:
+        pass
+
+    stub_module.OrderBook = OrderBook
+    sys.modules[module_name] = stub_module
+
+
+class LighterPerpetualUserStreamDataSourceTests(unittest.IsolatedAsyncioTestCase):
+
+    data_source_cls = None
+    auth_cls = None
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        _ensure_limit_order_stub()
+        _ensure_order_book_stub()
+        try:
+            from hummingbot.connector.derivative.lighter_perpetual.lighter_perpetual_auth import LighterPerpetualAuth
+            from hummingbot.connector.derivative.lighter_perpetual.lighter_perpetual_user_stream_data_source import (
+                LighterPerpetualUserStreamDataSource,
+            )
+
+            cls.data_source_cls = LighterPerpetualUserStreamDataSource
+            cls.auth_cls = LighterPerpetualAuth
+        except ModuleNotFoundError:
+            cls.data_source_cls = None
+
+    def setUp(self):
+        super().setUp()
+        if self.data_source_cls is None:
+            self.skipTest("Compiled hummingbot core modules are unavailable in this environment")
+
+        self.connector = MagicMock()
+        self.connector.rest_api_key = "api-key"
+
+        self.auth = self.auth_cls(
+            api_key="api-key",
+            api_secret="api-secret",
+            account_identifier="237600",
+        )
+        self.auth.user_wallet_public_key = "237600"
+
+        self.ws_assistant = AsyncMock()
+        self.api_factory = MagicMock()
+        self.api_factory.get_ws_assistant = AsyncMock(return_value=self.ws_assistant)
+
+        self.data_source = self.data_source_cls(
+            connector=self.connector,
+            api_factory=self.api_factory,
+            auth=self.auth,
+        )
+
+    @patch("hummingbot.connector.derivative.lighter_perpetual.lighter_perpetual_user_stream_data_source.safe_ensure_future")
+    async def test_connected_websocket_assistant_connects_with_api_key_header(self, safe_future_mock):
+        safe_future_mock.side_effect = lambda coro: (coro.close(), MagicMock())[1]
+        ws = await self.data_source._connected_websocket_assistant()
+
+        self.assertIs(self.ws_assistant, ws)
+        self.ws_assistant.connect.assert_awaited_once()
+        connect_kwargs = self.ws_assistant.connect.call_args.kwargs
+        self.assertEqual({"X-Api-Key": "api-key"}, connect_kwargs["ws_headers"])
+        self.assertEqual(1, safe_future_mock.call_count)
+
+    async def test_subscribe_channels_sends_all_private_subscriptions(self):
+        self.ws_assistant.receive = AsyncMock(return_value=SimpleNamespace(data={"type": "connected"}))
+
+        await self.data_source._subscribe_channels(self.ws_assistant)
+
+        self.ws_assistant.receive.assert_awaited_once()
+        self.assertEqual(1, self.ws_assistant.send.await_count)
+        payload = self.ws_assistant.send.call_args.args[0].payload
+        self.assertEqual({"type": "subscribe", "channel": "account_all/237600"}, payload)
+
+    async def test_subscribe_channels_raises_when_connected_message_missing(self):
+        self.ws_assistant.receive = AsyncMock(return_value=SimpleNamespace(data={"type": "unexpected"}))
+
+        with self.assertRaises(IOError):
+            await self.data_source._subscribe_channels(self.ws_assistant)
+
+    async def test_on_user_stream_interruption_cancels_ping_task(self):
+        ping_task = MagicMock()
+        self.data_source._ping_task = ping_task
+
+        await self.data_source._on_user_stream_interruption(None)
+
+        ping_task.cancel.assert_called_once()
+        self.assertIsNone(self.data_source._ping_task)
+
+    async def test_ping_loop_sends_ping_payload(self):
+        sent_payloads = []
+
+        async def send_side_effect(request):
+            sent_payloads.append(request.payload)
+            raise asyncio.CancelledError()
+
+        self.ws_assistant.send.side_effect = send_side_effect
+
+        with patch("hummingbot.connector.derivative.lighter_perpetual.lighter_perpetual_user_stream_data_source.asyncio.sleep", new=AsyncMock()):
+            with self.assertRaises(asyncio.CancelledError):
+                await self.data_source._ping_loop(self.ws_assistant)
+
+        self.assertEqual([{"type": "ping"}], sent_payloads)
+
+    async def test_ping_loop_returns_when_ws_disconnects(self):
+        self.ws_assistant.send.side_effect = RuntimeError("WS is not connected")
+
+        with patch("hummingbot.connector.derivative.lighter_perpetual.lighter_perpetual_user_stream_data_source.asyncio.sleep", new=AsyncMock()):
+            result = await self.data_source._ping_loop(self.ws_assistant)
+
+        self.assertIsNone(result)
+
+    async def test_subscribe_channels_raises_on_send_error(self):
+        self.ws_assistant.receive = AsyncMock(return_value=SimpleNamespace(data={"type": "connected"}))
+        self.ws_assistant.send.side_effect = Exception("boom")
+
+        with self.assertRaises(Exception):
+            await self.data_source._subscribe_channels(self.ws_assistant)
+
+    async def test_process_websocket_messages_replies_to_ping_and_enqueues_account_all_updates(self):
+        ws_messages = [
+            SimpleNamespace(data={"type": "ping"}),
+            SimpleNamespace(data={"type": "update/account_all", "channel": "account_all:237600", "positions": {}}),
+        ]
+
+        async def iter_messages():
+            for message in ws_messages:
+                yield message
+
+        self.ws_assistant.iter_messages = iter_messages
+        output = asyncio.Queue()
+
+        await self.data_source._process_websocket_messages(self.ws_assistant, output)
+
+        self.ws_assistant.send.assert_awaited_once()
+        self.assertEqual({"type": "pong"}, self.ws_assistant.send.call_args.args[0].payload)
+        queued_event = output.get_nowait()
+        self.assertEqual("update/account_all", queued_event["type"])

--- a/test/hummingbot/connector/derivative/lighter_perpetual/test_lighter_perpetual_utils.py
+++ b/test/hummingbot/connector/derivative/lighter_perpetual/test_lighter_perpetual_utils.py
@@ -1,0 +1,28 @@
+import unittest
+from decimal import Decimal
+
+from hummingbot.connector.derivative.lighter_perpetual import lighter_perpetual_utils as utils
+
+
+class LighterPerpetualUtilsTests(unittest.TestCase):
+    def test_default_fees_match_observed_base_tier(self):
+        self.assertEqual(Decimal("0.00015"), utils.DEFAULT_FEES.maker_percent_fee_decimal)
+        self.assertEqual(Decimal("0.0004"), utils.DEFAULT_FEES.taker_percent_fee_decimal)
+
+    def test_mainnet_config_aliases_and_connector_name(self):
+        config = utils.LighterPerpetualConfigMap(
+            lighter_perpetual_api_key="key",
+            lighter_perpetual_api_secret="secret",
+            lighter_perpetual_account_index="123",
+        )
+
+        self.assertEqual("lighter_perpetual", config.connector)
+        self.assertEqual("key", config.lighter_perpetual_api_key.get_secret_value())
+        self.assertEqual("secret", config.lighter_perpetual_api_secret.get_secret_value())
+        self.assertEqual("123", config.lighter_perpetual_account_index.get_secret_value())
+
+    def test_testnet_metadata_is_defined(self):
+        self.assertIn("lighter_perpetual_testnet", utils.OTHER_DOMAINS)
+        self.assertEqual("lighter_perpetual_testnet", utils.OTHER_DOMAINS_PARAMETER["lighter_perpetual_testnet"])
+        self.assertEqual("BTC-USD", utils.OTHER_DOMAINS_EXAMPLE_PAIR["lighter_perpetual_testnet"])
+        self.assertEqual([0.00015, 0.0004], utils.OTHER_DOMAINS_DEFAULT_FEES["lighter_perpetual_testnet"])

--- a/test/hummingbot/connector/derivative/lighter_perpetual/test_lighter_perpetual_web_utils.py
+++ b/test/hummingbot/connector/derivative/lighter_perpetual/test_lighter_perpetual_web_utils.py
@@ -1,0 +1,61 @@
+import importlib
+import sys
+import types
+import unittest
+
+
+def _ensure_limit_order_stub():
+    module_name = "hummingbot.core.data_type.limit_order"
+    if module_name in sys.modules:
+        return
+    stub_module = types.ModuleType(module_name)
+
+    class LimitOrder:
+        pass
+
+    stub_module.LimitOrder = LimitOrder
+    sys.modules[module_name] = stub_module
+
+
+try:
+    from hummingbot.connector.derivative.lighter_perpetual import (
+        lighter_perpetual_constants as CONSTANTS,
+        lighter_perpetual_web_utils as web_utils,
+    )
+except ModuleNotFoundError as import_error:
+    if import_error.name != "hummingbot.core.data_type.limit_order":
+        raise
+    _ensure_limit_order_stub()
+    CONSTANTS = importlib.import_module("hummingbot.connector.derivative.lighter_perpetual.lighter_perpetual_constants")
+    web_utils = importlib.import_module("hummingbot.connector.derivative.lighter_perpetual.lighter_perpetual_web_utils")
+
+
+class LighterPerpetualWebUtilsTests(unittest.TestCase):
+
+    def test_public_rest_url(self):
+        self.assertEqual(
+            f"{CONSTANTS.REST_URL}/orderBooks",
+            web_utils.public_rest_url("/orderBooks", domain=CONSTANTS.DEFAULT_DOMAIN),
+        )
+
+    def test_public_rest_url_mainnet(self):
+        self.assertEqual(
+            f"{CONSTANTS.REST_URL}/orderBooks",
+            web_utils.public_rest_url("/orderBooks", domain=CONSTANTS.DEFAULT_DOMAIN),
+        )
+
+    def test_public_rest_url_testnet(self):
+        self.assertEqual(
+            f"{CONSTANTS.TESTNET_REST_URL}/orderBooks",
+            web_utils.public_rest_url("/orderBooks", domain=CONSTANTS.TESTNET_DOMAIN),
+        )
+
+    def test_private_rest_url(self):
+        self.assertEqual(
+            f"{CONSTANTS.REST_URL}/account",
+            web_utils.private_rest_url("/account", domain=CONSTANTS.DEFAULT_DOMAIN),
+        )
+
+    def test_wss_url(self):
+        self.assertEqual(CONSTANTS.WSS_URL, web_utils.wss_url(domain=CONSTANTS.DEFAULT_DOMAIN))
+        self.assertEqual(CONSTANTS.TESTNET_WSS_URL, web_utils.wss_url(domain=CONSTANTS.TESTNET_DOMAIN))


### PR DESCRIPTION
Adds the Lighter perpetual derivative connector implementation under hummingbot/connector/derivative/lighter_perpetual with supporting auth, constants, web utils, order book data source, and user stream data source.

## PR Description

- [x] Your code builds clean without any errors or warnings
- [x] Tests all pass
- [x] You are using approved title (feat/, fix/, docs/, refactor/)

### A description of the changes proposed in the pull request:
Adds the Lighter perpetual derivative connector implementation under hummingbot/connector/derivative/lighter_perpetual with supporting auth, constants, web utils, order book data source, and user stream data source.

Includes connector configuration and test coverage under test/hummingbot/connector/derivative/lighter_perpetual.

Implements REST and WebSocket integration, account stream handling, trading rule parsing, order lifecycle handling, funding-related market data processing, and signer-based authenticated flows.

### Tests performed by the developer:
Unit tests executed for the connector test package and passing locally.

Live connectivity validated against Lighter endpoints (REST and WebSocket).

Order placement/cancel and account stream flows validated in integration checks.

No unrelated files modified in connector change set.

### Tips for QA testing:
Use a valid lighter_perpetual configuration with api_key, api_secret, and account_index.

Verify startup, trading pair discovery, order book updates, private account stream events, order placement, and order cancellation.

Confirm behavior on both nominal path and auth/network error paths.