### PR TITLE
docs: fix Docker Compose wording in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Alternatively, if you are building new connectors/strategies or adding custom co
 
 ### Install Hummingbot with Docker
 
-Install [Docker Compose website](https://docs.docker.com/compose/install/).
+Install [Docker Compose](https://docs.docker.com/compose/install/).
 
 Clone the repo and use the provided `docker-compose.yml` file:
 


### PR DESCRIPTION
## Summary
- replace the awkward `Docker Compose website` wording with `Docker Compose` in the README install section
- keep the change scoped to a single documentation line

## Testing
- not run (README wording fix only)