### PR TITLE
feat: add Lighter spot connector with tests and mainnet validation artifacts

### DIFF
--- a/hummingbot/connector/exchange/lighter/dummy.pyx
+++ b/hummingbot/connector/exchange/lighter/dummy.pyx
@@ -1,0 +1,2 @@
+cdef class dummy():
+    pass

--- a/hummingbot/connector/exchange/lighter/lighter_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/lighter/lighter_api_order_book_data_source.py
@@ -2,7 +2,7 @@ import asyncio
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from hummingbot.connector.exchange.lighter import lighter_constants as CONSTANTS, lighter_web_utils as web_utils
-from hummingbot.core.data_type.common import TradeType
+from hummingbot.connector.exchange.lighter.lighter_order_book import LighterOrderBook
 from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
 from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
 from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
@@ -59,14 +59,13 @@ class LighterAPIOrderBookDataSource(OrderBookTrackerDataSource):
     async def _order_book_snapshot(self, trading_pair: str) -> OrderBookMessage:
         order_book_snapshot_data = await self._request_order_book_snapshot(trading_pair)
         timestamp = order_book_snapshot_data["t"] / 1000
-        return OrderBookMessage(
-            OrderBookMessageType.SNAPSHOT,
-            {
-                "trading_pair": trading_pair,
+        return LighterOrderBook.snapshot_message_from_exchange(
+            msg={
                 "update_id": order_book_snapshot_data.get("li", order_book_snapshot_data["t"]),
                 "bids": [(bids["p"], bids["a"]) for bids in order_book_snapshot_data["l"][0]],
                 "asks": [(asks["p"], asks["a"]) for asks in order_book_snapshot_data["l"][1]],
             },
+            metadata={"trading_pair": trading_pair},
             timestamp=timestamp,
         )
 
@@ -118,15 +117,14 @@ class LighterAPIOrderBookDataSource(OrderBookTrackerDataSource):
         if update_id == 0:
             update_id = int(raw_message.get("offset") or order_book.get("offset") or raw_message.get("last_updated_at") or 0)
 
-        snapshot_msg = OrderBookMessage(
-            OrderBookMessageType.SNAPSHOT,
-            {
-                "trading_pair": trading_pair,
+        snapshot_msg = LighterOrderBook.snapshot_message_from_exchange(
+            msg={
                 "update_id": update_id,
                 "bids": [(bid["price"], bid["size"]) for bid in order_book.get("bids", [])],
                 "asks": [(ask["price"], ask["size"]) for ask in order_book.get("asks", [])],
             },
-            snapshot_timestamp,
+            metadata={"trading_pair": trading_pair},
+            timestamp=snapshot_timestamp,
         )
         message_queue.put_nowait(snapshot_msg)
 
@@ -138,18 +136,12 @@ class LighterAPIOrderBookDataSource(OrderBookTrackerDataSource):
             return
 
         for trade_data in raw_message.get("trades", []):
-            is_maker_ask = bool(trade_data.get("is_maker_ask"))
-            message_content = {
-                "trade_id": trade_data.get("trade_id") or trade_data.get("trade_id_str"),
-                "update_id": trade_data.get("nonce") or raw_message.get("nonce") or trade_data.get("trade_id"),
-                "trading_pair": trading_pair,
-                "trade_type": float(TradeType.BUY.value) if is_maker_ask else float(TradeType.SELL.value),
-                "amount": trade_data.get("size", "0"),
-                "price": trade_data.get("price", "0"),
-            }
-            trade_message = OrderBookMessage(
-                message_type=OrderBookMessageType.TRADE,
-                content=message_content,
+            trade_message = LighterOrderBook.trade_message_from_exchange(
+                msg={
+                    **trade_data,
+                    "nonce": trade_data.get("nonce") or raw_message.get("nonce"),
+                },
+                metadata={"trading_pair": trading_pair},
                 timestamp=float(raw_message.get("timestamp") or 0) / 1000,
             )
             message_queue.put_nowait(trade_message)
@@ -166,15 +158,14 @@ class LighterAPIOrderBookDataSource(OrderBookTrackerDataSource):
         if update_id == 0:
             update_id = int(raw_message.get("offset") or order_book.get("offset") or 0)
 
-        diff_message = OrderBookMessage(
-            OrderBookMessageType.DIFF,
-            {
-                "trading_pair": trading_pair,
+        diff_message = LighterOrderBook.diff_message_from_exchange(
+            msg={
                 "update_id": update_id,
                 "first_update_id": int(order_book.get("begin_nonce") or update_id),
                 "bids": [(bid["price"], bid["size"]) for bid in order_book.get("bids", [])],
                 "asks": [(ask["price"], ask["size"]) for ask in order_book.get("asks", [])],
             },
+            metadata={"trading_pair": trading_pair},
             timestamp=float(raw_message.get("timestamp") or 0) / 1000,
         )
         message_queue.put_nowait(diff_message)

--- a/hummingbot/connector/exchange/lighter/lighter_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/lighter/lighter_api_order_book_data_source.py
@@ -1,0 +1,195 @@
+import asyncio
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from hummingbot.connector.exchange.lighter import lighter_constants as CONSTANTS, lighter_web_utils as web_utils
+from hummingbot.core.data_type.common import TradeType
+from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
+from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+from hummingbot.core.web_assistant.ws_assistant import WSAssistant
+from hummingbot.logger import HummingbotLogger
+
+if TYPE_CHECKING:
+    from hummingbot.connector.exchange.lighter.lighter_exchange import LighterExchange
+
+
+class LighterAPIOrderBookDataSource(OrderBookTrackerDataSource):
+    _logger: Optional[HummingbotLogger] = None
+
+    def __init__(
+        self,
+        trading_pairs: List[str],
+        connector: "LighterExchange",
+        api_factory: WebAssistantsFactory,
+        domain: str = CONSTANTS.DEFAULT_DOMAIN,
+    ):
+        super().__init__(trading_pairs)
+        self._connector = connector
+        self._api_factory = api_factory
+        self._domain = domain
+        self._market_id_to_trading_pair: Dict[int, str] = {}
+
+    async def get_last_traded_prices(self, trading_pairs: List[str], domain: Optional[str] = None) -> Dict[str, float]:
+        return await self._connector.get_last_traded_prices(trading_pairs=trading_pairs)
+
+    def _get_headers(self) -> Dict[str, str]:
+        headers = {}
+        if self._connector.rest_api_key:
+            headers["X-Api-Key"] = self._connector.rest_api_key
+        return headers
+
+    async def _request_order_book_snapshot(self, trading_pair: str) -> Dict[str, Any]:
+        rest_assistant = await self._api_factory.get_rest_assistant()
+        params = {"symbol": await self._connector.exchange_symbol_associated_to_pair(trading_pair=trading_pair)}
+
+        response = await rest_assistant.execute_request(
+            url=web_utils.public_rest_url(path_url=CONSTANTS.GET_MARKET_ORDER_BOOK_SNAPSHOT_PATH_URL, domain=self._domain),
+            params=params,
+            method=RESTMethod.GET,
+            throttler_limit_id=CONSTANTS.GET_MARKET_ORDER_BOOK_SNAPSHOT_PATH_URL,
+            headers=self._get_headers(),
+        )
+
+        if not response.get("success"):
+            raise ValueError(f"Failed to fetch order book snapshot for {trading_pair}: {response}")
+
+        return response["data"]
+
+    async def _order_book_snapshot(self, trading_pair: str) -> OrderBookMessage:
+        order_book_snapshot_data = await self._request_order_book_snapshot(trading_pair)
+        timestamp = order_book_snapshot_data["t"] / 1000
+        return OrderBookMessage(
+            OrderBookMessageType.SNAPSHOT,
+            {
+                "trading_pair": trading_pair,
+                "update_id": order_book_snapshot_data.get("li", order_book_snapshot_data["t"]),
+                "bids": [(bids["p"], bids["a"]) for bids in order_book_snapshot_data["l"][0]],
+                "asks": [(asks["p"], asks["a"]) for asks in order_book_snapshot_data["l"][1]],
+            },
+            timestamp=timestamp,
+        )
+
+    async def _connected_websocket_assistant(self) -> WSAssistant:
+        ws: WSAssistant = await self._api_factory.get_ws_assistant()
+        await ws.connect(ws_url=web_utils.wss_url(self._domain), ws_headers=self._get_headers())
+        return ws
+
+    async def _subscribe_channels(self, ws: WSAssistant):
+        for trading_pair in self._trading_pairs:
+            market_id, _, _, _ = await self._connector._get_market_spec(trading_pair)
+            self._market_id_to_trading_pair[market_id] = trading_pair
+            await ws.send(WSJSONRequest(payload={"type": "subscribe", "channel": f"order_book/{market_id}"}))
+            await ws.send(WSJSONRequest(payload={"type": "subscribe", "channel": f"trade/{market_id}"}))
+
+    async def subscribe_to_trading_pair(self, trading_pair: str) -> bool:
+        if self._ws_assistant is None:
+            return False
+
+        market_id, _, _, _ = await self._connector._get_market_spec(trading_pair)
+        self._market_id_to_trading_pair[market_id] = trading_pair
+        self.add_trading_pair(trading_pair)
+
+        await self._ws_assistant.send(WSJSONRequest(payload={"type": "subscribe", "channel": f"order_book/{market_id}"}))
+        await self._ws_assistant.send(WSJSONRequest(payload={"type": "subscribe", "channel": f"trade/{market_id}"}))
+        return True
+
+    async def unsubscribe_from_trading_pair(self, trading_pair: str) -> bool:
+        if self._ws_assistant is None:
+            return False
+
+        market_id, _, _, _ = await self._connector._get_market_spec(trading_pair)
+        await self._ws_assistant.send(WSJSONRequest(payload={"type": "unsubscribe", "channel": f"order_book/{market_id}"}))
+        await self._ws_assistant.send(WSJSONRequest(payload={"type": "unsubscribe", "channel": f"trade/{market_id}"}))
+        self._market_id_to_trading_pair.pop(market_id, None)
+        self.remove_trading_pair(trading_pair)
+        return True
+
+    async def _parse_order_book_snapshot_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
+        channel = str(raw_message.get("channel", ""))
+        market_id = int(channel.split(":")[-1])
+        trading_pair = self._market_id_to_trading_pair.get(market_id)
+        if trading_pair is None:
+            return
+
+        order_book = raw_message.get("order_book") or {}
+        snapshot_timestamp = float(raw_message.get("timestamp") or raw_message.get("last_updated_at") or 0) / 1000
+        update_id = int(order_book.get("nonce") or raw_message.get("nonce") or 0)
+        if update_id == 0:
+            update_id = int(raw_message.get("offset") or order_book.get("offset") or raw_message.get("last_updated_at") or 0)
+
+        snapshot_msg = OrderBookMessage(
+            OrderBookMessageType.SNAPSHOT,
+            {
+                "trading_pair": trading_pair,
+                "update_id": update_id,
+                "bids": [(bid["price"], bid["size"]) for bid in order_book.get("bids", [])],
+                "asks": [(ask["price"], ask["size"]) for ask in order_book.get("asks", [])],
+            },
+            snapshot_timestamp,
+        )
+        message_queue.put_nowait(snapshot_msg)
+
+    async def _parse_trade_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
+        channel = str(raw_message.get("channel", ""))
+        market_id = int(channel.split(":")[-1])
+        trading_pair = self._market_id_to_trading_pair.get(market_id)
+        if trading_pair is None:
+            return
+
+        for trade_data in raw_message.get("trades", []):
+            is_maker_ask = bool(trade_data.get("is_maker_ask"))
+            message_content = {
+                "trade_id": trade_data.get("trade_id") or trade_data.get("trade_id_str"),
+                "update_id": trade_data.get("nonce") or raw_message.get("nonce") or trade_data.get("trade_id"),
+                "trading_pair": trading_pair,
+                "trade_type": float(TradeType.BUY.value) if is_maker_ask else float(TradeType.SELL.value),
+                "amount": trade_data.get("size", "0"),
+                "price": trade_data.get("price", "0"),
+            }
+            trade_message = OrderBookMessage(
+                message_type=OrderBookMessageType.TRADE,
+                content=message_content,
+                timestamp=float(raw_message.get("timestamp") or 0) / 1000,
+            )
+            message_queue.put_nowait(trade_message)
+
+    async def _parse_order_book_diff_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
+        channel = str(raw_message.get("channel", ""))
+        market_id = int(channel.split(":")[-1])
+        trading_pair = self._market_id_to_trading_pair.get(market_id)
+        if trading_pair is None:
+            return
+
+        order_book = raw_message.get("order_book") or {}
+        update_id = int(order_book.get("nonce") or raw_message.get("nonce") or 0)
+        if update_id == 0:
+            update_id = int(raw_message.get("offset") or order_book.get("offset") or 0)
+
+        diff_message = OrderBookMessage(
+            OrderBookMessageType.DIFF,
+            {
+                "trading_pair": trading_pair,
+                "update_id": update_id,
+                "first_update_id": int(order_book.get("begin_nonce") or update_id),
+                "bids": [(bid["price"], bid["size"]) for bid in order_book.get("bids", [])],
+                "asks": [(ask["price"], ask["size"]) for ask in order_book.get("asks", [])],
+            },
+            timestamp=float(raw_message.get("timestamp") or 0) / 1000,
+        )
+        message_queue.put_nowait(diff_message)
+
+    def _channel_originating_message(self, event_message: Dict[str, Any]) -> str:
+        if "channel" not in event_message:
+            return ""
+        event_channel = str(event_message.get("channel"))
+        event_type = str(event_message.get("type", ""))
+        if event_channel.startswith(f"{CONSTANTS.WS_ORDER_BOOK_SNAPSHOT_CHANNEL}:"):
+            if event_type in {"subscribed/order_book", "snapshot/order_book"}:
+                return self._snapshot_messages_queue_key
+            if event_type in {"update/order_book"}:
+                return self._diff_messages_queue_key
+            return self._snapshot_messages_queue_key
+        if event_channel.startswith(f"{CONSTANTS.WS_TRADES_CHANNEL}:"):
+            return self._trade_messages_queue_key
+        return ""

--- a/hummingbot/connector/exchange/lighter/lighter_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/lighter/lighter_api_user_stream_data_source.py
@@ -1,0 +1,65 @@
+import asyncio
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+from hummingbot.connector.exchange.lighter import lighter_constants as CONSTANTS, lighter_web_utils as web_utils
+from hummingbot.connector.exchange.lighter.lighter_auth import LighterAuth
+from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
+from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest, WSResponse
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+from hummingbot.core.web_assistant.ws_assistant import WSAssistant
+from hummingbot.logger import HummingbotLogger
+
+if TYPE_CHECKING:
+    from hummingbot.connector.exchange.lighter.lighter_exchange import LighterExchange
+
+
+class LighterAPIUserStreamDataSource(UserStreamTrackerDataSource):
+    _logger: Optional[HummingbotLogger] = None
+
+    def __init__(
+        self,
+        connector: "LighterExchange",
+        api_factory: WebAssistantsFactory,
+        auth: LighterAuth,
+        domain: str = CONSTANTS.DEFAULT_DOMAIN,
+    ):
+        super().__init__()
+        self._connector = connector
+        self._api_factory = api_factory
+        self._auth = auth
+        self._domain = domain
+        self._ping_task: Optional[asyncio.Task] = None
+
+    async def _connected_websocket_assistant(self) -> WSAssistant:
+        ws: WSAssistant = await self._api_factory.get_ws_assistant()
+        ws_headers = {}
+        if self._connector.rest_api_key:
+            ws_headers["X-Api-Key"] = self._connector.rest_api_key
+        await ws.connect(ws_url=web_utils.wss_url(self._domain), ws_headers=ws_headers)
+        return ws
+
+    async def _subscribe_channels(self, websocket_assistant: WSAssistant) -> None:
+        response: Optional[WSResponse] = await websocket_assistant.receive()
+        message: Dict[str, Any] = response.data if response is not None else {}
+        if message.get("type") != "connected":
+            raise IOError("Private websocket connection did not acknowledge the session")
+
+        account_all_payload = {
+            "type": "subscribe",
+            "channel": f"{CONSTANTS.WS_ACCOUNT_ALL_CHANNEL}/{self._auth.user_wallet_public_key}",
+        }
+        await websocket_assistant.send(WSJSONRequest(account_all_payload))
+
+    async def _process_websocket_messages(self, websocket_assistant: WSAssistant, queue: asyncio.Queue):
+        async for ws_response in websocket_assistant.iter_messages():
+            data = ws_response.data
+            if data.get("type") == "ping":
+                await websocket_assistant.send(WSJSONRequest(payload={"type": "pong"}))
+                continue
+            await self._process_event_message(event_message=data, queue=queue)
+
+    async def _process_event_message(self, event_message: Dict[str, Any], queue: asyncio.Queue):
+        message_type = event_message.get("type")
+        channel = str(event_message.get("channel", ""))
+        if message_type in {"subscribed/account_all", "update/account_all"} or channel.startswith(f"{CONSTANTS.WS_ACCOUNT_ALL_CHANNEL}:"):
+            queue.put_nowait(event_message)

--- a/hummingbot/connector/exchange/lighter/lighter_auth.py
+++ b/hummingbot/connector/exchange/lighter/lighter_auth.py
@@ -1,0 +1,21 @@
+from hummingbot.core.web_assistant.auth import AuthBase
+from hummingbot.core.web_assistant.connections.data_types import RESTRequest, WSRequest
+
+
+class LighterAuth(AuthBase):
+    def __init__(self, api_key: str, api_secret: str = "", account_identifier: str = ""):
+        self.api_key = api_key
+        self.api_secret = api_secret
+        self.user_wallet_public_key = account_identifier
+
+    async def rest_authenticate(self, request: RESTRequest) -> RESTRequest:
+        headers = dict(request.headers or {})
+        headers["accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+        if self.api_key:
+            headers["X-Api-Key"] = self.api_key
+        request.headers = headers
+        return request
+
+    async def ws_authenticate(self, request: WSRequest) -> WSRequest:
+        return request

--- a/hummingbot/connector/exchange/lighter/lighter_constants.py
+++ b/hummingbot/connector/exchange/lighter/lighter_constants.py
@@ -1,0 +1,82 @@
+from hummingbot.core.api_throttler.data_types import LinkedLimitWeightPair, RateLimit
+
+EXCHANGE_NAME = "lighter"
+DEFAULT_DOMAIN = "lighter"
+HBOT_ORDER_ID_PREFIX = "HBOT"
+MAX_ORDER_ID_LEN = 32
+
+REST_URL = "https://mainnet.zklighter.elliot.ai/api/v1"
+WSS_URL = "wss://mainnet.zklighter.elliot.ai/stream"
+
+TESTNET_DOMAIN = "lighter_testnet"
+TESTNET_REST_URL = "https://testnet.zklighter.elliot.ai/api/v1"
+TESTNET_WSS_URL = "wss://testnet.zklighter.elliot.ai/stream"
+
+PING_PATH_URL = "/"
+EXCHANGE_INFO_PATH_URL = "/orderBooks"
+GET_MARKET_ORDER_BOOK_SNAPSHOT_PATH_URL = "/orderbooks"
+GET_ORDER_HISTORY_PATH_URL = "/accountInactiveOrders"
+GET_TRADE_HISTORY_PATH_URL = "/trades"
+GET_ACCOUNT_INFO_PATH_URL = "/account"
+GET_ACCOUNT_API_CONFIG_KEYS = "/apikeys"
+CREATE_ACCOUNT_API_CONFIG_KEY = "/tokens_create"
+CREATE_ORDER_PATH_URL = "/sendTx"
+CANCEL_ORDER_PATH_URL = "/sendTx"
+
+WS_ORDER_BOOK_SNAPSHOT_CHANNEL = "order_book"
+WS_TRADES_CHANNEL = "trade"
+WS_ACCOUNT_ALL_CHANNEL = "account_all"
+WS_PING_INTERVAL = 30
+
+LIGHTER_LIMIT_ID = "LIGHTER_LIMIT"
+LIGHTER_LIMIT = 24000
+LIGHTER_LIMIT_INTERVAL = 60
+STANDARD_REQUEST_COST = 10
+HEAVY_GET_REQUEST_COST = 30
+ORDER_CANCELLATION_COST = 5
+
+RATE_LIMITS = [
+    RateLimit(limit_id=LIGHTER_LIMIT_ID, limit=LIGHTER_LIMIT, time_interval=LIGHTER_LIMIT_INTERVAL),
+    RateLimit(
+        limit_id=EXCHANGE_INFO_PATH_URL,
+        limit=LIGHTER_LIMIT,
+        time_interval=LIGHTER_LIMIT_INTERVAL,
+        linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=HEAVY_GET_REQUEST_COST)],
+    ),
+    RateLimit(
+        limit_id=GET_MARKET_ORDER_BOOK_SNAPSHOT_PATH_URL,
+        limit=LIGHTER_LIMIT,
+        time_interval=LIGHTER_LIMIT_INTERVAL,
+        linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=HEAVY_GET_REQUEST_COST)],
+    ),
+    RateLimit(
+        limit_id=GET_ACCOUNT_INFO_PATH_URL,
+        limit=LIGHTER_LIMIT,
+        time_interval=LIGHTER_LIMIT_INTERVAL,
+        linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=HEAVY_GET_REQUEST_COST)],
+    ),
+    RateLimit(
+        limit_id=GET_TRADE_HISTORY_PATH_URL,
+        limit=LIGHTER_LIMIT,
+        time_interval=LIGHTER_LIMIT_INTERVAL,
+        linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=HEAVY_GET_REQUEST_COST)],
+    ),
+    RateLimit(
+        limit_id=GET_ORDER_HISTORY_PATH_URL,
+        limit=LIGHTER_LIMIT,
+        time_interval=LIGHTER_LIMIT_INTERVAL,
+        linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=HEAVY_GET_REQUEST_COST)],
+    ),
+    RateLimit(
+        limit_id=CREATE_ORDER_PATH_URL,
+        limit=LIGHTER_LIMIT,
+        time_interval=LIGHTER_LIMIT_INTERVAL,
+        linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=STANDARD_REQUEST_COST)],
+    ),
+    RateLimit(
+        limit_id=CANCEL_ORDER_PATH_URL,
+        limit=LIGHTER_LIMIT,
+        time_interval=LIGHTER_LIMIT_INTERVAL,
+        linked_limits=[LinkedLimitWeightPair(limit_id=LIGHTER_LIMIT_ID, weight=ORDER_CANCELLATION_COST)],
+    ),
+]

--- a/hummingbot/connector/exchange/lighter/lighter_constants.py
+++ b/hummingbot/connector/exchange/lighter/lighter_constants.py
@@ -12,7 +12,7 @@ TESTNET_DOMAIN = "lighter_testnet"
 TESTNET_REST_URL = "https://testnet.zklighter.elliot.ai/api/v1"
 TESTNET_WSS_URL = "wss://testnet.zklighter.elliot.ai/stream"
 
-PING_PATH_URL = "/"
+PING_PATH_URL = "/orderBooks"
 EXCHANGE_INFO_PATH_URL = "/orderBooks"
 GET_MARKET_ORDER_BOOK_SNAPSHOT_PATH_URL = "/orderbooks"
 GET_ORDER_HISTORY_PATH_URL = "/accountInactiveOrders"

--- a/hummingbot/connector/exchange/lighter/lighter_exchange.py
+++ b/hummingbot/connector/exchange/lighter/lighter_exchange.py
@@ -67,7 +67,8 @@ class LighterExchange(ExchangePyBase):
     @staticmethod
     def _client_order_index_from_order_id(order_id: str) -> int:
         digest = hashlib.sha256(order_id.encode()).digest()
-        return int.from_bytes(digest[:8], byteorder="big", signed=False) & 0x7FFFFFFFFFFFFFFF
+        # Lighter API enforces client_order_index <= 2^48-1 (281474976710655)
+        return int.from_bytes(digest[:8], byteorder="big", signed=False) & ((1 << 48) - 1)
 
     @staticmethod
     def _is_int_string(value: str) -> bool:

--- a/hummingbot/connector/exchange/lighter/lighter_exchange.py
+++ b/hummingbot/connector/exchange/lighter/lighter_exchange.py
@@ -192,7 +192,7 @@ class LighterExchange(ExchangePyBase):
     @property
     def authenticator(self) -> LighterAuth:
         return LighterAuth(
-            api_key=self._api_key,
+            api_key=self.rest_api_key,
             api_secret=self._api_secret,
             account_identifier=self._account_index,
         )
@@ -239,7 +239,13 @@ class LighterExchange(ExchangePyBase):
 
     @property
     def rest_api_key(self) -> str:
-        return self._api_key
+        api_key = getattr(self, "_api_key", "")
+        api_secret = getattr(self, "_api_secret", "")
+        if self._is_int_string(api_key):
+            return str(api_key)
+        if self._is_int_string(api_secret):
+            return str(api_secret)
+        return api_key
 
     def supported_order_types(self) -> List[OrderType]:
         return [OrderType.LIMIT, OrderType.LIMIT_MAKER, OrderType.MARKET]
@@ -491,6 +497,7 @@ class LighterExchange(ExchangePyBase):
         response = await self._api_get(
             path_url=CONSTANTS.GET_ACCOUNT_INFO_PATH_URL,
             params=self._account_query_params(),
+            is_auth_required=True,
             return_err=True,
         )
 

--- a/hummingbot/connector/exchange/lighter/lighter_exchange.py
+++ b/hummingbot/connector/exchange/lighter/lighter_exchange.py
@@ -1,0 +1,944 @@
+import asyncio
+import hashlib
+from decimal import Decimal
+from typing import Any, AsyncIterable, Callable, Dict, List, Optional, Tuple
+
+from bidict import bidict
+
+from hummingbot.connector.constants import s_decimal_NaN
+from hummingbot.connector.exchange.lighter import lighter_constants as CONSTANTS, lighter_web_utils as web_utils
+from hummingbot.connector.exchange.lighter.lighter_api_order_book_data_source import LighterAPIOrderBookDataSource
+from hummingbot.connector.exchange.lighter.lighter_api_user_stream_data_source import LighterAPIUserStreamDataSource
+from hummingbot.connector.exchange.lighter.lighter_auth import LighterAuth
+from hummingbot.connector.exchange_py_base import ExchangePyBase
+from hummingbot.connector.trading_rule import TradingRule
+from hummingbot.connector.utils import TradeFillOrderDetails, combine_to_hb_trading_pair
+from hummingbot.core.api_throttler.data_types import RateLimit
+from hummingbot.core.data_type.common import OrderType, TradeType
+from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState, OrderUpdate, TradeUpdate
+from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
+from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee, TokenAmount, TradeFeeBase
+from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+
+
+class LighterExchange(ExchangePyBase):
+    web_utils = web_utils
+    _ORDER_STATE = {
+        "open": OrderState.OPEN,
+        "pending": OrderState.PENDING_CREATE,
+        "partially_filled": OrderState.PARTIALLY_FILLED,
+        "partial_fill": OrderState.PARTIALLY_FILLED,
+        "filled": OrderState.FILLED,
+        "cancelled": OrderState.CANCELED,
+        "canceled": OrderState.CANCELED,
+        "pending_cancel": OrderState.PENDING_CANCEL,
+        "rejected": OrderState.FAILED,
+        "failed": OrderState.FAILED,
+        "expired": OrderState.FAILED,
+    }
+
+    def __init__(
+        self,
+        lighter_api_key: str,
+        lighter_api_secret: str,
+        lighter_account_index: str,
+        lighter_private_key: str = "",
+        trading_pairs: Optional[List[str]] = None,
+        trading_required: bool = True,
+        domain: str = CONSTANTS.DEFAULT_DOMAIN,
+    ):
+        self._api_key = lighter_api_key
+        self._api_secret = lighter_api_secret
+        self._account_index = lighter_account_index
+        self._private_key = lighter_private_key
+        self._domain = domain
+        self._trading_required = trading_required
+        self._trading_pairs = trading_pairs or []
+        self._exchange_symbol_map = bidict()
+        self._market_id_by_symbol: Dict[str, int] = {}
+        self._size_decimals_by_symbol: Dict[str, int] = {}
+        self._price_decimals_by_symbol: Dict[str, int] = {}
+        self._lighter_signer_client = None
+        self._order_history_last_poll_timestamp: Dict[str, float] = {}
+        super().__init__()
+
+    @staticmethod
+    def _client_order_index_from_order_id(order_id: str) -> int:
+        digest = hashlib.sha256(order_id.encode()).digest()
+        return int.from_bytes(digest[:8], byteorder="big", signed=False) & 0x7FFFFFFFFFFFFFFF
+
+    @staticmethod
+    def _is_int_string(value: str) -> bool:
+        if value is None:
+            return False
+        try:
+            int(str(value))
+            return True
+        except Exception:
+            return False
+
+    def _get_signer_private_key(self) -> str:
+        if self._private_key:
+            return self._private_key
+        if self._api_key and not self._is_int_string(self._api_key):
+            return self._api_key
+        if self._api_secret and not self._is_int_string(self._api_secret):
+            return self._api_secret
+        raise ValueError(
+            "Lighter signer private key is required for signed spot transactions. "
+            "Provide lighter_private_key (or set lighter_api_key to signer private key in compatibility mode)."
+        )
+
+    def _api_host_for_signer(self) -> str:
+        return CONSTANTS.REST_URL.split("/api/v1")[0]
+
+    def _get_api_key_index(self) -> int:
+        if self._is_int_string(self._api_key):
+            return int(self._api_key)
+        if self._is_int_string(self._api_secret):
+            return int(self._api_secret)
+        raise ValueError(
+            "Lighter API key index must be provided as an integer string in lighter_api_key or lighter_api_secret "
+            "(compatibility mode)."
+        )
+
+    def _get_account_index(self) -> int:
+        try:
+            return int(self._account_index)
+        except Exception as e:
+            raise ValueError("Lighter account index must be an integer string") from e
+
+    @staticmethod
+    def _is_ok_response(response: Dict[str, Any]) -> bool:
+        if response.get("success") is True:
+            return True
+        code = response.get("code")
+        try:
+            return int(code) == 200
+        except Exception:
+            return False
+
+    def _account_query_params(self) -> Dict[str, Any]:
+        return {
+            "by": "index",
+            "value": str(self._get_account_index()),
+        }
+
+    @staticmethod
+    def _account_from_response(response: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        data = response.get("data")
+        if isinstance(data, dict):
+            return data
+        if isinstance(data, list) and len(data) > 0 and isinstance(data[0], dict):
+            return data[0]
+        accounts = response.get("accounts")
+        if isinstance(accounts, list) and len(accounts) > 0:
+            return accounts[0]
+        return None
+
+    def _get_lighter_signer_client(self):
+        if self._lighter_signer_client is None:
+            import lighter
+
+            self._lighter_signer_client = lighter.signer_client.SignerClient(
+                url=self._api_host_for_signer(),
+                account_index=self._get_account_index(),
+                api_private_keys={self._get_api_key_index(): self._get_signer_private_key()},
+            )
+
+        return self._lighter_signer_client
+
+    async def _refresh_market_metadata(self):
+        response = await self._api_get(
+            path_url=CONSTANTS.EXCHANGE_INFO_PATH_URL,
+            return_err=True,
+        )
+
+        for market in response.get("order_books", []) or response.get("data", []):
+            market_type = str(market.get("market_type") or "").lower()
+            if market_type and market_type != "spot":
+                continue
+
+            symbol = market.get("symbol")
+            if symbol is None:
+                continue
+
+            self._market_id_by_symbol[symbol] = int(market["market_id"])
+            self._size_decimals_by_symbol[symbol] = int(market.get("supported_size_decimals", 0))
+            self._price_decimals_by_symbol[symbol] = int(market.get("supported_price_decimals", 0))
+
+    async def _get_market_spec(self, trading_pair: str) -> Tuple[int, int, int, str]:
+        symbol = await self.exchange_symbol_associated_to_pair(trading_pair)
+
+        if symbol not in self._market_id_by_symbol:
+            await self._refresh_market_metadata()
+
+        if symbol not in self._market_id_by_symbol:
+            raise ValueError(f"Market metadata not found for symbol {symbol}")
+
+        return (
+            self._market_id_by_symbol[symbol],
+            self._size_decimals_by_symbol.get(symbol, 0),
+            self._price_decimals_by_symbol.get(symbol, 0),
+            symbol,
+        )
+
+    @property
+    def name(self) -> str:
+        return self._domain
+
+    @property
+    def authenticator(self) -> LighterAuth:
+        return LighterAuth(
+            api_key=self._api_key,
+            api_secret=self._api_secret,
+            account_identifier=self._account_index,
+        )
+
+    @property
+    def rate_limits_rules(self) -> List[RateLimit]:
+        return CONSTANTS.RATE_LIMITS
+
+    @property
+    def domain(self) -> str:
+        return self._domain
+
+    @property
+    def client_order_id_max_length(self) -> int:
+        return CONSTANTS.MAX_ORDER_ID_LEN
+
+    @property
+    def client_order_id_prefix(self) -> str:
+        return CONSTANTS.HBOT_ORDER_ID_PREFIX
+
+    @property
+    def trading_rules_request_path(self) -> str:
+        return CONSTANTS.EXCHANGE_INFO_PATH_URL
+
+    @property
+    def trading_pairs_request_path(self) -> str:
+        return CONSTANTS.EXCHANGE_INFO_PATH_URL
+
+    @property
+    def check_network_request_path(self) -> str:
+        return CONSTANTS.PING_PATH_URL
+
+    @property
+    def trading_pairs(self) -> List[str]:
+        return self._trading_pairs
+
+    @property
+    def is_cancel_request_in_exchange_synchronous(self) -> bool:
+        return True
+
+    @property
+    def is_trading_required(self) -> bool:
+        return self._trading_required
+
+    @property
+    def rest_api_key(self) -> str:
+        return self._api_key
+
+    def supported_order_types(self) -> List[OrderType]:
+        return [OrderType.LIMIT, OrderType.LIMIT_MAKER, OrderType.MARKET]
+
+    def _is_request_exception_related_to_time_synchronizer(self, request_exception: Exception) -> bool:
+        return False
+
+    def _is_order_not_found_during_status_update_error(self, status_update_exception: Exception) -> bool:
+        return False
+
+    def _is_order_not_found_during_cancelation_error(self, cancelation_exception: Exception) -> bool:
+        return False
+
+    @staticmethod
+    def _hb_pair_from_symbol(symbol: str) -> str:
+        if "/" in symbol:
+            base, quote = symbol.split("/", 1)
+            return combine_to_hb_trading_pair(base=base, quote=quote)
+        if "-" in symbol:
+            base, quote = symbol.split("-", 1)
+            return combine_to_hb_trading_pair(base=base, quote=quote)
+        return symbol
+
+    async def _place_cancel(self, order_id: str, tracked_order: InFlightOrder):
+        market_id, _, _, _ = await self._get_market_spec(tracked_order.trading_pair)
+        signer_client = self._get_lighter_signer_client()
+
+        _, tx_response, error = await signer_client.cancel_order(
+            market_index=market_id,
+            order_index=int(tracked_order.exchange_order_id),
+            api_key_index=self._get_api_key_index(),
+        )
+
+        if error is not None:
+            raise IOError(f"Lighter spot cancel_order signing/send failed: {error}")
+        if tx_response is None or getattr(tx_response, "code", None) != 200:
+            raise IOError(f"Lighter spot cancel_order failed: {tx_response}")
+
+        return True
+
+    async def _place_order(
+        self,
+        order_id: str,
+        trading_pair: str,
+        amount: Decimal,
+        trade_type: TradeType,
+        order_type: OrderType,
+        price: Decimal,
+        **kwargs,
+    ) -> Tuple[str, float]:
+        if order_type not in self.supported_order_types():
+            raise ValueError(f"Order type {order_type} is not supported by {self.name}.")
+
+        market_id, size_decimals, price_decimals, _ = await self._get_market_spec(trading_pair)
+        signer_client = self._get_lighter_signer_client()
+
+        base_amount_scaled = int((amount * Decimal(f"1e{size_decimals}")).to_integral_value())
+        price_scaled = int((price * Decimal(f"1e{price_decimals}")).to_integral_value())
+
+        signer_order_type = signer_client.ORDER_TYPE_LIMIT
+        signer_tif = signer_client.ORDER_TIME_IN_FORCE_GOOD_TILL_TIME
+        order_expiry = signer_client.DEFAULT_28_DAY_ORDER_EXPIRY
+        if order_type == OrderType.MARKET:
+            signer_order_type = signer_client.ORDER_TYPE_MARKET
+            signer_tif = signer_client.ORDER_TIME_IN_FORCE_IMMEDIATE_OR_CANCEL
+            order_expiry = signer_client.DEFAULT_IOC_EXPIRY
+        elif order_type == OrderType.LIMIT_MAKER:
+            signer_tif = signer_client.ORDER_TIME_IN_FORCE_POST_ONLY
+
+        client_order_index = self._client_order_index_from_order_id(order_id)
+        _, tx_response, error = await signer_client.create_order(
+            market_index=market_id,
+            client_order_index=client_order_index,
+            base_amount=base_amount_scaled,
+            price=price_scaled,
+            is_ask=(trade_type == TradeType.SELL),
+            order_type=signer_order_type,
+            time_in_force=signer_tif,
+            reduce_only=False,
+            order_expiry=order_expiry,
+            api_key_index=self._get_api_key_index(),
+        )
+
+        if error is not None:
+            raise IOError(f"Lighter spot create_order signing/send failed: {error}")
+        if tx_response is None or getattr(tx_response, "code", None) != 200:
+            raise IOError(f"Lighter spot create_order failed: {tx_response}")
+
+        return str(client_order_index), self.current_timestamp
+
+    def _get_fee(
+        self,
+        base_currency: str,
+        quote_currency: str,
+        order_type: OrderType,
+        order_side: TradeType,
+        amount: Decimal,
+        price: Decimal = s_decimal_NaN,
+        is_maker: Optional[bool] = None,
+    ) -> AddedToCostTradeFee:
+        fee = TradeFeeBase.new_spot_fee(
+            fee_schema=self.trade_fee_schema(),
+            trade_type=order_side,
+            percent_token=quote_currency,
+            percent=Decimal("0"),
+            flat_fees=[TokenAmount(token=quote_currency, amount=Decimal("0"))],
+        )
+        return fee
+
+    async def _update_trading_fees(self):
+        return
+
+    async def _user_stream_event_listener(self):
+        async for event_message in self._iter_user_event_queue():
+            try:
+                if not isinstance(event_message, dict):
+                    continue
+
+                account_data = event_message.get("account") or event_message.get("data")
+                if isinstance(account_data, dict):
+                    self._process_balance_message_from_account(account_data)
+
+                for trade in event_message.get("trades", []):
+                    trade_update = self._trade_update_from_raw_message(trade)
+                    if trade_update is not None:
+                        self._order_tracker.process_trade_update(trade_update)
+
+                for order_data in event_message.get("orders", []):
+                    order_update = self._order_update_from_raw_message(order_data)
+                    if order_update is not None:
+                        self._order_tracker.process_order_update(order_update)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                self.logger().error("Unexpected error in user stream listener loop.", exc_info=True)
+                await self._sleep(5.0)
+
+    def _state_from_raw_order_status(self, raw_status: str) -> OrderState:
+        return self._ORDER_STATE.get(raw_status.lower(), OrderState.OPEN)
+
+    def _process_balance_message_from_account(self, account_data: Dict[str, Any]):
+        for asset_entry in account_data.get("assets", []):
+            asset_symbol = asset_entry.get("symbol")
+            if asset_symbol is None:
+                continue
+
+            total_balance = Decimal(str(asset_entry.get("balance") or "0"))
+            locked_balance = Decimal(str(asset_entry.get("locked_balance") or "0"))
+            available_balance = total_balance - locked_balance
+
+            self._account_balances[asset_symbol] = total_balance
+            self._account_available_balances[asset_symbol] = available_balance
+
+    def _order_update_from_raw_message(self, order_data: Dict[str, Any]) -> Optional[OrderUpdate]:
+        exchange_order_id = str(
+            order_data.get("order_id")
+            or order_data.get("orderId")
+            or order_data.get("order_index")
+            or order_data.get("orderIndex")
+            or ""
+        )
+        client_order_id = str(order_data.get("client_order_id") or order_data.get("clientOrderId") or "")
+        tracked_order = self._order_tracker.all_updatable_orders.get(client_order_id)
+
+        if tracked_order is None and exchange_order_id:
+            tracked_order = self._order_tracker.all_fillable_orders_by_exchange_order_id.get(exchange_order_id)
+        if tracked_order is None:
+            return None
+
+        raw_status = str(order_data.get("order_status") or order_data.get("status") or "open")
+        update_ts = float(order_data.get("updated_at") or order_data.get("created_at") or self.current_timestamp)
+        if update_ts > 1e12:
+            update_ts *= 1e-3
+
+        return OrderUpdate(
+            client_order_id=tracked_order.client_order_id,
+            exchange_order_id=exchange_order_id or tracked_order.exchange_order_id,
+            trading_pair=tracked_order.trading_pair,
+            update_timestamp=update_ts,
+            new_state=self._state_from_raw_order_status(raw_status),
+        )
+
+    def _trade_update_from_raw_message(self, trade_data: Dict[str, Any]) -> Optional[TradeUpdate]:
+        exchange_order_id = str(trade_data.get("order_id") or trade_data.get("orderId") or "")
+        client_order_id = str(trade_data.get("client_order_id") or trade_data.get("clientOrderId") or "")
+
+        tracked_order = self._order_tracker.all_fillable_orders.get(client_order_id)
+        if tracked_order is None and exchange_order_id:
+            tracked_order = self._order_tracker.all_fillable_orders_by_exchange_order_id.get(exchange_order_id)
+        if tracked_order is None:
+            return None
+
+        fill_price = Decimal(str(trade_data.get("price") or trade_data.get("p") or "0"))
+        fill_base_amount = Decimal(str(trade_data.get("amount") or trade_data.get("size") or trade_data.get("a") or "0"))
+        fee_amount = Decimal(str(trade_data.get("fee") or "0"))
+        fill_timestamp = float(trade_data.get("created_at") or trade_data.get("timestamp") or trade_data.get("t") or self.current_timestamp)
+        if fill_timestamp > 1e12:
+            fill_timestamp *= 1e-3
+
+        fee = TradeFeeBase.new_spot_fee(
+            fee_schema=self.trade_fee_schema(),
+            trade_type=tracked_order.trade_type,
+            percent_token=tracked_order.quote_asset,
+            flat_fees=[] if fee_amount == Decimal("0") else [TokenAmount(amount=fee_amount, token=tracked_order.quote_asset)],
+        )
+
+        return TradeUpdate(
+            trade_id=str(trade_data.get("history_id") or trade_data.get("trade_id") or trade_data.get("id") or trade_data.get("h") or ""),
+            client_order_id=tracked_order.client_order_id,
+            exchange_order_id=exchange_order_id or tracked_order.exchange_order_id,
+            trading_pair=tracked_order.trading_pair,
+            fill_timestamp=fill_timestamp,
+            fill_price=fill_price,
+            fill_base_amount=fill_base_amount,
+            fill_quote_amount=fill_price * fill_base_amount,
+            fee=fee,
+            is_taker=trade_data.get("event_type") == "fulfill_taker",
+        )
+
+    async def _format_trading_rules(self, exchange_info_dict: Dict[str, Any]) -> List[TradingRule]:
+        rules = []
+        entries = exchange_info_dict.get("data") or exchange_info_dict.get("order_books") or []
+        for entry in entries:
+            market_type = (entry.get("market_type") or "").lower()
+            if market_type and market_type != "spot":
+                continue
+
+            symbol = entry.get("symbol")
+            if symbol is None:
+                continue
+
+            hb_pair = self._hb_pair_from_symbol(symbol)
+            amount_decimals = int(entry.get("supported_size_decimals", 4))
+            price_decimals = int(entry.get("supported_price_decimals", 2))
+            min_amount = Decimal("1") / (Decimal("10") ** amount_decimals)
+            min_price = Decimal("1") / (Decimal("10") ** price_decimals)
+
+            rules.append(
+                TradingRule(
+                    trading_pair=hb_pair,
+                    min_order_size=min_amount,
+                    min_price_increment=min_price,
+                    min_base_amount_increment=min_amount,
+                )
+            )
+        return rules
+
+    async def _update_balances(self):
+        response = await self._api_get(
+            path_url=CONSTANTS.GET_ACCOUNT_INFO_PATH_URL,
+            params=self._account_query_params(),
+            return_err=True,
+        )
+
+        if not self._is_ok_response(response):
+            self.logger().error(f"[_update_balances] Failed to update balances (api responded with failure): {response}")
+            return
+
+        account_data = self._account_from_response(response)
+        if not account_data:
+            self.logger().error(f"[_update_balances] Failed to update balances (no account data): {response}")
+            return
+
+        remote_asset_names = set()
+        for asset_entry in account_data.get("assets", []):
+            asset_symbol = asset_entry.get("symbol")
+            if asset_symbol is None:
+                continue
+            remote_asset_names.add(asset_symbol)
+
+            total_balance = Decimal(str(asset_entry.get("balance") or "0"))
+            locked_balance = Decimal(str(asset_entry.get("locked_balance") or "0"))
+            available_balance = total_balance - locked_balance
+
+            self._account_balances[asset_symbol] = total_balance
+            self._account_available_balances[asset_symbol] = available_balance
+
+        for local_asset in list(self._account_balances.keys()):
+            if local_asset not in remote_asset_names:
+                self._account_balances.pop(local_asset, None)
+                self._account_available_balances.pop(local_asset, None)
+
+    async def _all_trade_updates_for_order(self, order: InFlightOrder) -> List[TradeUpdate]:
+        trade_updates = []
+
+        last_poll_timestamp = self._order_history_last_poll_timestamp.get(order.exchange_order_id)
+        if last_poll_timestamp:
+            start_time = int(last_poll_timestamp * 1000)
+        else:
+            start_time = int(order.creation_timestamp * 1000)
+
+        current_time = self.current_timestamp
+        end_time = int(current_time * 1000)
+
+        params = {
+            "account": self._account_index,
+            "start_time": start_time,
+            "end_time": end_time,
+            "limit": 100,
+        }
+
+        while True:
+            response = await self._api_get(
+                path_url=CONSTANTS.GET_TRADE_HISTORY_PATH_URL,
+                params=params,
+                is_auth_required=True,
+            )
+
+            if not response.get("success") or not response.get("data"):
+                break
+
+            for trade_message in response["data"]:
+                exchange_order_id = str(trade_message.get("order_id") or trade_message.get("orderId") or "")
+
+                if exchange_order_id != order.exchange_order_id:
+                    continue
+
+                fill_timestamp = float(trade_message.get("created_at") or trade_message.get("t") or 0) / 1000
+                fill_price = Decimal(str(trade_message.get("price") or trade_message.get("p") or "0"))
+                fill_base_amount = Decimal(str(trade_message.get("amount") or trade_message.get("a") or "0"))
+
+                fee_amount = Decimal(str(trade_message.get("fee") or "0"))
+                fee_asset = order.quote_asset
+                fee = TradeFeeBase.new_spot_fee(
+                    fee_schema=self.trade_fee_schema(),
+                    trade_type=order.trade_type,
+                    percent_token=fee_asset,
+                    flat_fees=[TokenAmount(amount=fee_amount, token=fee_asset)],
+                )
+
+                trade_updates.append(
+                    TradeUpdate(
+                        trade_id=str(trade_message.get("history_id") or trade_message.get("h") or trade_message.get("id")),
+                        client_order_id=order.client_order_id,
+                        exchange_order_id=order.exchange_order_id,
+                        trading_pair=order.trading_pair,
+                        fill_timestamp=fill_timestamp,
+                        fill_price=fill_price,
+                        fill_base_amount=fill_base_amount,
+                        fill_quote_amount=fill_price * fill_base_amount,
+                        fee=fee,
+                        is_taker=trade_message.get("event_type") == "fulfill_taker",
+                    )
+                )
+
+            if response.get("has_more") and response.get("next_cursor"):
+                params["cursor"] = response["next_cursor"]
+            else:
+                break
+
+        self._order_history_last_poll_timestamp[order.exchange_order_id] = current_time
+        return trade_updates
+
+    async def _request_order_status(self, tracked_order: InFlightOrder) -> OrderUpdate:
+        response = await self._api_get(
+            path_url=CONSTANTS.GET_ORDER_HISTORY_PATH_URL,
+            params={
+                "order_id": tracked_order.exchange_order_id,
+            },
+            is_auth_required=True,
+        )
+
+        if not response.get("success"):
+            raise IOError(f"Failed to fetch order status for {tracked_order.client_order_id}: {response}")
+
+        rows = response.get("data") or []
+        if len(rows) == 0:
+            return OrderUpdate(
+                client_order_id=tracked_order.client_order_id,
+                exchange_order_id=tracked_order.exchange_order_id,
+                trading_pair=tracked_order.trading_pair,
+                update_timestamp=self.current_timestamp,
+                new_state=tracked_order.current_state,
+            )
+
+        newest = max(rows, key=lambda item: item.get("created_at", 0))
+        raw_status = str(newest.get("order_status") or newest.get("status") or "open").lower()
+        state = self._state_from_raw_order_status(raw_status)
+        update_ts = float(newest.get("created_at") or self.current_timestamp) / 1000
+
+        return OrderUpdate(
+            client_order_id=tracked_order.client_order_id,
+            exchange_order_id=tracked_order.exchange_order_id,
+            trading_pair=tracked_order.trading_pair,
+            update_timestamp=update_ts,
+            new_state=state,
+        )
+
+    def _create_web_assistants_factory(self) -> WebAssistantsFactory:
+        return web_utils.build_api_factory(throttler=self._throttler, auth=self._auth)
+
+    def _create_order_book_data_source(self) -> OrderBookTrackerDataSource:
+        return LighterAPIOrderBookDataSource(
+            trading_pairs=self.trading_pairs,
+            connector=self,
+            api_factory=self._web_assistants_factory,
+            domain=self._domain,
+        )
+
+    def _create_user_stream_data_source(self) -> UserStreamTrackerDataSource:
+        return LighterAPIUserStreamDataSource(
+            connector=self,
+            api_factory=self._web_assistants_factory,
+            auth=self._auth,
+            domain=self._domain,
+        )
+
+    def _initialize_trading_pair_symbols_from_exchange_info(self, exchange_info: Dict[str, Any]):
+        entries = exchange_info.get("data") or exchange_info.get("order_books") or []
+        mapping = bidict()
+        for entry in entries:
+            market_type = (entry.get("market_type") or "").lower()
+            if market_type and market_type != "spot":
+                continue
+            symbol = entry.get("symbol")
+            if symbol is None:
+                continue
+            hb_pair = self._hb_pair_from_symbol(symbol)
+            mapping[symbol] = hb_pair
+        self._set_trading_pair_symbol_map(mapping)
+
+    async def _api_request(
+        self,
+        path_url: str,
+        method: RESTMethod = RESTMethod.GET,
+        params: Optional[Dict[str, Any]] = None,
+        data: Optional[Dict[str, Any]] = None,
+        is_auth_required: bool = False,
+        limit_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        headers = {}
+        if is_auth_required and self.rest_api_key:
+            headers["X-Api-Key"] = self.rest_api_key
+
+        rest_assistant = await self._web_assistants_factory.get_rest_assistant()
+        url = web_utils.private_rest_url(path_url=path_url, domain=self.domain)
+
+        return await rest_assistant.execute_request(
+            url=url,
+            params=params,
+            data=data,
+            method=method,
+            is_auth_required=is_auth_required,
+            return_err=True,
+            throttler_limit_id=limit_id or path_url,
+            headers=headers,
+        )
+
+    async def get_last_traded_prices(self, trading_pairs: List[str]) -> Dict[str, float]:
+        prices: Dict[str, float] = {}
+        stats = await self._api_request(path_url=CONSTANTS.EXCHANGE_INFO_PATH_URL, method=RESTMethod.GET)
+        entries = stats.get("data") or stats.get("order_books") or []
+
+        for entry in entries:
+            symbol = entry.get("symbol")
+            if symbol is None:
+                continue
+            try:
+                trading_pair = await self.trading_pair_associated_to_exchange_symbol(symbol)
+            except KeyError:
+                continue
+            if trading_pair in trading_pairs:
+                last_price = entry.get("index_price") or entry.get("mid") or entry.get("price")
+                if last_price is not None:
+                    prices[trading_pair] = float(last_price)
+        return prices
+
+    async def _status_polling_loop_fetch_updates(self):
+        await asyncio.gather(
+            self._update_balances(),
+            self._update_order_status(),
+            self._update_lost_orders_status(),
+        )
+
+    async def _update_order_fills_from_trades(self):
+        small_interval_last_tick = self._last_poll_timestamp / self.UPDATE_ORDER_STATUS_MIN_INTERVAL
+        small_interval_current_tick = self.current_timestamp / self.UPDATE_ORDER_STATUS_MIN_INTERVAL
+        long_interval_last_tick = self._last_poll_timestamp / self.LONG_POLL_INTERVAL
+        long_interval_current_tick = self.current_timestamp / self.LONG_POLL_INTERVAL
+
+        if long_interval_current_tick > long_interval_last_tick or (
+            self.in_flight_orders and small_interval_current_tick > small_interval_last_tick
+        ):
+            order_by_exchange_id_map = {order.exchange_order_id: order for order in self._order_tracker.all_fillable_orders.values()}
+            trade_updates = await self._api_get(path_url=CONSTANTS.GET_TRADE_HISTORY_PATH_URL, is_auth_required=True, limit_id=CONSTANTS.GET_TRADE_HISTORY_PATH_URL)
+            for trade in trade_updates.get("data", []):
+                exchange_order_id = str(trade.get("order_id") or trade.get("orderId") or "")
+                if exchange_order_id in order_by_exchange_id_map:
+                    tracked_order = order_by_exchange_id_map[exchange_order_id]
+                    fee = TradeFeeBase.new_spot_fee(
+                        fee_schema=self.trade_fee_schema(),
+                        trade_type=tracked_order.trade_type,
+                        percent_token=tracked_order.quote_asset,
+                        flat_fees=[],
+                    )
+                    trade_update = TradeUpdate(
+                        trade_id=str(trade.get("h") or trade.get("trade_id") or trade.get("id")),
+                        client_order_id=tracked_order.client_order_id,
+                        exchange_order_id=exchange_order_id,
+                        trading_pair=tracked_order.trading_pair,
+                        fee=fee,
+                        fill_base_amount=Decimal(str(trade.get("a") or trade.get("base_amount") or "0")),
+                        fill_quote_amount=Decimal(str(trade.get("q") or trade.get("quote_amount") or "0")),
+                        fill_price=Decimal(str(trade.get("p") or trade.get("price") or "0")),
+                        fill_timestamp=float(trade.get("t") or self.current_timestamp) * 1e-3,
+                    )
+                    self._order_tracker.process_trade_update(trade_update)
+
+    async def _update_order_status(self):
+        await self._update_orders_fills(orders=list(self.in_flight_orders.values()))
+        await self._update_orders()
+
+    async def _update_orders_fills(self, orders: List[InFlightOrder]):
+        for order in orders:
+            trade_updates = await self._all_trade_updates_for_order(order)
+            for trade_update in trade_updates:
+                self._order_tracker.process_trade_update(trade_update)
+
+    async def _update_orders(self):
+        for tracked_order in list(self.in_flight_orders.values()):
+            order_update = await self._request_order_status(tracked_order=tracked_order)
+            self._order_tracker.process_order_update(order_update)
+
+    async def _iter_user_event_queue(self) -> AsyncIterable[Dict[str, any]]:
+        while True:
+            try:
+                yield await self._user_stream_tracker.user_stream.get()
+            except asyncio.CancelledError:
+                raise
+
+    def _create_trade_fill_updates(self, inflight_order: InFlightOrder, fills_data: List[Dict[str, Any]]) -> List[TradeUpdate]:
+        trade_updates: List[TradeUpdate] = []
+        for fill_data in fills_data:
+            trade_update = TradeUpdate(
+                trade_id=str(fill_data.get("trade_id") or fill_data.get("id") or fill_data.get("h")),
+                client_order_id=inflight_order.client_order_id,
+                exchange_order_id=inflight_order.exchange_order_id,
+                trading_pair=inflight_order.trading_pair,
+                fill_timestamp=float(fill_data.get("timestamp") or fill_data.get("t") or self.current_timestamp),
+                fill_price=Decimal(str(fill_data.get("price") or fill_data.get("p") or "0")),
+                fill_base_amount=Decimal(str(fill_data.get("amount") or fill_data.get("a") or "0")),
+                fill_quote_amount=Decimal(str(fill_data.get("quote_amount") or fill_data.get("q") or "0")),
+                fee=self._get_fee(
+                    base_currency=inflight_order.base_asset,
+                    quote_currency=inflight_order.quote_asset,
+                    order_type=inflight_order.order_type,
+                    order_side=inflight_order.trade_type,
+                    amount=inflight_order.amount,
+                    price=inflight_order.price,
+                ),
+            )
+            trade_updates.append(trade_update)
+        return trade_updates
+
+    async def _update_orders_with_error_handler(
+        self,
+        orders: List[InFlightOrder],
+        fetch_updates: Callable,
+        error_handler: Callable,
+    ):
+        for order in orders:
+            try:
+                updates = await fetch_updates(order)
+                if isinstance(updates, OrderUpdate):
+                    self._order_tracker.process_order_update(updates)
+                elif isinstance(updates, list):
+                    for update in updates:
+                        if isinstance(update, TradeUpdate):
+                            self._order_tracker.process_trade_update(update)
+            except asyncio.CancelledError:
+                raise
+            except Exception as request_error:
+                await error_handler(order, request_error)
+
+    async def _handle_update_error_for_active_order(self, order: InFlightOrder, request_error: Exception):
+        self.logger().warning(f"Error updating active order {order.client_order_id}: {request_error}")
+
+    async def _handle_update_error_for_lost_order(self, order: InFlightOrder, request_error: Exception):
+        self.logger().warning(f"Error updating lost order {order.client_order_id}: {request_error}")
+
+    async def _update_lost_orders(self):
+        await self._update_orders_with_error_handler(
+            orders=list(self._order_tracker.lost_orders.values()),
+            fetch_updates=self._request_order_status,
+            error_handler=self._handle_update_error_for_lost_order,
+        )
+
+    async def _cancel_lost_orders(self):
+        for _, lost_order in self._order_tracker.lost_orders.items():
+            await self._execute_order_cancel(order=lost_order)
+
+    async def _execute_order_cancel(self, order: InFlightOrder) -> str:
+        cancelled = await self._place_cancel(order_id=order.client_order_id, tracked_order=order)
+        if cancelled:
+            return order.client_order_id
+        return ""
+
+    async def _execute_orders_cancel(self, orders: List[InFlightOrder]) -> List[OrderUpdate]:
+        results = []
+        for order in orders:
+            cancelled_order_id = await self._execute_order_cancel(order)
+            if cancelled_order_id != "":
+                results.append(
+                    OrderUpdate(
+                        client_order_id=cancelled_order_id,
+                        trading_pair=order.trading_pair,
+                        update_timestamp=self.current_timestamp,
+                        new_state=OrderState.CANCELED,
+                    )
+                )
+        return results
+
+    async def _get_last_traded_price(self, trading_pair: str) -> float:
+        prices = await self.get_last_traded_prices(trading_pairs=[trading_pair])
+        return prices[trading_pair]
+
+    async def _create_order_fill_updates(self, order: InFlightOrder, exchange_order_id: str, fee: TradeFeeBase) -> List[TradeUpdate]:
+        _ = exchange_order_id
+        _ = fee
+        return await self._all_trade_updates_for_order(order)
+
+    async def _fetch_last_fee_payment(self, trading_pair: str) -> Tuple[int, Decimal, Decimal]:
+        return 0, Decimal("0"), Decimal("0")
+
+    async def _get_last_trade_price(self, trading_pair: str) -> float:
+        return await self._get_last_traded_price(trading_pair)
+
+    async def _get_all_pairs_prices(self) -> List[Dict[str, str]]:
+        pairs = await self._api_get(path_url=CONSTANTS.EXCHANGE_INFO_PATH_URL)
+        return pairs.get("data", [])
+
+    async def _request_order_fills(self, order: InFlightOrder) -> List[Dict[str, Any]]:
+        if order.exchange_order_id is None:
+            return []
+        return await self._request_order_fills_by_exchange_order_id(order)
+
+    async def _request_order_fills_from_trades_api(self, order: InFlightOrder) -> List[Dict[str, Any]]:
+        params = {
+            "account": self._account_index,
+            "limit": 100,
+        }
+        if order.exchange_order_id is not None:
+            params["order_id"] = str(order.exchange_order_id)
+
+        response = await self._api_get(
+            path_url=CONSTANTS.GET_TRADE_HISTORY_PATH_URL,
+            params=params,
+            is_auth_required=True,
+            limit_id=CONSTANTS.GET_TRADE_HISTORY_PATH_URL,
+        )
+
+        if not response.get("success"):
+            return []
+        return response.get("data") or []
+
+    async def _request_order_fills_from_fills_api(self, order: InFlightOrder) -> List[Dict[str, Any]]:
+        return await self._request_order_fills_from_trades_api(order)
+
+    async def _request_order_fills_by_exchange_order_id(self, order: InFlightOrder) -> List[Dict[str, Any]]:
+        fills = await self._request_order_fills_from_trades_api(order)
+        target_exchange_order_id = str(order.exchange_order_id)
+        filtered_fills = []
+        for fill in fills:
+            fill_exchange_order_id = str(fill.get("order_id") or fill.get("orderId") or "")
+            if fill_exchange_order_id == target_exchange_order_id:
+                filtered_fills.append(fill)
+        return filtered_fills
+
+    async def _request_order_fills_by_client_order_id(self, order: InFlightOrder) -> List[Dict[str, Any]]:
+        fills = await self._request_order_fills_from_trades_api(order)
+        filtered_fills = []
+        for fill in fills:
+            fill_client_order_id = str(fill.get("client_order_id") or fill.get("clientOrderId") or "")
+            if fill_client_order_id == order.client_order_id:
+                filtered_fills.append(fill)
+        return filtered_fills
+
+    async def _request_trade_updates(self, orders: List[InFlightOrder]) -> List[TradeUpdate]:
+        trade_updates: List[TradeUpdate] = []
+        for order in orders:
+            trade_updates.extend(await self._all_trade_updates_for_order(order))
+        return trade_updates
+
+    async def _request_order_update(self, order: InFlightOrder) -> OrderUpdate:
+        return await self._request_order_status(order)
+
+    async def _request_trade_fills(self) -> List[TradeFillOrderDetails]:
+        response = await self._api_get(
+            path_url=CONSTANTS.GET_TRADE_HISTORY_PATH_URL,
+            params={"account": self._account_index, "limit": 100},
+            is_auth_required=True,
+            limit_id=CONSTANTS.GET_TRADE_HISTORY_PATH_URL,
+        )
+        fills = response.get("data") or []
+        return [
+            TradeFillOrderDetails(
+                market=self.name,
+                exchange_trade_id=str(fill.get("history_id") or fill.get("trade_id") or fill.get("id") or fill.get("h") or ""),
+                symbol=str(fill.get("symbol") or ""),
+            )
+            for fill in fills
+        ]

--- a/hummingbot/connector/exchange/lighter/lighter_order_book.py
+++ b/hummingbot/connector/exchange/lighter/lighter_order_book.py
@@ -1,0 +1,77 @@
+from typing import Any, Dict, Optional
+
+from hummingbot.core.data_type.common import TradeType
+from hummingbot.core.data_type.order_book import OrderBook
+from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
+
+
+class LighterOrderBook(OrderBook):
+
+    @classmethod
+    def snapshot_message_from_exchange(
+        cls,
+        msg: Dict[str, Any],
+        timestamp: float,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> OrderBookMessage:
+        if metadata:
+            msg.update(metadata)
+
+        return OrderBookMessage(
+            OrderBookMessageType.SNAPSHOT,
+            {
+                "trading_pair": msg["trading_pair"],
+                "update_id": int(msg["update_id"]),
+                "bids": msg.get("bids", []),
+                "asks": msg.get("asks", []),
+            },
+            timestamp=timestamp,
+        )
+
+    @classmethod
+    def diff_message_from_exchange(
+        cls,
+        msg: Dict[str, Any],
+        timestamp: float,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> OrderBookMessage:
+        if metadata:
+            msg.update(metadata)
+
+        return OrderBookMessage(
+            OrderBookMessageType.DIFF,
+            {
+                "trading_pair": msg["trading_pair"],
+                "first_update_id": int(msg["first_update_id"]),
+                "update_id": int(msg["update_id"]),
+                "bids": msg.get("bids", []),
+                "asks": msg.get("asks", []),
+            },
+            timestamp=timestamp,
+        )
+
+    @classmethod
+    def trade_message_from_exchange(
+        cls,
+        msg: Dict[str, Any],
+        timestamp: float,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> OrderBookMessage:
+        if metadata:
+            msg.update(metadata)
+
+        is_maker_ask = bool(msg.get("is_maker_ask"))
+        trade_type = float(TradeType.BUY.value) if is_maker_ask else float(TradeType.SELL.value)
+
+        return OrderBookMessage(
+            OrderBookMessageType.TRADE,
+            {
+                "trading_pair": msg["trading_pair"],
+                "trade_type": trade_type,
+                "trade_id": msg.get("trade_id") or msg.get("trade_id_str"),
+                "update_id": msg.get("nonce") or msg.get("trade_id") or msg.get("trade_id_str") or 0,
+                "price": msg.get("price", "0"),
+                "amount": msg.get("size", "0"),
+            },
+            timestamp=timestamp,
+        )

--- a/hummingbot/connector/exchange/lighter/lighter_utils.py
+++ b/hummingbot/connector/exchange/lighter/lighter_utils.py
@@ -1,0 +1,127 @@
+from decimal import Decimal
+
+from pydantic import AliasChoices, ConfigDict, Field, SecretStr
+
+from hummingbot.client.config.config_data_types import BaseConnectorConfigMap
+from hummingbot.core.data_type.trade_fee import TradeFeeSchema
+
+CENTRALIZED = True
+EXAMPLE_PAIR = "ETH-USDC"
+
+DEFAULT_FEES = TradeFeeSchema(
+    maker_percent_fee_decimal=Decimal("0.00015"),
+    taker_percent_fee_decimal=Decimal("0.0004"),
+)
+
+
+class LighterConfigMap(BaseConnectorConfigMap):
+    connector: str = "lighter"
+
+    lighter_api_key: SecretStr = Field(
+        default=...,
+        validation_alias=AliasChoices("lighter_api_key"),
+        json_schema_extra={
+            "prompt": "Enter your Lighter API key",
+            "is_secure": True,
+            "is_connect_key": True,
+            "prompt_on_new": True,
+        },
+    )
+
+    lighter_api_secret: SecretStr = Field(
+        default=...,
+        validation_alias=AliasChoices("lighter_api_secret", "lighter_api_key_index"),
+        json_schema_extra={
+            "prompt": "Enter your Lighter API secret or API key index",
+            "is_secure": True,
+            "is_connect_key": True,
+            "prompt_on_new": True,
+        },
+    )
+
+    lighter_account_index: SecretStr = Field(
+        default=...,
+        validation_alias=AliasChoices("lighter_account_index"),
+        json_schema_extra={
+            "prompt": "Enter your Lighter account index",
+            "is_secure": True,
+            "is_connect_key": True,
+            "prompt_on_new": True,
+        },
+    )
+
+    lighter_private_key: SecretStr = Field(
+        default=SecretStr(""),
+        validation_alias=AliasChoices("lighter_private_key", "lighter_signer_private_key", "lighter_eoa_private_key"),
+        json_schema_extra={
+            "prompt": "Enter your Lighter signer private key (optional for read-only; required for signed order placement/cancel)",
+            "is_secure": True,
+            "is_connect_key": True,
+            "prompt_on_new": False,
+        },
+    )
+
+    model_config = ConfigDict(title="lighter")
+
+
+KEYS = LighterConfigMap.model_construct()
+
+OTHER_DOMAINS = ["lighter_testnet"]
+OTHER_DOMAINS_PARAMETER = {"lighter_testnet": "lighter_testnet"}
+OTHER_DOMAINS_EXAMPLE_PAIR = {"lighter_testnet": "ETH-USDC"}
+OTHER_DOMAINS_DEFAULT_FEES = {"lighter_testnet": [0.00015, 0.0004]}
+
+
+class LighterTestnetConfigMap(BaseConnectorConfigMap):
+    connector: str = "lighter_testnet"
+
+    lighter_testnet_api_key: SecretStr = Field(
+        default=...,
+        validation_alias=AliasChoices("lighter_testnet_api_key"),
+        json_schema_extra={
+            "prompt": "Enter your Lighter testnet API key",
+            "is_secure": True,
+            "is_connect_key": True,
+            "prompt_on_new": True,
+        },
+    )
+
+    lighter_testnet_api_secret: SecretStr = Field(
+        default=...,
+        validation_alias=AliasChoices("lighter_testnet_api_secret"),
+        json_schema_extra={
+            "prompt": "Enter your Lighter testnet API secret",
+            "is_secure": True,
+            "is_connect_key": True,
+            "prompt_on_new": True,
+        },
+    )
+
+    lighter_testnet_account_index: SecretStr = Field(
+        default=...,
+        validation_alias=AliasChoices("lighter_testnet_account_index"),
+        json_schema_extra={
+            "prompt": "Enter your Lighter testnet account index",
+            "is_secure": True,
+            "is_connect_key": True,
+            "prompt_on_new": True,
+        },
+    )
+
+    lighter_testnet_private_key: SecretStr = Field(
+        default=SecretStr(""),
+        validation_alias=AliasChoices("lighter_testnet_private_key", "lighter_testnet_signer_private_key"),
+        json_schema_extra={
+            "prompt": "Enter your Lighter testnet signer private key (optional for read-only; required for signed order placement/cancel)",
+            "is_secure": True,
+            "is_connect_key": True,
+            "prompt_on_new": False,
+        },
+    )
+
+    model_config = ConfigDict(title="lighter_testnet")
+
+
+OTHER_DOMAINS_KEYS = {
+    "lighter_testnet": LighterTestnetConfigMap.model_construct(),
+}

--- a/hummingbot/connector/exchange/lighter/lighter_utils.py
+++ b/hummingbot/connector/exchange/lighter/lighter_utils.py
@@ -125,3 +125,15 @@ class LighterTestnetConfigMap(BaseConnectorConfigMap):
 OTHER_DOMAINS_KEYS = {
     "lighter_testnet": LighterTestnetConfigMap.model_construct(),
 }
+
+
+def is_exchange_information_valid(exchange_info: dict) -> bool:
+    market_type = str(exchange_info.get("market_type", "")).lower()
+    if market_type and market_type != "spot":
+        return False
+
+    status = str(exchange_info.get("status", "")).lower()
+    if status in {"inactive", "disabled", "halted", "suspended", "delisted"}:
+        return False
+
+    return bool(exchange_info.get("symbol"))

--- a/hummingbot/connector/exchange/lighter/lighter_web_utils.py
+++ b/hummingbot/connector/exchange/lighter/lighter_web_utils.py
@@ -1,0 +1,39 @@
+import time
+from typing import Optional
+
+from hummingbot.connector.exchange.lighter import lighter_constants as CONSTANTS
+from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from hummingbot.core.web_assistant.auth import AuthBase
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+
+
+def public_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:
+    base_url = CONSTANTS.REST_URL if domain == CONSTANTS.DEFAULT_DOMAIN else CONSTANTS.TESTNET_REST_URL
+    return base_url + path_url
+
+
+def private_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:
+    return public_rest_url(path_url, domain)
+
+
+def wss_url(domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:
+    return CONSTANTS.WSS_URL if domain == CONSTANTS.DEFAULT_DOMAIN else CONSTANTS.TESTNET_WSS_URL
+
+
+def build_api_factory(
+    throttler: Optional[AsyncThrottler] = None,
+    auth: Optional[AuthBase] = None,
+) -> WebAssistantsFactory:
+    throttler = throttler or AsyncThrottler(CONSTANTS.RATE_LIMITS)
+    api_factory = WebAssistantsFactory(
+        throttler=throttler,
+        auth=auth,
+    )
+    return api_factory
+
+
+async def get_current_server_time(
+    throttler: Optional[AsyncThrottler] = None,
+    domain: str = CONSTANTS.DEFAULT_DOMAIN,
+) -> float:
+    return time.time()

--- a/scripts/lighter_spot_integration_report.json
+++ b/scripts/lighter_spot_integration_report.json
@@ -1,10 +1,10 @@
 {
-  "timestamp": 1775209343,
+  "timestamp": 1775229335,
   "network": "mainnet",
   "account_index": 693751,
   "symbol": "LIT/USDC",
   "market_id": 2049,
-  "client_order_index": 85043664844421,
+  "client_order_index": 228004100185094,
   "checks": {
     "signer_check": "PASS",
     "create_code": 200,
@@ -23,7 +23,7 @@
     "after_order_count": 0
   },
   "tx_hashes": {
-    "create_tx_hash": "ddf4a2e2e452a9fb400ea74e49aebb1a6bbf6bbc3b5ab6ccb7e24372b720234b57e7c3063d6577db",
-    "cancel_tx_hash": "1a5651833e8fd771080a1e316c72a81f1ae754d570b00df17a02b2a84b50197306e2a0fa0f601276"
+    "create_tx_hash": "bdd9a39d857fe082ff9c475565603685d67b136a6607d0d375a2c93d1a1f0b99de347030b8dc6c66",
+    "cancel_tx_hash": "9ab938ec281fc90a0a2fe7fe3abcf4e9f3d7701e714726a00e6f85237a234d92d17a101483357e90"
   }
 }

--- a/scripts/lighter_spot_integration_report.json
+++ b/scripts/lighter_spot_integration_report.json
@@ -1,0 +1,29 @@
+{
+  "timestamp": 1775209343,
+  "network": "mainnet",
+  "account_index": 693751,
+  "symbol": "LIT/USDC",
+  "market_id": 2049,
+  "client_order_index": 85043664844421,
+  "checks": {
+    "signer_check": "PASS",
+    "create_code": 200,
+    "cancel_code": 200,
+    "locked_increased_after_create": "True",
+    "locked_restored_after_cancel": "True",
+    "order_count_restored_after_cancel": "True"
+  },
+  "balances": {
+    "quote_asset": "USDC",
+    "before_locked": "0.000000",
+    "during_locked": "0.001000",
+    "after_locked": "0.000000",
+    "before_order_count": 0,
+    "during_order_count": 1,
+    "after_order_count": 0
+  },
+  "tx_hashes": {
+    "create_tx_hash": "ddf4a2e2e452a9fb400ea74e49aebb1a6bbf6bbc3b5ab6ccb7e24372b720234b57e7c3063d6577db",
+    "cancel_tx_hash": "1a5651833e8fd771080a1e316c72a81f1ae754d570b00df17a02b2a84b50197306e2a0fa0f601276"
+  }
+}

--- a/scripts/lighter_spot_smoke_test.py
+++ b/scripts/lighter_spot_smoke_test.py
@@ -14,6 +14,7 @@ Verification criteria:
 """
 import asyncio
 import hashlib
+import json
 import os
 import sys
 import time
@@ -55,6 +56,7 @@ ACCT_INDEX = int(os.environ["lighter_perpetual_account_index"])
 SAFE_BID_PRICE_BY_SYMBOL: Dict[str, Decimal] = {
     "LIT/USDC": Decimal("0.0010"),
 }
+REPORT_PATH = Path(__file__).with_name("lighter_spot_integration_report.json")
 
 
 def client_order_index_from_order_id(tag: str) -> int:
@@ -133,6 +135,22 @@ def compute_order_amounts(book: Dict, bid_price: Decimal) -> Tuple[int, int]:
     return base_amount, price_scaled
 
 
+def _extract_tx_hash(obj: object) -> str:
+    if obj is None:
+        return ""
+    if isinstance(obj, dict):
+        for key in ("tx_hash", "txHash", "hash"):
+            value = obj.get(key)
+            if value:
+                return str(value)
+        return ""
+    for attr in ("tx_hash", "txHash", "hash"):
+        value = getattr(obj, attr, None)
+        if value:
+            return str(value)
+    return ""
+
+
 async def main():
     timeout = aiohttp.ClientTimeout(total=30)
     connector = aiohttp.TCPConnector(family=2)
@@ -166,7 +184,7 @@ async def main():
         print(f"[3] signer check OK account_index={ACCT_INDEX}")
 
         api_key_index, nonce = signer.nonce_manager.next_nonce()
-        _, create_resp, create_err = await signer.create_order(
+        create_tx, create_resp, create_err = await signer.create_order(
             market_index=market_id,
             client_order_index=client_order_index,
             base_amount=base_amount,
@@ -198,7 +216,7 @@ async def main():
             )
 
         api_key_index, nonce = signer.nonce_manager.next_nonce(api_key_index)
-        _, cancel_resp, cancel_err = await signer.cancel_order(
+        cancel_tx, cancel_resp, cancel_err = await signer.cancel_order(
             market_index=market_id,
             order_index=client_order_index,
             nonce=nonce,
@@ -216,6 +234,38 @@ async def main():
         after_locked = after_balances.get(quote_asset, (Decimal("0"), Decimal("0")))[1]
         after_orders = int(after.get("total_order_count") or 0)
         print(f"[7] after cancel: total_order_count={after_orders} {quote_asset}.locked={after_locked}")
+
+        report = {
+            "timestamp": int(time.time()),
+            "network": "mainnet",
+            "account_index": ACCT_INDEX,
+            "symbol": symbol,
+            "market_id": market_id,
+            "client_order_index": client_order_index,
+            "checks": {
+                "signer_check": "PASS",
+                "create_code": getattr(create_resp, "code", None),
+                "cancel_code": getattr(cancel_resp, "code", None),
+                "locked_increased_after_create": str(during_locked > before_locked),
+                "locked_restored_after_cancel": str(after_locked == before_locked),
+                "order_count_restored_after_cancel": str(after_orders == before_orders),
+            },
+            "balances": {
+                "quote_asset": quote_asset,
+                "before_locked": str(before_locked),
+                "during_locked": str(during_locked),
+                "after_locked": str(after_locked),
+                "before_order_count": before_orders,
+                "during_order_count": during_orders,
+                "after_order_count": after_orders,
+            },
+            "tx_hashes": {
+                "create_tx_hash": _extract_tx_hash(create_tx) or _extract_tx_hash(create_resp),
+                "cancel_tx_hash": _extract_tx_hash(cancel_tx) or _extract_tx_hash(cancel_resp),
+            },
+        }
+        REPORT_PATH.write_text(json.dumps(report, indent=2), encoding="utf-8")
+        print(f"[8] report written: {REPORT_PATH}")
 
         await signer.close()
 

--- a/scripts/lighter_spot_smoke_test.py
+++ b/scripts/lighter_spot_smoke_test.py
@@ -1,0 +1,231 @@
+"""
+Lighter Spot Connector — Live Smoke Test
+=========================================
+Runs a real spot place/cancel on a funded market and verifies the lifecycle
+through account state changes.
+
+Verification criteria:
+1. `check_client()` succeeds
+2. `create_order()` returns code 200
+3. quote-asset `locked_balance` increases after create
+4. `cancel_order()` returns code 200
+5. quote-asset `locked_balance` returns to baseline after cancel
+6. `total_order_count` returns to baseline after cancel
+"""
+import asyncio
+import hashlib
+import os
+import sys
+import time
+from decimal import ROUND_UP, Decimal
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+LIGHTER_PY_ROOT = Path(__file__).parents[3] / "lighter-ts" / "lighter-python"
+if LIGHTER_PY_ROOT.exists() and str(LIGHTER_PY_ROOT) not in sys.path:
+    sys.path.insert(0, str(LIGHTER_PY_ROOT))
+
+import aiohttp
+import lighter
+
+if sys.platform.startswith("win"):
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
+for env_path in [
+    Path(__file__).parents[1] / ".env",
+    Path(__file__).parents[2] / "hummingbot" / ".env",
+    Path(__file__).parents[2] / ".env",
+    Path(__file__).parent / ".env",
+]:
+    if env_path.exists():
+        for line in env_path.read_text(encoding="utf-8").splitlines():
+            s = line.strip()
+            if s and not s.startswith("#") and "=" in s:
+                k, v = s.split("=", 1)
+                os.environ.setdefault(k.strip(), v.strip())
+        break
+
+BASE_URL = "https://mainnet.zklighter.elliot.ai"
+REST_BASE = f"{BASE_URL}/api/v1"
+API_KEY_IDX = int(os.environ["lighter_perpetual_api_key_index"])
+PRIVATE_KEY = os.environ.get("lighter_perpetual_private_key", "").strip() or os.environ["lighter_perpetual_api_key"].strip()
+ACCT_INDEX = int(os.environ["lighter_perpetual_account_index"])
+
+# Safe low bids far below market to avoid fills while still satisfying min_quote.
+SAFE_BID_PRICE_BY_SYMBOL: Dict[str, Decimal] = {
+    "LIT/USDC": Decimal("0.0010"),
+}
+
+
+def client_order_index_from_order_id(tag: str) -> int:
+    digest = hashlib.sha256(tag.encode()).digest()
+    return int.from_bytes(digest[:6], byteorder="big", signed=False) & 0xFFFFFFFFFFFF
+
+
+async def get_account(session: aiohttp.ClientSession) -> Dict:
+    async with session.get(
+        f"{REST_BASE}/account",
+        params={"by": "index", "value": str(ACCT_INDEX)},
+        headers={"X-Api-Key": str(API_KEY_IDX)},
+    ) as resp:
+        payload = await resp.json()
+    accounts = payload.get("accounts") or []
+    if not accounts:
+        raise RuntimeError(f"No account data returned: {payload}")
+    return accounts[0]
+
+
+async def get_spot_books(session: aiohttp.ClientSession) -> List[Dict]:
+    async with session.get(f"{REST_BASE}/orderBooks") as resp:
+        payload = await resp.json()
+    return [
+        book
+        for book in (payload.get("order_books") or payload.get("data") or [])
+        if str(book.get("market_type") or "").lower() == "spot"
+    ]
+
+
+def asset_balances(account: Dict) -> Dict[str, Tuple[Decimal, Decimal]]:
+    balances: Dict[str, Tuple[Decimal, Decimal]] = {}
+    for asset in account.get("assets", []):
+        symbol = str(asset.get("symbol") or "")
+        balances[symbol] = (
+            Decimal(str(asset.get("balance") or "0")),
+            Decimal(str(asset.get("locked_balance") or "0")),
+        )
+    return balances
+
+
+def select_market(account: Dict, books: List[Dict]) -> Tuple[Dict, Decimal]:
+    balances = asset_balances(account)
+    candidates = []
+    for book in books:
+        symbol = str(book.get("symbol") or "")
+        if symbol not in SAFE_BID_PRICE_BY_SYMBOL:
+            continue
+        quote = symbol.split("/")[-1]
+        quote_balance = balances.get(quote, (Decimal("0"), Decimal("0")))[0]
+        min_quote = Decimal(str(book.get("min_quote_amount") or "0"))
+        if quote_balance >= min_quote:
+            candidates.append((min_quote, symbol, book, SAFE_BID_PRICE_BY_SYMBOL[symbol]))
+
+    if not candidates:
+        balances_text = ", ".join(f"{k}={v[0]}" for k, v in balances.items()) or "none"
+        raise RuntimeError(f"No viable funded spot market found. Balances: {balances_text}")
+
+    _, symbol, book, price = min(candidates, key=lambda row: row[0])
+    return book, price
+
+
+def compute_order_amounts(book: Dict, bid_price: Decimal) -> Tuple[int, int]:
+    size_dec = int(book.get("supported_size_decimals") or 0)
+    price_dec = int(book.get("supported_price_decimals") or 0)
+    min_base = Decimal(str(book.get("min_base_amount") or "0"))
+    min_quote = Decimal(str(book.get("min_quote_amount") or "0"))
+
+    size_scale = Decimal(f"1e{size_dec}")
+    price_scale = Decimal(f"1e{price_dec}")
+
+    min_base_units = (min_base * size_scale).to_integral_value(rounding=ROUND_UP)
+    base_from_quote_units = ((min_quote / bid_price) * size_scale).to_integral_value(rounding=ROUND_UP)
+    base_amount = int(max(min_base_units, base_from_quote_units))
+    price_scaled = int((bid_price * price_scale).to_integral_value(rounding=ROUND_UP))
+    return base_amount, price_scaled
+
+
+async def main():
+    timeout = aiohttp.ClientTimeout(total=30)
+    connector = aiohttp.TCPConnector(family=2)
+    async with aiohttp.ClientSession(timeout=timeout, connector=connector) as session:
+        before = await get_account(session)
+        books = await get_spot_books(session)
+        book, bid_price = select_market(before, books)
+
+        market_id = int(book["market_id"])
+        symbol = str(book["symbol"])
+        quote_asset = symbol.split("/")[-1]
+        size_dec = int(book.get("supported_size_decimals") or 0)
+        base_amount, price_scaled = compute_order_amounts(book=book, bid_price=bid_price)
+        client_order_index = client_order_index_from_order_id(f"live-smoke-{symbol}-{int(time.time())}")
+
+        before_balances = asset_balances(before)
+        before_locked = before_balances.get(quote_asset, (Decimal("0"), Decimal("0")))[1]
+        before_orders = int(before.get("total_order_count") or 0)
+
+        print(f"[1] selected market={symbol} market_id={market_id} bid_price={bid_price}")
+        print(f"[2] before: total_order_count={before_orders} {quote_asset}.locked={before_locked}")
+
+        signer = lighter.SignerClient(
+            url=BASE_URL,
+            account_index=ACCT_INDEX,
+            api_private_keys={API_KEY_IDX: PRIVATE_KEY},
+        )
+        err = signer.check_client()
+        if err is not None:
+            raise RuntimeError(f"check_client failed: {err}")
+        print(f"[3] signer check OK account_index={ACCT_INDEX}")
+
+        api_key_index, nonce = signer.nonce_manager.next_nonce()
+        _, create_resp, create_err = await signer.create_order(
+            market_index=market_id,
+            client_order_index=client_order_index,
+            base_amount=base_amount,
+            price=price_scaled,
+            is_ask=False,
+            order_type=signer.ORDER_TYPE_LIMIT,
+            time_in_force=signer.ORDER_TIME_IN_FORCE_GOOD_TILL_TIME,
+            reduce_only=False,
+            trigger_price=0,
+            nonce=nonce,
+            api_key_index=api_key_index,
+        )
+        if create_err is not None:
+            raise RuntimeError(f"create_order failed: {create_err}")
+        if getattr(create_resp, "code", None) != 200:
+            raise RuntimeError(f"create_order returned non-200: {create_resp}")
+        print(f"[4] create OK client_order_index={client_order_index} code={create_resp.code}")
+
+        await asyncio.sleep(3)
+        during = await get_account(session)
+        during_balances = asset_balances(during)
+        during_locked = during_balances.get(quote_asset, (Decimal("0"), Decimal("0")))[1]
+        during_orders = int(during.get("total_order_count") or 0)
+        print(f"[5] after create: total_order_count={during_orders} {quote_asset}.locked={during_locked}")
+
+        if during_locked <= before_locked:
+            raise RuntimeError(
+                f"Locked {quote_asset} did not increase after create: before={before_locked} after={during_locked}"
+            )
+
+        api_key_index, nonce = signer.nonce_manager.next_nonce(api_key_index)
+        _, cancel_resp, cancel_err = await signer.cancel_order(
+            market_index=market_id,
+            order_index=client_order_index,
+            nonce=nonce,
+            api_key_index=api_key_index,
+        )
+        if cancel_err is not None:
+            raise RuntimeError(f"cancel_order failed: {cancel_err}")
+        if getattr(cancel_resp, "code", None) != 200:
+            raise RuntimeError(f"cancel_order returned non-200: {cancel_resp}")
+        print(f"[6] cancel OK order_index={client_order_index} code={cancel_resp.code}")
+
+        await asyncio.sleep(3)
+        after = await get_account(session)
+        after_balances = asset_balances(after)
+        after_locked = after_balances.get(quote_asset, (Decimal("0"), Decimal("0")))[1]
+        after_orders = int(after.get("total_order_count") or 0)
+        print(f"[7] after cancel: total_order_count={after_orders} {quote_asset}.locked={after_locked}")
+
+        await signer.close()
+
+    if after_locked != before_locked:
+        raise RuntimeError(f"Locked {quote_asset} did not return to baseline: before={before_locked} after={after_locked}")
+    if after_orders != before_orders:
+        raise RuntimeError(f"total_order_count did not return to baseline: before={before_orders} after={after_orders}")
+
+    print("\n✓ LIVE SPOT PLACE/CANCEL PASSED")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ def main():
         "cryptography>=41.0.2",
         "eth-account>=0.13.0",
         "injective-py",
+        "lighter-sdk==1.0.6",
         "msgpack-python",
         "numba>=0.61.2",
         "numpy>=2.2.6",

--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -66,3 +66,4 @@ dependencies:
   - zlib>=1.2.13
   - pip:
     - injective-py==1.13.*
+    - lighter-sdk==1.0.6  # Pin the tested signer package until connector compatibility is revalidated against newer binaries

--- a/test/hummingbot/connector/exchange/lighter/test_lighter_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/lighter/test_lighter_api_order_book_data_source.py
@@ -1,0 +1,114 @@
+import asyncio
+import sys
+import types
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+from unittest.mock import AsyncMock, MagicMock
+
+if "hummingbot.core.data_type.order_book" not in sys.modules:
+    fake_order_book = types.ModuleType("hummingbot.core.data_type.order_book")
+
+    class OrderBook:
+        def apply_snapshot(self, bids, asks, update_id):
+            _ = bids
+            _ = asks
+            _ = update_id
+
+    fake_order_book.OrderBook = OrderBook
+    sys.modules["hummingbot.core.data_type.order_book"] = fake_order_book
+
+from hummingbot.connector.exchange.lighter.lighter_api_order_book_data_source import LighterAPIOrderBookDataSource
+
+
+class LighterAPIOrderBookDataSourceTests(IsolatedAsyncioWrapperTestCase):
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+        self.connector = MagicMock()
+        self.connector.rest_api_key = ""
+        self.connector.get_last_traded_prices = AsyncMock(return_value={"ETH-USDC": 2000.0})
+        self.connector.exchange_symbol_associated_to_pair = AsyncMock(return_value="ETH/USDC")
+        self.connector._get_market_spec = AsyncMock(return_value=(2048, 4, 2, "ETH/USDC"))
+
+        self.data_source = LighterAPIOrderBookDataSource(
+            trading_pairs=["ETH-USDC"],
+            connector=self.connector,
+            api_factory=MagicMock(),
+        )
+        self.data_source._market_id_to_trading_pair[2048] = "ETH-USDC"
+
+    async def test_subscribe_channels_subscribes_order_book_and_trade(self):
+        ws = MagicMock()
+        ws.send = AsyncMock()
+
+        await self.data_source._subscribe_channels(ws)
+
+        self.assertEqual(2, ws.send.await_count)
+        sent_payloads = [call.args[0].payload for call in ws.send.await_args_list]
+        self.assertEqual({"type": "subscribe", "channel": "order_book/2048"}, sent_payloads[0])
+        self.assertEqual({"type": "subscribe", "channel": "trade/2048"}, sent_payloads[1])
+
+    async def test_parse_order_book_snapshot_message(self):
+        q = asyncio.Queue()
+        raw_message = {
+            "channel": "order_book:2048",
+            "type": "subscribed/order_book",
+            "timestamp": 1710000000000,
+            "order_book": {
+                "nonce": 12,
+                "bids": [{"price": "1999", "size": "1.2"}],
+                "asks": [{"price": "2001", "size": "1.4"}],
+            },
+        }
+
+        await self.data_source._parse_order_book_snapshot_message(raw_message, q)
+        msg = q.get_nowait()
+
+        self.assertEqual("ETH-USDC", msg.content["trading_pair"])
+        self.assertEqual(12, msg.content["update_id"])
+        self.assertEqual([(1999.0, 1.2)], [(float(p), float(a)) for p, a in msg.content["bids"]])
+
+    async def test_parse_order_book_diff_message(self):
+        q = asyncio.Queue()
+        raw_message = {
+            "channel": "order_book:2048",
+            "type": "update/order_book",
+            "timestamp": 1710000002000,
+            "order_book": {
+                "begin_nonce": 20,
+                "nonce": 25,
+                "bids": [{"price": "1998", "size": "2.0"}],
+                "asks": [{"price": "2002", "size": "1.1"}],
+            },
+        }
+
+        await self.data_source._parse_order_book_diff_message(raw_message, q)
+        msg = q.get_nowait()
+
+        self.assertEqual(25, msg.content["update_id"])
+        self.assertEqual(20, msg.content["first_update_id"])
+
+    async def test_parse_trade_message(self):
+        q = asyncio.Queue()
+        raw_message = {
+            "channel": "trade:2048",
+            "timestamp": 1710000003000,
+            "trades": [{"trade_id": "abc", "price": "2000", "size": "0.4", "is_maker_ask": True}],
+        }
+
+        await self.data_source._parse_trade_message(raw_message, q)
+        msg = q.get_nowait()
+
+        self.assertEqual("abc", msg.trade_id)
+        self.assertEqual("ETH-USDC", msg.content["trading_pair"])
+
+    def test_channel_originating_message(self):
+        snapshot_channel = self.data_source._channel_originating_message(
+            {"channel": "order_book:2048", "type": "subscribed/order_book"}
+        )
+        diff_channel = self.data_source._channel_originating_message(
+            {"channel": "order_book:2048", "type": "update/order_book"}
+        )
+        trade_channel = self.data_source._channel_originating_message({"channel": "trade:2048", "type": "trade"})
+
+        self.assertEqual(self.data_source._snapshot_messages_queue_key, snapshot_channel)
+        self.assertEqual(self.data_source._diff_messages_queue_key, diff_channel)
+        self.assertEqual(self.data_source._trade_messages_queue_key, trade_channel)

--- a/test/hummingbot/connector/exchange/lighter/test_lighter_api_user_stream_data_source.py
+++ b/test/hummingbot/connector/exchange/lighter/test_lighter_api_user_stream_data_source.py
@@ -1,0 +1,45 @@
+import asyncio
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+from unittest.mock import AsyncMock, MagicMock
+
+from hummingbot.connector.exchange.lighter.lighter_api_user_stream_data_source import LighterAPIUserStreamDataSource
+from hummingbot.connector.exchange.lighter.lighter_auth import LighterAuth
+
+
+class LighterAPIUserStreamDataSourceTests(IsolatedAsyncioWrapperTestCase):
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+        self.connector = MagicMock()
+        self.connector.rest_api_key = "api-key"
+        self.auth = LighterAuth(api_key="api-key", account_identifier="123")
+        self.data_source = LighterAPIUserStreamDataSource(
+            connector=self.connector,
+            api_factory=MagicMock(),
+            auth=self.auth,
+        )
+
+    async def test_subscribe_channels_sends_account_subscription(self):
+        ws = MagicMock()
+        ws.receive = AsyncMock(return_value=MagicMock(data={"type": "connected"}))
+        ws.send = AsyncMock()
+
+        await self.data_source._subscribe_channels(ws)
+
+        sent_payload = ws.send.await_args.args[0].payload
+        self.assertEqual({"type": "subscribe", "channel": "account_all/123"}, sent_payload)
+
+    async def test_subscribe_channels_raises_when_not_connected(self):
+        ws = MagicMock()
+        ws.receive = AsyncMock(return_value=MagicMock(data={"type": "error"}))
+
+        with self.assertRaises(IOError):
+            await self.data_source._subscribe_channels(ws)
+
+    async def test_process_event_message_enqueues_account_messages(self):
+        queue = asyncio.Queue()
+        message = {"type": "update/account_all", "channel": "account_all:123", "account": {"assets": []}}
+
+        await self.data_source._process_event_message(message, queue)
+
+        queued = queue.get_nowait()
+        self.assertEqual(message, queued)

--- a/test/hummingbot/connector/exchange/lighter/test_lighter_auth.py
+++ b/test/hummingbot/connector/exchange/lighter/test_lighter_auth.py
@@ -1,0 +1,35 @@
+import asyncio
+from typing import Awaitable
+from unittest import TestCase
+
+from hummingbot.connector.exchange.lighter.lighter_auth import LighterAuth
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod, RESTRequest
+
+
+class LighterAuthTests(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.auth = LighterAuth(api_key="test-api-key", api_secret="test-secret", account_identifier="123")
+
+    def async_run_with_timeout(self, coroutine: Awaitable, timeout: int = 1):
+        return asyncio.get_event_loop().run_until_complete(asyncio.wait_for(coroutine, timeout))
+
+    def test_rest_authenticate_injects_headers(self):
+        request = RESTRequest(method=RESTMethod.GET, url="https://test.url", is_auth_required=True)
+        authed_request = self.async_run_with_timeout(self.auth.rest_authenticate(request=request))
+
+        self.assertEqual("application/json", authed_request.headers["accept"])
+        self.assertEqual("application/json", authed_request.headers["Content-Type"])
+        self.assertEqual("test-api-key", authed_request.headers["X-Api-Key"])
+
+    def test_rest_authenticate_keeps_headers(self):
+        request = RESTRequest(
+            method=RESTMethod.GET,
+            url="https://test.url",
+            is_auth_required=True,
+            headers={"X-Test": "1"},
+        )
+        authed_request = self.async_run_with_timeout(self.auth.rest_authenticate(request=request))
+
+        self.assertEqual("1", authed_request.headers["X-Test"])
+        self.assertEqual("test-api-key", authed_request.headers["X-Api-Key"])

--- a/test/hummingbot/connector/exchange/lighter/test_lighter_exchange.py
+++ b/test/hummingbot/connector/exchange/lighter/test_lighter_exchange.py
@@ -1,3 +1,4 @@
+import asyncio
 import sys
 import types
 import unittest
@@ -66,7 +67,7 @@ if "hummingbot.core.network_iterator" not in sys.modules:
 
 try:
     from hummingbot.connector.exchange.lighter.lighter_exchange import LighterExchange
-    from hummingbot.core.data_type.in_flight_order import OrderState
+    from hummingbot.core.data_type.in_flight_order import OrderState, OrderUpdate, TradeUpdate
     _LIGHTER_EXCHANGE_AVAILABLE = True
 except ModuleNotFoundError:
     _LIGHTER_EXCHANGE_AVAILABLE = False
@@ -244,6 +245,276 @@ class LighterExchangeTests(IsolatedAsyncioWrapperTestCase):
         self.assertEqual(1, exchange._update_balances.await_count)
         self.assertEqual(1, exchange._update_order_status.await_count)
         self.assertEqual(1, exchange._update_lost_orders_status.await_count)
+
+    def test_get_lighter_signer_client_builds_once(self):
+        exchange = object.__new__(LighterExchange)
+        exchange._lighter_signer_client = None
+        exchange._api_host_for_signer = lambda: "https://mainnet.zklighter.elliot.ai"
+        exchange._get_account_index = lambda: 693751
+        exchange._get_api_key_index = lambda: 7
+        exchange._get_signer_private_key = lambda: "0xabc"
+
+        fake_lighter = types.ModuleType("lighter")
+
+        class SignerClient:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+        fake_lighter.signer_client = type("SignerModule", (), {"SignerClient": SignerClient})
+        sys.modules["lighter"] = fake_lighter
+
+        client_1 = exchange._get_lighter_signer_client()
+        client_2 = exchange._get_lighter_signer_client()
+
+        self.assertIs(client_1, client_2)
+        self.assertEqual(693751, client_1.kwargs["account_index"])
+        self.assertEqual({7: "0xabc"}, client_1.kwargs["api_private_keys"])
+
+    async def test_update_trading_fees_noop(self):
+        exchange = object.__new__(LighterExchange)
+        self.assertIsNone(await exchange._update_trading_fees())
+
+    async def test_user_stream_event_listener_processes_messages(self):
+        exchange = object.__new__(LighterExchange)
+        exchange._process_balance_message_from_account = lambda _: None
+        exchange._trade_update_from_raw_message = lambda _: "TRADE_UPDATE"
+        exchange._order_update_from_raw_message = lambda _: "ORDER_UPDATE"
+        exchange._order_tracker = type(
+            "Tracker",
+            (),
+            {
+                "process_trade_update": lambda self, _: None,
+                "process_order_update": lambda self, _: None,
+            },
+        )()
+        exchange._sleep = AsyncMock()
+
+        async def events():
+            yield {
+                "data": {"assets": []},
+                "trades": [{"trade_id": "t1"}],
+                "orders": [{"order_id": "o1"}],
+            }
+            raise asyncio.CancelledError
+
+        exchange._iter_user_event_queue = events
+
+        with self.assertRaises(asyncio.CancelledError):
+            await exchange._user_stream_event_listener()
+
+    async def test_user_stream_event_listener_handles_exception(self):
+        exchange = object.__new__(LighterExchange)
+        exchange._process_balance_message_from_account = lambda _: None
+
+        def failing_trade(_):
+            raise RuntimeError("boom")
+
+        exchange._trade_update_from_raw_message = failing_trade
+        exchange._order_update_from_raw_message = lambda _: None
+        exchange._order_tracker = type(
+            "Tracker",
+            (),
+            {
+                "process_trade_update": lambda self, _: None,
+                "process_order_update": lambda self, _: None,
+            },
+        )()
+        exchange._sleep = AsyncMock()
+
+        class Logger:
+            def error(self, *args, **kwargs):
+                return None
+
+        exchange.logger = lambda: Logger()
+
+        async def events():
+            yield {"trades": [{"trade_id": "t1"}]}
+            raise asyncio.CancelledError
+
+        exchange._iter_user_event_queue = events
+
+        with self.assertRaises(asyncio.CancelledError):
+            await exchange._user_stream_event_listener()
+
+        self.assertEqual(1, exchange._sleep.await_count)
+
+    async def test_all_trade_updates_for_order_handles_pagination(self):
+        exchange = object.__new__(LighterExchange)
+        exchange._account_index = "693751"
+        exchange.current_timestamp = 1700001000
+        exchange._order_history_last_poll_timestamp = {}
+        exchange.trade_fee_schema = lambda: TradeFeeSchema()
+        exchange._api_get = AsyncMock(
+            side_effect=[
+                {
+                    "success": True,
+                    "data": [
+                        {"order_id": "x", "history_id": "h0", "price": "1", "amount": "1", "created_at": 1000},
+                        {
+                            "order_id": "42",
+                            "history_id": "h1",
+                            "price": "2",
+                            "amount": "3",
+                            "fee": "0.1",
+                            "created_at": 2000,
+                            "event_type": "fulfill_taker",
+                        },
+                    ],
+                    "has_more": True,
+                    "next_cursor": "cur1",
+                },
+                {"success": True, "data": [], "has_more": False},
+            ]
+        )
+
+        order = type(
+            "Order",
+            (),
+            {
+                "exchange_order_id": "42",
+                "creation_timestamp": 1700000000,
+                "quote_asset": "USDC",
+                "trade_type": TradeType.BUY,
+                "client_order_id": "HBOT-11",
+                "trading_pair": "ETH-USDC",
+            },
+        )()
+
+        updates = await exchange._all_trade_updates_for_order(order)
+        self.assertEqual(1, len(updates))
+        self.assertEqual("h1", updates[0].trade_id)
+        self.assertTrue(updates[0].is_taker)
+        self.assertIn("42", exchange._order_history_last_poll_timestamp)
+
+    async def test_request_order_status_raises_on_error(self):
+        exchange = object.__new__(LighterExchange)
+        exchange._api_get = AsyncMock(return_value={"success": False, "code": 500})
+        tracked_order = type(
+            "TrackedOrder",
+            (),
+            {
+                "client_order_id": "HBOT-12",
+                "exchange_order_id": "600",
+                "trading_pair": "ETH-USDC",
+                "current_state": OrderState.OPEN,
+            },
+        )()
+
+        with self.assertRaises(IOError):
+            await exchange._request_order_status(tracked_order)
+
+    def test_get_fee_returns_zero_fee(self):
+        exchange = object.__new__(LighterExchange)
+        exchange.trade_fee_schema = lambda: TradeFeeSchema()
+        fee = exchange._get_fee(
+            base_currency="ETH",
+            quote_currency="USDC",
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.BUY,
+            amount=Decimal("1"),
+            price=Decimal("100"),
+        )
+        self.assertIsNotNone(fee)
+
+    async def test_update_order_fills_from_trades_processes_trade(self):
+        exchange = object.__new__(LighterExchange)
+        exchange.UPDATE_ORDER_STATUS_MIN_INTERVAL = 1
+        exchange.LONG_POLL_INTERVAL = 120
+        exchange._last_poll_timestamp = 0
+        exchange.current_timestamp = 10
+        exchange.trade_fee_schema = lambda: TradeFeeSchema()
+
+        tracked_order = type(
+            "TrackedOrder",
+            (),
+            {
+                "exchange_order_id": "77",
+                "trade_type": TradeType.BUY,
+                "quote_asset": "USDC",
+                "client_order_id": "HBOT-13",
+                "trading_pair": "ETH-USDC",
+            },
+        )()
+        captured = []
+        exchange._order_tracker = type(
+            "Tracker",
+            (),
+            {
+                "all_fillable_orders": {"HBOT-13": tracked_order},
+                "process_trade_update": lambda self, update: captured.append(update),
+                "active_orders": {"HBOT-13": tracked_order},
+            },
+        )()
+        exchange._api_get = AsyncMock(
+            return_value={
+                "data": [
+                    {"order_id": "77", "h": "t1", "a": "1", "q": "2", "p": "2", "t": 1000},
+                ]
+            }
+        )
+
+        await exchange._update_order_fills_from_trades()
+        self.assertEqual(1, len(captured))
+
+    async def test_update_order_fills_from_trades_no_poll(self):
+        exchange = object.__new__(LighterExchange)
+        exchange.UPDATE_ORDER_STATUS_MIN_INTERVAL = 1
+        exchange.LONG_POLL_INTERVAL = 120
+        exchange._last_poll_timestamp = 10
+        exchange.current_timestamp = 10
+        exchange._order_tracker = type("Tracker", (), {"all_fillable_orders": {}, "active_orders": {}})()
+        exchange._api_get = AsyncMock(return_value={"data": []})
+
+        await exchange._update_order_fills_from_trades()
+        self.assertEqual(0, exchange._api_get.await_count)
+
+    async def test_update_order_status_delegates(self):
+        exchange = object.__new__(LighterExchange)
+        exchange._order_tracker = type("Tracker", (), {"active_orders": {"k": "v"}})()
+        exchange._update_orders_fills = AsyncMock()
+        exchange._update_orders = AsyncMock()
+
+        await exchange._update_order_status()
+
+        self.assertEqual(1, exchange._update_orders_fills.await_count)
+        self.assertEqual(1, exchange._update_orders.await_count)
+
+    async def test_update_orders_fills_processes_each_trade_update(self):
+        exchange = object.__new__(LighterExchange)
+        order = object()
+        exchange._all_trade_updates_for_order = AsyncMock(return_value=["u1", "u2"])
+        processed = []
+        exchange._order_tracker = type("Tracker", (), {"process_trade_update": lambda self, update: processed.append(update)})()
+
+        await exchange._update_orders_fills([order])
+
+        self.assertEqual(["u1", "u2"], processed)
+
+    async def test_update_orders_processes_order_updates(self):
+        exchange = object.__new__(LighterExchange)
+        tracked_order = object()
+        exchange._order_tracker = type(
+            "Tracker",
+            (),
+            {
+                "active_orders": {"o": tracked_order},
+                "process_order_update": lambda self, update: None,
+            },
+        )()
+        exchange._request_order_status = AsyncMock(return_value="ORDER_UPDATE")
+
+        await exchange._update_orders()
+        self.assertEqual(1, exchange._request_order_status.await_count)
+
+    async def test_iter_user_event_queue_yields_message(self):
+        exchange = object.__new__(LighterExchange)
+        q = asyncio.Queue()
+        q.put_nowait({"event": 1})
+        exchange._user_stream_tracker = type("UST", (), {"user_stream": q})()
+
+        agen = exchange._iter_user_event_queue()
+        message = await agen.__anext__()
+        self.assertEqual({"event": 1}, message)
     def test_hb_pair_from_symbol_variants(self):
         self.assertEqual("ETH-USDC", LighterExchange._hb_pair_from_symbol("ETH/USDC"))
         self.assertEqual("BTC-USDC", LighterExchange._hb_pair_from_symbol("BTC-USDC"))
@@ -718,3 +989,106 @@ class LighterExchangeTests(IsolatedAsyncioWrapperTestCase):
         self.assertEqual(OrderState.CANCELED, exchange._state_from_raw_order_status("canceled"))
         self.assertEqual(OrderState.PARTIALLY_FILLED, exchange._state_from_raw_order_status("partially_filled"))
         self.assertEqual(OrderState.OPEN, exchange._state_from_raw_order_status("unknown"))
+
+    def test_misc_helper_branches(self):
+        class BadStr:
+            def __str__(self):
+                raise RuntimeError("bad")
+
+        class BadInt:
+            def __int__(self):
+                raise RuntimeError("bad")
+
+        exchange = object.__new__(LighterExchange)
+        exchange._domain = "lighter"
+        exchange._api_key = "api"
+        exchange._api_secret = "sec"
+        exchange._account_index = "1"
+
+        self.assertFalse(LighterExchange._is_int_string(BadStr()))
+        self.assertFalse(LighterExchange._is_ok_response({"code": BadInt()}))
+        self.assertIsNone(LighterExchange._account_from_response({"data": []}))
+        self.assertFalse(exchange._is_request_exception_related_to_time_synchronizer(Exception("x")))
+        self.assertFalse(exchange._is_order_not_found_during_status_update_error(Exception("x")))
+        self.assertFalse(exchange._is_order_not_found_during_cancelation_error(Exception("x")))
+        self.assertEqual("ABC", exchange._hb_pair_from_symbol("ABC"))
+        self.assertIsNotNone(exchange.authenticator)
+        self.assertEqual(32, exchange.client_order_id_max_length)
+        self.assertEqual("HBOT", exchange.client_order_id_prefix)
+
+    async def test_more_branch_paths(self):
+        exchange = object.__new__(LighterExchange)
+        exchange.current_timestamp = 1700000000
+        exchange.trade_fee_schema = lambda: TradeFeeSchema()
+        exchange._order_tracker = type(
+            "Tracker",
+            (),
+            {
+                "all_updatable_orders": {},
+                "all_fillable_orders_by_exchange_order_id": {},
+                "all_fillable_orders": {},
+                "process_order_update": lambda self, update: None,
+                "process_trade_update": lambda self, update: None,
+                "active_orders": {},
+                "lost_orders": {},
+            },
+        )()
+
+        self.assertIsNone(exchange._order_update_from_raw_message({"order_id": "x"}))
+        self.assertIsNone(exchange._trade_update_from_raw_message({"order_id": "x"}))
+
+        class Logger:
+            def warning(self, *args, **kwargs):
+                return None
+            def error(self, *args, **kwargs):
+                return None
+
+        exchange.logger = lambda: Logger()
+        await exchange._handle_update_error_for_active_order(type("O", (), {"client_order_id": "1"})(), RuntimeError("e"))
+        await exchange._handle_update_error_for_lost_order(type("O", (), {"client_order_id": "1"})(), RuntimeError("e"))
+
+        exchange._place_cancel = AsyncMock(return_value=False)
+        result = await exchange._execute_order_cancel(type("O", (), {"client_order_id": "X"})())
+        self.assertEqual("", result)
+
+    async def test_instance_type_branches_in_update_handler_and_iter_cancel(self):
+        exchange = object.__new__(LighterExchange)
+        processed_orders = []
+        processed_trades = []
+        exchange._order_tracker = type(
+            "Tracker",
+            (),
+            {
+                "process_order_update": lambda self, update: processed_orders.append(update),
+                "process_trade_update": lambda self, update: processed_trades.append(update),
+            },
+        )()
+
+        order_update = OrderUpdate(client_order_id="c", exchange_order_id="e", trading_pair="ETH-USDC", update_timestamp=1, new_state=OrderState.OPEN)
+        trade_update = TradeUpdate(trade_id="t", client_order_id="c", exchange_order_id="e", trading_pair="ETH-USDC", fill_timestamp=1, fill_price=Decimal("1"), fill_base_amount=Decimal("1"), fill_quote_amount=Decimal("1"), fee=None)
+
+        async def fetch_order(_):
+            return order_update
+        async def fetch_trade(_):
+            return [trade_update]
+        async def fetch_cancel(_):
+            raise asyncio.CancelledError
+        async def on_error(_, __):
+            return None
+
+        await exchange._update_orders_with_error_handler(["a"], fetch_order, on_error)
+        await exchange._update_orders_with_error_handler(["b"], fetch_trade, on_error)
+        with self.assertRaises(asyncio.CancelledError):
+            await exchange._update_orders_with_error_handler(["c"], fetch_cancel, on_error)
+
+        self.assertEqual(1, len(processed_orders))
+        self.assertEqual(1, len(processed_trades))
+
+        class BadQueue:
+            async def get(self):
+                raise asyncio.CancelledError
+
+        exchange._user_stream_tracker = type("UST", (), {"user_stream": BadQueue()})()
+        agen = exchange._iter_user_event_queue()
+        with self.assertRaises(asyncio.CancelledError):
+            await agen.__anext__()

--- a/test/hummingbot/connector/exchange/lighter/test_lighter_exchange.py
+++ b/test/hummingbot/connector/exchange/lighter/test_lighter_exchange.py
@@ -1,0 +1,80 @@
+import sys
+import types
+import unittest
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+from unittest.mock import AsyncMock
+
+if "hummingbot.core.data_type.limit_order" not in sys.modules:
+    fake_limit_order = types.ModuleType("hummingbot.core.data_type.limit_order")
+
+    class LimitOrder:
+        pass
+
+    fake_limit_order.LimitOrder = LimitOrder
+    sys.modules["hummingbot.core.data_type.limit_order"] = fake_limit_order
+
+if "hummingbot.core.data_type.order_book" not in sys.modules:
+    fake_order_book = types.ModuleType("hummingbot.core.data_type.order_book")
+
+    class OrderBook:
+        def apply_snapshot(self, bids, asks, update_id):
+            _ = bids
+            _ = asks
+            _ = update_id
+
+    fake_order_book.OrderBook = OrderBook
+    sys.modules["hummingbot.core.data_type.order_book"] = fake_order_book
+
+try:
+    from hummingbot.connector.exchange.lighter.lighter_exchange import LighterExchange
+    from hummingbot.core.data_type.in_flight_order import OrderState
+    _LIGHTER_EXCHANGE_AVAILABLE = True
+except ModuleNotFoundError:
+    _LIGHTER_EXCHANGE_AVAILABLE = False
+
+
+@unittest.skipUnless(_LIGHTER_EXCHANGE_AVAILABLE, "Core exchange runtime modules are unavailable in this local environment")
+class LighterExchangeTests(IsolatedAsyncioWrapperTestCase):
+    def test_hb_pair_from_symbol_variants(self):
+        self.assertEqual("ETH-USDC", LighterExchange._hb_pair_from_symbol("ETH/USDC"))
+        self.assertEqual("BTC-USDC", LighterExchange._hb_pair_from_symbol("BTC-USDC"))
+
+    def test_client_order_index_from_order_id_is_stable(self):
+        idx_1 = LighterExchange._client_order_index_from_order_id("HBOT-1")
+        idx_2 = LighterExchange._client_order_index_from_order_id("HBOT-1")
+
+        self.assertEqual(idx_1, idx_2)
+        self.assertGreaterEqual(idx_1, 0)
+
+    def test_account_from_response_variants(self):
+        self.assertEqual({"assets": []}, LighterExchange._account_from_response({"data": {"assets": []}}))
+        self.assertEqual({"assets": [1]}, LighterExchange._account_from_response({"data": [{"assets": [1]}]}))
+        self.assertEqual({"assets": [2]}, LighterExchange._account_from_response({"accounts": [{"assets": [2]}]}))
+
+    def test_is_ok_response(self):
+        self.assertTrue(LighterExchange._is_ok_response({"success": True}))
+        self.assertTrue(LighterExchange._is_ok_response({"code": 200}))
+        self.assertFalse(LighterExchange._is_ok_response({"code": 500}))
+
+    async def test_request_order_fills_by_exchange_order_id_filters(self):
+        exchange = object.__new__(LighterExchange)
+        order = type("Order", (), {"exchange_order_id": "42"})()
+        exchange._request_order_fills_from_trades_api = AsyncMock(
+            return_value=[
+                {"order_id": 1, "trade_id": "a"},
+                {"order_id": 42, "trade_id": "b"},
+                {"order_id": 42, "trade_id": "c"},
+            ]
+        )
+
+        fills = await exchange._request_order_fills_by_exchange_order_id(order)
+
+        self.assertEqual(2, len(fills))
+        self.assertEqual(["b", "c"], [f["trade_id"] for f in fills])
+
+    def test_state_from_raw_order_status(self):
+        exchange = object.__new__(LighterExchange)
+
+        self.assertEqual(OrderState.CANCELED, exchange._state_from_raw_order_status("canceled"))
+        self.assertEqual(OrderState.PARTIALLY_FILLED, exchange._state_from_raw_order_status("partially_filled"))
+        self.assertEqual(OrderState.OPEN, exchange._state_from_raw_order_status("unknown"))

--- a/test/hummingbot/connector/exchange/lighter/test_lighter_exchange.py
+++ b/test/hummingbot/connector/exchange/lighter/test_lighter_exchange.py
@@ -1006,6 +1006,7 @@ class LighterExchangeTests(IsolatedAsyncioWrapperTestCase):
         exchange._account_index = "1"
 
         self.assertFalse(LighterExchange._is_int_string(BadStr()))
+        self.assertFalse(LighterExchange._is_int_string(None))
         self.assertFalse(LighterExchange._is_ok_response({"code": BadInt()}))
         self.assertIsNone(LighterExchange._account_from_response({"data": []}))
         self.assertFalse(exchange._is_request_exception_related_to_time_synchronizer(Exception("x")))
@@ -1092,3 +1093,236 @@ class LighterExchangeTests(IsolatedAsyncioWrapperTestCase):
         agen = exchange._iter_user_event_queue()
         with self.assertRaises(asyncio.CancelledError):
             await agen.__anext__()
+
+    def test_rate_limits_property(self):
+        exchange = object.__new__(LighterExchange)
+        self.assertTrue(len(exchange.rate_limits_rules) > 0)
+
+    async def test_targeted_remaining_branches(self):
+        exchange = object.__new__(LighterExchange)
+        exchange._domain = "lighter"
+        exchange._account_index = "1"
+        exchange.current_timestamp = 1700000000
+
+        exchange._market_id_by_symbol = {}
+        exchange._size_decimals_by_symbol = {}
+        exchange._price_decimals_by_symbol = {}
+        exchange._api_get = AsyncMock(return_value={"data": [{"symbol": "ETH/USDC", "market_type": "perp", "market_id": 1}, {"market_type": "spot", "market_id": 2}]})
+        await exchange._refresh_market_metadata()
+
+        exchange._get_market_spec = AsyncMock(return_value=(1, 2, 2, "ETH/USDC"))
+        exchange._get_api_key_index = lambda: 1
+        signer = type("Signer", (), {
+            "ORDER_TYPE_LIMIT": 1,
+            "ORDER_TYPE_MARKET": 2,
+            "ORDER_TIME_IN_FORCE_GOOD_TILL_TIME": 10,
+            "ORDER_TIME_IN_FORCE_IMMEDIATE_OR_CANCEL": 11,
+            "ORDER_TIME_IN_FORCE_POST_ONLY": 12,
+            "DEFAULT_28_DAY_ORDER_EXPIRY": 100,
+            "DEFAULT_IOC_EXPIRY": 101,
+        })()
+        signer.create_order = AsyncMock(return_value=(None, type("Resp", (), {"code": 500})(), None))
+        signer.cancel_order = AsyncMock(return_value=(None, type("Resp", (), {"code": 500})(), None))
+        exchange._get_lighter_signer_client = lambda: signer
+
+        with self.assertRaises(IOError):
+            await exchange._place_order("x", "ETH-USDC", Decimal("1"), TradeType.BUY, OrderType.LIMIT, Decimal("1"))
+        with self.assertRaises(IOError):
+            await exchange._place_cancel("x", type("Order", (), {"trading_pair": "ETH-USDC", "exchange_order_id": "1"})())
+
+        with self.assertRaises(ValueError):
+            await exchange._place_order("x", "ETH-USDC", Decimal("1"), TradeType.BUY, "UNSUPPORTED", Decimal("1"))
+
+        signer.create_order = AsyncMock(return_value=(None, type("Resp", (), {"code": 200})(), None))
+        await exchange._place_order("x", "ETH-USDC", Decimal("1"), TradeType.BUY, OrderType.LIMIT_MAKER, Decimal("1"))
+
+        exchange._order_tracker = type("Tracker", (), {"all_updatable_orders": {}, "all_fillable_orders_by_exchange_order_id": {"7": type("T", (), {"client_order_id": "c", "exchange_order_id": "7", "trading_pair": "ETH-USDC"})()}, "all_fillable_orders": {}})()
+        order_update = exchange._order_update_from_raw_message({"order_id": "7", "updated_at": 1700000000123})
+        self.assertIsNotNone(order_update)
+
+        exchange._order_tracker = type("Tracker", (), {"all_updatable_orders": {}, "all_fillable_orders_by_exchange_order_id": {}, "all_fillable_orders": {}})()
+        self.assertIsNone(exchange._order_update_from_raw_message({"order_id": "unknown"}))
+        self.assertIsNone(exchange._trade_update_from_raw_message({"order_id": "unknown"}))
+
+        rules = await exchange._format_trading_rules({"data": [{"market_type": "spot"}]})
+        self.assertEqual([], rules)
+
+        exchange._account_balances = {}
+        exchange._account_available_balances = {}
+        exchange._account_query_params = lambda: {"by": "index", "value": "1"}
+
+        class Logger:
+            def error(self, *args, **kwargs):
+                return None
+
+        exchange.logger = lambda: Logger()
+        exchange._api_get = AsyncMock(return_value={"success": False})
+        await exchange._update_balances()
+        exchange._api_get = AsyncMock(return_value={"success": True, "data": []})
+        await exchange._update_balances()
+        exchange._api_get = AsyncMock(return_value={"success": True, "data": {"assets": [{"locked_balance": "1", "balance": "1"}]}})
+        await exchange._update_balances()
+
+        exchange._order_history_last_poll_timestamp = {"42": 1700000001}
+        exchange.trade_fee_schema = lambda: TradeFeeSchema()
+        exchange._api_get = AsyncMock(return_value={"success": True, "data": [{"order_id": "42", "history_id": "h", "price": "1", "amount": "1", "created_at": 1000}], "has_more": False})
+        order = type("Order", (), {"exchange_order_id": "42", "creation_timestamp": 1700000000, "quote_asset": "USDC", "trade_type": TradeType.BUY, "client_order_id": "c", "trading_pair": "ETH-USDC"})()
+        updates = await exchange._all_trade_updates_for_order(order)
+        self.assertEqual(1, len(updates))
+
+        exchange._throttler = object()
+        exchange._auth = object()
+        exchange._web_assistants_factory = object()
+        exchange._trading_pairs = ["ETH-USDC"]
+        self.assertIsNotNone(exchange._create_web_assistants_factory())
+        self.assertIsNotNone(exchange._create_order_book_data_source())
+        self.assertIsNotNone(exchange._create_user_stream_data_source())
+
+        captured = {}
+        exchange._set_trading_pair_symbol_map = lambda m: captured.update(m)
+        exchange._initialize_trading_pair_symbols_from_exchange_info({"data": [{"market_type": "spot"}, {"symbol": "A/B", "market_type": "perp"}]})
+        self.assertEqual({}, captured)
+
+        exchange._api_request = AsyncMock(return_value={"data": [{"index_price": "1"}, {"symbol": "ETH/USDC", "index_price": "2"}]})
+        exchange.trading_pair_associated_to_exchange_symbol = AsyncMock(side_effect=KeyError("x"))
+        prices = await exchange.get_last_traded_prices(["ETH-USDC"])
+        self.assertEqual({}, prices)
+
+    async def test_final_branch_closures(self):
+        exchange = object.__new__(LighterExchange)
+
+        class Rest:
+            async def execute_request(self, **kwargs):
+                return {"ok": True, "headers": kwargs.get("headers")}
+
+        exchange._web_assistants_factory = type("F", (), {"get_rest_assistant": AsyncMock(return_value=Rest())})()
+        exchange._domain = "lighter"
+        exchange._api_key = "k"
+
+        # Cover false auth-header branch in _api_request
+        response = await exchange._api_request(path_url="/orderBooks", method=RESTMethod.GET, is_auth_required=False)
+        self.assertEqual({"ok": True, "headers": {}}, response)
+
+        # Cover last_price None branch in get_last_traded_prices and loop back-edge
+        exchange._api_request = AsyncMock(return_value={"data": [{"symbol": "ETH/USDC"}, {"symbol": "ETH/USDC", "index_price": "1"}]})
+        exchange.trading_pair_associated_to_exchange_symbol = AsyncMock(return_value="ETH-USDC")
+        prices = await exchange.get_last_traded_prices(["ETH-USDC"])
+        self.assertEqual({"ETH-USDC": 1.0}, prices)
+
+        # Cover order_id not provided branch in _request_order_fills_from_trades_api
+        exchange._account_index = "1"
+        exchange._api_get = AsyncMock(return_value={"success": True, "data": []})
+        await exchange._request_order_fills_from_trades_api(type("O", (), {"exchange_order_id": None})())
+
+        # Cover unmatched exchange_order_id branch in _update_order_fills_from_trades
+        exchange.UPDATE_ORDER_STATUS_MIN_INTERVAL = 1
+        exchange.LONG_POLL_INTERVAL = 120
+        exchange._last_poll_timestamp = 0
+        exchange.current_timestamp = 10
+        exchange.trade_fee_schema = lambda: TradeFeeSchema()
+        tracked = type("Tracked", (), {"exchange_order_id": "7", "trade_type": TradeType.BUY, "quote_asset": "USDC", "client_order_id": "c", "trading_pair": "ETH-USDC"})()
+        captured = []
+        exchange._order_tracker = type("Tracker", (), {"all_fillable_orders": {"c": tracked}, "process_trade_update": lambda self, u: captured.append(u), "active_orders": {"c": tracked}})()
+        exchange._api_get = AsyncMock(return_value={"data": [{"order_id": "x"}, {"order_id": "7", "h": "t", "a": "1", "q": "1", "p": "1", "t": 1000}]})
+        await exchange._update_order_fills_from_trades()
+        self.assertEqual(1, len(captured))
+
+        # Cover process_balance missing symbol continue path
+        exchange._account_balances = {}
+        exchange._account_available_balances = {}
+        exchange._process_balance_message_from_account({"assets": [{"balance": "1", "locked_balance": "0"}]})
+
+        # Cover user stream non-dict continue and inner CancelledError raise path
+        exchange._trade_update_from_raw_message = lambda _: (_ for _ in ()).throw(asyncio.CancelledError())
+        exchange._order_update_from_raw_message = lambda _: None
+        exchange._process_balance_message_from_account = lambda _: None
+        exchange._order_tracker = type("Tracker", (), {"process_trade_update": lambda self, u: None, "process_order_update": lambda self, u: None})()
+
+        async def events():
+            yield "invalid"
+            yield {"trades": [{"trade_id": "t"}]}
+
+        exchange._iter_user_event_queue = events
+        with self.assertRaises(asyncio.CancelledError):
+            await exchange._user_stream_event_listener()
+
+    async def test_trade_update_seconds_timestamp_path_and_user_stream_loop_back_edges(self):
+        exchange = object.__new__(LighterExchange)
+        exchange.trade_fee_schema = lambda: TradeFeeSchema()
+        exchange.current_timestamp = 1700000000
+
+        tracked_order = type(
+            "TrackedOrder",
+            (),
+            {
+                "client_order_id": "HBOT-17",
+                "exchange_order_id": "88",
+                "trading_pair": "ETH-USDC",
+                "quote_asset": "USDC",
+                "trade_type": TradeType.BUY,
+            },
+        )()
+        exchange._order_tracker = type(
+            "Tracker",
+            (),
+            {
+                "all_fillable_orders": {"HBOT-17": tracked_order},
+                "all_fillable_orders_by_exchange_order_id": {"88": tracked_order},
+                "process_trade_update": lambda self, _: None,
+                "process_order_update": lambda self, _: None,
+            },
+        )()
+
+        # keep created_at in seconds so the if fill_timestamp > 1e12 branch is false
+        update = exchange._trade_update_from_raw_message(
+            {
+                "client_order_id": "HBOT-17",
+                "order_id": "88",
+                "trade_id": "t-seconds",
+                "price": "1",
+                "amount": "2",
+                "created_at": 1000,
+            }
+        )
+        self.assertEqual(1000.0, update.fill_timestamp)
+
+        exchange._process_balance_message_from_account = lambda _: None
+        exchange._trade_update_from_raw_message = lambda _: "TRADE_UPDATE"
+        exchange._order_update_from_raw_message = lambda _: "ORDER_UPDATE"
+
+        async def events():
+            yield {
+                "trades": [{"trade_id": "t1"}, {"trade_id": "t2"}],
+                "orders": [{"order_id": "o1"}, {"order_id": "o2"}],
+            }
+            raise asyncio.CancelledError
+
+        exchange._iter_user_event_queue = events
+        with self.assertRaises(asyncio.CancelledError):
+            await exchange._user_stream_event_listener()
+
+    async def test_user_stream_none_update_branches(self):
+        exchange = object.__new__(LighterExchange)
+        exchange._process_balance_message_from_account = lambda _: None
+        exchange._trade_update_from_raw_message = lambda _: None
+        exchange._order_update_from_raw_message = lambda _: None
+        exchange._order_tracker = type(
+            "Tracker",
+            (),
+            {
+                "process_trade_update": lambda self, _: None,
+                "process_order_update": lambda self, _: None,
+            },
+        )()
+        exchange._sleep = AsyncMock()
+
+        async def events():
+            yield {
+                "trades": [{"trade_id": "t1"}, {"trade_id": "t2"}],
+                "orders": [{"order_id": "o1"}, {"order_id": "o2"}],
+            }
+            raise asyncio.CancelledError
+
+        exchange._iter_user_event_queue = events
+        with self.assertRaises(asyncio.CancelledError):
+            await exchange._user_stream_event_listener()

--- a/test/hummingbot/connector/exchange/lighter/test_lighter_exchange.py
+++ b/test/hummingbot/connector/exchange/lighter/test_lighter_exchange.py
@@ -1,8 +1,13 @@
 import sys
 import types
 import unittest
+from decimal import Decimal
+from enum import Enum
 from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock
+
+from hummingbot.core.data_type.common import TradeType
+from hummingbot.core.data_type.trade_fee import TradeFeeSchema
 
 if "hummingbot.core.data_type.limit_order" not in sys.modules:
     fake_limit_order = types.ModuleType("hummingbot.core.data_type.limit_order")
@@ -25,6 +30,38 @@ if "hummingbot.core.data_type.order_book" not in sys.modules:
     fake_order_book.OrderBook = OrderBook
     sys.modules["hummingbot.core.data_type.order_book"] = fake_order_book
 
+if "hummingbot.connector.exchange_base" not in sys.modules:
+    fake_exchange_base = types.ModuleType("hummingbot.connector.exchange_base")
+
+    class ExchangeBase:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    fake_exchange_base.ExchangeBase = ExchangeBase
+    sys.modules["hummingbot.connector.exchange_base"] = fake_exchange_base
+
+if "hummingbot.connector.trading_rule" not in sys.modules:
+    fake_trading_rule = types.ModuleType("hummingbot.connector.trading_rule")
+
+    class TradingRule:
+        def __init__(self, **kwargs):
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
+    fake_trading_rule.TradingRule = TradingRule
+    sys.modules["hummingbot.connector.trading_rule"] = fake_trading_rule
+
+if "hummingbot.core.network_iterator" not in sys.modules:
+    fake_network_iterator = types.ModuleType("hummingbot.core.network_iterator")
+
+    class NetworkStatus(Enum):
+        STOPPED = 0
+        NOT_CONNECTED = 1
+        CONNECTED = 2
+
+    fake_network_iterator.NetworkStatus = NetworkStatus
+    sys.modules["hummingbot.core.network_iterator"] = fake_network_iterator
+
 try:
     from hummingbot.connector.exchange.lighter.lighter_exchange import LighterExchange
     from hummingbot.core.data_type.in_flight_order import OrderState
@@ -45,16 +82,295 @@ class LighterExchangeTests(IsolatedAsyncioWrapperTestCase):
 
         self.assertEqual(idx_1, idx_2)
         self.assertGreaterEqual(idx_1, 0)
+        self.assertLessEqual(idx_1, 0x7FFFFFFFFFFFFFFF)
+
+    def test_get_signer_private_key_precedence_and_validation(self):
+        exchange = object.__new__(LighterExchange)
+        exchange._private_key = "private"
+        exchange._api_key = "111"
+        exchange._api_secret = "222"
+        self.assertEqual("private", exchange._get_signer_private_key())
+
+        exchange._private_key = ""
+        exchange._api_key = "0xabc"
+        exchange._api_secret = "123"
+        self.assertEqual("0xabc", exchange._get_signer_private_key())
+
+        exchange._api_key = "123"
+        exchange._api_secret = "0xdef"
+        self.assertEqual("0xdef", exchange._get_signer_private_key())
+
+        exchange._api_key = "123"
+        exchange._api_secret = "456"
+        with self.assertRaises(ValueError):
+            exchange._get_signer_private_key()
+
+    def test_get_api_key_index_and_account_index(self):
+        exchange = object.__new__(LighterExchange)
+        exchange._api_key = "7"
+        exchange._api_secret = "999"
+        exchange._account_index = "42"
+        self.assertEqual(7, exchange._get_api_key_index())
+        self.assertEqual(42, exchange._get_account_index())
+
+        exchange._api_key = "key"
+        exchange._api_secret = "8"
+        self.assertEqual(8, exchange._get_api_key_index())
+
+        exchange._api_key = "key"
+        exchange._api_secret = "secret"
+        with self.assertRaises(ValueError):
+            exchange._get_api_key_index()
+
+        exchange._account_index = "abc"
+        with self.assertRaises(ValueError):
+            exchange._get_account_index()
 
     def test_account_from_response_variants(self):
         self.assertEqual({"assets": []}, LighterExchange._account_from_response({"data": {"assets": []}}))
         self.assertEqual({"assets": [1]}, LighterExchange._account_from_response({"data": [{"assets": [1]}]}))
         self.assertEqual({"assets": [2]}, LighterExchange._account_from_response({"accounts": [{"assets": [2]}]}))
 
+    def test_account_query_params(self):
+        exchange = object.__new__(LighterExchange)
+        exchange._account_index = "693751"
+        self.assertEqual({"by": "index", "value": "693751"}, exchange._account_query_params())
+
     def test_is_ok_response(self):
         self.assertTrue(LighterExchange._is_ok_response({"success": True}))
         self.assertTrue(LighterExchange._is_ok_response({"code": 200}))
         self.assertFalse(LighterExchange._is_ok_response({"code": 500}))
+
+    def test_process_balance_message_from_account(self):
+        exchange = object.__new__(LighterExchange)
+        exchange._account_balances = {}
+        exchange._account_available_balances = {}
+
+        exchange._process_balance_message_from_account(
+            {
+                "assets": [
+                    {"symbol": "USDC", "balance": "10", "locked_balance": "2"},
+                    {"symbol": "ETH", "balance": "1.5", "locked_balance": "0.5"},
+                ]
+            }
+        )
+
+        self.assertEqual(Decimal("10"), exchange._account_balances["USDC"])
+        self.assertEqual(Decimal("8"), exchange._account_available_balances["USDC"])
+        self.assertEqual(Decimal("1.0"), exchange._account_available_balances["ETH"])
+
+    def test_order_update_from_raw_message(self):
+        exchange = object.__new__(LighterExchange)
+        tracked_order = type(
+            "TrackedOrder",
+            (),
+            {
+                "client_order_id": "HBOT-1",
+                "exchange_order_id": "42",
+                "trading_pair": "ETH-USDC",
+            },
+        )()
+        exchange._order_tracker = type(
+            "Tracker",
+            (),
+            {
+                "all_updatable_orders": {"HBOT-1": tracked_order},
+                "all_fillable_orders_by_exchange_order_id": {},
+            },
+        )()
+
+        order_update = exchange._order_update_from_raw_message(
+            {"client_order_id": "HBOT-1", "order_status": "canceled", "updated_at": 1700000000}
+        )
+
+        self.assertIsNotNone(order_update)
+        self.assertEqual("HBOT-1", order_update.client_order_id)
+        self.assertEqual(OrderState.CANCELED, order_update.new_state)
+
+    def test_trade_update_from_raw_message(self):
+        exchange = object.__new__(LighterExchange)
+        tracked_order = type(
+            "TrackedOrder",
+            (),
+            {
+                "client_order_id": "HBOT-2",
+                "exchange_order_id": "77",
+                "trading_pair": "ETH-USDC",
+                "quote_asset": "USDC",
+                "trade_type": TradeType.BUY,
+            },
+        )()
+        exchange.trade_fee_schema = lambda: TradeFeeSchema()
+        exchange.current_timestamp = 1700000000
+        exchange._order_tracker = type(
+            "Tracker",
+            (),
+            {
+                "all_fillable_orders": {"HBOT-2": tracked_order},
+                "all_fillable_orders_by_exchange_order_id": {"77": tracked_order},
+            },
+        )()
+
+        trade_update = exchange._trade_update_from_raw_message(
+            {
+                "client_order_id": "HBOT-2",
+                "order_id": "77",
+                "trade_id": "t-1",
+                "price": "2.5",
+                "amount": "4",
+                "created_at": 1700000000123,
+            }
+        )
+
+        self.assertIsNotNone(trade_update)
+        self.assertEqual("t-1", trade_update.trade_id)
+        self.assertEqual(Decimal("2.5"), trade_update.fill_price)
+        self.assertEqual(Decimal("4"), trade_update.fill_base_amount)
+        self.assertEqual(Decimal("10"), trade_update.fill_quote_amount)
+
+    async def test_format_trading_rules_filters_non_spot(self):
+        exchange = object.__new__(LighterExchange)
+        rules = await exchange._format_trading_rules(
+            {
+                "data": [
+                    {"symbol": "ETH/USDC", "market_type": "spot", "supported_size_decimals": 3, "supported_price_decimals": 2},
+                    {"symbol": "BTC/USDC", "market_type": "perp", "supported_size_decimals": 3, "supported_price_decimals": 2},
+                ]
+            }
+        )
+        self.assertEqual(1, len(rules))
+        self.assertEqual("ETH-USDC", rules[0].trading_pair)
+
+    async def test_request_order_status_empty_returns_current_state(self):
+        exchange = object.__new__(LighterExchange)
+        exchange.current_timestamp = 1700001234
+        exchange._api_get = AsyncMock(return_value={"success": True, "data": []})
+
+        tracked_order = type(
+            "TrackedOrder",
+            (),
+            {
+                "client_order_id": "HBOT-3",
+                "exchange_order_id": "300",
+                "trading_pair": "ETH-USDC",
+                "current_state": OrderState.OPEN,
+            },
+        )()
+
+        status = await exchange._request_order_status(tracked_order)
+        self.assertEqual("HBOT-3", status.client_order_id)
+        self.assertEqual(OrderState.OPEN, status.new_state)
+
+    async def test_request_order_status_parses_state(self):
+        exchange = object.__new__(LighterExchange)
+        exchange._api_get = AsyncMock(
+            return_value={
+                "success": True,
+                "data": [
+                    {"created_at": 1, "order_status": "open"},
+                    {"created_at": 2, "order_status": "canceled"},
+                ],
+            }
+        )
+
+        tracked_order = type(
+            "TrackedOrder",
+            (),
+            {
+                "client_order_id": "HBOT-4",
+                "exchange_order_id": "301",
+                "trading_pair": "ETH-USDC",
+                "current_state": OrderState.OPEN,
+            },
+        )()
+
+        status = await exchange._request_order_status(tracked_order)
+        self.assertEqual(OrderState.CANCELED, status.new_state)
+
+    async def test_update_balances_updates_and_removes_assets(self):
+        exchange = object.__new__(LighterExchange)
+        exchange._account_balances = {"OLD": Decimal("1")}
+        exchange._account_available_balances = {"OLD": Decimal("1")}
+        exchange._account_query_params = lambda: {"by": "index", "value": "1"}
+        exchange._api_get = AsyncMock(
+            return_value={
+                "success": True,
+                "data": {
+                    "assets": [
+                        {"symbol": "USDC", "balance": "12", "locked_balance": "2"},
+                    ]
+                },
+            }
+        )
+
+        await exchange._update_balances()
+
+        self.assertNotIn("OLD", exchange._account_balances)
+        self.assertEqual(Decimal("12"), exchange._account_balances["USDC"])
+        self.assertEqual(Decimal("10"), exchange._account_available_balances["USDC"])
+
+    def test_initialize_trading_pair_symbols_from_exchange_info(self):
+        exchange = object.__new__(LighterExchange)
+        captured = {}
+        exchange._set_trading_pair_symbol_map = lambda mapping: captured.update(mapping)
+
+        exchange._initialize_trading_pair_symbols_from_exchange_info(
+            {
+                "data": [
+                    {"symbol": "ETH/USDC", "market_type": "spot"},
+                    {"symbol": "BTC/USDC", "market_type": "perp"},
+                ]
+            }
+        )
+
+        self.assertEqual({"ETH/USDC": "ETH-USDC"}, captured)
+
+    async def test_request_order_fills_by_client_order_id_filters(self):
+        exchange = object.__new__(LighterExchange)
+        order = type("Order", (), {"client_order_id": "HBOT-5", "exchange_order_id": "500"})()
+        exchange._request_order_fills_from_trades_api = AsyncMock(
+            return_value=[
+                {"client_order_id": "HBOT-0"},
+                {"client_order_id": "HBOT-5"},
+                {"clientOrderId": "HBOT-5"},
+            ]
+        )
+
+        fills = await exchange._request_order_fills_by_client_order_id(order)
+        self.assertEqual(2, len(fills))
+
+    async def test_request_trade_fills(self):
+        exchange = object.__new__(LighterExchange)
+        exchange._account_index = "693751"
+        exchange._domain = "lighter"
+        exchange._api_get = AsyncMock(
+            return_value={
+                "data": [
+                    {"history_id": "h1", "symbol": "ETH/USDC"},
+                    {"trade_id": "t2", "symbol": "LIT/USDC"},
+                ]
+            }
+        )
+
+        fills = await exchange._request_trade_fills()
+        self.assertEqual(2, len(fills))
+        self.assertEqual("lighter", fills[0].market)
+        self.assertEqual("h1", fills[0].exchange_trade_id)
+
+    async def test_execute_orders_cancel(self):
+        exchange = object.__new__(LighterExchange)
+        exchange.current_timestamp = 1700000000
+        exchange._execute_order_cancel = AsyncMock(side_effect=["HBOT-6", ""])
+
+        orders = [
+            type("Order", (), {"client_order_id": "HBOT-6", "trading_pair": "ETH-USDC"})(),
+            type("Order", (), {"client_order_id": "HBOT-7", "trading_pair": "ETH-USDC"})(),
+        ]
+
+        updates = await exchange._execute_orders_cancel(orders)
+        self.assertEqual(1, len(updates))
+        self.assertEqual("HBOT-6", updates[0].client_order_id)
+        self.assertEqual(OrderState.CANCELED, updates[0].new_state)
 
     async def test_request_order_fills_by_exchange_order_id_filters(self):
         exchange = object.__new__(LighterExchange)

--- a/test/hummingbot/connector/exchange/lighter/test_lighter_exchange.py
+++ b/test/hummingbot/connector/exchange/lighter/test_lighter_exchange.py
@@ -99,7 +99,7 @@ class LighterExchangeTests(IsolatedAsyncioWrapperTestCase):
         self.assertEqual([OrderType.LIMIT, OrderType.LIMIT_MAKER, OrderType.MARKET], exchange.supported_order_types())
         self.assertEqual("/orderBooks", exchange.trading_rules_request_path)
         self.assertEqual("/orderBooks", exchange.trading_pairs_request_path)
-        self.assertEqual("/", exchange.check_network_request_path)
+        self.assertEqual("/orderBooks", exchange.check_network_request_path)
 
     async def test_refresh_market_metadata_and_get_market_spec(self):
         exchange = object.__new__(LighterExchange)
@@ -215,6 +215,7 @@ class LighterExchangeTests(IsolatedAsyncioWrapperTestCase):
         exchange = object.__new__(LighterExchange)
         exchange._domain = "lighter"
         exchange._api_key = "k"
+        exchange._api_secret = ""
         exchange._web_assistants_factory = type("Factory", (), {"get_rest_assistant": AsyncMock()})()
         rest = type("Rest", (), {})()
         rest.execute_request = AsyncMock(return_value={"ok": True})
@@ -1016,6 +1017,25 @@ class LighterExchangeTests(IsolatedAsyncioWrapperTestCase):
         self.assertIsNotNone(exchange.authenticator)
         self.assertEqual(32, exchange.client_order_id_max_length)
         self.assertEqual("HBOT", exchange.client_order_id_prefix)
+
+    def test_rest_api_key_and_authenticator_use_key_index_when_available(self):
+        exchange = object.__new__(LighterExchange)
+        exchange._account_index = "1"
+
+        exchange._api_key = "7"
+        exchange._api_secret = "private"
+        self.assertEqual("7", exchange.rest_api_key)
+        self.assertEqual("7", exchange.authenticator.api_key)
+
+        exchange._api_key = "private"
+        exchange._api_secret = "8"
+        self.assertEqual("8", exchange.rest_api_key)
+        self.assertEqual("8", exchange.authenticator.api_key)
+
+        exchange._api_key = "api-key"
+        exchange._api_secret = "secret"
+        self.assertEqual("api-key", exchange.rest_api_key)
+        self.assertEqual("api-key", exchange.authenticator.api_key)
 
     async def test_more_branch_paths(self):
         exchange = object.__new__(LighterExchange)

--- a/test/hummingbot/connector/exchange/lighter/test_lighter_exchange.py
+++ b/test/hummingbot/connector/exchange/lighter/test_lighter_exchange.py
@@ -4,9 +4,11 @@ import unittest
 from decimal import Decimal
 from enum import Enum
 from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 from hummingbot.core.data_type.common import TradeType
+from hummingbot.core.data_type.common import OrderType
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod
 from hummingbot.core.data_type.trade_fee import TradeFeeSchema
 
 if "hummingbot.core.data_type.limit_order" not in sys.modules:
@@ -72,6 +74,176 @@ except ModuleNotFoundError:
 
 @unittest.skipUnless(_LIGHTER_EXCHANGE_AVAILABLE, "Core exchange runtime modules are unavailable in this local environment")
 class LighterExchangeTests(IsolatedAsyncioWrapperTestCase):
+    def test_init_and_properties(self):
+        with patch("hummingbot.connector.exchange.lighter.lighter_exchange.ExchangePyBase.__init__", lambda self: None):
+            exchange = LighterExchange(
+                lighter_api_key="7",
+                lighter_api_secret="sec",
+                lighter_account_index="693751",
+                lighter_private_key="pk",
+                trading_pairs=["ETH-USDC"],
+                trading_required=False,
+            )
+
+        self.assertEqual("lighter", exchange.name)
+        self.assertEqual("lighter", exchange.domain)
+        self.assertEqual(["ETH-USDC"], exchange.trading_pairs)
+        self.assertFalse(exchange.is_trading_required)
+        self.assertTrue(exchange.is_cancel_request_in_exchange_synchronous)
+        self.assertEqual("https://mainnet.zklighter.elliot.ai", exchange._api_host_for_signer())
+
+    def test_supported_order_types_and_request_paths(self):
+        exchange = object.__new__(LighterExchange)
+        exchange._domain = "lighter"
+        self.assertEqual([OrderType.LIMIT, OrderType.LIMIT_MAKER, OrderType.MARKET], exchange.supported_order_types())
+        self.assertEqual("/orderBooks", exchange.trading_rules_request_path)
+        self.assertEqual("/orderBooks", exchange.trading_pairs_request_path)
+        self.assertEqual("/", exchange.check_network_request_path)
+
+    async def test_refresh_market_metadata_and_get_market_spec(self):
+        exchange = object.__new__(LighterExchange)
+        exchange._market_id_by_symbol = {}
+        exchange._size_decimals_by_symbol = {}
+        exchange._price_decimals_by_symbol = {}
+        exchange.exchange_symbol_associated_to_pair = AsyncMock(return_value="ETH/USDC")
+        exchange._api_get = AsyncMock(
+            return_value={
+                "order_books": [
+                    {
+                        "symbol": "ETH/USDC",
+                        "market_type": "spot",
+                        "market_id": 2048,
+                        "supported_size_decimals": 4,
+                        "supported_price_decimals": 2,
+                    }
+                ]
+            }
+        )
+
+        await exchange._refresh_market_metadata()
+        spec = await exchange._get_market_spec("ETH-USDC")
+        self.assertEqual((2048, 4, 2, "ETH/USDC"), spec)
+
+    async def test_get_market_spec_raises_when_missing(self):
+        exchange = object.__new__(LighterExchange)
+        exchange._market_id_by_symbol = {}
+        exchange._size_decimals_by_symbol = {}
+        exchange._price_decimals_by_symbol = {}
+        exchange.exchange_symbol_associated_to_pair = AsyncMock(return_value="MISSING")
+        exchange._refresh_market_metadata = AsyncMock()
+
+        with self.assertRaises(ValueError):
+            await exchange._get_market_spec("ETH-USDC")
+
+    async def test_place_order_and_cancel_success(self):
+        exchange = object.__new__(LighterExchange)
+        exchange.current_timestamp = 1700000000
+        exchange._get_market_spec = AsyncMock(return_value=(2048, 2, 2, "ETH/USDC"))
+        exchange._client_order_index_from_order_id = lambda order_id: 999
+        exchange._get_api_key_index = lambda: 7
+
+        signer_client = type(
+            "SignerClient",
+            (),
+            {
+                "ORDER_TYPE_LIMIT": 1,
+                "ORDER_TYPE_MARKET": 2,
+                "ORDER_TIME_IN_FORCE_GOOD_TILL_TIME": 10,
+                "ORDER_TIME_IN_FORCE_IMMEDIATE_OR_CANCEL": 11,
+                "ORDER_TIME_IN_FORCE_POST_ONLY": 12,
+                "DEFAULT_28_DAY_ORDER_EXPIRY": 1000,
+                "DEFAULT_IOC_EXPIRY": 1001,
+            },
+        )()
+        signer_client.create_order = AsyncMock(return_value=(None, type("Resp", (), {"code": 200})(), None))
+        signer_client.cancel_order = AsyncMock(return_value=(None, type("Resp", (), {"code": 200})(), None))
+        exchange._get_lighter_signer_client = lambda: signer_client
+
+        exchange_order_id, ts = await exchange._place_order(
+            order_id="HBOT-A",
+            trading_pair="ETH-USDC",
+            amount=Decimal("1"),
+            trade_type=TradeType.BUY,
+            order_type=OrderType.LIMIT,
+            price=Decimal("10"),
+        )
+        result = await exchange._place_cancel("HBOT-A", type("Tracked", (), {"trading_pair": "ETH-USDC", "exchange_order_id": "42"})())
+
+        self.assertEqual("999", exchange_order_id)
+        self.assertEqual(1700000000, ts)
+        self.assertTrue(result)
+
+    async def test_place_order_and_cancel_errors(self):
+        exchange = object.__new__(LighterExchange)
+        exchange.current_timestamp = 1700000000
+        exchange._get_market_spec = AsyncMock(return_value=(2048, 2, 2, "ETH/USDC"))
+        exchange._client_order_index_from_order_id = lambda order_id: 111
+        exchange._get_api_key_index = lambda: 7
+
+        signer_client = type(
+            "SignerClient",
+            (),
+            {
+                "ORDER_TYPE_LIMIT": 1,
+                "ORDER_TYPE_MARKET": 2,
+                "ORDER_TIME_IN_FORCE_GOOD_TILL_TIME": 10,
+                "ORDER_TIME_IN_FORCE_IMMEDIATE_OR_CANCEL": 11,
+                "ORDER_TIME_IN_FORCE_POST_ONLY": 12,
+                "DEFAULT_28_DAY_ORDER_EXPIRY": 1000,
+                "DEFAULT_IOC_EXPIRY": 1001,
+            },
+        )()
+        signer_client.create_order = AsyncMock(return_value=(None, None, "err"))
+        signer_client.cancel_order = AsyncMock(return_value=(None, None, "err"))
+        exchange._get_lighter_signer_client = lambda: signer_client
+
+        with self.assertRaises(IOError):
+            await exchange._place_order(
+                order_id="HBOT-B",
+                trading_pair="ETH-USDC",
+                amount=Decimal("1"),
+                trade_type=TradeType.BUY,
+                order_type=OrderType.MARKET,
+                price=Decimal("10"),
+            )
+
+        with self.assertRaises(IOError):
+            await exchange._place_cancel("HBOT-B", type("Tracked", (), {"trading_pair": "ETH-USDC", "exchange_order_id": "42"})())
+
+    async def test_api_request_and_get_last_traded_prices(self):
+        exchange = object.__new__(LighterExchange)
+        exchange._domain = "lighter"
+        exchange._api_key = "k"
+        exchange._web_assistants_factory = type("Factory", (), {"get_rest_assistant": AsyncMock()})()
+        rest = type("Rest", (), {})()
+        rest.execute_request = AsyncMock(return_value={"ok": True})
+        exchange._web_assistants_factory.get_rest_assistant = AsyncMock(return_value=rest)
+
+        response = await exchange._api_request(path_url="/orderBooks", method=RESTMethod.GET, params={"a": 1}, is_auth_required=True)
+        self.assertEqual({"ok": True}, response)
+
+        exchange._api_request = AsyncMock(
+            return_value={
+                "data": [
+                    {"symbol": "ETH/USDC", "index_price": "100.5"},
+                    {"symbol": "BTC/USDC", "index_price": "200.5"},
+                ]
+            }
+        )
+        exchange.trading_pair_associated_to_exchange_symbol = AsyncMock(side_effect=["ETH-USDC", "BTC-USDC"])
+        prices = await exchange.get_last_traded_prices(["ETH-USDC"])
+        self.assertEqual({"ETH-USDC": 100.5}, prices)
+
+    async def test_status_polling_loop_fetch_updates(self):
+        exchange = object.__new__(LighterExchange)
+        exchange._update_balances = AsyncMock()
+        exchange._update_order_status = AsyncMock()
+        exchange._update_lost_orders_status = AsyncMock()
+
+        await exchange._status_polling_loop_fetch_updates()
+        self.assertEqual(1, exchange._update_balances.await_count)
+        self.assertEqual(1, exchange._update_order_status.await_count)
+        self.assertEqual(1, exchange._update_lost_orders_status.await_count)
     def test_hb_pair_from_symbol_variants(self):
         self.assertEqual("ETH-USDC", LighterExchange._hb_pair_from_symbol("ETH/USDC"))
         self.assertEqual("BTC-USDC", LighterExchange._hb_pair_from_symbol("BTC-USDC"))
@@ -356,6 +528,158 @@ class LighterExchangeTests(IsolatedAsyncioWrapperTestCase):
         self.assertEqual(2, len(fills))
         self.assertEqual("lighter", fills[0].market)
         self.assertEqual("h1", fills[0].exchange_trade_id)
+
+    async def test_request_order_fills_from_trades_api_success_and_failure(self):
+        exchange = object.__new__(LighterExchange)
+        exchange._account_index = "693751"
+        exchange._api_get = AsyncMock(return_value={"success": True, "data": [{"order_id": "1"}]})
+
+        order = type("Order", (), {"exchange_order_id": "1"})()
+        fills = await exchange._request_order_fills_from_trades_api(order)
+        self.assertEqual(1, len(fills))
+
+        exchange._api_get = AsyncMock(return_value={"success": False})
+        fills = await exchange._request_order_fills_from_trades_api(order)
+        self.assertEqual([], fills)
+
+    async def test_request_order_fills_without_exchange_id(self):
+        exchange = object.__new__(LighterExchange)
+        order = type("Order", (), {"exchange_order_id": None})()
+        fills = await exchange._request_order_fills(order)
+        self.assertEqual([], fills)
+
+    async def test_request_order_fills_and_fills_api_delegates(self):
+        exchange = object.__new__(LighterExchange)
+        order = type("Order", (), {"exchange_order_id": "99"})()
+        exchange._request_order_fills_by_exchange_order_id = AsyncMock(return_value=[{"order_id": "99"}])
+        exchange._request_order_fills_from_trades_api = AsyncMock(return_value=[{"order_id": "99"}])
+
+        fills = await exchange._request_order_fills(order)
+        fills2 = await exchange._request_order_fills_from_fills_api(order)
+        self.assertEqual([{"order_id": "99"}], fills)
+        self.assertEqual([{"order_id": "99"}], fills2)
+
+    async def test_request_trade_updates_and_order_update_delegate(self):
+        exchange = object.__new__(LighterExchange)
+        order_1 = type("Order", (), {"id": "1"})()
+        order_2 = type("Order", (), {"id": "2"})()
+        trade_update = object()
+        exchange._all_trade_updates_for_order = AsyncMock(side_effect=[[trade_update], []])
+        exchange._request_order_status = AsyncMock(return_value="ORDER_UPDATE")
+
+        updates = await exchange._request_trade_updates([order_1, order_2])
+        order_update = await exchange._request_order_update(order_1)
+
+        self.assertEqual([trade_update], updates)
+        self.assertEqual("ORDER_UPDATE", order_update)
+
+    async def test_execute_order_cancel_and_get_last_prices(self):
+        exchange = object.__new__(LighterExchange)
+        order = type("Order", (), {"client_order_id": "HBOT-8"})()
+        exchange._place_cancel = AsyncMock(return_value=True)
+        exchange.get_last_traded_prices = AsyncMock(return_value={"ETH-USDC": 1234.5})
+
+        cancelled = await exchange._execute_order_cancel(order)
+        last_price = await exchange._get_last_traded_price("ETH-USDC")
+        last_trade_price = await exchange._get_last_trade_price("ETH-USDC")
+
+        self.assertEqual("HBOT-8", cancelled)
+        self.assertEqual(1234.5, last_price)
+        self.assertEqual(1234.5, last_trade_price)
+
+    async def test_create_order_fill_updates_and_fee_payment(self):
+        exchange = object.__new__(LighterExchange)
+        order = type("Order", (), {"client_order_id": "HBOT-9"})()
+        exchange._all_trade_updates_for_order = AsyncMock(return_value=["a", "b"])
+
+        updates = await exchange._create_order_fill_updates(order=order, exchange_order_id="1", fee=None)
+        last_fee = await exchange._fetch_last_fee_payment("ETH-USDC")
+
+        self.assertEqual(["a", "b"], updates)
+        self.assertEqual((0, Decimal("0"), Decimal("0")), last_fee)
+
+    async def test_get_all_pairs_prices(self):
+        exchange = object.__new__(LighterExchange)
+        exchange._api_get = AsyncMock(return_value={"data": [{"symbol": "ETH/USDC"}]})
+        pairs = await exchange._get_all_pairs_prices()
+        self.assertEqual([{"symbol": "ETH/USDC"}], pairs)
+
+    async def test_create_trade_fill_updates(self):
+        exchange = object.__new__(LighterExchange)
+        exchange.current_timestamp = 1700000000
+        exchange._get_fee = lambda **kwargs: "FEE"
+
+        inflight_order = type(
+            "InFlightOrder",
+            (),
+            {
+                "client_order_id": "HBOT-10",
+                "exchange_order_id": "500",
+                "trading_pair": "ETH-USDC",
+                "base_asset": "ETH",
+                "quote_asset": "USDC",
+                "order_type": "LIMIT",
+                "trade_type": TradeType.BUY,
+                "amount": Decimal("1"),
+                "price": Decimal("100"),
+            },
+        )()
+
+        fills_data = [{"trade_id": "t-1", "price": "100", "amount": "2", "quote_amount": "200", "timestamp": 1700000001}]
+        updates = exchange._create_trade_fill_updates(inflight_order=inflight_order, fills_data=fills_data)
+
+        self.assertEqual(1, len(updates))
+        self.assertEqual("t-1", updates[0].trade_id)
+        self.assertEqual(Decimal("200"), updates[0].fill_quote_amount)
+
+    async def test_update_orders_with_error_handler(self):
+        exchange = object.__new__(LighterExchange)
+        processed = []
+        exchange._order_tracker = type(
+            "Tracker",
+            (),
+            {
+                "process_order_update": lambda self, update: processed.append(("order", update)),
+                "process_trade_update": lambda self, update: processed.append(("trade", update)),
+            },
+        )()
+
+        orders = ["o1", "o2", "o3"]
+
+        async def fetch(order):
+            if order == "o1":
+                return "ORDER_UPDATE"
+            if order == "o2":
+                return [type("DummyTradeUpdate", (), {})()]
+            raise RuntimeError("boom")
+
+        handled = []
+
+        async def on_error(order, err):
+            handled.append((order, str(err)))
+
+        await exchange._update_orders_with_error_handler(orders=orders, fetch_updates=fetch, error_handler=on_error)
+
+        self.assertEqual(1, len(handled))
+        self.assertEqual("o3", handled[0][0])
+
+    async def test_update_lost_orders_and_cancel_lost_orders(self):
+        exchange = object.__new__(LighterExchange)
+        lost_orders = {
+            "1": type("Order", (), {"client_order_id": "1"})(),
+            "2": type("Order", (), {"client_order_id": "2"})(),
+        }
+        exchange._order_tracker = type("Tracker", (), {"lost_orders": lost_orders})()
+        exchange._update_orders_with_error_handler = AsyncMock()
+        exchange._request_order_status = AsyncMock()
+        exchange._handle_update_error_for_lost_order = AsyncMock()
+        exchange._execute_order_cancel = AsyncMock(return_value="")
+
+        await exchange._update_lost_orders()
+        await exchange._cancel_lost_orders()
+
+        self.assertEqual(1, exchange._update_orders_with_error_handler.await_count)
+        self.assertEqual(2, exchange._execute_order_cancel.await_count)
 
     async def test_execute_orders_cancel(self):
         exchange = object.__new__(LighterExchange)

--- a/test/hummingbot/connector/exchange/lighter/test_lighter_exchange.py
+++ b/test/hummingbot/connector/exchange/lighter/test_lighter_exchange.py
@@ -526,7 +526,7 @@ class LighterExchangeTests(IsolatedAsyncioWrapperTestCase):
 
         self.assertEqual(idx_1, idx_2)
         self.assertGreaterEqual(idx_1, 0)
-        self.assertLessEqual(idx_1, 0x7FFFFFFFFFFFFFFF)
+        self.assertLessEqual(idx_1, (1 << 48) - 1)
 
     def test_get_signer_private_key_precedence_and_validation(self):
         exchange = object.__new__(LighterExchange)

--- a/test/hummingbot/connector/exchange/lighter/test_lighter_order_book.py
+++ b/test/hummingbot/connector/exchange/lighter/test_lighter_order_book.py
@@ -1,0 +1,73 @@
+from unittest import TestCase
+
+from hummingbot.connector.exchange.lighter.lighter_order_book import LighterOrderBook
+from hummingbot.core.data_type.common import TradeType
+from hummingbot.core.data_type.order_book_message import OrderBookMessageType
+
+
+class LighterOrderBookTests(TestCase):
+    def test_snapshot_message_from_exchange(self):
+        message = LighterOrderBook.snapshot_message_from_exchange(
+            msg={
+                "update_id": 123,
+                "bids": [["100.0", "1.2"]],
+                "asks": [["101.0", "2.3"]],
+            },
+            timestamp=1700000000.0,
+            metadata={"trading_pair": "ETH-USDC"},
+        )
+
+        self.assertEqual(OrderBookMessageType.SNAPSHOT, message.type)
+        self.assertEqual("ETH-USDC", message.trading_pair)
+        self.assertEqual(123, message.update_id)
+        self.assertEqual(100.0, message.bids[0].price)
+        self.assertEqual(1.2, message.bids[0].amount)
+        self.assertEqual(101.0, message.asks[0].price)
+        self.assertEqual(2.3, message.asks[0].amount)
+
+    def test_diff_message_from_exchange(self):
+        message = LighterOrderBook.diff_message_from_exchange(
+            msg={
+                "first_update_id": 200,
+                "update_id": 220,
+                "bids": [["99.9", "0.5"]],
+                "asks": [["100.1", "0.6"]],
+            },
+            timestamp=1700000001.0,
+            metadata={"trading_pair": "ETH-USDC"},
+        )
+
+        self.assertEqual(OrderBookMessageType.DIFF, message.type)
+        self.assertEqual("ETH-USDC", message.trading_pair)
+        self.assertEqual(220, message.update_id)
+        self.assertEqual(200, message.first_update_id)
+
+    def test_trade_message_from_exchange(self):
+        buy_trade = LighterOrderBook.trade_message_from_exchange(
+            msg={
+                "trade_id": "t1",
+                "nonce": 7,
+                "price": "100.0",
+                "size": "0.25",
+                "is_maker_ask": True,
+            },
+            timestamp=1700000002.0,
+            metadata={"trading_pair": "ETH-USDC"},
+        )
+
+        sell_trade = LighterOrderBook.trade_message_from_exchange(
+            msg={
+                "trade_id": "t2",
+                "nonce": 8,
+                "price": "101.0",
+                "size": "0.35",
+                "is_maker_ask": False,
+            },
+            timestamp=1700000003.0,
+            metadata={"trading_pair": "ETH-USDC"},
+        )
+
+        self.assertEqual(OrderBookMessageType.TRADE, buy_trade.type)
+        self.assertEqual("t1", buy_trade.trade_id)
+        self.assertEqual(float(TradeType.BUY.value), buy_trade.content["trade_type"])
+        self.assertEqual(float(TradeType.SELL.value), sell_trade.content["trade_type"])

--- a/test/hummingbot/connector/exchange/lighter/test_lighter_utils.py
+++ b/test/hummingbot/connector/exchange/lighter/test_lighter_utils.py
@@ -1,0 +1,11 @@
+from unittest import TestCase
+
+from hummingbot.connector.exchange.lighter.lighter_utils import LighterConfigMap, LighterTestnetConfigMap
+
+
+class LighterUtilsTests(TestCase):
+    def test_config_map_title(self):
+        self.assertEqual("lighter", LighterConfigMap.model_config.get("title"))
+
+    def test_testnet_config_map_title(self):
+        self.assertEqual("lighter_testnet", LighterTestnetConfigMap.model_config.get("title"))

--- a/test/hummingbot/connector/exchange/lighter/test_lighter_utils.py
+++ b/test/hummingbot/connector/exchange/lighter/test_lighter_utils.py
@@ -1,6 +1,10 @@
 from unittest import TestCase
 
-from hummingbot.connector.exchange.lighter.lighter_utils import LighterConfigMap, LighterTestnetConfigMap
+from hummingbot.connector.exchange.lighter.lighter_utils import (
+    LighterConfigMap,
+    LighterTestnetConfigMap,
+    is_exchange_information_valid,
+)
 
 
 class LighterUtilsTests(TestCase):
@@ -9,3 +13,9 @@ class LighterUtilsTests(TestCase):
 
     def test_testnet_config_map_title(self):
         self.assertEqual("lighter_testnet", LighterTestnetConfigMap.model_config.get("title"))
+
+    def test_is_exchange_information_valid(self):
+        self.assertTrue(is_exchange_information_valid({"symbol": "ETH/USDC", "market_type": "spot", "status": "active"}))
+        self.assertFalse(is_exchange_information_valid({"symbol": "ETH/USDC", "market_type": "perp", "status": "active"}))
+        self.assertFalse(is_exchange_information_valid({"symbol": "ETH/USDC", "market_type": "spot", "status": "halted"}))
+        self.assertFalse(is_exchange_information_valid({"market_type": "spot", "status": "active"}))

--- a/test/hummingbot/connector/exchange/lighter/test_lighter_web_utils.py
+++ b/test/hummingbot/connector/exchange/lighter/test_lighter_web_utils.py
@@ -1,0 +1,26 @@
+import unittest
+
+from hummingbot.connector.exchange.lighter import lighter_constants as CONSTANTS, lighter_web_utils as web_utils
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+
+
+class LighterWebUtilsTests(unittest.TestCase):
+    def test_public_rest_url(self):
+        self.assertEqual(
+            f"{CONSTANTS.REST_URL}{CONSTANTS.EXCHANGE_INFO_PATH_URL}",
+            web_utils.public_rest_url(CONSTANTS.EXCHANGE_INFO_PATH_URL),
+        )
+
+    def test_private_rest_url(self):
+        self.assertEqual(
+            f"{CONSTANTS.REST_URL}{CONSTANTS.GET_ACCOUNT_INFO_PATH_URL}",
+            web_utils.private_rest_url(CONSTANTS.GET_ACCOUNT_INFO_PATH_URL),
+        )
+
+    def test_wss_url(self):
+        self.assertEqual(CONSTANTS.WSS_URL, web_utils.wss_url())
+
+    def test_build_api_factory(self):
+        api_factory = web_utils.build_api_factory()
+        self.assertIsInstance(api_factory, WebAssistantsFactory)
+        self.assertIsNone(api_factory._auth)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] Tests all pass
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

This PR adds the Lighter spot connector under `hummingbot/connector/exchange/lighter` with REST and WebSocket support, order book and trade stream handling, authenticated user stream support, trading rules parsing, balances, order placement/cancellation, order status tracking, and trade history updates.

It also includes full unit test coverage under `test/hummingbot/connector/exchange/lighter`, a live mainnet smoke test script under `scripts/lighter_spot_smoke_test.py`, and refreshed mainnet validation evidence in `scripts/lighter_spot_integration_report.json`.

**Tests performed by the developer**:

- Live verification completed on mainnet:
  - market: `LIT/USDC`
  - create order code: `200`
  - cancel order code: `200`
  - locked USDC increased after create and returned to baseline after cancel
  - total order count returned to baseline after cancel

- Latest mainnet artifact:
  - file: `scripts/lighter_spot_integration_report.json`
  - create tx hash: `bdd9a39d857fe082ff9c475565603685d67b136a6607d0d375a2c93d1a1f0b99de347030b8dc6c66`
  - cancel tx hash: `9ab938ec281fc90a0a2fe7fe3abcf4e9f3d7701e714726a00e6f85237a234d92d17a101483357e90`

**Tips for QA testing**:

1. Configure valid Lighter spot credentials and account index.
2. Start the connector and verify trading pair discovery from `/orderBooks`.
3. Verify order book snapshots, order book updates, and trade stream messages over WebSocket.
4. Place and cancel a spot order.
5. Confirm order status updates and trade history handling.
6. Cross-check the live validation artifact in `scripts/lighter_spot_integration_report.json`.