### PR TITLE
(fix) update backpack perpetual balance calculation

### DIFF
--- a/hummingbot/connector/derivative/backpack_perpetual/backpack_perpetual_constants.py
+++ b/hummingbot/connector/derivative/backpack_perpetual/backpack_perpetual_constants.py
@@ -2,6 +2,7 @@ from hummingbot.core.api_throttler.data_types import LinkedLimitWeightPair, Rate
 from hummingbot.core.data_type.in_flight_order import OrderState
 
 DEFAULT_DOMAIN = "exchange"
+CURRENCY = "USDC"
 
 REST_URL = "https://api.backpack.{}/"
 WSS_URL = "wss://ws.backpack.{}/"
@@ -38,7 +39,7 @@ PING_PATH_URL = "api/v1/ping"
 SERVER_TIME_PATH_URL = "api/v1/time"
 EXCHANGE_INFO_PATH_URL = "api/v1/markets"
 SNAPSHOT_PATH_URL = "api/v1/depth"
-BALANCE_PATH_URL = "api/v1/capital"  # instruction balanceQuery
+BALANCE_PATH_URL = "api/v1/capital/collateral"  # instruction balanceQuery
 TICKER_BOOK_PATH_URL = "api/v1/tickers"
 TICKER_PRICE_CHANGE_PATH_URL = "api/v1/ticker"
 ORDER_PATH_URL = "api/v1/order"

--- a/hummingbot/connector/derivative/backpack_perpetual/backpack_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/backpack_perpetual/backpack_perpetual_derivative.py
@@ -555,26 +555,19 @@ class BackpackPerpetualDerivative(PerpetualDerivativePyBase):
         return order_update
 
     async def _update_balances(self):
-        local_asset_names = set(self._account_balances.keys())
-        remote_asset_names = set()
-
+        """
+        Calls the REST API to update total and available balances.
+        For perpetual futures with cross-margin, we report the netEquity and netEquityAvailable
+        as the total and available balances in the quote currency (USDC).
+        """
         account_info = await self._api_get(
             path_url=CONSTANTS.BALANCE_PATH_URL,
-            params={"instruction": "balanceQuery"},
+            params={"instruction": "collateralQuery"},
             is_auth_required=True)
 
-        if account_info:
-            for asset_name, balance_entry in account_info.items():
-                free_balance = Decimal(balance_entry["available"])
-                total_balance = Decimal(balance_entry["available"]) + Decimal(balance_entry["locked"])
-                self._account_available_balances[asset_name] = free_balance
-                self._account_balances[asset_name] = total_balance
-                remote_asset_names.add(asset_name)
-
-            asset_names_to_remove = local_asset_names.difference(remote_asset_names)
-            for asset_name in asset_names_to_remove:
-                del self._account_available_balances[asset_name]
-                del self._account_balances[asset_name]
+        quote = CONSTANTS.CURRENCY
+        self._account_balances[quote] = Decimal(account_info["netEquity"])
+        self._account_available_balances[quote] = Decimal(account_info["netEquityAvailable"])
 
     def _initialize_trading_pair_symbols_from_exchange_info(self, exchange_info: List[Dict[str, Any]]):
         mapping = bidict()

--- a/test/hummingbot/connector/derivative/backpack_perpetual/test_backpack_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/backpack_perpetual/test_backpack_perpetual_derivative.py
@@ -878,11 +878,20 @@ class BackpackPerpetualDerivativeUnitTest(IsolatedAsyncioWrapperTestCase):
         regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
 
         response = {
-            self.quote_asset: {
-                "available": "100.5",
-                "locked": "50.5",
-                "staked": "0"
-            }
+            "netEquity": "151.0",
+            "netEquityAvailable": "100.5",
+            "collateral": [
+                {
+                    "symbol": "USDC",
+                    "totalQuantity": "150.0",
+                    "availableQuantity": "100.0"
+                },
+                {
+                    "symbol": "SOL",
+                    "totalQuantity": "0.01",
+                    "availableQuantity": "0.005"
+                }
+            ]
         }
 
         mock_api.get(regex_url, body=json.dumps(response))
@@ -891,8 +900,9 @@ class BackpackPerpetualDerivativeUnitTest(IsolatedAsyncioWrapperTestCase):
         available_balances = self.exchange.available_balances
         total_balances = self.exchange.get_all_balances()
 
-        self.assertEqual(Decimal("100.5"), available_balances[self.quote_asset])
-        self.assertEqual(Decimal("151"), total_balances[self.quote_asset])
+        # Should use USDC (CONSTANTS.CURRENCY) as the quote currency
+        self.assertEqual(Decimal("100.5"), available_balances[CONSTANTS.CURRENCY])
+        self.assertEqual(Decimal("151.0"), total_balances[CONSTANTS.CURRENCY])
 
     async def test_user_stream_logs_errors(self):
         mock_user_stream = AsyncMock()
@@ -1114,44 +1124,56 @@ class BackpackPerpetualDerivativeUnitTest(IsolatedAsyncioWrapperTestCase):
 
     @aioresponses()
     async def test_update_balances_with_asset_removal(self, mock_api):
-        """Test balance update that removes assets no longer present"""
+        """Test balance update - perpetual futures only track quote currency (USDC)"""
         url = web_utils.private_rest_url(CONSTANTS.BALANCE_PATH_URL, domain=self.domain)
         regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
 
-        # First update with two assets
+        # First update
         response = {
-            self.quote_asset: {
-                "available": "100.5",
-                "locked": "50.5",
-                "staked": "0"
-            },
-            self.base_asset: {
-                "available": "200.0",
-                "locked": "0",
-                "staked": "0"
-            }
+            "netEquity": "250.0",
+            "netEquityAvailable": "200.5",
+            "collateral": [
+                {
+                    "symbol": "USDC",
+                    "totalQuantity": "200.0",
+                    "availableQuantity": "180.0"
+                },
+                {
+                    "symbol": "SOL",
+                    "totalQuantity": "1.0",
+                    "availableQuantity": "0.5"
+                }
+            ]
         }
 
         mock_api.get(regex_url, body=json.dumps(response))
         await self.exchange._update_balances()
 
-        self.assertIn(self.quote_asset, self.exchange.available_balances)
-        self.assertIn(self.base_asset, self.exchange.available_balances)
+        # For perpetual futures, only USDC (quote currency) is tracked
+        self.assertIn(CONSTANTS.CURRENCY, self.exchange.available_balances)
+        self.assertEqual(Decimal("200.5"), self.exchange.available_balances[CONSTANTS.CURRENCY])
+        self.assertEqual(Decimal("250.0"), self.exchange.get_all_balances()[CONSTANTS.CURRENCY])
 
-        # Second update with only one asset (base_asset removed)
+        # Second update with different equity values
         response2 = {
-            self.quote_asset: {
-                "available": "100.5",
-                "locked": "50.5",
-                "staked": "0"
-            }
+            "netEquity": "150.0",
+            "netEquityAvailable": "100.5",
+            "collateral": [
+                {
+                    "symbol": "USDC",
+                    "totalQuantity": "150.0",
+                    "availableQuantity": "100.0"
+                }
+            ]
         }
 
         mock_api.get(regex_url, body=json.dumps(response2))
         await self.exchange._update_balances()
 
-        self.assertIn(self.quote_asset, self.exchange.available_balances)
-        self.assertNotIn(self.base_asset, self.exchange.available_balances)
+        # Should update to new values
+        self.assertIn(CONSTANTS.CURRENCY, self.exchange.available_balances)
+        self.assertEqual(Decimal("100.5"), self.exchange.available_balances[CONSTANTS.CURRENCY])
+        self.assertEqual(Decimal("150.0"), self.exchange.get_all_balances()[CONSTANTS.CURRENCY])
 
     async def test_collateral_token_getters(self):
         """Test buy and sell collateral token getters"""


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] Tests all pass
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Fix incorrect balance endpoint assignment.

**Tests performed by the developer**:
-


**Tips for QA testing**:
- The backpack_perpetual balance should now display only USDC.
- Available equity should be visible, which was not accessible before.