### PR TITLE
Fix unhandled exceptions in Dexalot rate oracle and queued orders

### DIFF
--- a/hummingbot/connector/exchange/dexalot/dexalot_exchange.py
+++ b/hummingbot/connector/exchange/dexalot/dexalot_exchange.py
@@ -852,7 +852,7 @@ class DexalotExchange(ExchangePyBase):
                 await asyncio.shield(task)
                 sleep_time = (self.clock.tick_size * 0.5
                               if self.clock is not None
-                              else self._orders_processing_delta_time)
+                              else getattr(self, "_orders_processing_delta_time", 1.0))
                 await self._sleep(sleep_time)
             except NotImplementedError:
                 raise
@@ -860,7 +860,10 @@ class DexalotExchange(ExchangePyBase):
                 raise
             except Exception:
                 self.logger().exception("Unexpected error while processing queued individual orders", exc_info=True)
-                await self._sleep(self.clock.tick_size * 0.5)
+                sleep_time = (self.clock.tick_size * 0.5
+                              if self.clock is not None
+                              else getattr(self, "_orders_processing_delta_time", 1.0))
+                await self._sleep(sleep_time)
 
     async def _cancel_and_create_queued_orders(self):
         if len(self._orders_queued_to_cancel) > 0 or len(self._orders_queued_to_create) > 0:

--- a/hummingbot/core/rate_oracle/sources/dexalot_rate_source.py
+++ b/hummingbot/core/rate_oracle/sources/dexalot_rate_source.py
@@ -30,9 +30,13 @@ class DexalotRateSource(RateSourceBase):
                     # Ignore results for which their symbols is not tracked by the connector
                     continue
 
-                if Decimal(str(record["low"])) > 0 and Decimal(str(record["high"])) > 0:
-                    results[pair] = (Decimal(str(record["low"])) +
-                                     Decimal(str(record["high"]))) / Decimal("2")
+                try:
+                    low = Decimal(str(record["low"]))
+                    high = Decimal(str(record["high"]))
+                    if low > 0 and high > 0:
+                        results[pair] = (low + high) / Decimal("2")
+                except Exception:
+                    continue
         except Exception:
             self.logger().exception(
                 msg="Unexpected error while retrieving rates from Dexalot. Check the log file for more info.",


### PR DESCRIPTION
**Fixes #7335**

### Context
When using the Dexalot rate oracle source, dirty data in `record["low"]` and `record["high"]` (such as `None` or empty strings) would cause `Decimal` to crash with an `InvalidOperation` exception, abruptly terminating the process. 
Furthermore, when exceptions correctly bubbled up in queued order processing, the exception handler itself crashed due to `AttributeError` on a `NoneType` `self.clock` (when clock is None), destroying the exception stack trace and halting execution improperly.

### Resolution
- Wrapped the rate oracle record parsing in a `try/except` block to safely drop improperly formatted and missing rate data from Dexalot.
- Added a proper `getattr()` and `None` fallback check for `self.clock` within the `except Exception:` block. This ensures safe execution fallback when the component handles secondary exceptions.
