### PR TITLE
fix / hyperliquid: remove stale positions after partial close

### DIFF
--- a/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_derivative.py
@@ -1156,6 +1156,7 @@ class HyperliquidPerpetualDerivative(PerpetualDerivativePyBase):
 
         # Process all positions
         processed_coins = set()  # Track processed coins to avoid duplicates
+        seen_keys = set()
         for position in all_positions:
             position = position.get("position")
             ex_trading_pair = position.get("coin")
@@ -1177,6 +1178,7 @@ class HyperliquidPerpetualDerivative(PerpetualDerivativePyBase):
             amount = Decimal(position.get("szi", 0))
             leverage = Decimal(position.get("leverage").get("value"))
             pos_key = self._perpetual_trading.position_key(hb_trading_pair, position_side)
+            seen_keys.add(pos_key)
             if amount != 0:
                 _position = Position(
                     trading_pair=hb_trading_pair,
@@ -1189,9 +1191,12 @@ class HyperliquidPerpetualDerivative(PerpetualDerivativePyBase):
                 self._perpetual_trading.set_position(pos_key, _position)
             else:
                 self._perpetual_trading.remove_position(pos_key)
-        if not all_positions:
-            keys = list(self._perpetual_trading.account_positions.keys())
-            for key in keys:
+
+        # Remove any cached position that the exchange no longer reports.
+        # Hyperliquid omits closed positions from assetPositions entirely, so the old
+        # "only clean up when list is empty" guard left stale entries in the cache forever.
+        for key in list(self._perpetual_trading.account_positions.keys()):
+            if key not in seen_keys:
                 self._perpetual_trading.remove_position(key)
 
     async def _get_position_mode(self) -> Optional[PositionMode]:

--- a/test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_derivative.py
@@ -3090,6 +3090,66 @@ class HyperliquidPerpetualDerivativeTests(AbstractPerpetualDerivativeTests.Perpe
         self.assertLess(pos.amount, 0)
 
     @aioresponses()
+    def test_update_positions_removes_stale_on_partial_close(self, mock_api):
+        """Closed positions must be evicted from the cache even when other positions remain open.
+
+        Hyperliquid omits closed positions from assetPositions entirely — it does not return
+        them with szi=0.  If only some positions are closed the response is non-empty, so the
+        previous 'if not all_positions' guard was never triggered and stale entries remained in
+        account_positions indefinitely.
+        """
+        self._simulate_trading_rules_initialized()
+
+        url = web_utils.public_rest_url(CONSTANTS.POSITION_INFORMATION_URL)
+
+        # First poll: two open positions (BTC and ETH).
+        mock_api.post(url, body=json.dumps({
+            "assetPositions": [
+                {
+                    "position": {
+                        "coin": "BTC",
+                        "szi": "0.5",
+                        "entryPx": "50000.0",
+                        "unrealizedPnl": "100.0",
+                        "leverage": {"value": 10},
+                    }
+                },
+                {
+                    "position": {
+                        "coin": "ETH",
+                        "szi": "2.0",
+                        "entryPx": "3000.0",
+                        "unrealizedPnl": "50.0",
+                        "leverage": {"value": 5},
+                    }
+                },
+            ]
+        }))
+        self.async_run_with_timeout(self.exchange._update_positions())
+        self.assertEqual(2, len(self.exchange.account_positions))
+
+        # Second poll: ETH position closed — exchange returns only BTC.
+        mock_api.post(url, body=json.dumps({
+            "assetPositions": [
+                {
+                    "position": {
+                        "coin": "BTC",
+                        "szi": "0.5",
+                        "entryPx": "50000.0",
+                        "unrealizedPnl": "120.0",
+                        "leverage": {"value": 10},
+                    }
+                }
+            ]
+        }))
+        self.async_run_with_timeout(self.exchange._update_positions())
+
+        positions = self.exchange.account_positions
+        self.assertEqual(1, len(positions), "Stale ETH position was not removed after it closed on exchange")
+        pos = list(positions.values())[0]
+        self.assertEqual("BTC-USD", pos.trading_pair)
+
+    @aioresponses()
     def test_get_last_traded_price_for_hip3_market(self, mock_api):
         """Test _get_last_traded_price for HIP-3 market includes dex param."""
         self._simulate_trading_rules_initialized()


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] Tests all pass
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Closes #8215.

`_update_positions` left closed positions in `account_positions` indefinitely whenever other positions remained open. The root cause is that Hyperliquid's `clearinghouseState` API omits closed positions from `assetPositions` entirely — it does not return them with `szi=0`. The old reconciliation loop only touched positions the exchange *did* return, so a position that vanished from the response was never evicted. The guard `if not all_positions` only fired when the response was completely empty, which never happens while any other position is open.

**Change:** added `seen_keys` tracking during the reconciliation loop. After the loop, any key present in `account_positions` but absent from `seen_keys` is removed. This replaces the `if not all_positions` block entirely and covers all cases correctly:

```python
seen_keys = set()
for position in all_positions:
    ...
    seen_keys.add(pos_key)
    ...

# Evict cached positions no longer reported by the exchange.
for key in list(self._perpetual_trading.account_positions.keys()):
    if key not in seen_keys:
        self._perpetual_trading.remove_position(key)
```

Files changed:
- `hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_derivative.py` — fix in `_update_positions`
- `test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_derivative.py` — new regression test `test_update_positions_removes_stale_on_partial_close`

**Tests performed by the developer**:

- New regression test `test_update_positions_removes_stale_on_partial_close`: seeds cache with BTC+ETH, polls with only BTC returned, asserts ETH is evicted.
- All existing `test_update_positions_*` tests still pass.
- Ran: `pytest test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_derivative.py` — all pass.

**Tips for QA testing**:

1. Open two perpetual positions on Hyperliquid (e.g. BTC-USD and ETH-USD).
2. Close one of them manually on the Hyperliquid UI.
3. Wait one polling cycle (~5 s).
4. Check `connector.account_positions` — before this fix the closed position remained; after the fix it is gone.