### PR TITLE
fix(xrpl): carry custom markets through startup config

### DIFF
--- a/hummingbot/connector/exchange/xrpl/xrpl_exchange.py
+++ b/hummingbot/connector/exchange/xrpl/xrpl_exchange.py
@@ -62,6 +62,7 @@ from hummingbot.connector.exchange.xrpl.xrpl_utils import (  # AddLiquidityReque
     PoolInfo,
     QuoteLiquidityResponse,
     RemoveLiquidityResponse,
+    XRPLConfigMap,
     XRPLMarket,
     XRPLNodePool,
     autofill,
@@ -107,6 +108,7 @@ class XrplExchange(ExchangePyBase):
         trading_pairs: Optional[List[str]] = None,
         trading_required: bool = True,
         custom_markets: Optional[Dict[str, XRPLMarket]] = None,
+        connector_configuration: Optional[XRPLConfigMap] = None,
     ):
         self._xrpl_secret_key = xrpl_secret_key
 
@@ -136,7 +138,10 @@ class XrplExchange(ExchangePyBase):
         self._trading_pair_fee_rules: Dict[str, Dict[str, Any]] = {}
 
         self._nonce_creator = NonceCreator.for_milliseconds()
-        self._custom_markets = custom_markets or {}
+        if connector_configuration is not None:
+            self._custom_markets = connector_configuration.custom_markets or {}
+        else:
+            self._custom_markets = custom_markets or {}
         self._last_clients_refresh_time = 0
 
         # Order state locking to prevent concurrent status updates

--- a/hummingbot/connector/exchange/xrpl/xrpl_utils.py
+++ b/hummingbot/connector/exchange/xrpl/xrpl_utils.py
@@ -437,6 +437,8 @@ class XRPLConfigMap(BaseConnectorConfigMap):
         },
     )
 
+    receive_connector_configuration: bool = Field(default=True)
+
     max_request_per_minute: int = Field(
         default=12,
         json_schema_extra={

--- a/test/hummingbot/connector/exchange/xrpl/test_xrpl_utils.py
+++ b/test/hummingbot/connector/exchange/xrpl/test_xrpl_utils.py
@@ -24,6 +24,7 @@ from hummingbot.connector.exchange.xrpl.xrpl_utils import (
     get_token_from_changes,
     parse_offer_create_transaction,
 )
+from hummingbot.connector.exchange.xrpl.xrpl_exchange import XrplExchange
 
 
 class TestXRPLUtils(IsolatedAsyncioWrapperTestCase):
@@ -277,6 +278,38 @@ class TestXRPLUtils(IsolatedAsyncioWrapperTestCase):
         self.assertIn("BBRL-RLUSD", api_keys["custom_markets"])
         self.assertEqual(api_keys["custom_markets"]["BBRL-RLUSD"].base, "BBRL")
         self.assertEqual(api_keys["custom_markets"]["BBRL-RLUSD"].quote, "RLUSD")
+
+    def test_connector_configuration_custom_markets_are_used(self):
+        """Custom markets forwarded through connector_configuration should be usable at startup."""
+        from hummingbot.connector.exchange.xrpl.xrpl_utils import XRPLMarket
+
+        custom_market = XRPLMarket(
+            base="BBRL",
+            quote="RLUSD",
+            base_issuer="rBBRLissuerAddress",
+            quote_issuer="rRLUSDissuerAddress",
+            trading_pair_symbol="BBRL-RLUSD",
+        )
+        config_map = XRPLConfigMap(
+            xrpl_secret_key="test_secret_key",
+            wss_node_urls=["wss://xrplcluster.com/"],
+            custom_markets={"BBRL-RLUSD": custom_market},
+            max_request_per_minute=12,
+        )
+
+        exchange = XrplExchange(
+            xrpl_secret_key="test_secret_key",
+            wss_node_urls=["wss://xrplcluster.com/"],
+            max_request_per_minute=12,
+            trading_pairs=["BBRL-RLUSD"],
+            trading_required=False,
+            connector_configuration=config_map,
+        )
+
+        base_currency, quote_currency = exchange.get_currencies_from_trading_pair("BBRL-RLUSD")
+
+        self.assertEqual(base_currency.issuer, "rBBRLissuerAddress")
+        self.assertEqual(quote_currency.issuer, "rRLUSDissuerAddress")
 
     async def test_auto_fill(self):
         client = AsyncMock()


### PR DESCRIPTION
**A description of the changes proposed in the pull request**:

  This PR carries the XRPL `custom_markets` configuration through connector startup so that custom market definitions
  are available when the exchange is initialized.

  Changes:
  - `XrplExchange` now uses the connector configuration when available.
  - `XRPLConfigMap` forwards the connector configuration into the exchange startup path.
  - Added regression coverage for resolving a custom XRPL market from connector configuration during startup.

  **Tests performed by the developer**:

  - `python -m py_compile hummingbot/connector/exchange/xrpl/xrpl_exchange.py hummingbot/connector/exchange/xrpl/
  xrpl_utils.py test/hummingbot/connector/exchange/xrpl/test_xrpl_utils.py`

  **Tips for QA testing**:

  - Configure XRPL with a custom market such as `BBRL-RLUSD`.
  - Start the connector from the config path used by Hummingbot.
  - Verify the custom market resolves correctly at startup and is available for trading pair lookups.
  - Confirm the behavior matches the original XRPL startup regression repro.