### PR TITLE
(fix) Bybit WS order book snapshot timestamp scaling

### DIFF
--- a/hummingbot/connector/exchange/bybit/bybit_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/bybit/bybit_api_order_book_data_source.py
@@ -234,7 +234,7 @@ class BybitAPIOrderBookDataSource(OrderBookTrackerDataSource):
                 trading_pair = await self._connector.trading_pair_associated_to_exchange_symbol(
                     symbol=data["s"])
                 order_book_message: OrderBookMessage = BybitOrderBook.snapshot_message_from_exchange_websocket(
-                    data, json_msg["ts"], {"trading_pair": trading_pair})
+                    data, json_msg["ts"] * 1e-3, {"trading_pair": trading_pair})
                 snapshot_queue.put_nowait(order_book_message)
             except asyncio.CancelledError:
                 raise

--- a/test/hummingbot/connector/exchange/bybit/test_bybit_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/bybit/test_bybit_api_order_book_data_source.py
@@ -585,26 +585,12 @@ class TestBybitAPIOrderBookDataSource(IsolatedAsyncioWrapperTestCase):
             "data": {
                 "s": f"{self.ex_trading_pair}",
                 "b": [
-                    ...,
-                    [
-                        "16493.50",
-                        "0.006"
-                    ],
-                    [
-                        "16493.00",
-                        "0.100"
-                    ]
+                    ["16493.50", "0.006"],
+                    ["16493.00", "0.100"],
                 ],
                 "a": [
-                    [
-                        "16611.00",
-                        "0.029"
-                    ],
-                    [
-                        "16612.00",
-                        "0.213"
-                    ],
-                    ...,
+                    ["16611.00", "0.029"],
+                    ["16612.00", "0.213"],
                 ],
                 "u": 18521288,
                 "seq": 7961638724
@@ -612,20 +598,23 @@ class TestBybitAPIOrderBookDataSource(IsolatedAsyncioWrapperTestCase):
             "cts": 1672304484976
         }
         mock_queue.get.side_effect = [snapshot_event, asyncio.CancelledError()]
-        self.ob_data_source._message_queue["order_book_diff"] = mock_queue
+        self.ob_data_source._message_queue["order_book_snapshot"] = mock_queue
 
         msg_queue: asyncio.Queue = asyncio.Queue()
 
         try:
             self.listening_task = self.local_event_loop.create_task(
-                self.ob_data_source.listen_for_order_book_diffs(self.local_event_loop, msg_queue)
+                self.ob_data_source._process_ob_snapshot(snapshot_queue=msg_queue)
             )
         except asyncio.CancelledError:
             pass
 
         msg: OrderBookMessage = await msg_queue.get()
 
-        self.assertTrue(snapshot_event["data"]["u"], msg.update_id)
+        self.assertEqual(snapshot_event["data"]["u"], msg.update_id)
+        # ts is delivered by Bybit V5 in milliseconds; the message timestamp must be in seconds
+        # to stay consistent with REST snapshots and WS diffs (which already apply 1e-3).
+        self.assertEqual(snapshot_event["ts"] * 1e-3, msg.timestamp)
 
     # Dynamic subscription tests
     async def test_subscribe_to_trading_pair_successful(self):


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] Tests all pass
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

In `BybitAPIOrderBookDataSource._process_ob_snapshot` the websocket snapshot path passed `json_msg["ts"]` directly as the `OrderBookMessage` timestamp. Bybit V5 delivers all timestamps in milliseconds, and the three other paths in this file already convert to seconds:

| Path | Conversion |
|---|---|
| `_order_book_snapshot` (REST) | `float(snapshot["ts"]) * 1e-3` |
| `_parse_order_book_diff_message` (WS diff) | `raw_message["ts"] * 1e-3` |
| `_take_full_order_book_snapshot` (REST refresh) | `float(snapshot["ts"]) * 1e-3` |
| `_process_ob_snapshot` (WS snapshot) | `json_msg["ts"]` ← missing `* 1e-3` |

The websocket snapshot path was the only one missing the `1e-3` scaling, so WS-pushed snapshots ended up with timestamps roughly three orders of magnitude larger than every other source. This breaks ordering against REST snapshots (which run hourly) and any downstream consumer that mixes WS snapshot timestamps with WS diff or REST snapshot timestamps.

The fix applies the same `* 1e-3` scaling already used by the other three paths.

This may be related to #7953 (Bybit order book bid/ask size not matching the exchange UI), since stale or out-of-order snapshots can cause the local book to drift from the exchange state. Filing as a standalone consistency fix rather than claiming a definitive close, since reproducing #7953 requires comparing live exchange data against the local book.

**Tests performed by the developer**:

The existing `test_listen_for_order_book_snapshots_successful_ws` test in `test_bybit_api_order_book_data_source.py` did not actually exercise the websocket snapshot path:

- it routed the snapshot-shaped message into the `order_book_diff` queue and ran `listen_for_order_book_diffs`, so it exercised the diff code path instead of `_process_ob_snapshot`
- the bid/ask fixture contained `Ellipsis` (`...`) entries mixed with real `[price, size]` rows, which was an accidental placeholder rather than valid order book data
- it asserted only `update_id` with `assertTrue`, so it would have passed for any truthy value

The rewritten test feeds the snapshot event into the `order_book_snapshot` queue, calls `_process_ob_snapshot` directly, and asserts both `update_id` and the scaled timestamp (`ts * 1e-3 == msg.timestamp`).

**Tips for QA testing**:

1. Subscribe to a Bybit spot order book in Hummingbot (e.g. `BTC-USDT`).
2. After receiving WS snapshots, inspect any logged or downstream-consumed `OrderBookMessage.timestamp` for that pair. Before this PR the value is on the order of `1.7e12` (milliseconds-as-seconds); after this PR it should be a normal Unix timestamp in seconds (`~1.7e9`).
3. The REST snapshot path (taken on startup and every hour) and the WS diff path are unchanged.