### PR TITLE
(fix) kucoin_perpetual order placement fails with 330005 margin mode mismatch (#8224)

### DIFF
--- a/hummingbot/connector/derivative/kucoin_perpetual/kucoin_perpetual_constants.py
+++ b/hummingbot/connector/derivative/kucoin_perpetual/kucoin_perpetual_constants.py
@@ -14,6 +14,7 @@ REST_URLS = {"kucoin_perpetual_main": "https://api-futures.kucoin.com/"}
 WSS_PUBLIC_URLS = {"kucoin_perpetual_main": "wss://stream.kucoin.com/realtime_public"}
 WSS_PRIVATE_URLS = {"kucoin_perpetual_main": "wss://stream.kucoin.com/realtime_private"}
 REST_API_VERSION = "api/v1"
+REST_API_VERSION_V2 = "api/v2"
 
 HB_PARTNER_ID = "Hummingbot"
 HB_PARTNER_KEY = "8fb50686-81a8-408a-901c-07c5ac5bd758"
@@ -54,6 +55,7 @@ QUERY_ORDER_BY_EXCHANGE_ORDER_ID_PATH_URL = f"{REST_API_VERSION}/orders/{{orderi
 QUERY_ORDER_BY_CLIENT_ORDER_ID_PATH_URL = f"{REST_API_VERSION}/orders/byClientOid?clientOid={{clientorderid}}"
 GET_RISK_LIMIT_LEVEL_PATH_URL = f"{REST_API_VERSION}/contracts/risk-limit/{{symbol}}"
 SET_LEVERAGE_PATH_URL = f"{REST_API_VERSION}/position/risk-limit-level/change"
+GET_MARGIN_MODE_PATH_URL = f"{REST_API_VERSION_V2}/position/getMarginMode"
 GET_RECENT_FILLS_INFO_PATH_URL = f"{REST_API_VERSION}/recentFills"
 GET_FILL_INFO_PATH_URL = f"{REST_API_VERSION}/fills?orderId={{orderid}}"
 GET_WALLET_BALANCE_PATH_URL = f"{REST_API_VERSION}/account-overview?currency={{currency}}"
@@ -94,6 +96,10 @@ ORDER_STATE = {
     "cancelExist": OrderState.CANCELED,
 }
 
+# Margin mode values accepted by the Place Order endpoint's marginMode field
+MARGIN_MODE_ISOLATED = "ISOLATED"
+MARGIN_MODE_CROSS = "CROSS"
+
 # Request error codes
 RET_CODE_OK = "200000"
 RET_CODE_PARAMS_ERROR = "100001"
@@ -104,6 +110,7 @@ RET_CODE_MODE_NOT_MODIFIED = "300010"
 RET_CODE_LEVERAGE_NOT_MODIFIED = "300016"
 RET_CODE_POSITION_ZERO = "300009"
 RET_CODE_AUTH_TIMESTAMP_ERROR = "400002"
+RET_CODE_MARGIN_MODE_MISMATCH = "330005"
 
 NO_LIMIT = sys.maxsize
 RATE_LIMITS = [
@@ -116,6 +123,7 @@ RATE_LIMITS = [
     RateLimit(limit_id=ORDER_BOOK_ENDPOINT, limit=30, time_interval=3),
     RateLimit(limit_id=SERVER_TIME_PATH_URL, limit=NO_LIMIT, time_interval=1),
     RateLimit(limit_id=SET_LEVERAGE_PATH_URL, limit=NO_LIMIT, time_interval=1),
+    RateLimit(limit_id=GET_MARGIN_MODE_PATH_URL, limit=9, time_interval=3),
     RateLimit(limit_id=GET_LAST_FUNDING_RATE_PATH_URL, limit=9, time_interval=3),
     RateLimit(limit_id=GET_POSITIONS_PATH_URL, limit=9, time_interval=3),
     RateLimit(limit_id=QUERY_ORDER_BY_EXCHANGE_ORDER_ID_PATH_URL, limit=30, time_interval=3),

--- a/hummingbot/connector/derivative/kucoin_perpetual/kucoin_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/kucoin_perpetual/kucoin_perpetual_derivative.py
@@ -57,6 +57,11 @@ class KucoinPerpetualDerivative(PerpetualDerivativePyBase):
         self._trading_pairs = trading_pairs
         self._domain = domain
         self._last_trade_history_timestamp = None
+        # Per-trading-pair cache of the exchange-side margin mode ("ISOLATED" or "CROSS").
+        # Populated lazily by _get_margin_mode() on first order placement so the order
+        # payload's marginMode field matches the user's configured mode and avoids the
+        # 330005 "order's margin mode does not match" rejection.
+        self._margin_mode_cache: Dict[str, str] = {}
 
         super().__init__(balance_asset_limit, rate_limits_share_pct)
 
@@ -195,6 +200,14 @@ class KucoinPerpetualDerivative(PerpetualDerivativePyBase):
             "type": CONSTANTS.ORDER_TYPE_MAP[order_type],
             "leverage": str(self.get_leverage(trading_pair)),
         }
+        # marginMode is an optional field on the Place Order endpoint, but when omitted
+        # KuCoin applies an account-level default that may not match the per-contract
+        # margin mode the user configured on the exchange — producing error 330005.
+        # _get_margin_mode caches the value per trading pair after the first lookup;
+        # if the lookup fails we fall back to the legacy omit-the-field behaviour.
+        margin_mode = await self._get_margin_mode(trading_pair)
+        if margin_mode is not None:
+            data["marginMode"] = margin_mode
         if order_type.is_limit_type():
             data["price"] = float(price)
             if order_type is OrderType.LIMIT_MAKER:
@@ -862,6 +875,59 @@ class KucoinPerpetualDerivative(PerpetualDerivativePyBase):
             self.logger().error(f"Max leverage for {trading_pair} is {max_leverage}.")
             return False, f"Max leverage for {trading_pair} is {max_leverage}."
         return True, ""
+
+    async def _get_margin_mode(self, trading_pair: str) -> Optional[str]:
+        """
+        Look up the exchange-side margin mode ("ISOLATED" or "CROSS") for the given
+        trading pair, with an in-memory cache that fills on first call.
+
+        The value is returned for inclusion in the Place Order payload so the order's
+        marginMode field matches the user's per-contract setting on KuCoin, avoiding
+        error 330005 ("The order's margin mode does not match the selected one").
+
+        Returns None on any failure (HTTP error, unexpected response shape, missing
+        field). The caller treats None as "omit marginMode from the order payload",
+        which reproduces the pre-fix behaviour and avoids regressing accounts where
+        the absent-field default already matches.
+        """
+        cached = self._margin_mode_cache.get(trading_pair)
+        if cached is not None:
+            return cached
+        try:
+            exchange_symbol = await self.exchange_symbol_associated_to_pair(trading_pair)
+            resp: Dict[str, Any] = await self._api_get(
+                path_url=CONSTANTS.GET_MARGIN_MODE_PATH_URL,
+                params={"symbol": exchange_symbol},
+                is_auth_required=True,
+                trading_pair=trading_pair,
+                limit_id=CONSTANTS.GET_MARGIN_MODE_PATH_URL,
+            )
+        except Exception as e:
+            self.logger().warning(
+                f"Failed to fetch margin mode for {trading_pair}: {e}. "
+                f"Order will be submitted without an explicit marginMode field."
+            )
+            return None
+        if not isinstance(resp, dict) or resp.get("code") != CONSTANTS.RET_CODE_OK:
+            formatted_ret_code = self._format_ret_code_for_print(
+                resp.get("code") if isinstance(resp, dict) else "unknown"
+            )
+            self.logger().warning(
+                f"Unexpected response when fetching margin mode for {trading_pair}: "
+                f"{formatted_ret_code}. Order will be submitted without an explicit "
+                f"marginMode field."
+            )
+            return None
+        margin_mode = (resp.get("data") or {}).get("marginMode")
+        if margin_mode not in (CONSTANTS.MARGIN_MODE_ISOLATED, CONSTANTS.MARGIN_MODE_CROSS):
+            self.logger().warning(
+                f"KuCoin returned unrecognised margin mode {margin_mode!r} for "
+                f"{trading_pair}. Order will be submitted without an explicit "
+                f"marginMode field."
+            )
+            return None
+        self._margin_mode_cache[trading_pair] = margin_mode
+        return margin_mode
 
     async def _fetch_last_fee_payment(self, trading_pair: str) -> Tuple[int, Decimal, Decimal]:
         exchange_symbol = await self.exchange_symbol_associated_to_pair(trading_pair)

--- a/test/hummingbot/connector/derivative/kucoin_perpetual/test_kucoin_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/kucoin_perpetual/test_kucoin_perpetual_derivative.py
@@ -1779,3 +1779,123 @@ class KucoinPerpetualDerivativeTests(AbstractPerpetualDerivativeTests.PerpetualD
                 message=f"Error setting leverage {target_leverage} for {self.trading_pair}: Max leverage for {self.trading_pair} is {max_leverage}.",
             )
         )
+
+    def _margin_mode_url_regex(self):
+        url = web_utils.get_rest_url_for_endpoint(endpoint=CONSTANTS.GET_MARGIN_MODE_PATH_URL)
+        return re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?") + ".*")
+
+    def _mock_margin_mode_response(self, mock_api: aioresponses, margin_mode: str):
+        mock_response = {
+            "code": "200000",
+            "data": {
+                "symbol": self.exchange_trading_pair,
+                "marginMode": margin_mode,
+            },
+        }
+        mock_api.get(self._margin_mode_url_regex(), body=json.dumps(mock_response))
+
+    @aioresponses()
+    def test_place_order_includes_margin_mode_isolated(self, mock_api):
+        self._simulate_trading_rules_initialized()
+        self.exchange._set_current_timestamp(1640780000)
+
+        self._mock_margin_mode_response(mock_api, CONSTANTS.MARGIN_MODE_ISOLATED)
+        request_sent_event = asyncio.Event()
+        mock_api.post(
+            self.order_creation_url,
+            body=json.dumps(self.order_creation_request_successful_mock_response),
+            callback=lambda *args, **kwargs: request_sent_event.set(),
+        )
+
+        order_id = self.place_buy_limit_maker_order()
+        self.async_run_with_timeout(request_sent_event.wait())
+
+        order_request = self._all_executed_requests(mock_api, self.order_creation_url)[0]
+        request_data = json.loads(order_request.kwargs["data"])
+        self.assertEqual(CONSTANTS.MARGIN_MODE_ISOLATED, request_data["marginMode"])
+        self.assertIn(order_id, self.exchange.in_flight_orders)
+
+    @aioresponses()
+    def test_place_order_includes_margin_mode_cross(self, mock_api):
+        self._simulate_trading_rules_initialized()
+        self.exchange._set_current_timestamp(1640780000)
+
+        self._mock_margin_mode_response(mock_api, CONSTANTS.MARGIN_MODE_CROSS)
+        request_sent_event = asyncio.Event()
+        mock_api.post(
+            self.order_creation_url,
+            body=json.dumps(self.order_creation_request_successful_mock_response),
+            callback=lambda *args, **kwargs: request_sent_event.set(),
+        )
+
+        order_id = self.place_buy_limit_maker_order()
+        self.async_run_with_timeout(request_sent_event.wait())
+
+        order_request = self._all_executed_requests(mock_api, self.order_creation_url)[0]
+        request_data = json.loads(order_request.kwargs["data"])
+        self.assertEqual(CONSTANTS.MARGIN_MODE_CROSS, request_data["marginMode"])
+        self.assertIn(order_id, self.exchange.in_flight_orders)
+
+    @aioresponses()
+    def test_place_order_caches_margin_mode_per_pair(self, mock_api):
+        self._simulate_trading_rules_initialized()
+        self.exchange._set_current_timestamp(1640780000)
+
+        self._mock_margin_mode_response(mock_api, CONSTANTS.MARGIN_MODE_ISOLATED)
+        pending_events = [asyncio.Event(), asyncio.Event()]
+
+        def order_callback(*args, **kwargs):
+            pending_events.pop(0).set()
+
+        mock_api.post(
+            self.order_creation_url,
+            body=json.dumps(self.order_creation_request_successful_mock_response),
+            callback=order_callback,
+            repeat=True,
+        )
+
+        first_event, second_event = pending_events[0], pending_events[1]
+        self.place_buy_limit_maker_order()
+        self.async_run_with_timeout(first_event.wait())
+        self.place_buy_limit_maker_order(amount=Decimal("200"))
+        self.async_run_with_timeout(second_event.wait())
+
+        margin_mode_requests = self._all_executed_requests(mock_api, self._margin_mode_url_regex())
+        self.assertEqual(
+            1,
+            len(margin_mode_requests),
+            "Margin mode endpoint should only be hit once because the value is cached per trading pair.",
+        )
+        order_requests = self._all_executed_requests(mock_api, self.order_creation_url)
+        self.assertEqual(2, len(order_requests))
+        for order_request in order_requests:
+            request_data = json.loads(order_request.kwargs["data"])
+            self.assertEqual(CONSTANTS.MARGIN_MODE_ISOLATED, request_data["marginMode"])
+
+    @aioresponses()
+    def test_place_order_graceful_when_margin_mode_query_fails(self, mock_api):
+        self._simulate_trading_rules_initialized()
+        self.exchange._set_current_timestamp(1640780000)
+
+        mock_api.get(
+            self._margin_mode_url_regex(),
+            body=json.dumps({"code": "500001", "msg": "internal error"}),
+        )
+        request_sent_event = asyncio.Event()
+        mock_api.post(
+            self.order_creation_url,
+            body=json.dumps(self.order_creation_request_successful_mock_response),
+            callback=lambda *args, **kwargs: request_sent_event.set(),
+        )
+
+        order_id = self.place_buy_limit_maker_order()
+        self.async_run_with_timeout(request_sent_event.wait())
+
+        order_request = self._all_executed_requests(mock_api, self.order_creation_url)[0]
+        request_data = json.loads(order_request.kwargs["data"])
+        self.assertNotIn(
+            "marginMode",
+            request_data,
+            "marginMode must be omitted when the query fails so behaviour matches the pre-fix legacy path.",
+        )
+        self.assertIn(order_id, self.exchange.in_flight_orders)


### PR DESCRIPTION
## Summary

Fixes #8224. KuCoin perpetual order placement consistently failed with `ret_code <330005> - The order's margin mode does not match the selected one` because the connector built the order payload without a `marginMode` field. The endpoint treats `marginMode` as optional, but when omitted KuCoin applies an account-level default that does not necessarily match the per-contract margin mode the user configured on the exchange UI.

This change fetches the exchange-side margin mode for each trading pair (via the `api/v2/position/getMarginMode` endpoint) and echoes it back in the order payload. The value is cached per trading pair so each connector instance only hits the endpoint once per pair.

## Changes

- `kucoin_perpetual_constants.py`: add `GET_MARGIN_MODE_PATH_URL`, `MARGIN_MODE_ISOLATED`, `MARGIN_MODE_CROSS`, `RET_CODE_MARGIN_MODE_MISMATCH`, plus the rate-limit entry for the new endpoint.
- `kucoin_perpetual_derivative.py`: add `self._margin_mode_cache` and a new `_get_margin_mode(trading_pair)` helper. `_place_order` now includes `data["marginMode"]` whenever the helper returns a known value (`ISOLATED` or `CROSS`).
- Graceful fallback: if the `getMarginMode` call fails (HTTP error, non-200000 response, unrecognised mode), `_get_margin_mode` logs a warning and returns `None`, and `_place_order` omits the field. Accounts whose absent-field default already matched the per-contract mode see no behavioural change.

## Tests

Four new unit tests in `test_kucoin_perpetual_derivative.py`:

- `test_place_order_includes_margin_mode_isolated` — mock `getMarginMode` -> `ISOLATED`, assert order payload contains `marginMode: ISOLATED`.
- `test_place_order_includes_margin_mode_cross` — same for `CROSS`.
- `test_place_order_caches_margin_mode_per_pair` — two consecutive orders on the same pair only trigger one `getMarginMode` request.
- `test_place_order_graceful_when_margin_mode_query_fails` — endpoint returns a non-`200000` error response; order is still submitted, just without the `marginMode` field.

## Test plan

- [x] py_compile clean on all three edited files
- [ ] CI runs new unit tests (Hummingbot dev environment not installed locally)
- [ ] Manual reproduction once merged: a user with `ISOLATED` per-contract setting can place orders without 330005 rejection
