### PR TITLE
(fix) Bybit Perpetual REST order book snapshot timestamp scaling

### DIFF
--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_api_order_book_data_source.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_api_order_book_data_source.py
@@ -267,7 +267,13 @@ class BybitPerpetualAPIOrderBookDataSource(PerpetualAPIOrderBookDataSource):
     async def _order_book_snapshot(self, trading_pair: str) -> OrderBookMessage:
         snapshot_response = await self._request_order_book_snapshot(trading_pair)
         snapshot_data = snapshot_response["result"]
-        timestamp = float(snapshot_data["ts"])
+        # Bybit V5 returns the snapshot's `ts` field in milliseconds; the other
+        # paths in this file (_parse_order_book_diff_message, _parse_trade_message,
+        # _parse_funding_info_message) already convert to seconds, but the REST
+        # snapshot path was passing raw milliseconds straight through as the
+        # OrderBookMessage timestamp, leaving it ~1000x larger than every other
+        # source and breaking ordering against WS diffs.
+        timestamp = float(snapshot_data["ts"]) * 1e-3
         update_id = self._nonce_provider.get_tracking_nonce(timestamp=timestamp)
 
         bids, asks = self._get_bids_and_asks_from_rest_msg_data(snapshot_data)

--- a/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_api_order_book_data_source.py
@@ -642,8 +642,13 @@ class BybitPerpetualAPIOrderBookDataSourceTests(IsolatedAsyncioWrapperTestCase):
 
         self.assertEqual(OrderBookMessageType.SNAPSHOT, msg.type)
         self.assertEqual(-1, msg.trade_id)
-        self.assertEqual(float(resp["result"]["ts"]), msg.timestamp)
-        expected_update_id = float(resp["result"]["ts"]) * 1e6
+        # Bybit V5 `ts` is milliseconds; the snapshot path now scales it to
+        # seconds (* 1e-3) to match every other source. assertAlmostEqual
+        # because the 1e-3 multiply introduces float-rounding noise.
+        self.assertAlmostEqual(float(resp["result"]["ts"]) * 1e-3, msg.timestamp, places=3)
+        # update_id = NonceCreator.for_microseconds nonce of the seconds
+        # timestamp: int(seconds * 1e6) == ts_ms * 1e3.
+        expected_update_id = int(float(resp["result"]["ts"]) * 1e3)
         self.assertEqual(expected_update_id, msg.update_id)
 
         bids = msg.bids

--- a/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_api_order_book_data_source.py
@@ -313,7 +313,12 @@ class BybitPerpetualAPIOrderBookDataSourceTests(IsolatedAsyncioWrapperTestCase):
 
         order_book = await self.data_source.get_new_order_book(self.trading_pair)
 
-        expected_update_id = float(snapshot_data["ts"] * 1e6)
+        # NonceCreator.for_microseconds().get_tracking_nonce(timestamp=seconds)
+        # returns int(seconds * 1e6). With the REST snapshot ts now correctly
+        # converted from milliseconds to seconds before being passed to the
+        # nonce provider (ts_ms * 1e-3 * 1e6 == ts_ms * 1e3), the expected nonce
+        # is ts_ms * 1000, not the pre-fix ts_ms * 1e6 which conflated units.
+        expected_update_id = int(snapshot_data["ts"]) * 1000
 
         self.assertEqual(expected_update_id, order_book.snapshot_uid)
         bids = list(order_book.bid_entries())
@@ -326,6 +331,29 @@ class BybitPerpetualAPIOrderBookDataSourceTests(IsolatedAsyncioWrapperTestCase):
         self.assertEqual(65557.7, asks[0].price)
         self.assertEqual(16.606555, asks[0].amount)
         self.assertEqual(expected_update_id, asks[0].update_id)
+
+    @aioresponses()
+    async def test_order_book_snapshot_timestamp_is_scaled_to_seconds(self, mock_api):
+        """Regression: REST snapshot path used to pass `snapshot_data["ts"]`
+        (milliseconds per Bybit V5) directly as the OrderBookMessage timestamp,
+        leaving the value ~1000x larger than the WS diff path which already
+        scaled by 1e-3. The fix multiplies by 1e-3 to match the other paths
+        and to keep the timestamp comparable across REST and WS sources.
+        """
+        endpoint = CONSTANTS.ORDER_BOOK_ENDPOINT
+        url = web_utils.get_rest_url_for_endpoint(endpoint, self.trading_pair, self.domain)
+        regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
+        resp = self.get_rest_snapshot_msg()
+        raw_ts_ms = resp["result"]["ts"]
+        mock_api.get(regex_url, body=json.dumps(resp))
+
+        snapshot_msg = await self.data_source._order_book_snapshot(self.trading_pair)
+
+        self.assertEqual(OrderBookMessageType.SNAPSHOT, snapshot_msg.type)
+        self.assertAlmostEqual(raw_ts_ms / 1000.0, snapshot_msg.timestamp, places=3)
+        # Sanity-check: the timestamp is plausibly a recent Unix second, not a
+        # 13-digit millisecond value that would land beyond the year 56000.
+        self.assertLess(snapshot_msg.timestamp, 10 ** 11)
 
     @aioresponses()
     async def test_get_new_order_book_raises_exception(self, mock_api):


### PR DESCRIPTION
## Summary

Same anti-pattern as #8226 (Bybit Spot), but in the Perpetual connector and at a different code path.

`BybitPerpetualAPIOrderBookDataSource._order_book_snapshot` passed `snapshot_data["ts"]` directly as the `OrderBookMessage` timestamp. Bybit V5 returns all timestamps in milliseconds, and the three other paths in this file already convert to seconds:

- `_parse_order_book_diff_message` (WS): `int(raw_message["ts"]) / 1e3`
- `_parse_trade_message` (WS): `ts_ms * 1e-3`
- `_parse_funding_info_message` (WS): `int(entry["nextFundingTime"]) // 1e3`

The REST snapshot path was the only one missing the `1e-3` scaling, so it produced snapshots with a `timestamp` ~1000x larger than every WS source. The derived `update_id` (via `NonceCreator.for_microseconds`, which multiplies the supplied timestamp by 1e6) then conflated the millisecond and second units. This breaks ordering against WS diff messages (which run continuously) and any downstream consumer that mixes REST snapshot timestamps with WS diff timestamps.

## Changes

- `hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_api_order_book_data_source.py`: multiply the REST snapshot `ts` by `1e-3` at the only remaining unscaled site (line ~270), matching the other paths in the same file.

## Tests

- Updated `test_get_new_order_book_successful` whose `expected_update_id = float(ts * 1e6)` was encoding the pre-fix behaviour. After the fix, the timestamp arriving at the nonce provider is in seconds, so the resulting nonce is `ts_ms * 1000` not `ts_ms * 1e6`.
- Added `test_order_book_snapshot_timestamp_is_scaled_to_seconds` as a dedicated regression test that asserts the snapshot timestamp is in seconds (within 1e-3 of `ts_ms / 1000`) and is plausibly a recent Unix second rather than a 13-digit millisecond value.

## Test plan

- [x] `py_compile` clean on both files
- [ ] CI runs the regression tests
- [ ] Manual verification once merged: REST snapshot timestamps now align with WS diff timestamps (both in seconds, within tens of milliseconds of each other)
