### PR TITLE
(fix) Hyperliquid REST order book snapshot timestamp scaling (spot + perpetual)

### DIFF
--- a/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_api_order_book_data_source.py
+++ b/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_api_order_book_data_source.py
@@ -140,12 +140,19 @@ class HyperliquidPerpetualAPIOrderBookDataSource(PerpetualAPIOrderBookDataSource
     async def _order_book_snapshot(self, trading_pair: str) -> OrderBookMessage:
         snapshot_response: Dict[str, Any] = await self._request_order_book_snapshot(trading_pair)
         snapshot_response.update({"trading_pair": trading_pair})
+        # Hyperliquid returns `time` in milliseconds; the WS paths in this file
+        # (_parse_order_book_diff_message, _parse_order_book_snapshot_message,
+        # _parse_trade_message) already convert with `* 1e-3` before populating
+        # OrderBookMessage.timestamp, but the REST snapshot path was passing the
+        # raw millisecond value through, leaving the snapshot's timestamp
+        # ~1000x larger than every WS source.
+        snapshot_timestamp: float = int(snapshot_response['time']) * 1e-3
         snapshot_msg: OrderBookMessage = OrderBookMessage(OrderBookMessageType.SNAPSHOT, {
             "trading_pair": snapshot_response["trading_pair"],
             "update_id": int(snapshot_response['time']),
             "bids": [[float(i['px']), float(i['sz'])] for i in snapshot_response['levels'][0]],
             "asks": [[float(i['px']), float(i['sz'])] for i in snapshot_response['levels'][1]],
-        }, timestamp=int(snapshot_response['time']))
+        }, timestamp=snapshot_timestamp)
         return snapshot_msg
 
     async def _connected_websocket_assistant(self) -> WSAssistant:

--- a/hummingbot/connector/exchange/hyperliquid/hyperliquid_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/hyperliquid/hyperliquid_api_order_book_data_source.py
@@ -60,7 +60,13 @@ class HyperliquidAPIOrderBookDataSource(OrderBookTrackerDataSource):
     async def _order_book_snapshot(self, trading_pair: str) -> OrderBookMessage:
         snapshot: Dict[str, Any] = await self._request_order_book_snapshot(trading_pair)
         snapshot.update({"trading_pair": trading_pair})
-        snapshot_timestamp: float = snapshot['time']
+        # Hyperliquid returns `time` in milliseconds; the WS paths in this file
+        # (_parse_order_book_diff_message, _parse_order_book_snapshot_message)
+        # already convert with `* 1e-3` before populating
+        # OrderBookMessage.timestamp, but the REST snapshot path was passing the
+        # raw millisecond value through, leaving the snapshot's timestamp
+        # ~1000x larger than every WS source.
+        snapshot_timestamp: float = int(snapshot['time']) * 1e-3
         snapshot_msg: OrderBookMessage = HyperliquidOrderBook.snapshot_message_from_exchange(
             snapshot,
             snapshot_timestamp,

--- a/test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_api_order_book_data_source.py
@@ -183,6 +183,29 @@ class HyperliquidPerpetualAPIOrderBookDataSourceTests(IsolatedAsyncioWrapperTest
         with self.assertRaises(IOError):
             await self.data_source.get_new_order_book(self.trading_pair)
 
+    @aioresponses()
+    async def test_order_book_snapshot_timestamp_is_scaled_to_seconds(self, mock_api):
+        """Regression: REST snapshot path used to pass `snapshot_response['time']`
+        (Hyperliquid returns it in milliseconds) directly as the
+        OrderBookMessage timestamp, leaving the value ~1000x larger than the WS
+        diff/snapshot/trade paths which already scaled by 1e-3. The fix
+        multiplies by 1e-3 to match the other paths.
+        """
+        endpoint = CONSTANTS.SNAPSHOT_REST_URL
+        url = web_utils.public_rest_url(endpoint)
+        regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?") + ".*")
+        resp = self.get_rest_snapshot_msg()
+        raw_ts_ms = resp["time"]
+        mock_api.post(regex_url, body=json.dumps(resp))
+
+        snapshot_msg = await self.data_source._order_book_snapshot(self.trading_pair)
+
+        self.assertEqual(OrderBookMessageType.SNAPSHOT, snapshot_msg.type)
+        self.assertAlmostEqual(raw_ts_ms / 1000.0, snapshot_msg.timestamp, places=3)
+        # Sanity-check: the timestamp is plausibly a recent Unix second, not a
+        # 13-digit millisecond value that would land beyond the year 56000.
+        self.assertLess(snapshot_msg.timestamp, 10 ** 11)
+
     @patch("aiohttp.ClientSession.ws_connect", new_callable=AsyncMock)
     async def test_listen_for_subscriptions_subscribes_to_trades_diffs_and_orderbooks(self, ws_connect_mock):
         ws_connect_mock.return_value = self.mocking_assistant.create_websocket_mock()

--- a/test/hummingbot/connector/exchange/hyperliquid/test_hyperliquid_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/hyperliquid/test_hyperliquid_api_order_book_data_source.py
@@ -219,6 +219,30 @@ class HyperliquidAPIOrderBookDataSourceTests(IsolatedAsyncioWrapperTestCase):
         with self.assertRaises(IOError):
             await self.data_source.get_new_order_book(self.trading_pair)
 
+    @aioresponses()
+    async def test_order_book_snapshot_timestamp_is_scaled_to_seconds(self, mock_api):
+        """Regression: REST snapshot path used to pass `snapshot['time']`
+        (Hyperliquid returns it in milliseconds) directly as the
+        OrderBookMessage timestamp, leaving the value ~1000x larger than the WS
+        diff/snapshot paths which already scaled by 1e-3. The fix multiplies by
+        1e-3 to match the other paths.
+        """
+        self._simulate_trading_rules_initialized()
+        endpoint = CONSTANTS.SNAPSHOT_REST_URL
+        url = web_utils.public_rest_url(endpoint)
+        regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?") + ".*")
+        resp = self.get_rest_snapshot_msg()
+        raw_ts_ms = resp["time"]
+        mock_api.post(regex_url, body=json.dumps(resp))
+
+        snapshot_msg = await self.data_source._order_book_snapshot(self.trading_pair)
+
+        self.assertEqual(OrderBookMessageType.SNAPSHOT, snapshot_msg.type)
+        self.assertAlmostEqual(raw_ts_ms / 1000.0, snapshot_msg.timestamp, places=3)
+        # Sanity-check: the timestamp is plausibly a recent Unix second, not a
+        # 13-digit millisecond value that would land beyond the year 56000.
+        self.assertLess(snapshot_msg.timestamp, 10 ** 11)
+
     @patch("aiohttp.ClientSession.ws_connect", new_callable=AsyncMock)
     async def test_listen_for_subscriptions_subscribes_to_trades_diffs_and_orderbooks(self, ws_connect_mock):
         self._simulate_trading_rules_initialized()


### PR DESCRIPTION
## Summary

Same anti-pattern as #8226 (Bybit Spot), #8229 (Bybit Perpetual), and #8230 (OKX Perpetual) — but applied to **both** Hyperliquid OBDS files (spot exchange and perpetual derivative).

Both `_order_book_snapshot` methods pass the REST snapshot's `time` field directly as the `OrderBookMessage.timestamp`:

| File | Line | Code |
|---|---|---|
| `exchange/hyperliquid/hyperliquid_api_order_book_data_source.py` | 63 | `snapshot_timestamp: float = snapshot['time']` |
| `derivative/hyperliquid_perpetual/hyperliquid_perpetual_api_order_book_data_source.py` | 148 | `}, timestamp=int(snapshot_response['time']))` |

Hyperliquid returns `time` in milliseconds, which every WS path in both files already converts with `* 1e-3` before populating the message timestamp (`_parse_order_book_diff_message`, `_parse_order_book_snapshot_message`, `_parse_trade_message`). The REST snapshot was the only path that left the value in milliseconds, leaving snapshots with a `timestamp` ~1000x larger than every WS source. This breaks ordering against WS diffs and any downstream consumer that mixes REST snapshot timestamps with WS diff or trade timestamps.

## Changes

- `hummingbot/connector/exchange/hyperliquid/hyperliquid_api_order_book_data_source.py`: scale REST snapshot `time` by `1e-3`.
- `hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_api_order_book_data_source.py`: scale REST snapshot `time` by `1e-3`.

## Tests

The existing `test_get_new_order_book_successful` tests in both connectors already pass after the fix because they assert `snapshot_uid` (derived from `int(msg['time'])` independently of the timestamp argument). Two new dedicated regression tests (`test_order_book_snapshot_timestamp_is_scaled_to_seconds`, one per connector) call `_order_book_snapshot` directly and assert the resulting `OrderBookMessage.timestamp` is within 1e-3 of `raw_ts_ms / 1000` and is plausibly a recent Unix second rather than a 13-digit millisecond value.

## Test plan

- [x] `py_compile` clean on all four files
- [ ] CI runs the new regression tests and the existing tests
- [ ] Manual verification once merged: Hyperliquid REST snapshot timestamps now align with WS message timestamps
