### PR TITLE
fix: coerce Kraken fill timestamp to float (#8199)

### DIFF
--- a/hummingbot/connector/exchange/kraken/kraken_exchange.py
+++ b/hummingbot/connector/exchange/kraken/kraken_exchange.py
@@ -490,7 +490,10 @@ class KrakenExchange(ExchangePyBase):
             fill_base_amount=Decimal(order_fill["vol"]),
             fill_quote_amount=Decimal(order_fill["vol"]) * Decimal(order_fill["price"]),
             fill_price=Decimal(order_fill["price"]),
-            fill_timestamp=order_fill["time"],
+            # Kraken returns the fill time as a numeric string in some payloads
+            # (e.g. ownTrades) and a float in others; coerce so that
+            # InFlightOrder.last_update_timestamp keeps its declared float type.
+            fill_timestamp=float(order_fill["time"]),
         )
         return trade_update
 

--- a/test/hummingbot/connector/exchange/kraken/test_kraken_exchange.py
+++ b/test/hummingbot/connector/exchange/kraken/test_kraken_exchange.py
@@ -1369,3 +1369,33 @@ class KrakenExchangeTests(AbstractExchangeConnectorTests.ExchangeConnectorTests)
 
             # Verify the result
             self.assertEqual(self.latest_prices_request_mock_response["result"], ticker_data)
+
+    def test_create_trade_update_handles_string_fill_timestamp(self):
+        # Regression for #8199: Kraken returns the fill time as a numeric
+        # string in some payloads (ownTrades). It must be coerced to float so
+        # InFlightOrder.last_update_timestamp keeps its declared float type and
+        # downstream consumers (e.g. controllers calling max()) do not crash
+        # with "'>' not supported between instances of 'str' and 'float'".
+        self.exchange._set_current_timestamp(1640780000)
+        self.exchange.start_tracking_order(
+            order_id="OID1",
+            exchange_order_id="100234",
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            trade_type=TradeType.BUY,
+            price=Decimal("10000"),
+            amount=Decimal("1"),
+        )
+        order = self.exchange.in_flight_orders["OID1"]
+        order_fill = {
+            "trade_id": 30000,
+            "ordertxid": "OQCLML-BW3P3-BUCMWZ",
+            "fee": "30",
+            "vol": "1",
+            "price": "10000",
+            "time": "1560516023.070651",
+        }
+        trade_update = self.exchange._create_trade_update_with_order_fill_data(
+            order_fill=order_fill, order=order)
+        self.assertIsInstance(trade_update.fill_timestamp, float)
+        self.assertEqual(trade_update.fill_timestamp, 1560516023.070651)


### PR DESCRIPTION
## Summary
Fixes #8199. On partial fills with the Kraken connector, the bot enters an infinite per-tick error loop and freezes:
`'>' not supported between instances of 'str' and 'float'` (raised from `max(open_order_updates)` in `controllers/generic/pmm_mister.py`).

## Root cause
`KrakenExchange._create_trade_update_with_order_fill_data()` builds `TradeUpdate(fill_timestamp=order_fill["time"])`. Kraken returns the fill `time` as a **numeric string** in some payloads (e.g. `ownTrades` — see existing test fixture `"time": "1560516023.070651"`) and a **float** in others. The raw string propagates into `InFlightOrder.last_update_timestamp` (declared `: float`) via `TradeUpdate.fill_timestamp`. Any consumer that orders/aggregates that value across executors (here `max([...])` over a mix of `str` and `float`) then raises `TypeError` every control tick, freezing the client until the order is manually closed.

## Fix
Coerce `order_fill["time"]` to `float` at the connector boundary so the declared `InFlightOrder.last_update_timestamp: float` contract is upheld for all consumers. Kraken `time` is always a unix-epoch value (string or float), never ISO, so `float()` is correct and total.

## Changes
- `hummingbot/connector/exchange/kraken/kraken_exchange.py`: `fill_timestamp=float(order_fill["time"])` (+ comment).
- `test/.../kraken/test_kraken_exchange.py`: +1 regression test asserting a string `time` yields a `float` `fill_timestamp`.

## Testing
`pytest test/hummingbot/connector/exchange/kraken/test_kraken_exchange.py` -> **50 passed** (49 existing + 1 new) on a locally-built Cython env. flake8 clean.