### PR TITLE
fix: coerce Gate.io fill timestamp to float (#8199-class)

### DIFF
--- a/hummingbot/connector/exchange/gate_io/gate_io_exchange.py
+++ b/hummingbot/connector/exchange/gate_io/gate_io_exchange.py
@@ -463,7 +463,9 @@ class GateIoExchange(ExchangePyBase):
             fill_base_amount=Decimal(order_fill["amount"]),
             fill_quote_amount=Decimal(order_fill["amount"]) * Decimal(order_fill["price"]),
             fill_price=Decimal(order_fill["price"]),
-            fill_timestamp=order_fill["create_time"],
+            # Gate.io returns create_time as a numeric string; coerce so that
+            # InFlightOrder.last_update_timestamp keeps its declared float type.
+            fill_timestamp=float(order_fill["create_time"]),
         )
         return trade_update
 

--- a/test/hummingbot/connector/exchange/gate_io/test_gate_io_exchange.py
+++ b/test/hummingbot/connector/exchange/gate_io/test_gate_io_exchange.py
@@ -1791,3 +1791,23 @@ class TestGateIoExchange(IsolatedAsyncioWrapperTestCase):
         exception = IOError("HTTP status is 403. "
                             "Error: {'label':'REQUEST_EXPIRED','message':'gap between request Timestamp and server time exceeds 60'}")
         self.assertTrue(self.exchange._is_request_exception_related_to_time_synchronizer(exception))
+
+    def test_create_trade_update_handles_string_fill_timestamp(self):
+        # Regression for #8199-class: Gate.io returns create_time as a
+        # numeric string. It must be coerced to float so
+        # InFlightOrder.last_update_timestamp keeps its declared float type
+        # and downstream cross-executor aggregation does not crash with
+        # "'>' not supported between instances of 'str' and 'float'".
+        order = self.get_in_flight_order(client_order_id="OID1")
+        order_fill = {
+            "id": 5736713,
+            "fee": "0.00200000",
+            "fee_currency": self.quote_asset,
+            "amount": "1",
+            "price": "5.00032",
+            "create_time": "1548000000",
+        }
+        trade_update = self.exchange._create_trade_update_with_order_fill_data(
+            order_fill=order_fill, order=order)
+        self.assertIsInstance(trade_update.fill_timestamp, float)
+        self.assertEqual(trade_update.fill_timestamp, 1548000000.0)


### PR DESCRIPTION
## Summary
Sibling of #8233 / #8199. `GateIoExchange._create_trade_update_with_order_fill_data()` builds `TradeUpdate(fill_timestamp=order_fill["create_time"])`. Gate.io returns `create_time` as a **numeric string** (see the connector's own fixture: `get_order_create_response_mock` → `"create_time": "1548000000"`). The raw string propagates into `InFlightOrder.last_update_timestamp` (declared `: float`); any consumer that orders/aggregates that value across executors (e.g. `max([...])` in `controllers/generic/pmm_mister.py`) then raises `'>' not supported between instances of 'str' and 'float'` every control tick, freezing the client on partial fills.

## Fix
Coerce `order_fill["create_time"]` to `float` at the connector boundary so the declared `InFlightOrder.last_update_timestamp: float` contract holds for all consumers. Gate.io `create_time` is always a unix-epoch value, never ISO, so `float()` is correct and total. Identified via a cross-connector sweep of the #8199 root cause (Kraken fix in #8233).

## Changes
- `hummingbot/connector/exchange/gate_io/gate_io_exchange.py`: `fill_timestamp=float(order_fill["create_time"])` (+ comment).
- `test/.../gate_io/test_gate_io_exchange.py`: +1 regression test.

## Testing
`pytest test/hummingbot/connector/exchange/gate_io/test_gate_io_exchange.py` → **41 passed** (40 + 1 new) on a locally-built Cython env. flake8 clean.