### PR TITLE
fix: parse dYdX v4 fill createdAt ISO string to epoch float (#8199-class)

### DIFF
--- a/hummingbot/connector/derivative/dydx_v4_perpetual/dydx_v4_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/dydx_v4_perpetual/dydx_v4_perpetual_derivative.py
@@ -3,6 +3,7 @@ import time
 from decimal import Decimal
 from typing import Any, Dict, List, Optional, Tuple
 
+import dateutil.parser as dp
 from bidict import bidict
 
 import hummingbot.connector.derivative.dydx_v4_perpetual.dydx_v4_perpetual_constants as CONSTANTS
@@ -610,7 +611,10 @@ class DydxV4PerpetualDerivative(PerpetualDerivativePyBase):
                 client_order_id=order.client_order_id,
                 exchange_order_id=order.exchange_order_id,
                 trading_pair=order.trading_pair,
-                fill_timestamp=fill_data["createdAt"],
+                # dYdX returns createdAt as an ISO-8601 string; parse to epoch
+                # seconds so InFlightOrder.last_update_timestamp keeps its
+                # declared float type (mirrors the order book data source).
+                fill_timestamp=dp.parse(fill_data["createdAt"]).timestamp(),
                 fill_price=Decimal(fill_data["price"]),
                 fill_base_amount=Decimal(fill_data["size"]),
                 fill_quote_amount=Decimal(fill_data["price"]) * Decimal(fill_data["size"]),

--- a/test/hummingbot/connector/derivative/dydx_v4_perpetual/test_dydx_v4_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/dydx_v4_perpetual/test_dydx_v4_perpetual_derivative.py
@@ -1636,3 +1636,30 @@ class DydxV4PerpetualDerivativeTests(AbstractPerpetualDerivativeTests.PerpetualD
             self.target_funding_info_next_funding_utc_timestamp, funding_info.next_funding_utc_timestamp
         )
         self.assertEqual(self.target_funding_info_rate, funding_info.rate)
+
+    def test_process_order_fills_parses_iso_createdat_to_float(self):
+        # Regression: dYdX returns fill createdAt as an ISO-8601 string.
+        # It must be parsed to epoch-seconds float so
+        # InFlightOrder.last_update_timestamp keeps its declared float type
+        # (a raw string crashes downstream max()/arithmetic consumers).
+        self.exchange.start_tracking_order(
+            order_id=self.client_order_id_prefix + "1",
+            exchange_order_id=self.expected_exchange_order_id,
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            trade_type=TradeType.BUY,
+            price=Decimal("10000"),
+            amount=Decimal("1"),
+        )
+        order = self.exchange.in_flight_orders[self.client_order_id_prefix + "1"]
+        fill_data = {
+            "id": "fill-1",
+            "side": "BUY",
+            "fee": "0.1",
+            "price": "10000",
+            "size": "1",
+            "createdAt": "2021-01-04T23:44:59.690Z",
+        }
+        trade_update = self.exchange._process_order_fills(fill_data=fill_data, order=order)
+        self.assertIsInstance(trade_update.fill_timestamp, float)
+        self.assertAlmostEqual(trade_update.fill_timestamp, 1609803899.69, places=2)


### PR DESCRIPTION
## Summary
Discovered via the cross-connector sweep of the #8199 root cause (Kraken #8233, Gate.io #8234). `DydxV4PerpetualDerivative._process_order_fills()` builds `TradeUpdate(fill_timestamp=fill_data["createdAt"])` with the **raw dYdX Indexer ISO-8601 string** (the connector's own fixtures show `"createdAt": "2021-01-04T23:44:59.690Z"` consistently — never numeric).

This violates the `InFlightOrder.last_update_timestamp: float  # seconds` contract (`TradeUpdate`/`OrderUpdate` are `NamedTuple`s — the annotation is not runtime-enforced). Consequences: any consumer that orders/aggregates that value across executors (e.g. `max([...])` in `controllers/generic/pmm_mister.py`, or `current_time - last_update_timestamp` arithmetic) raises `TypeError` every control tick — same defect family as #8199, but **worse**: the plain `float()` fix used for Kraken/Gate.io would itself `raise ValueError` on an ISO string.

## Fix
Parse `createdAt` to epoch **seconds** with `dateutil.parser`, exactly mirroring the established in-package pattern in the sibling module `dydx_v4_perpetual_api_order_book_data_source.py:174` (`dp.parse(...).timestamp()`). Note: **no `* 1e3`** here — `TradeUpdate.fill_timestamp` is documented seconds, whereas the OB data source needs ms. Every other timestamp in this connector already uses float seconds (`self.current_timestamp` / `self._time_synchronizer.time()`); this line was the lone anomaly.

## Changes
- `hummingbot/connector/derivative/dydx_v4_perpetual/dydx_v4_perpetual_derivative.py`: `import dateutil.parser as dp` + parse `createdAt` (+ comment).
- `test/.../dydx_v4_perpetual/test_dydx_v4_perpetual_derivative.py`: +1 regression test (ISO string → float epoch).

## Testing
flake8 / isort / py_compile **clean**. Local pytest execution of the dydx_v4 suite is blocked in my environment by an unrelated `v4_proto` / protobuf gencode-runtime cross-version conflict (dydx_v4 connector dependency, not touched by this change) — so per contributor-side verification the change was validated by static gates + diff-correctness against the production-proven sibling pattern. The added test is standard and will execute under CI (which provisions `v4_proto`).