### PR TITLE
feat(decibel): fetch trading fees from user_fee_rates API

### DIFF
--- a/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_constants.py
+++ b/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_constants.py
@@ -53,6 +53,7 @@ GET_ACCOUNT_POSITIONS_PATH_URL = "/api/v1/account_positions"
 GET_ORDER_PATH_URL = "/api/v1/orders"
 GET_USER_TRADE_HISTORY_PATH_URL = "/api/v1/trade_history"
 GET_USER_FUNDING_HISTORY_PATH_URL = "/api/v1/funding_rate_history"
+GET_USER_FEE_RATES_PATH_URL = "/api/v1/user_fee_rates"
 
 # WebSocket Channels
 # Public channels - topics use market addresses, not market names
@@ -82,24 +83,6 @@ HEAVY_REQUEST_COST = 10
 # Market order slippage (IOC orders simulate market orders)
 MARKET_ORDER_SLIPPAGE = Decimal("0.08")  # 8%
 
-# Fee tier schedule (source: https://docs.decibel.trade/for-traders/fees).
-# Decibel has no public endpoint to query a user's tier directly; the Decibel
-# team confirmed the tiers are computed off the 30-day trading volume returned
-# by /api/v1/account_overviews when queried with volume_window="30d".
-# Entries are sorted DESCENDING by min 30-day volume so the highest qualifying
-# tier matches first when iterating.
-VOLUME_WINDOW_30D = "30d"
-FEE_TIER_SCHEDULE = [
-    # (tier, min_30d_volume_usd, maker_decimal, taker_decimal)
-    (6, Decimal("15000000000"), Decimal("0"), Decimal("0.00018")),      # > $15B
-    (5, Decimal("4000000000"), Decimal("0"), Decimal("0.00019")),       # > $4B
-    (4, Decimal("1000000000"), Decimal("0"), Decimal("0.00021")),       # > $1B
-    (3, Decimal("200000000"), Decimal("0.00003"), Decimal("0.00022")),  # > $200M
-    (2, Decimal("50000000"), Decimal("0.00006"), Decimal("0.00025")),   # > $50M
-    (1, Decimal("10000000"), Decimal("0.00009"), Decimal("0.0003")),    # > $10M
-    (0, Decimal("0"), Decimal("0.00011"), Decimal("0.00034")),          # Tier 0 (default)
-]
-
 # Single rate limit tier (API key required for all requests)
 RATE_LIMITS = [
     RateLimit(limit_id=DECIBEL_LIMIT_ID, limit=DECIBEL_API_LIMIT, time_interval=DECIBEL_LIMIT_INTERVAL),
@@ -117,4 +100,6 @@ RATE_LIMITS = [
               linked_limits=[LinkedLimitWeightPair(limit_id=DECIBEL_LIMIT_ID, weight=HEAVY_REQUEST_COST)]),
     RateLimit(limit_id=GET_USER_FUNDING_HISTORY_PATH_URL, limit=DECIBEL_API_LIMIT, time_interval=DECIBEL_LIMIT_INTERVAL,
               linked_limits=[LinkedLimitWeightPair(limit_id=DECIBEL_LIMIT_ID, weight=HEAVY_REQUEST_COST)]),
+    RateLimit(limit_id=GET_USER_FEE_RATES_PATH_URL, limit=DECIBEL_API_LIMIT, time_interval=DECIBEL_LIMIT_INTERVAL,
+              linked_limits=[LinkedLimitWeightPair(limit_id=DECIBEL_LIMIT_ID, weight=STANDARD_REQUEST_COST)]),
 ]

--- a/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/decibel_perpetual/decibel_perpetual_derivative.py
@@ -427,10 +427,10 @@ class DecibelPerpetualDerivative(PerpetualDerivativePyBase):
         """
         Calculate trading fee.
 
-        Uses the tier-specific TradeFeeSchema populated by _update_trading_fees
-        (based on the user's 30-day volume) when available. Falls back to the
-        DEFAULT_FEES Tier 0 schema from utils.py until the first successful poll
-        — conservative overstatement rather than understatement.
+        Uses the TradeFeeSchema populated by _update_trading_fees (from the
+        Decibel user_fee_rates API) when available. Falls back to the DEFAULT_FEES
+        Tier 0 schema from utils.py until the first successful poll — conservative
+        overstatement rather than understatement.
         """
         is_maker = is_maker or (order_type is OrderType.LIMIT_MAKER)
         trading_pair = combine_to_hb_trading_pair(base=base_currency, quote=quote_currency)
@@ -1470,52 +1470,37 @@ class DecibelPerpetualDerivative(PerpetualDerivativePyBase):
             return True, ""
         return False, f"Position mode {mode} not supported by Decibel."
 
-    @staticmethod
-    def _fees_for_30d_volume(volume: Decimal) -> Tuple[Decimal, Decimal]:
-        """
-        Map a 30-day USD trading volume to (maker_decimal, taker_decimal) using
-        CONSTANTS.FEE_TIER_SCHEDULE. The schedule is sorted high-to-low, so the
-        first matching threshold wins. Tier 0 (min_volume=0) guarantees a match.
-        """
-        for _tier, min_volume, maker, taker in CONSTANTS.FEE_TIER_SCHEDULE:
-            if volume >= min_volume:
-                return maker, taker
-
     async def _update_trading_fees(self):
         """
-        Update trading fees based on the user's 30-day volume tier.
+        Update trading fees from Decibel's user_fee_rates endpoint.
 
-        Decibel exposes tier-dependent fees (Tier 0: 0.0110% maker / 0.0340% taker,
-        decreasing at higher tiers with maker reaching 0% from Tier 4 onward).
-        There is no direct "current fee tier" endpoint, so - per guidance from
-        the Decibel team - we derive the tier by reading the 30-day volume from
-        /api/v1/account_overviews (with volume_window="30d") and mapping it
-        against CONSTANTS.FEE_TIER_SCHEDULE.
+        https://docs.decibel.trade/api-reference/account/get-user-fees-and-fee-schedule
 
-        On transient failure we leave any previously computed fees in place so
-        strategies keep working; the base class polling loop will retry.
+        Uses the user's effective maker/taker rates (after referral discount when
+        applicable). On transient failure we leave any previously computed fees in
+        place so strategies keep working; the base class polling loop will retry.
         """
         account_addr = self.authenticator.main_wallet_address
         try:
             response = await self._api_get(
-                path_url=CONSTANTS.GET_ACCOUNT_OVERVIEW_PATH_URL,
-                params={"account": account_addr, "volume_window": CONSTANTS.VOLUME_WINDOW_30D},
-                limit_id=CONSTANTS.GET_ACCOUNT_OVERVIEW_PATH_URL,
+                path_url=CONSTANTS.GET_USER_FEE_RATES_PATH_URL,
+                params={"account": account_addr},
+                limit_id=CONSTANTS.GET_USER_FEE_RATES_PATH_URL,
                 is_auth_required=True,
             )
         except asyncio.CancelledError:
             raise
         except Exception:
             self.logger().warning(
-                "Failed to fetch 30d volume from account_overviews; keeping previous "
-                "fee tier. Strategies will temporarily use the last-known (or Tier 0 default) fees.",
+                "Failed to fetch user fee rates; keeping previous fee tier. "
+                "Strategies will temporarily use the last-known (or Tier 0 default) fees.",
                 exc_info=True,
             )
             return
 
-        # `volume` may be null for accounts with no trading history → treat as 0 (Tier 0).
-        volume_30d = Decimal(str(response.get("volume") or 0))
-        maker_decimal, taker_decimal = self._fees_for_30d_volume(volume_30d)
+        maker_decimal = Decimal(str(response["user_maker_rate"]))
+        taker_decimal = Decimal(str(response["user_taker_rate"]))
+        fee_tier = response.get("fee_tier")
 
         fee_schema = TradeFeeSchema(
             maker_percent_fee_decimal=maker_decimal,
@@ -1526,7 +1511,7 @@ class DecibelPerpetualDerivative(PerpetualDerivativePyBase):
             self._trading_fees[trading_pair] = fee_schema
 
         self.logger().debug(
-            f"Updated trading fees from 30d volume ${volume_30d}: "
+            f"Updated trading fees (fee_tier={fee_tier}): "
             f"maker={maker_decimal}, taker={taker_decimal}"
         )
 

--- a/test/hummingbot/connector/derivative/decibel_perpetual/test_decibel_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/decibel_perpetual/test_decibel_perpetual_derivative.py
@@ -123,6 +123,28 @@ class DecibelPerpetualDerivativeUnitTest(IsolatedAsyncioWrapperTestCase):
         mock_rest_assistant.execute_request.return_value = return_value
         return mock_rest_assistant
 
+    def _user_fee_rates_response(
+        self,
+        user_maker_rate: float = 0.00011,
+        user_taker_rate: float = 0.00034,
+        fee_tier: int = 0,
+        active_referral_discount: float = 0.0,
+    ) -> Dict[str, Any]:
+        return {
+            "account": "0xtest",
+            "user_maker_rate": user_maker_rate,
+            "user_taker_rate": user_taker_rate,
+            "fee_tier": fee_tier,
+            "active_referral_discount": active_referral_discount,
+            "fee_schedule": {
+                "maker": 0.00011,
+                "taker": 0.00034,
+                "referral_discount": 0.04,
+                "tiers": {"vip": [], "market_maker": []},
+            },
+            "daily_user_volume": [],
+        }
+
     def _get_exchange_info_mock_response(
             self,
             min_size: int = 1000,
@@ -299,28 +321,14 @@ class DecibelPerpetualDerivativeUnitTest(IsolatedAsyncioWrapperTestCase):
     async def test_update_time_synchronizer_noop(self):
         await self.exchange._update_time_synchronizer()
 
-    def test_fees_for_30d_volume_matches_tier_schedule(self):
-        """Each documented tier threshold should map to its documented (maker, taker)."""
-        cases = [
-            (Decimal("0"), Decimal("0.00011"), Decimal("0.00034")),           # Tier 0
-            (Decimal("5000000"), Decimal("0.00011"), Decimal("0.00034")),     # Tier 0 (below 10M)
-            (Decimal("10000000"), Decimal("0.00009"), Decimal("0.0003")),     # Tier 1 boundary
-            (Decimal("50000000"), Decimal("0.00006"), Decimal("0.00025")),    # Tier 2 boundary
-            (Decimal("200000000"), Decimal("0.00003"), Decimal("0.00022")),   # Tier 3 boundary
-            (Decimal("1000000000"), Decimal("0"), Decimal("0.00021")),        # Tier 4 boundary
-            (Decimal("4000000000"), Decimal("0"), Decimal("0.00019")),        # Tier 5 boundary
-            (Decimal("15000000000"), Decimal("0"), Decimal("0.00018")),       # Tier 6 boundary
-            (Decimal("100000000000"), Decimal("0"), Decimal("0.00018")),      # Well above Tier 6
-        ]
-        for volume, expected_maker, expected_taker in cases:
-            maker, taker = self.exchange._fees_for_30d_volume(volume)
-            self.assertEqual(expected_maker, maker, f"maker mismatch at volume={volume}")
-            self.assertEqual(expected_taker, taker, f"taker mismatch at volume={volume}")
-
-    async def test_update_trading_fees_uses_30d_volume(self):
-        """Volume above $10M should land the user on Tier 1 fees."""
+    async def test_update_trading_fees_uses_api_rates(self):
+        """user_fee_rates returns the user's effective maker/taker rates."""
         self.exchange._trading_fees.clear()
-        self._mock_rest_assistant({"volume": 25000000})  # Tier 1 (>$10M)
+        self._mock_rest_assistant(self._user_fee_rates_response(
+            user_maker_rate=0.00009,
+            user_taker_rate=0.0003,
+            fee_tier=1,
+        ))
 
         await self.exchange._update_trading_fees()
 
@@ -328,10 +336,10 @@ class DecibelPerpetualDerivativeUnitTest(IsolatedAsyncioWrapperTestCase):
         self.assertEqual(Decimal("0.00009"), schema.maker_percent_fee_decimal)
         self.assertEqual(Decimal("0.0003"), schema.taker_percent_fee_decimal)
 
-    async def test_update_trading_fees_handles_null_volume(self):
-        """New accounts have volume=null → default to Tier 0."""
+    async def test_update_trading_fees_handles_tier_0_rates(self):
+        """New accounts receive Tier 0 rates from the API."""
         self.exchange._trading_fees.clear()
-        self._mock_rest_assistant({"volume": None})
+        self._mock_rest_assistant(self._user_fee_rates_response())
 
         await self.exchange._update_trading_fees()
 


### PR DESCRIPTION
Fixes #8242

## Summary
- Replace hardcoded `FEE_TIER_SCHEDULE` and `account_overviews` volume-based tier lookup with Decibel `GET /api/v1/user_fee_rates`.
- Use `user_maker_rate` / `user_taker_rate` (effective rates, including referral discount when applicable) for `TradeFeeSchema`, matching the Pacifica connector pattern.
- Add rate limit entry for the new endpoint; preserve failure fallback and Tier 0 defaults.

## Test plan
- [x] Updated unit tests: `test_update_trading_fees_uses_api_rates`, `test_update_trading_fees_handles_tier_0_rates`, `test_update_trading_fees_keeps_previous_on_error`
- [x] Run locally: `pytest test/hummingbot/connector/derivative/decibel_perpetual/test_decibel_perpetual_derivative.py -k trading_fees` (5 passed)
- [x] Full decibel derivative test file: 107 passed
- [ ] QA: connect testnet/mainnet and confirm maker/taker in logs match Decibel account fee display

**Tips for QA testing**:
- Start connector with valid API keys; check debug logs for `Updated trading fees (fee_tier=...)`.
- Compare logged maker/taker decimals against Decibel UI / `user_fee_rates` API response.