### PR TITLE
fix: skip market making executors with invalid prices

### DIFF
--- a/hummingbot/strategy_v2/controllers/market_making_controller_base.py
+++ b/hummingbot/strategy_v2/controllers/market_making_controller_base.py
@@ -1,4 +1,4 @@
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from typing import List, Optional, Tuple, Union
 
 from pydantic import Field, field_validator
@@ -244,6 +244,11 @@ class MarketMakingControllerBase(ControllerBase):
         levels_to_execute = self.get_levels_to_execute()
         for level_id in levels_to_execute:
             price, amount = self.get_price_and_amount(level_id)
+            if not self._is_positive_finite_decimal(price) or not self._is_positive_finite_decimal(amount):
+                self.logger().debug(
+                    f"Skipping executor creation for {level_id}: invalid price={price} amount={amount}"
+                )
+                continue
             executor_config = self.get_executor_config(level_id, price, amount)
             if executor_config is not None:
                 create_actions.append(CreateExecutorAction(
@@ -345,6 +350,10 @@ class MarketMakingControllerBase(ControllerBase):
         if "_perpetual" in self.config.connector_name or "reference_price" not in self.processed_data or self.config.skip_rebalance:
             return None
 
+        reference_price = Decimal(self.processed_data["reference_price"])
+        if not self._is_positive_finite_decimal(reference_price):
+            return None
+
         active_rebalance = self.filter_executors(
             executors=self.executors_info,
             filter_func=lambda x: x.is_active and x.custom_info.get("level_id") == "position_rebalance"
@@ -353,7 +362,7 @@ class MarketMakingControllerBase(ControllerBase):
             # If there's already an active rebalance executor, skip rebalancing
             return None
 
-        required_base_amount = self.config.get_required_base_amount(Decimal(self.processed_data["reference_price"]))
+        required_base_amount = self.config.get_required_base_amount(reference_price)
         current_base_amount = self.get_current_base_position()
 
         # Calculate the difference
@@ -412,3 +421,11 @@ class MarketMakingControllerBase(ControllerBase):
             controller_id=self.config.id,
             executor_config=order_config
         )
+
+    @staticmethod
+    def _is_positive_finite_decimal(value: Optional[Decimal]) -> bool:
+        try:
+            value = Decimal(value)
+        except (InvalidOperation, TypeError, ValueError):
+            return False
+        return value.is_finite() and value > Decimal("0")

--- a/test/hummingbot/strategy_v2/controllers/test_market_making_controller_base.py
+++ b/test/hummingbot/strategy_v2/controllers/test_market_making_controller_base.py
@@ -71,6 +71,33 @@ class TestMarketMakingControllerBase(IsolatedAsyncioWrapperTestCase):
         for action in stop_actions:
             self.assertIsInstance(action, StopExecutorAction)
 
+    @patch(
+        "hummingbot.strategy_v2.controllers.market_making_controller_base.MarketMakingControllerBase.get_executor_config",
+        new_callable=MagicMock,
+    )
+    def test_create_actions_proposal_skips_invalid_price_and_amount(self, executor_config_mock: MagicMock):
+        self.controller.processed_data = {"reference_price": Decimal("NaN"), "spread_multiplier": Decimal("1")}
+        self.controller.executors_info = []
+
+        actions = self.controller.create_actions_proposal()
+
+        self.assertEqual([], actions)
+        executor_config_mock.assert_not_called()
+
+    def test_check_position_rebalance_skips_invalid_reference_price(self):
+        self.mock_controller_config.connector_name = "binance"
+        controller = MarketMakingControllerBase(
+            config=self.mock_controller_config,
+            market_data_provider=self.mock_market_data_provider,
+            actions_queue=self.mock_actions_queue
+        )
+        controller.processed_data = {"reference_price": Decimal("NaN")}
+        controller.executors_info = []
+
+        result = controller.check_position_rebalance()
+
+        self.assertIsNone(result)
+
     def test_validate_order_type(self):
         for order_type_name in OrderType.__members__:
             self.assertEqual(


### PR DESCRIPTION
## Description

Fixes #7823.

This prevents V2 market making controllers from creating executor actions when the calculated price or amount is not a positive finite Decimal. This can happen while market data is not ready and `reference_price` is still `NaN`.

## Changes

- Skip executor creation when calculated price/amount is invalid.
- Skip spot rebalance when `reference_price` is invalid.
- Add regression tests for both cases.

## Testing

- `python -m py_compile hummingbot/strategy_v2/controllers/market_making_controller_base.py test/hummingbot/strategy_v2/controllers/test_market_making_controller_base.py`

I was not able to run the full unit test locally because the local Python environment is missing project dependencies (`ruamel.yaml`).