### PR TITLE
fix: handle missing KuCoin predicted funding rate

### DIFF
--- a/hummingbot/connector/derivative/kucoin_perpetual/kucoin_perpetual_api_order_book_data_source.py
+++ b/hummingbot/connector/derivative/kucoin_perpetual/kucoin_perpetual_api_order_book_data_source.py
@@ -1,6 +1,6 @@
 import asyncio
 import time
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import pandas as pd
@@ -48,14 +48,29 @@ class KucoinPerpetualAPIOrderBookDataSource(PerpetualAPIOrderBookDataSource):
             symbol_info = funding_info_response["data"]
         else:
             symbol_info = funding_info_response["data"][0]
+        funding_rate = self._decimal_or_none(symbol_info.get("predictedFundingFeeRate"))
+        if funding_rate is None:
+            funding_rate = self._decimal_or_none(symbol_info.get("fundingFeeRate")) or Decimal("0")
         funding_info = FundingInfo(
             trading_pair=trading_pair,
             index_price=Decimal(str(symbol_info["indexPrice"])),
             mark_price=Decimal(str(symbol_info["markPrice"])),
             next_funding_utc_timestamp=int(pd.Timestamp(symbol_info["nextFundingRateTime"]).timestamp()),
-            rate=Decimal(str(symbol_info["predictedFundingFeeRate"])),
+            rate=funding_rate,
         )
         return funding_info
+
+    @staticmethod
+    def _decimal_or_none(value: Any) -> Optional[Decimal]:
+        if value is None:
+            return None
+        value_as_str = str(value).strip()
+        if value_as_str == "":
+            return None
+        try:
+            return Decimal(value_as_str)
+        except (InvalidOperation, ValueError):
+            return None
 
     async def _subscribe_channels(self, ws: WSAssistant):
         try:

--- a/test/hummingbot/connector/derivative/kucoin_perpetual/test_kucoin_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/kucoin_perpetual/test_kucoin_perpetual_api_order_book_data_source.py
@@ -624,6 +624,30 @@ class KucoinPerpetualAPIOrderBookDataSourceTests(IsolatedAsyncioWrapperTestCase)
         self.assertEqual(self.trading_pair, funding_info.trading_pair)
         self.assertEqual(Decimal(str(future_info_response["data"]["indexPrice"])), funding_info.index_price)
         self.assertEqual(Decimal(str(future_info_response["data"]["markPrice"])), funding_info.mark_price)
+        self.assertEqual(Decimal(str(future_info_response["data"]["predictedFundingFeeRate"])), funding_info.rate)
+
+    @aioresponses()
+    async def test_get_funding_info_falls_back_to_current_rate_when_predicted_rate_is_missing(self, mock_api):
+        future_info_url = web_utils.get_rest_url_for_endpoint(
+            endpoint=CONSTANTS.GET_CONTRACT_INFO_PATH_URL.format(symbol=self.ex_trading_pair)
+        )
+        future_info_regex_url = re.compile(f"^{future_info_url}".replace(".", r"\.").replace("?", r"\?"))
+        future_info_response = {
+            "code": "200000",
+            "data": {
+                "symbol": self.ex_trading_pair,
+                "fundingFeeRate": -0.000019,
+                "predictedFundingFeeRate": None,
+                "markPrice": 101.6,
+                "indexPrice": 101.59,
+                "nextFundingRateTime": 22646889,
+            }
+        }
+        mock_api.get(future_info_regex_url, body=json.dumps(future_info_response))
+
+        funding_info: FundingInfo = await self.data_source.get_funding_info(self.trading_pair)
+
+        self.assertEqual(Decimal(str(future_info_response["data"]["fundingFeeRate"])), funding_info.rate)
 
     def _simulate_trading_rules_initialized(self):
         self.connector._trading_rules = {


### PR DESCRIPTION
## Summary
- Fall back from `predictedFundingFeeRate` to `fundingFeeRate` when KuCoin returns a missing/empty predicted rate.
- Default to zero only when both funding-rate fields are unavailable, so connector initialization does not crash on `Decimal(None)`/empty values.
- Add regression coverage for the fallback path and assert the normal predicted-rate path.

Fixes #7994

## Testing
- `python -m py_compile hummingbot/connector/derivative/kucoin_perpetual/kucoin_perpetual_api_order_book_data_source.py test/hummingbot/connector/derivative/kucoin_perpetual/test_kucoin_perpetual_api_order_book_data_source.py`
