### PR TITLE
fix: update Binance futures market WebSocket URLs

### DIFF
--- a/hummingbot/data_feed/candles_feed/binance_perpetual_candles/constants.py
+++ b/hummingbot/data_feed/candles_feed/binance_perpetual_candles/constants.py
@@ -6,7 +6,7 @@ REST_URL = "https://fapi.binance.com"
 HEALTH_CHECK_ENDPOINT = "/fapi/v1/ping"
 CANDLES_ENDPOINT = "/fapi/v1/klines"
 
-WSS_URL = "wss://fstream.binance.com/market/stream"
+WSS_URL = "wss://fstream.binance.com/market/ws"
 
 INTERVALS = bidict({
     "1s": 1,

--- a/hummingbot/data_feed/liquidations_feed/binance/constants.py
+++ b/hummingbot/data_feed/liquidations_feed/binance/constants.py
@@ -4,7 +4,7 @@ REST_URL = "https://fapi.binance.com"
 HEALTH_CHECK_ENDPOINT = "/fapi/v1/ping"
 EXCHANGE_INFO = "/fapi/v1/exchangeInfo"
 
-WSS_URL = "wss://fstream.binance.com/market/stream"
+WSS_URL = "wss://fstream.binance.com/market/ws"
 
 REQUEST_WEIGHT = "REQUEST_WEIGHT"
 

--- a/test/hummingbot/data_feed/candles_feed/binance_perpetual_candles/test_binance_perpetual_candles.py
+++ b/test/hummingbot/data_feed/candles_feed/binance_perpetual_candles/test_binance_perpetual_candles.py
@@ -3,6 +3,7 @@ from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandles
 
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.data_feed.candles_feed.binance_perpetual_candles import BinancePerpetualCandles
+from hummingbot.data_feed.candles_feed.binance_perpetual_candles import constants as CONSTANTS
 
 
 class TestBinancePerpetualCandles(TestCandlesBase):
@@ -31,6 +32,10 @@ class TestBinancePerpetualCandles(TestCandlesBase):
         await super().asyncSetUp()
         self.mocking_assistant = NetworkMockingAssistant()
         self.resume_test_event = asyncio.Event()
+
+    def test_wss_url_uses_binance_market_ws_endpoint(self):
+        self.assertEqual("wss://fstream.binance.com/market/ws", CONSTANTS.WSS_URL)
+        self.assertEqual(CONSTANTS.WSS_URL, self.data_feed.wss_url)
 
     def get_candles_rest_data_mock(self):
         data = [

--- a/test/hummingbot/data_feed/liquidations_feed/binance/test_binance_liquidations.py
+++ b/test/hummingbot/data_feed/liquidations_feed/binance/test_binance_liquidations.py
@@ -34,6 +34,10 @@ class TestBinanceLiquidations(IsolatedAsyncioWrapperTestCase):
         self.mocking_assistant = NetworkMockingAssistant()
         self.resume_test_event = asyncio.Event()
 
+    def test_wss_url_uses_binance_market_ws_endpoint(self):
+        self.assertEqual("wss://fstream.binance.com/market/ws", CONSTANTS.WSS_URL)
+        self.assertEqual(CONSTANTS.WSS_URL, self.liquidations_feed.wss_url)
+
     def handle(self, record):
         self.log_records.append(record)
 


### PR DESCRIPTION
## Summary
- Update Binance perpetual candles to use the routed USD-M Futures market WebSocket endpoint.
- Update Binance perpetual liquidations to the same `/market/ws` endpoint because `forceOrder` streams are classified as market streams.
- Add simple regression checks for both feed URLs.

Fixes #8213

## References
- Binance USD-M Futures WebSocket upgrade notice: legacy URLs retired on 2026-04-23, market data routed through `/market`.
- Binance WebSocket docs: kline/candlestick and liquidation streams are listed under the Market endpoint mapping.

## Testing
- `python -m py_compile hummingbot/data_feed/candles_feed/binance_perpetual_candles/constants.py hummingbot/data_feed/liquidations_feed/binance/constants.py test/hummingbot/data_feed/candles_feed/binance_perpetual_candles/test_binance_perpetual_candles.py test/hummingbot/data_feed/liquidations_feed/binance/test_binance_liquidations.py`
