### PR TITLE
Feat/improve position mode set

### DIFF
--- a/controllers/generic/pmm_mister.py
+++ b/controllers/generic/pmm_mister.py
@@ -5,9 +5,14 @@ from typing import Dict, List, Optional, Tuple, Union
 from pydantic import Field, field_validator
 from pydantic_core.core_schema import ValidationInfo
 
-from hummingbot.core.data_type.common import MarketDict, OrderType, PositionMode, PriceType, TradeType
+from hummingbot.core.data_type.common import MarketDict, OrderType, PositionAction, PositionMode, PriceType, TradeType
 from hummingbot.strategy_v2.controllers.controller_base import ControllerBase, ControllerConfigBase
 from hummingbot.strategy_v2.executors.data_types import ConnectorPair
+from hummingbot.strategy_v2.executors.order_executor.data_types import (
+    ExecutionStrategy,
+    LimitChaserConfig,
+    OrderExecutorConfig,
+)
 from hummingbot.strategy_v2.executors.position_executor.data_types import PositionExecutorConfig, TripleBarrierConfig
 from hummingbot.strategy_v2.models.executor_actions import CreateExecutorAction, ExecutorAction, StopExecutorAction
 from hummingbot.strategy_v2.utils.common import parse_comma_separated_list, parse_enum_value
@@ -56,6 +61,20 @@ class PMMisterConfig(ControllerConfigBase):
     global_take_profit: Decimal = Field(default=Decimal("0.03"), json_schema_extra={"is_updatable": True})
     global_stop_loss: Decimal = Field(default=Decimal("0.05"), json_schema_extra={"is_updatable": True})
 
+    # Global TP/SL activation settings
+    global_tp_enabled: bool = Field(default=False, json_schema_extra={"is_updatable": True})
+    global_sl_enabled: bool = Field(default=False, json_schema_extra={"is_updatable": True})
+    # TP activates when position >= this threshold: "min_base" (earlier) or "target_base" (later)
+    global_tp_activation_from: str = Field(default="min_base", json_schema_extra={"is_updatable": True})
+    # SL activates when position >= this threshold: "target_base" (earlier) or "max_base" (later)
+    global_sl_activation_from: str = Field(default="target_base", json_schema_extra={"is_updatable": True})
+    # PnL reference: "position" = pnl/position_value, "portfolio" = pnl/total_amount_quote
+    global_pnl_reference: str = Field(default="position", json_schema_extra={"is_updatable": True})
+
+    # Limit chaser config for position closing (tight values for fast fills)
+    close_chaser_distance: Decimal = Field(default=Decimal("0.0003"), json_schema_extra={"is_updatable": True})
+    close_chaser_refresh_threshold: Decimal = Field(default=Decimal("0.0003"), json_schema_extra={"is_updatable": True})
+
     @field_validator("take_profit", mode="before")
     @classmethod
     def validate_target(cls, v):
@@ -101,6 +120,30 @@ class PMMisterConfig(ControllerConfigBase):
     @classmethod
     def validate_position_mode(cls, v) -> PositionMode:
         return parse_enum_value(PositionMode, v, "position_mode")
+
+    @field_validator('global_tp_activation_from', mode="before")
+    @classmethod
+    def validate_tp_activation_from(cls, v):
+        valid = {"min_base", "target_base"}
+        if v not in valid:
+            raise ValueError(f"global_tp_activation_from must be one of {valid}")
+        return v
+
+    @field_validator('global_sl_activation_from', mode="before")
+    @classmethod
+    def validate_sl_activation_from(cls, v):
+        valid = {"target_base", "max_base"}
+        if v not in valid:
+            raise ValueError(f"global_sl_activation_from must be one of {valid}")
+        return v
+
+    @field_validator('global_pnl_reference', mode="before")
+    @classmethod
+    def validate_pnl_reference(cls, v):
+        valid = {"position", "portfolio"}
+        if v not in valid:
+            raise ValueError(f"global_pnl_reference must be one of {valid}")
+        return v
 
     @field_validator('price_distance_tolerance', 'refresh_tolerance', 'tolerance_scaling', mode="before")
     @classmethod
@@ -198,6 +241,8 @@ class PMMister(ControllerBase):
         self.order_history = []
         self.max_order_history = 20
         self.processed_data = {}
+        self._closing_position = False
+        self._close_trigger_reason = None
 
     # ── Market data (called by framework) ─────────────────────────────────
 
@@ -237,12 +282,152 @@ class PMMister(ControllerBase):
 
     def determine_executor_actions(self) -> List[ExecutorAction]:
         self._update_position_state()
+
+        # Handle active position closing
+        if self._closing_position:
+            return self._handle_closing_state()
+
+        # Check global TP/SL before normal logic
+        tp_sl_actions = self._check_global_tp_sl()
+        if tp_sl_actions is not None:
+            return tp_sl_actions
+
         self._compute_executor_analysis()
 
         actions = []
         actions.extend(self.create_actions_proposal())
         actions.extend(self.stop_actions_proposal())
         return actions
+
+    # ── Global TP/SL ──────────────────────────────────────────────────────
+
+    def _get_tp_activation_threshold(self) -> Decimal:
+        if self.config.global_tp_activation_from == "min_base":
+            return self.config.min_base_pct
+        return self.config.target_base_pct
+
+    def _get_sl_activation_threshold(self) -> Decimal:
+        if self.config.global_sl_activation_from == "target_base":
+            return self.config.target_base_pct
+        return self.config.max_base_pct
+
+    def _check_global_tp_sl(self) -> Optional[List[ExecutorAction]]:
+        current_base_pct = self.processed_data.get("current_base_pct", Decimal("0"))
+        unrealized_pnl_pct = self.processed_data.get("unrealized_pnl_pct", Decimal("0"))
+        position_amount = self.processed_data.get("position_amount", Decimal("0"))
+
+        if position_amount == Decimal("0"):
+            return None
+
+        triggered = False
+        trigger_reason = ""
+
+        # Check take profit
+        if self.config.global_tp_enabled and current_base_pct >= self._get_tp_activation_threshold():
+            if unrealized_pnl_pct >= self.config.global_take_profit:
+                triggered = True
+                trigger_reason = "take_profit"
+
+        # Check stop loss
+        if not triggered and self.config.global_sl_enabled and current_base_pct >= self._get_sl_activation_threshold():
+            if unrealized_pnl_pct <= -self.config.global_stop_loss:
+                triggered = True
+                trigger_reason = "stop_loss"
+
+        if not triggered:
+            return None
+
+        self.logger().info(
+            f"Global {trigger_reason} triggered! PnL: {unrealized_pnl_pct:.2%}, Position: {current_base_pct:.2%}"
+        )
+        self._closing_position = True
+        self._close_trigger_reason = trigger_reason
+
+        actions: List[ExecutorAction] = []
+
+        # Stop all active executors (keep positions intact for the close executor)
+        for executor in self.executors_info:
+            if executor.is_active:
+                actions.append(StopExecutorAction(
+                    controller_id=self.config.id,
+                    keep_position=True,
+                    executor_id=executor.id,
+                ))
+
+        # Create limit chaser to close the full position
+        close_action = self._create_close_action(position_amount)
+        if close_action:
+            actions.append(close_action)
+
+        return actions
+
+    def _handle_closing_state(self) -> List[ExecutorAction]:
+        position_amount = self.processed_data.get("position_amount", Decimal("0"))
+
+        # Check if position is effectively closed
+        quantized = self.market_data_provider.quantize_order_amount(
+            self.config.connector_name, self.config.trading_pair, abs(position_amount)
+        )
+        if quantized == Decimal("0"):
+            self.logger().info(
+                f"Global {self._close_trigger_reason} completed. Restarting market making."
+            )
+            self._closing_position = False
+            self._close_trigger_reason = None
+            return []
+
+        # Check if close executor is still active
+        close_executors = [
+            e for e in self.executors_info
+            if e.is_active and e.custom_info.get("level_id") == "global_close"
+        ]
+        if close_executors:
+            return []
+
+        # No close executor running but position remains — retry
+        actions: List[ExecutorAction] = []
+        for executor in self.executors_info:
+            if executor.is_active:
+                actions.append(StopExecutorAction(
+                    controller_id=self.config.id,
+                    keep_position=True,
+                    executor_id=executor.id,
+                ))
+
+        self.logger().info(f"Retrying position close. Remaining: {position_amount}")
+        close_action = self._create_close_action(position_amount)
+        if close_action:
+            actions.append(close_action)
+
+        return actions
+
+    def _create_close_action(self, position_amount: Decimal) -> Optional[CreateExecutorAction]:
+        if position_amount == Decimal("0"):
+            return None
+
+        side = TradeType.SELL if position_amount > 0 else TradeType.BUY
+        amount = abs(position_amount)
+
+        config = OrderExecutorConfig(
+            timestamp=self.market_data_provider.time(),
+            trading_pair=self.config.trading_pair,
+            connector_name=self.config.connector_name,
+            side=side,
+            amount=amount,
+            execution_strategy=ExecutionStrategy.LIMIT_CHASER,
+            position_action=PositionAction.CLOSE,
+            chaser_config=LimitChaserConfig(
+                distance=self.config.close_chaser_distance,
+                refresh_threshold=self.config.close_chaser_refresh_threshold,
+            ),
+            leverage=self.config.leverage,
+            level_id="global_close",
+        )
+
+        return CreateExecutorAction(
+            controller_id=self.config.id,
+            executor_config=config,
+        )
 
     # ── Single-pass executor analysis ─────────────────────────────────────
 
@@ -283,6 +468,8 @@ class PMMister(ControllerBase):
         breakeven_price = self.processed_data.get("breakeven_price")
 
         for level_id in all_level_ids:
+            if not level_id.startswith(("buy_", "sell_")):
+                continue
             executors = executors_by_level.get(level_id, [])
             active = [e for e in executors if e.is_active]
             active_not_trading = [e for e in active if not e.is_trading]
@@ -502,8 +689,12 @@ class PMMister(ControllerBase):
         if position_held is not None:
             current_base_pct = position_held.amount_quote / self.config.total_amount_quote
             deviation = (target_position - position_held.amount_quote) / target_position
-            unrealized_pnl_pct = (position_held.unrealized_pnl_quote / position_held.amount_quote
-                                  if position_held.amount_quote != 0 else Decimal("0"))
+            if self.config.global_pnl_reference == "portfolio":
+                unrealized_pnl_pct = (position_held.unrealized_pnl_quote / self.config.total_amount_quote
+                                      if self.config.total_amount_quote != 0 else Decimal("0"))
+            else:
+                unrealized_pnl_pct = (position_held.unrealized_pnl_quote / position_held.amount_quote
+                                      if position_held.amount_quote != 0 else Decimal("0"))
             breakeven_price = position_held.breakeven_price
             position_amount = position_held.amount
         else:
@@ -699,6 +890,50 @@ class PMMister(ControllerBase):
     def get_level_from_level_id(self, level_id: str) -> int:
         return int(level_id.split('_')[1])
 
+    # ── Custom info (MQTT / broker) ──────────────────────────────────────
+
+    def get_custom_info(self) -> dict:
+        if not self.processed_data:
+            return {}
+
+        reference_price = self.processed_data.get("reference_price", Decimal("0"))
+        position_amount = self.processed_data.get("position_amount", Decimal("0"))
+        current_base_pct = self.processed_data.get("current_base_pct", Decimal("0"))
+        unrealized_pnl_pct = self.processed_data.get("unrealized_pnl_pct", Decimal("0"))
+        breakeven_price = self.processed_data.get("breakeven_price")
+        buy_skew = self.processed_data.get("buy_skew", Decimal("1"))
+        sell_skew = self.processed_data.get("sell_skew", Decimal("1"))
+        executor_stats = self.processed_data.get("executor_stats", {})
+        level_conditions = self.processed_data.get("level_conditions", {})
+
+        # Distance to global TP/SL
+        distance_to_tp = float(self.config.global_take_profit - unrealized_pnl_pct)
+        distance_to_sl = float(unrealized_pnl_pct + self.config.global_stop_loss)
+
+        # Executable levels count
+        can_buy = sum(1 for lc in level_conditions.values() if lc.get("trade_type") == "BUY" and lc.get("can_execute"))
+        can_sell = sum(1 for lc in level_conditions.values() if lc.get("trade_type") == "SELL" and lc.get("can_execute"))
+
+        return {
+            "reference_price": float(reference_price),
+            "position_amount": float(position_amount),
+            "current_base_pct": float(current_base_pct),
+            "unrealized_pnl_pct": float(unrealized_pnl_pct),
+            "breakeven_price": float(breakeven_price) if breakeven_price is not None else None,
+            "buy_skew": float(buy_skew),
+            "sell_skew": float(sell_skew),
+            "distance_to_tp": distance_to_tp,
+            "distance_to_sl": distance_to_sl,
+            "global_tp_enabled": self.config.global_tp_enabled,
+            "global_sl_enabled": self.config.global_sl_enabled,
+            "closing_position": self._closing_position,
+            "close_trigger_reason": self._close_trigger_reason,
+            "active_executors": executor_stats.get("total_active", 0),
+            "trading_executors": executor_stats.get("total_trading", 0),
+            "executable_buy_levels": can_buy,
+            "executable_sell_levels": can_sell,
+        }
+
     # ── Status display ────────────────────────────────────────────────────
 
     def to_format_status(self) -> List[str]:
@@ -712,6 +947,26 @@ class PMMister(ControllerBase):
         if not hasattr(self, 'processed_data') or not self.processed_data:
             status.append("╒" + "═" * inner_width + "╕")
             status.append(f"│ {'Initializing controller... please wait':<{inner_width}} │")
+            status.append(f"╘{'═' * inner_width}╛")
+            return status
+
+        if self._closing_position:
+            reason = (self._close_trigger_reason or "unknown").upper().replace("_", " ")
+            pnl = self.processed_data.get('unrealized_pnl_pct', Decimal('0'))
+            pos_amt = self.processed_data.get('position_amount', Decimal('0'))
+            close_active = any(
+                e.is_active and e.custom_info.get("level_id") == "global_close"
+                for e in self.executors_info
+            )
+            close_status = "LIMIT CHASER ACTIVE" if close_active else "WAITING FOR CLOSE EXECUTOR..."
+            status.append("╒" + "═" * inner_width + "╕")
+            status.append(f"│ {'⚠️  CLOSING POSITION — ' + reason:<{inner_width}} │")
+            status.append(f"├{'─' * inner_width}┤")
+            status.append(f"│ {'Status: ' + close_status:<{inner_width}} │")
+            status.append(f"│ {'PnL: ' + f'{pnl:+.2%}':<{inner_width}} │")
+            status.append(f"│ {'Remaining amount: ' + f'{pos_amt}':<{inner_width}} │")
+            chaser_info = f"Chaser: dist={self.config.close_chaser_distance:.4%} refresh={self.config.close_chaser_refresh_threshold:.4%}"
+            status.append(f"│ {chaser_info:<{inner_width}} │")
             status.append(f"╘{'═' * inner_width}╛")
             return status
 
@@ -870,10 +1125,15 @@ class PMMister(ControllerBase):
         distance_to_tp = self.config.global_take_profit - pnl if pnl < self.config.global_take_profit else Decimal('0')
         distance_to_sl = pnl + self.config.global_stop_loss if pnl > -self.config.global_stop_loss else Decimal('0')
 
+        tp_active = self.config.global_tp_enabled and base_pct >= self._get_tp_activation_threshold()
+        sl_active = self.config.global_sl_enabled and base_pct >= self._get_sl_activation_threshold()
+        tp_status = "ACTIVE" if tp_active else ("OFF" if not self.config.global_tp_enabled else f"from {self.config.global_tp_activation_from}")
+        sl_status = "ACTIVE" if sl_active else ("OFF" if not self.config.global_sl_enabled else f"from {self.config.global_sl_activation_from}")
+
         pnl_info = [
             f"Unrealized: {pnl_sign}{pnl:.2%}",
-            f"Take Profit: {self.config.global_take_profit:.2%} (Δ{distance_to_tp:.2%})",
-            f"Stop Loss: {-self.config.global_stop_loss:.2%} (Δ{distance_to_sl:.2%})",
+            f"TP: {self.config.global_take_profit:.2%} (Δ{distance_to_tp:.2%}) [{tp_status}]",
+            f"SL: {-self.config.global_stop_loss:.2%} (Δ{distance_to_sl:.2%}) [{sl_status}]",
             f"Breakeven: {breakeven_str}"
         ]
 

--- a/controllers/generic/pmm_mister.py
+++ b/controllers/generic/pmm_mister.py
@@ -50,10 +50,12 @@ class PMMisterConfig(ControllerConfigBase):
     tolerance_scaling: Decimal = Field(default=Decimal("1.2"), json_schema_extra={"is_updatable": True})
 
     leverage: int = Field(default=20, json_schema_extra={"is_updatable": True})
-    position_mode: PositionMode = Field(default="ONEWAY")
+    position_mode: PositionMode = Field(default=PositionMode.ONEWAY)
+    # LONG: buys accumulate, sells reduce. SHORT: sells accumulate, buys reduce.
+    position_side: TradeType = Field(default=TradeType.BUY)
     take_profit: Optional[Decimal] = Field(default=Decimal("0.0001"), gt=0, json_schema_extra={"is_updatable": True})
-    take_profit_order_type: Optional[OrderType] = Field(default="LIMIT_MAKER", json_schema_extra={"is_updatable": True})
-    open_order_type: Optional[OrderType] = Field(default="LIMIT_MAKER", json_schema_extra={"is_updatable": True})
+    take_profit_order_type: Optional[OrderType] = Field(default=OrderType.LIMIT_MAKER, json_schema_extra={"is_updatable": True})
+    open_order_type: Optional[OrderType] = Field(default=OrderType.LIMIT_MAKER, json_schema_extra={"is_updatable": True})
     max_active_executors_by_level: Optional[int] = Field(default=4, json_schema_extra={"is_updatable": True})
     tick_mode: bool = Field(default=False, json_schema_extra={"is_updatable": True})
     position_profit_protection: bool = Field(default=False, json_schema_extra={"is_updatable": True})
@@ -121,10 +123,21 @@ class PMMisterConfig(ControllerConfigBase):
     def validate_position_mode(cls, v) -> PositionMode:
         return parse_enum_value(PositionMode, v, "position_mode")
 
+    @field_validator('position_side', mode="before")
+    @classmethod
+    def validate_position_side(cls, v) -> TradeType:
+        if isinstance(v, TradeType):
+            return v
+        mapping = {"BUY": TradeType.BUY, "SELL": TradeType.SELL, "LONG": TradeType.BUY, "SHORT": TradeType.SELL}
+        upper = str(v).upper()
+        if upper in mapping:
+            return mapping[upper]
+        raise ValueError(f"position_side must be BUY/LONG or SELL/SHORT, got {v}")
+
     @field_validator('global_tp_activation_from', mode="before")
     @classmethod
     def validate_tp_activation_from(cls, v):
-        valid = {"min_base", "target_base"}
+        valid = {"always", "min_base", "target_base"}
         if v not in valid:
             raise ValueError(f"global_tp_activation_from must be one of {valid}")
         return v
@@ -154,6 +167,10 @@ class PMMisterConfig(ControllerConfigBase):
         if field_name == 'tolerance_scaling' and Decimal(str(v)) <= 0:
             raise ValueError(f"{field_name} must be greater than 0")
         return v
+
+    @property
+    def is_short(self) -> bool:
+        return self.position_side == TradeType.SELL
 
     @property
     def triple_barrier_config(self) -> TripleBarrierConfig:
@@ -241,8 +258,33 @@ class PMMister(ControllerBase):
         self.order_history = []
         self.max_order_history = 20
         self.processed_data = {}
-        self._closing_position = False
-        self._close_trigger_reason = None
+        self._position_mode_verified = False
+        self._global_close_phase: Optional[str] = None  # None | "stopping" | "closing"
+
+    def _verify_position_mode(self) -> bool:
+        """Check that the connector's position mode matches the config. Blocks trading until confirmed."""
+        if self._position_mode_verified:
+            return True
+        try:
+            connector = self.market_data_provider.get_connector(self.config.connector_name)
+            # Only perpetual connectors have position_mode; skip check for spot connectors
+            if not hasattr(connector, 'position_mode'):
+                self._position_mode_verified = True
+                return True
+            exchange_mode = connector.position_mode
+            config_mode = self.config.position_mode
+            if exchange_mode != config_mode:
+                self.logger().warning(
+                    f"Position mode mismatch: exchange={exchange_mode}, config={config_mode}. "
+                    f"Waiting for position mode to be set correctly before trading.")
+                return False
+            self._position_mode_verified = True
+            self.logger().info(
+                f"Position mode verified: {exchange_mode} matches config. Trading enabled.")
+            return True
+        except Exception as e:
+            self.logger().warning(f"Could not verify position mode: {e}. Blocking trading.")
+            return False
 
     # ── Market data (called by framework) ─────────────────────────────────
 
@@ -281,20 +323,24 @@ class PMMister(ControllerBase):
     # ── Executor actions (called by framework) ────────────────────────────
 
     def determine_executor_actions(self) -> List[ExecutorAction]:
+        # Guard: verify position mode matches config before operating
+        if not self._verify_position_mode():
+            return []
+
         self._update_position_state()
-
-        # Handle active position closing
-        if self._closing_position:
-            return self._handle_closing_state()
-
-        # Check global TP/SL before normal logic
-        tp_sl_actions = self._check_global_tp_sl()
-        if tp_sl_actions is not None:
-            return tp_sl_actions
-
         self._compute_executor_analysis()
 
         actions = []
+
+        # Check global TP/SL — two-phase: stop executors, then close position
+        tp_sl_actions = self._check_global_tp_sl()
+        if tp_sl_actions:
+            actions.extend(tp_sl_actions)
+
+        # Block normal trading while global close is in progress
+        if self._global_close_phase is not None:
+            return actions
+
         actions.extend(self.create_actions_proposal())
         actions.extend(self.stop_actions_proposal())
         return actions
@@ -302,6 +348,8 @@ class PMMister(ControllerBase):
     # ── Global TP/SL ──────────────────────────────────────────────────────
 
     def _get_tp_activation_threshold(self) -> Decimal:
+        if self.config.global_tp_activation_from == "always":
+            return Decimal("0")
         if self.config.global_tp_activation_from == "min_base":
             return self.config.min_base_pct
         return self.config.target_base_pct
@@ -311,95 +359,106 @@ class PMMister(ControllerBase):
             return self.config.target_base_pct
         return self.config.max_base_pct
 
-    def _check_global_tp_sl(self) -> Optional[List[ExecutorAction]]:
+    def _check_global_tp_sl(self) -> List[ExecutorAction]:
+        """Check global TP/SL using a two-phase approach:
+        Phase 1 (stopping): Stop all active executors with keep_position=True.
+        Phase 2 (closing): Once no active executors remain, close the actual position."""
+
+        # --- Phase: stopping --- wait for all executors to finish, then transition to closing
+        if self._global_close_phase == "stopping":
+            active_non_close = [
+                e for e in self.executors_info
+                if e.is_active and e.custom_info.get("level_id") != "global_close"
+            ]
+            if active_non_close:
+                self.logger().debug(
+                    f"Global close phase=stopping: waiting for {len(active_non_close)} executors to finish"
+                )
+                return []
+            # All executors stopped — transition to closing phase
+            self._global_close_phase = "closing"
+            self.logger().info("Global close phase=stopping complete. All executors stopped. Transitioning to closing.")
+
+        # --- Phase: closing --- create close executor for the real position
+        if self._global_close_phase == "closing":
+            # If a close executor is already active, wait for it
+            close_executors = [
+                e for e in self.executors_info
+                if e.is_active and e.custom_info.get("level_id") == "global_close"
+            ]
+            if close_executors:
+                return []
+
+            position_amount = self.processed_data.get("position_amount", Decimal("0"))
+            if position_amount == Decimal("0"):
+                self.logger().info("Global close phase=closing: position is already 0. Done.")
+                self._global_close_phase = None
+                return []
+
+            quantized = self.market_data_provider.quantize_order_amount(
+                self.config.connector_name, self.config.trading_pair, abs(position_amount)
+            )
+            if quantized == Decimal("0"):
+                self._global_close_phase = None
+                return []
+
+            self.logger().info(
+                f"=== GLOBAL CLOSE — PHASE 2: CLOSING POSITION ===\n"
+                f"  Position amount: {position_amount} | Creating close executor."
+            )
+            close_action = self._create_close_action(position_amount)
+            return [close_action] if close_action else []
+
+        # --- No phase active: check if TP/SL should trigger ---
         current_base_pct = self.processed_data.get("current_base_pct", Decimal("0"))
         unrealized_pnl_pct = self.processed_data.get("unrealized_pnl_pct", Decimal("0"))
         position_amount = self.processed_data.get("position_amount", Decimal("0"))
 
         if position_amount == Decimal("0"):
-            return None
+            return []
 
         triggered = False
         trigger_reason = ""
 
         # Check take profit
-        if self.config.global_tp_enabled and current_base_pct >= self._get_tp_activation_threshold():
+        tp_threshold = self._get_tp_activation_threshold()
+        if self.config.global_tp_enabled and current_base_pct >= tp_threshold:
             if unrealized_pnl_pct >= self.config.global_take_profit:
                 triggered = True
                 trigger_reason = "take_profit"
 
         # Check stop loss
-        if not triggered and self.config.global_sl_enabled and current_base_pct >= self._get_sl_activation_threshold():
+        sl_threshold = self._get_sl_activation_threshold()
+        if not triggered and self.config.global_sl_enabled and current_base_pct >= sl_threshold:
             if unrealized_pnl_pct <= -self.config.global_stop_loss:
                 triggered = True
                 trigger_reason = "stop_loss"
 
         if not triggered:
-            return None
+            return []
+
+        # --- Trigger: enter stopping phase --- stop all active executors first
+        self._global_close_phase = "stopping"
+        active_executors = [
+            e for e in self.executors_info
+            if e.is_active and e.custom_info.get("level_id") != "global_close"
+        ]
 
         self.logger().info(
-            f"Global {trigger_reason} triggered! PnL: {unrealized_pnl_pct:.2%}, Position: {current_base_pct:.2%}"
+            f"=== GLOBAL {trigger_reason.upper()} TRIGGERED — PHASE 1: STOPPING EXECUTORS ===\n"
+            f"  PnL: {unrealized_pnl_pct:.4%} | Position: {position_amount} | Base%: {current_base_pct:.4%}\n"
+            f"  Stopping {len(active_executors)} active executors before closing position."
         )
-        self._closing_position = True
-        self._close_trigger_reason = trigger_reason
 
-        actions: List[ExecutorAction] = []
+        stop_actions = []
+        for executor in active_executors:
+            stop_actions.append(StopExecutorAction(
+                controller_id=self.config.id,
+                keep_position=True,
+                executor_id=executor.id,
+            ))
 
-        # Stop all active executors (keep positions intact for the close executor)
-        for executor in self.executors_info:
-            if executor.is_active:
-                actions.append(StopExecutorAction(
-                    controller_id=self.config.id,
-                    keep_position=True,
-                    executor_id=executor.id,
-                ))
-
-        # Create limit chaser to close the full position
-        close_action = self._create_close_action(position_amount)
-        if close_action:
-            actions.append(close_action)
-
-        return actions
-
-    def _handle_closing_state(self) -> List[ExecutorAction]:
-        position_amount = self.processed_data.get("position_amount", Decimal("0"))
-
-        # Check if position is effectively closed
-        quantized = self.market_data_provider.quantize_order_amount(
-            self.config.connector_name, self.config.trading_pair, abs(position_amount)
-        )
-        if quantized == Decimal("0"):
-            self.logger().info(
-                f"Global {self._close_trigger_reason} completed. Restarting market making."
-            )
-            self._closing_position = False
-            self._close_trigger_reason = None
-            return []
-
-        # Check if close executor is still active
-        close_executors = [
-            e for e in self.executors_info
-            if e.is_active and e.custom_info.get("level_id") == "global_close"
-        ]
-        if close_executors:
-            return []
-
-        # No close executor running but position remains — retry
-        actions: List[ExecutorAction] = []
-        for executor in self.executors_info:
-            if executor.is_active:
-                actions.append(StopExecutorAction(
-                    controller_id=self.config.id,
-                    keep_position=True,
-                    executor_id=executor.id,
-                ))
-
-        self.logger().info(f"Retrying position close. Remaining: {position_amount}")
-        close_action = self._create_close_action(position_amount)
-        if close_action:
-            actions.append(close_action)
-
-        return actions
+        return stop_actions
 
     def _create_close_action(self, position_amount: Decimal) -> Optional[CreateExecutorAction]:
         if position_amount == Decimal("0"):
@@ -407,6 +466,12 @@ class PMMister(ControllerBase):
 
         side = TradeType.SELL if position_amount > 0 else TradeType.BUY
         amount = abs(position_amount)
+
+        self.logger().info(
+            f"Creating close executor: side={side.name} amount={amount} "
+            f"action=CLOSE chaser_dist={self.config.close_chaser_distance:.4%} "
+            f"chaser_refresh={self.config.close_chaser_refresh_threshold:.4%}"
+        )
 
         config = OrderExecutorConfig(
             timestamp=self.market_data_provider.time(),
@@ -531,15 +596,23 @@ class PMMister(ControllerBase):
                     blocking.append("price_distance")
 
             # e) Position constraints
-            if current_pct < self.config.min_base_pct and not is_buy:
+            is_accumulation = self._is_accumulation_side(trade_type)
+            if current_pct < self.config.min_base_pct and not is_accumulation:
                 blocking.append("below_min_position")
-            elif current_pct > self.config.max_base_pct and is_buy:
+            elif current_pct > self.config.max_base_pct and is_accumulation:
                 blocking.append("above_max_position")
 
-            # f) Position profit protection
-            if (self.config.position_profit_protection and not is_buy
-                    and breakeven_price and breakeven_price > 0 and reference_price < breakeven_price):
-                blocking.append("position_profit_protection")
+            # f) Position profit protection — block the reduction side when price is unfavorable
+            is_reduction = not is_accumulation
+            if self.config.position_profit_protection and is_reduction and breakeven_price and breakeven_price > 0:
+                if self.config.is_short:
+                    # SHORT: buying to reduce — block if price > breakeven (would realize a loss)
+                    if reference_price > breakeven_price:
+                        blocking.append("position_profit_protection")
+                else:
+                    # LONG: selling to reduce — block if price < breakeven (would realize a loss)
+                    if reference_price < breakeven_price:
+                        blocking.append("position_profit_protection")
 
             # Execution-blocking conditions determine "working" levels
             execution_blocking = {"active_not_trading", "max_active_executors", "cooldown", "price_distance"}
@@ -687,28 +760,52 @@ class PMMister(ControllerBase):
         target_position = self.config.total_amount_quote * self.config.target_base_pct
 
         if position_held is not None:
-            current_base_pct = position_held.amount_quote / self.config.total_amount_quote
-            deviation = (target_position - position_held.amount_quote) / target_position
-            if self.config.global_pnl_reference == "portfolio":
-                unrealized_pnl_pct = (position_held.unrealized_pnl_quote / self.config.total_amount_quote
-                                      if self.config.total_amount_quote != 0 else Decimal("0"))
-            else:
-                unrealized_pnl_pct = (position_held.unrealized_pnl_quote / position_held.amount_quote
-                                      if position_held.amount_quote != 0 else Decimal("0"))
+            # Use abs(amount_quote) so current_base_pct is always positive for both long and short
+            current_base_pct = abs(position_held.amount_quote) / self.config.total_amount_quote
+            deviation = (target_position - abs(position_held.amount_quote)) / target_position
             breakeven_price = position_held.breakeven_price
             position_amount = position_held.amount
+            position_cum_fees = position_held.cum_fees_quote
+            position_realized_pnl = position_held.realized_pnl_quote
+            position_unrealized_pnl = position_held.unrealized_pnl_quote
+            position_volume = position_held.volume_traded_quote
+            if self.config.global_pnl_reference == "portfolio":
+                pnl_denominator = self.config.total_amount_quote
+            else:
+                # Use entry value (breakeven * amount) for stable PnL % instead of mark-price based amount_quote
+                pnl_denominator = (abs(position_amount) * breakeven_price
+                                   if breakeven_price and breakeven_price > 0
+                                   else abs(position_held.amount_quote))
+            unrealized_pnl_pct = (position_held.unrealized_pnl_quote / pnl_denominator
+                                  if pnl_denominator != 0 else Decimal("0"))
         else:
             current_base_pct = Decimal("0")
             deviation = Decimal("1")
             unrealized_pnl_pct = Decimal("0")
             breakeven_price = None
             position_amount = Decimal("0")
+            position_cum_fees = Decimal("0")
+            position_realized_pnl = Decimal("0")
+            position_unrealized_pnl = Decimal("0")
+            position_volume = Decimal("0")
+
+        # Executor fees (from active executors)
+        executor_fees = sum(
+            (e.cum_fees_quote for e in self.executors_info if e.is_active),
+            Decimal("0")
+        )
 
         min_pct = self.config.min_base_pct
         max_pct = self.config.max_base_pct
         if max_pct > min_pct:
-            buy_skew = (max_pct - current_base_pct) / (max_pct - min_pct)
-            sell_skew = (current_base_pct - min_pct) / (max_pct - min_pct)
+            if self.config.is_short:
+                # SHORT: sell accumulates → sell_skew high when position small, buy_skew high when position large
+                sell_skew = (max_pct - current_base_pct) / (max_pct - min_pct)
+                buy_skew = (current_base_pct - min_pct) / (max_pct - min_pct)
+            else:
+                # LONG: buy accumulates → buy_skew high when position small, sell_skew high when position large
+                buy_skew = (max_pct - current_base_pct) / (max_pct - min_pct)
+                sell_skew = (current_base_pct - min_pct) / (max_pct - min_pct)
             buy_skew = max(min(buy_skew, Decimal("1.0")), self.config.min_skew)
             sell_skew = max(min(sell_skew, Decimal("1.0")), self.config.min_skew)
         else:
@@ -722,6 +819,12 @@ class PMMister(ControllerBase):
             "position_amount": position_amount,
             "buy_skew": buy_skew,
             "sell_skew": sell_skew,
+            "position_cum_fees": position_cum_fees,
+            "position_realized_pnl": position_realized_pnl,
+            "position_unrealized_pnl": position_unrealized_pnl,
+            "position_volume": position_volume,
+            "executor_fees": executor_fees,
+            "total_fees": position_cum_fees + executor_fees,
         })
 
     # ── Create / stop proposals ───────────────────────────────────────────
@@ -763,11 +866,16 @@ class PMMister(ControllerBase):
                 self.logger().warning(f"The amount of the level {level_id} is 0. Skipping.")
                 continue
 
-            # Position profit protection: don't place sell orders below breakeven
-            if self.config.position_profit_protection and trade_type == TradeType.SELL:
+            # Position profit protection: block reduction-side orders at unfavorable prices
+            if self.config.position_profit_protection and not self._is_accumulation_side(trade_type):
                 breakeven_price = self.processed_data.get("breakeven_price")
-                if breakeven_price is not None and breakeven_price > 0 and price < breakeven_price:
-                    continue
+                if breakeven_price is not None and breakeven_price > 0:
+                    # LONG reduces by selling → skip if price < breakeven
+                    # SHORT reduces by buying → skip if price > breakeven
+                    if self.config.is_short and price > breakeven_price:
+                        continue
+                    elif not self.config.is_short and price < breakeven_price:
+                        continue
 
             executor_config = self.get_executor_config(level_id, price, amount)
             if executor_config is not None:
@@ -820,12 +928,22 @@ class PMMister(ControllerBase):
             if f"sell_{i}" not in working_levels
         ]
 
+        # Determine which side accumulates vs reduces based on position_side
+        if self.config.is_short:
+            accumulation_levels = sell_missing
+            reduction_levels = buy_missing
+        else:
+            accumulation_levels = buy_missing
+            reduction_levels = sell_missing
+
         current_pct = self.processed_data.get("current_base_pct", Decimal("0"))
 
+        # Below min → only accumulate
         if current_pct < self.config.min_base_pct:
-            return buy_missing
+            return accumulation_levels
+        # Above max → only reduce
         elif current_pct > self.config.max_base_pct:
-            return sell_missing
+            return reduction_levels
 
         if self.config.position_profit_protection:
             breakeven_price = self.processed_data.get("breakeven_price")
@@ -833,10 +951,20 @@ class PMMister(ControllerBase):
             target_pct = self.config.target_base_pct
 
             if breakeven_price is not None and breakeven_price > 0:
-                if current_pct < target_pct and reference_price < breakeven_price:
-                    return buy_missing
-                elif current_pct > target_pct and reference_price > breakeven_price:
-                    return sell_missing
+                if self.config.is_short:
+                    # SHORT: below target & price above breakeven → only accumulate (sell more)
+                    if current_pct < target_pct and reference_price > breakeven_price:
+                        return accumulation_levels
+                    # SHORT: above target & price below breakeven → only reduce (buy back)
+                    elif current_pct > target_pct and reference_price < breakeven_price:
+                        return reduction_levels
+                else:
+                    # LONG: below target & price below breakeven → only accumulate (buy more)
+                    if current_pct < target_pct and reference_price < breakeven_price:
+                        return accumulation_levels
+                    # LONG: above target & price above breakeven → only reduce (sell)
+                    elif current_pct > target_pct and reference_price > breakeven_price:
+                        return reduction_levels
 
         return buy_missing + sell_missing
 
@@ -881,6 +1009,13 @@ class PMMister(ControllerBase):
             side=trade_type,
         )
 
+    def _is_accumulation_side(self, trade_type: TradeType) -> bool:
+        """Returns True if trade_type is the side that accumulates position.
+        LONG: BUY accumulates. SHORT: SELL accumulates."""
+        if self.config.is_short:
+            return trade_type == TradeType.SELL
+        return trade_type == TradeType.BUY
+
     def get_level_id_from_side(self, trade_type: TradeType, level: int) -> str:
         return f"{trade_type.name.lower()}_{level}"
 
@@ -888,7 +1023,11 @@ class PMMister(ControllerBase):
         return TradeType.BUY if level_id.startswith("buy") else TradeType.SELL
 
     def get_level_from_level_id(self, level_id: str) -> int:
-        return int(level_id.split('_')[1])
+        parts = level_id.split('_')
+        try:
+            return int(parts[1])
+        except (ValueError, IndexError):
+            return -1
 
     # ── Custom info (MQTT / broker) ──────────────────────────────────────
 
@@ -926,8 +1065,8 @@ class PMMister(ControllerBase):
             "distance_to_sl": distance_to_sl,
             "global_tp_enabled": self.config.global_tp_enabled,
             "global_sl_enabled": self.config.global_sl_enabled,
-            "closing_position": self._closing_position,
-            "close_trigger_reason": self._close_trigger_reason,
+            "global_close_phase": self._global_close_phase,
+            "closing_position": self._global_close_phase is not None,
             "active_executors": executor_stats.get("total_active", 0),
             "trading_executors": executor_stats.get("total_trading", 0),
             "executable_buy_levels": can_buy,
@@ -947,26 +1086,6 @@ class PMMister(ControllerBase):
         if not hasattr(self, 'processed_data') or not self.processed_data:
             status.append("╒" + "═" * inner_width + "╕")
             status.append(f"│ {'Initializing controller... please wait':<{inner_width}} │")
-            status.append(f"╘{'═' * inner_width}╛")
-            return status
-
-        if self._closing_position:
-            reason = (self._close_trigger_reason or "unknown").upper().replace("_", " ")
-            pnl = self.processed_data.get('unrealized_pnl_pct', Decimal('0'))
-            pos_amt = self.processed_data.get('position_amount', Decimal('0'))
-            close_active = any(
-                e.is_active and e.custom_info.get("level_id") == "global_close"
-                for e in self.executors_info
-            )
-            close_status = "LIMIT CHASER ACTIVE" if close_active else "WAITING FOR CLOSE EXECUTOR..."
-            status.append("╒" + "═" * inner_width + "╕")
-            status.append(f"│ {'⚠️  CLOSING POSITION — ' + reason:<{inner_width}} │")
-            status.append(f"├{'─' * inner_width}┤")
-            status.append(f"│ {'Status: ' + close_status:<{inner_width}} │")
-            status.append(f"│ {'PnL: ' + f'{pnl:+.2%}':<{inner_width}} │")
-            status.append(f"│ {'Remaining amount: ' + f'{pos_amt}':<{inner_width}} │")
-            chaser_info = f"Chaser: dist={self.config.close_chaser_distance:.4%} refresh={self.config.close_chaser_refresh_threshold:.4%}"
-            status.append(f"│ {chaser_info:<{inner_width}} │")
             status.append(f"╘{'═' * inner_width}╛")
             return status
 
@@ -1113,11 +1232,15 @@ class PMMister(ControllerBase):
 
         skew = base_pct - target_pct
         skew_pct = skew / target_pct if target_pct != 0 else Decimal('0')
+        pos_side_label = "SHORT" if self.config.is_short else "LONG"
+        pos_amount = self.processed_data.get('position_amount', Decimal('0'))
         position_info = [
-            f"Current: {base_pct:.2%} (Target: {target_pct:.2%})",
+            f"Current: {base_pct:.2%} (Target: {target_pct:.2%}) [{pos_side_label}]",
             f"Range: {min_pct:.2%} - {max_pct:.2%}",
+            f"Amount: {pos_amount}",
             f"Skew: {skew_pct:+.2%} (min {self.config.min_skew:.2%})",
-            f"Buy Skew: {buy_skew:.2f} | Sell Skew: {sell_skew:.2f}"
+            f"Buy Skew: {buy_skew:.2f} | Sell Skew: {sell_skew:.2f}",
+            "",
         ]
 
         breakeven_str = f"{breakeven:.2f}" if breakeven is not None else "N/A"
@@ -1130,8 +1253,19 @@ class PMMister(ControllerBase):
         tp_status = "ACTIVE" if tp_active else ("OFF" if not self.config.global_tp_enabled else f"from {self.config.global_tp_activation_from}")
         sl_status = "ACTIVE" if sl_active else ("OFF" if not self.config.global_sl_enabled else f"from {self.config.global_sl_activation_from}")
 
+        # Fee and PnL data
+        position_fees = self.processed_data.get('position_cum_fees', Decimal('0'))
+        executor_fees = self.processed_data.get('executor_fees', Decimal('0'))
+        total_fees = self.processed_data.get('total_fees', Decimal('0'))
+        realized_pnl = self.processed_data.get('position_realized_pnl', Decimal('0'))
+        unrealized_pnl_quote = self.processed_data.get('position_unrealized_pnl', Decimal('0'))
+        volume = self.processed_data.get('position_volume', Decimal('0'))
+        quote = self.config.trading_pair.split("-")[1]
+
         pnl_info = [
-            f"Unrealized: {pnl_sign}{pnl:.2%}",
+            f"Unrealized: {pnl_sign}{pnl:.2%} ({unrealized_pnl_quote:+.4f} {quote})",
+            f"Realized: {realized_pnl:+.4f} {quote} | Vol: {volume:.2f} {quote}",
+            f"Fees: {total_fees:.4f} {quote} (pos:{position_fees:.4f} exec:{executor_fees:.4f})",
             f"TP: {self.config.global_take_profit:.2%} (Δ{distance_to_tp:.2%}) [{tp_status}]",
             f"SL: {-self.config.global_stop_loss:.2%} (Δ{distance_to_sl:.2%}) [{sl_status}]",
             f"Breakeven: {breakeven_str}"
@@ -1345,8 +1479,9 @@ class PMMister(ControllerBase):
         else:
             pnl_bar = "─" * bar_width
 
-        pnl_status = "PROFIT" if pnl > 0 else "LOSS" if pnl < 0 else "BREAK-EVEN"
-        lines.append(f"│ PnL:        [{pnl_bar}] {pnl_status} │")
+        pnl_sign = "+" if pnl > 0 else ""
+        pnl_status = f"{pnl_sign}{pnl:.2%}"
+        lines.append(f"│ Position PnL: [{pnl_bar}] {pnl_status} (S={-self.config.global_stop_loss:.2%} T={self.config.global_take_profit:.2%}) │")
 
         return lines
 

--- a/controllers/generic/pmm_mister.py
+++ b/controllers/generic/pmm_mister.py
@@ -260,6 +260,7 @@ class PMMister(ControllerBase):
         self.processed_data = {}
         self._position_mode_verified = False
         self._global_close_phase: Optional[str] = None  # None | "stopping" | "closing"
+        self._global_close_side: Optional[TradeType] = None  # Side of the position when TP/SL triggered
 
     def _verify_position_mode(self) -> bool:
         """Check that the connector's position mode matches the config. Blocks trading until confirmed."""
@@ -389,24 +390,47 @@ class PMMister(ControllerBase):
             if close_executors:
                 return []
 
-            position_amount = self.processed_data.get("position_amount", Decimal("0"))
-            if position_amount == Decimal("0"):
+            # Read LIVE position from positions_held (not processed_data snapshot)
+            position_held = next((p for p in self.positions_held if
+                                  p.trading_pair == self.config.trading_pair and
+                                  p.connector_name == self.config.connector_name), None)
+
+            if position_held is None or position_held.amount == Decimal("0"):
                 self.logger().info("Global close phase=closing: position is already 0. Done.")
                 self._global_close_phase = None
+                self._global_close_side = None
                 return []
 
+            # SAFETY: Detect position side flip — if position flipped direction, abort close
+            if self._global_close_side is not None and position_held.side != self._global_close_side:
+                self.logger().warning(
+                    f"=== GLOBAL CLOSE ABORTED: Position side flipped! ===\n"
+                    f"  Original side: {self._global_close_side.name} | "
+                    f"Current side: {position_held.side.name} | Amount: {position_held.amount}\n"
+                    f"  This indicates over-selling. Aborting global close to prevent further damage."
+                )
+                self._global_close_phase = None
+                self._global_close_side = None
+                return []
+
+            position_amount = position_held.amount
             quantized = self.market_data_provider.quantize_order_amount(
-                self.config.connector_name, self.config.trading_pair, abs(position_amount)
+                self.config.connector_name, self.config.trading_pair, position_amount
             )
             if quantized == Decimal("0"):
                 self._global_close_phase = None
+                self._global_close_side = None
                 return []
+
+            # Determine close side from the LIVE position side
+            close_side = TradeType.SELL if position_held.side == TradeType.BUY else TradeType.BUY
 
             self.logger().info(
                 f"=== GLOBAL CLOSE — PHASE 2: CLOSING POSITION ===\n"
-                f"  Position amount: {position_amount} | Creating close executor."
+                f"  Position side: {position_held.side.name} | Amount: {position_amount} | "
+                f"Close side: {close_side.name} | Creating close executor."
             )
-            close_action = self._create_close_action(position_amount)
+            close_action = self._create_close_action_with_side(close_side, position_amount)
             return [close_action] if close_action else []
 
         # --- No phase active: check if TP/SL should trigger ---
@@ -439,6 +463,11 @@ class PMMister(ControllerBase):
 
         # --- Trigger: enter stopping phase --- stop all active executors first
         self._global_close_phase = "stopping"
+        # Remember the position side at trigger time so we always close in the right direction
+        position_held = next((p for p in self.positions_held if
+                              p.trading_pair == self.config.trading_pair and
+                              p.connector_name == self.config.connector_name), None)
+        self._global_close_side = position_held.side if position_held else None
         active_executors = [
             e for e in self.executors_info
             if e.is_active and e.custom_info.get("level_id") != "global_close"
@@ -461,11 +490,18 @@ class PMMister(ControllerBase):
         return stop_actions
 
     def _create_close_action(self, position_amount: Decimal) -> Optional[CreateExecutorAction]:
-        if position_amount == Decimal("0"):
+        """Create a close action by inferring the side from position_held. Kept for backward compat."""
+        position_held = next((p for p in self.positions_held if
+                              p.trading_pair == self.config.trading_pair and
+                              p.connector_name == self.config.connector_name), None)
+        if position_held is None or position_amount == Decimal("0"):
             return None
+        close_side = TradeType.SELL if position_held.side == TradeType.BUY else TradeType.BUY
+        return self._create_close_action_with_side(close_side, abs(position_amount))
 
-        side = TradeType.SELL if position_amount > 0 else TradeType.BUY
-        amount = abs(position_amount)
+    def _create_close_action_with_side(self, side: TradeType, amount: Decimal) -> Optional[CreateExecutorAction]:
+        if amount == Decimal("0"):
+            return None
 
         self.logger().info(
             f"Creating close executor: side={side.name} amount={amount} "

--- a/controllers/generic/pmm_mister.py
+++ b/controllers/generic/pmm_mister.py
@@ -77,10 +77,6 @@ class PMMisterConfig(ControllerConfigBase):
     # PnL reference: "position" = pnl/position_value, "portfolio" = pnl/total_amount_quote
     global_pnl_reference: str = Field(default="position", json_schema_extra={"is_updatable": True})
 
-    # Limit chaser config for position closing (tight values for fast fills)
-    close_chaser_distance: Decimal = Field(default=Decimal("0.0001"), json_schema_extra={"is_updatable": True})
-    close_chaser_refresh_threshold: Decimal = Field(default=Decimal("0.0005"), json_schema_extra={"is_updatable": True})
-
     @field_validator("take_profit", mode="before")
     @classmethod
     def validate_target(cls, v):

--- a/controllers/generic/pmm_mister.py
+++ b/controllers/generic/pmm_mister.py
@@ -5,14 +5,18 @@ from typing import Dict, List, Optional, Tuple, Union
 from pydantic import Field, field_validator
 from pydantic_core.core_schema import ValidationInfo
 
-from hummingbot.core.data_type.common import MarketDict, OrderType, PositionAction, PositionMode, PriceType, TradeType
+from hummingbot.core.data_type.common import (
+    MarketDict,
+    OrderType,
+    PositionAction,
+    PositionMode,
+    PositionSide,
+    PriceType,
+    TradeType,
+)
 from hummingbot.strategy_v2.controllers.controller_base import ControllerBase, ControllerConfigBase
 from hummingbot.strategy_v2.executors.data_types import ConnectorPair
-from hummingbot.strategy_v2.executors.order_executor.data_types import (
-    ExecutionStrategy,
-    LimitChaserConfig,
-    OrderExecutorConfig,
-)
+from hummingbot.strategy_v2.executors.order_executor.data_types import ExecutionStrategy, OrderExecutorConfig
 from hummingbot.strategy_v2.executors.position_executor.data_types import PositionExecutorConfig, TripleBarrierConfig
 from hummingbot.strategy_v2.models.executor_actions import CreateExecutorAction, ExecutorAction, StopExecutorAction
 from hummingbot.strategy_v2.utils.common import parse_comma_separated_list, parse_enum_value
@@ -261,6 +265,7 @@ class PMMister(ControllerBase):
         self._position_mode_verified = False
         self._global_close_phase: Optional[str] = None  # None | "stopping" | "closing"
         self._global_close_side: Optional[TradeType] = None  # Side of the position when TP/SL triggered
+        self._global_close_retries: int = 0  # Count how many times PHASE 2 has created a close executor
 
     def _verify_position_mode(self) -> bool:
         """Check that the connector's position mode matches the config. Blocks trading until confirmed."""
@@ -360,6 +365,27 @@ class PMMister(ControllerBase):
             return self.config.target_base_pct
         return self.config.max_base_pct
 
+    def _get_exchange_position(self) -> Tuple[Decimal, Optional[TradeType]]:
+        """Read the REAL position from the exchange connector (WebSocket-updated, no orchestrator delay).
+        Returns (abs_amount, side) where side is BUY for long, SELL for short, None if no position."""
+        try:
+            connector = self.market_data_provider.get_connector(self.config.connector_name)
+            if not hasattr(connector, '_perpetual_trading'):
+                return Decimal("0"), None
+            perp = connector._perpetual_trading
+            pos = perp.get_position(self.config.trading_pair, PositionSide.BOTH)
+            if pos is None or pos.amount == Decimal("0"):
+                return Decimal("0"), None
+            amount = pos.amount
+            # Binance ONEWAY: positive amount = long, negative = short
+            if amount > 0:
+                return amount, TradeType.BUY
+            else:
+                return abs(amount), TradeType.SELL
+        except Exception as e:
+            self.logger().warning(f"Failed to read exchange position: {e}")
+            return Decimal("0"), None
+
     def _check_global_tp_sl(self) -> List[ExecutorAction]:
         """Check global TP/SL using a two-phase approach:
         Phase 1 (stopping): Stop all active executors with keep_position=True.
@@ -390,47 +416,60 @@ class PMMister(ControllerBase):
             if close_executors:
                 return []
 
-            # Read LIVE position from positions_held (not processed_data snapshot)
-            position_held = next((p for p in self.positions_held if
-                                  p.trading_pair == self.config.trading_pair and
-                                  p.connector_name == self.config.connector_name), None)
-
-            if position_held is None or position_held.amount == Decimal("0"):
-                self.logger().info("Global close phase=closing: position is already 0. Done.")
+            # Guard: abort after too many failed close attempts (e.g. below min notional)
+            if self._global_close_retries >= 3:
+                self.logger().warning(
+                    f"=== GLOBAL CLOSE ABORTED: {self._global_close_retries} close attempts failed. ===\n"
+                    f"  Position may be below minimum notional. Aborting to prevent infinite loop."
+                )
                 self._global_close_phase = None
                 self._global_close_side = None
+                self._global_close_retries = 0
+                return []
+
+            # Read position from the EXCHANGE CONNECTOR (WebSocket-updated, no orchestrator delay)
+            # This avoids the race condition where positions_held is stale
+            exchange_amount, exchange_side = self._get_exchange_position()
+
+            if exchange_amount == Decimal("0") or exchange_side is None:
+                self.logger().info("Global close phase=closing: exchange position is 0. Done.")
+                self._global_close_phase = None
+                self._global_close_side = None
+                self._global_close_retries = 0
                 return []
 
             # SAFETY: Detect position side flip — if position flipped direction, abort close
-            if self._global_close_side is not None and position_held.side != self._global_close_side:
+            if self._global_close_side is not None and exchange_side != self._global_close_side:
                 self.logger().warning(
                     f"=== GLOBAL CLOSE ABORTED: Position side flipped! ===\n"
                     f"  Original side: {self._global_close_side.name} | "
-                    f"Current side: {position_held.side.name} | Amount: {position_held.amount}\n"
+                    f"Current side: {exchange_side.name} | Amount: {exchange_amount}\n"
                     f"  This indicates over-selling. Aborting global close to prevent further damage."
                 )
                 self._global_close_phase = None
                 self._global_close_side = None
+                self._global_close_retries = 0
                 return []
 
-            position_amount = position_held.amount
             quantized = self.market_data_provider.quantize_order_amount(
-                self.config.connector_name, self.config.trading_pair, position_amount
+                self.config.connector_name, self.config.trading_pair, exchange_amount
             )
             if quantized == Decimal("0"):
                 self._global_close_phase = None
                 self._global_close_side = None
+                self._global_close_retries = 0
                 return []
 
-            # Determine close side from the LIVE position side
-            close_side = TradeType.SELL if position_held.side == TradeType.BUY else TradeType.BUY
+            # Determine close side from the EXCHANGE position side
+            close_side = TradeType.SELL if exchange_side == TradeType.BUY else TradeType.BUY
 
+            self._global_close_retries += 1
             self.logger().info(
-                f"=== GLOBAL CLOSE — PHASE 2: CLOSING POSITION ===\n"
-                f"  Position side: {position_held.side.name} | Amount: {position_amount} | "
+                f"=== GLOBAL CLOSE — PHASE 2: CLOSING POSITION (attempt {self._global_close_retries}/3) ===\n"
+                f"  Exchange position: {exchange_side.name} {exchange_amount} | "
                 f"Close side: {close_side.name} | Creating close executor."
             )
-            close_action = self._create_close_action_with_side(close_side, position_amount)
+            close_action = self._create_close_action_with_side(close_side, exchange_amount)
             return [close_action] if close_action else []
 
         # --- No phase active: check if TP/SL should trigger ---
@@ -463,6 +502,7 @@ class PMMister(ControllerBase):
 
         # --- Trigger: enter stopping phase --- stop all active executors first
         self._global_close_phase = "stopping"
+        self._global_close_retries = 0
         # Remember the position side at trigger time so we always close in the right direction
         position_held = next((p for p in self.positions_held if
                               p.trading_pair == self.config.trading_pair and
@@ -505,8 +545,7 @@ class PMMister(ControllerBase):
 
         self.logger().info(
             f"Creating close executor: side={side.name} amount={amount} "
-            f"action=CLOSE chaser_dist={self.config.close_chaser_distance:.4%} "
-            f"chaser_refresh={self.config.close_chaser_refresh_threshold:.4%}"
+            f"action=CLOSE strategy=MARKET (reduceOnly on exchange)"
         )
 
         config = OrderExecutorConfig(
@@ -515,12 +554,8 @@ class PMMister(ControllerBase):
             connector_name=self.config.connector_name,
             side=side,
             amount=amount,
-            execution_strategy=ExecutionStrategy.LIMIT_CHASER,
+            execution_strategy=ExecutionStrategy.MARKET,
             position_action=PositionAction.CLOSE,
-            chaser_config=LimitChaserConfig(
-                distance=self.config.close_chaser_distance,
-                refresh_threshold=self.config.close_chaser_refresh_threshold,
-            ),
             leverage=self.config.leverage,
             level_id="global_close",
         )

--- a/controllers/generic/pmm_mister.py
+++ b/controllers/generic/pmm_mister.py
@@ -74,8 +74,8 @@ class PMMisterConfig(ControllerConfigBase):
     global_pnl_reference: str = Field(default="position", json_schema_extra={"is_updatable": True})
 
     # Limit chaser config for position closing (tight values for fast fills)
-    close_chaser_distance: Decimal = Field(default=Decimal("0.0003"), json_schema_extra={"is_updatable": True})
-    close_chaser_refresh_threshold: Decimal = Field(default=Decimal("0.0003"), json_schema_extra={"is_updatable": True})
+    close_chaser_distance: Decimal = Field(default=Decimal("0.0001"), json_schema_extra={"is_updatable": True})
+    close_chaser_refresh_threshold: Decimal = Field(default=Decimal("0.0005"), json_schema_extra={"is_updatable": True})
 
     @field_validator("take_profit", mode="before")
     @classmethod

--- a/hummingbot/connector/derivative/binance_perpetual/binance_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/binance_perpetual/binance_perpetual_derivative.py
@@ -726,7 +726,6 @@ class BinancePerpetualDerivative(PerpetualDerivativePyBase):
             path_url=CONSTANTS.CHANGE_POSITION_MODE_URL,
             is_auth_required=True,
             limit_id=CONSTANTS.GET_POSITION_MODE_LIMIT_ID,
-            return_err=True
         )
         self._position_mode = PositionMode.HEDGE if response.get("dualSidePosition") else PositionMode.ONEWAY
         return self._position_mode

--- a/hummingbot/connector/derivative/binance_perpetual/binance_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/binance_perpetual/binance_perpetual_derivative.py
@@ -259,6 +259,10 @@ class BinancePerpetualDerivative(PerpetualDerivativePyBase):
                 api_params["positionSide"] = "LONG" if trade_type is TradeType.BUY else "SHORT"
             else:
                 api_params["positionSide"] = "SHORT" if trade_type is TradeType.BUY else "LONG"
+        elif position_action == PositionAction.CLOSE:
+            # In ONEWAY mode, reduceOnly ensures the order can only reduce the position,
+            # never open a new one or flip direction. This prevents over-selling.
+            api_params["reduceOnly"] = "true"
         try:
             order_result = await self._api_post(
                 path_url=CONSTANTS.ORDER_URL,

--- a/hummingbot/connector/derivative/bitget_perpetual/bitget_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/bitget_perpetual/bitget_perpetual_derivative.py
@@ -662,6 +662,24 @@ class BitgetPerpetualDerivative(PerpetualDerivativePyBase):
 
             self.logger().info(f"Margin mode set to {margin_mode}")
 
+    async def _execute_set_position_mode(self, mode: PositionMode):
+        """Bitget derives productType from trading_pair, so we must loop over all trading pairs."""
+        all_success = True
+        msg = ""
+        for trading_pair in self.trading_pairs:
+            success, msg = await self._trading_pair_position_mode_set(mode, trading_pair)
+            if not success:
+                all_success = False
+                self.logger().network(f"Error switching {trading_pair} mode to {mode}: {msg}")
+                break
+
+        if all_success:
+            self._perpetual_trading.set_position_mode(mode)
+            self.logger().info(f"Position mode switched to {mode}.")
+        else:
+            self.logger().error(f"Failed to set position mode to {mode}: {msg}")
+        self._fire_position_mode_events(mode, success=all_success, message=msg)
+
     async def _trading_pair_position_mode_set(
         self,
         mode: PositionMode,

--- a/hummingbot/connector/derivative/bitget_perpetual/bitget_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/bitget_perpetual/bitget_perpetual_derivative.py
@@ -128,7 +128,7 @@ class BitgetPerpetualDerivative(PerpetualDerivativePyBase):
         await super().start_network()
         if self.is_trading_required:
             await self.set_margin_mode(self._margin_mode)
-            self.set_position_mode(PositionMode.HEDGE)
+            await self._initialize_position_mode()
 
     def supported_order_types(self) -> List[OrderType]:
         return [OrderType.LIMIT, OrderType.MARKET]
@@ -161,10 +161,14 @@ class BitgetPerpetualDerivative(PerpetualDerivativePyBase):
 
         return collateral_token
 
-    async def get_exchange_position_mode(self, trading_pair: str) -> None:
+    async def _fetch_account_position_mode(self) -> Optional[PositionMode]:
         """
-        Returns the current exchange position mode.
+        Fetches the current position mode from the Bitget exchange account.
+        Uses the first trading pair to query the account info.
         """
+        if not self.trading_pairs:
+            return None
+        trading_pair = self.trading_pairs[0]
         product_type = await self.product_type_associated_to_trading_pair(trading_pair)
         account_info_response: Dict[str, Any] = await self._api_get(
             path_url=CONSTANTS.ACCOUNT_INFO_ENDPOINT,
@@ -180,7 +184,7 @@ class BitgetPerpetualDerivative(PerpetualDerivativePyBase):
                 account_info_response["code"],
                 f"Error getting position mode for {trading_pair}: {account_info_response['msg']}"
             ))
-            return
+            return None
 
         position_modes = {
             "one_way_mode": PositionMode.ONEWAY,
@@ -188,8 +192,8 @@ class BitgetPerpetualDerivative(PerpetualDerivativePyBase):
         }
 
         position_mode = position_modes[account_info_response["data"]["posMode"]]
-
         self.logger().info(f"Position mode for {trading_pair}: {position_mode}")
+        return position_mode
 
     def get_buy_collateral_token(self, trading_pair: str) -> str:
         trading_rule: TradingRule = self._trading_rules.get(trading_pair, None)
@@ -665,7 +669,21 @@ class BitgetPerpetualDerivative(PerpetualDerivativePyBase):
     async def _execute_set_position_mode(self, mode: PositionMode):
         """Bitget derives productType from trading_pair, so we must loop over all trading pairs."""
         async with self._set_position_mode_lock:
-            if mode == self._perpetual_trading.position_mode:
+            try:
+                exchange_mode = await self._fetch_account_position_mode()
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                self.logger().warning(f"Could not fetch position mode from exchange: {e}")
+                exchange_mode = None
+
+            self.logger().info(
+                f"Setting position mode: requested={mode}, current_exchange={exchange_mode}")
+
+            if exchange_mode == mode:
+                self._perpetual_trading.set_position_mode(mode)
+                self._fire_position_mode_events(mode, success=True)
+                self.logger().info(f"Position mode already set to {mode} on exchange.")
                 return
 
             all_success = True

--- a/hummingbot/connector/derivative/bitget_perpetual/bitget_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/bitget_perpetual/bitget_perpetual_derivative.py
@@ -664,21 +664,25 @@ class BitgetPerpetualDerivative(PerpetualDerivativePyBase):
 
     async def _execute_set_position_mode(self, mode: PositionMode):
         """Bitget derives productType from trading_pair, so we must loop over all trading pairs."""
-        all_success = True
-        msg = ""
-        for trading_pair in self.trading_pairs:
-            success, msg = await self._trading_pair_position_mode_set(mode, trading_pair)
-            if not success:
-                all_success = False
-                self.logger().network(f"Error switching {trading_pair} mode to {mode}: {msg}")
-                break
+        async with self._set_position_mode_lock:
+            if mode == self._perpetual_trading.position_mode:
+                return
 
-        if all_success:
-            self._perpetual_trading.set_position_mode(mode)
-            self.logger().info(f"Position mode switched to {mode}.")
-        else:
-            self.logger().error(f"Failed to set position mode to {mode}: {msg}")
-        self._fire_position_mode_events(mode, success=all_success, message=msg)
+            all_success = True
+            msg = ""
+            for trading_pair in self.trading_pairs:
+                success, msg = await self._trading_pair_position_mode_set(mode, trading_pair)
+                if not success:
+                    all_success = False
+                    self.logger().network(f"Error switching {trading_pair} mode to {mode}: {msg}")
+                    break
+
+            if all_success:
+                self._perpetual_trading.set_position_mode(mode)
+                self.logger().info(f"Position mode switched to {mode}.")
+            else:
+                self.logger().error(f"Failed to set position mode to {mode}: {msg}")
+            self._fire_position_mode_events(mode, success=all_success, message=msg)
 
     async def _trading_pair_position_mode_set(
         self,

--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_derivative.py
@@ -774,9 +774,6 @@ class BybitPerpetualDerivative(PerpetualDerivativePyBase):
     async def _execute_set_position_mode(self, mode: PositionMode):
         """Bybit sets position mode per-symbol, so we must loop over all trading pairs."""
         async with self._set_position_mode_lock:
-            if mode == self._perpetual_trading.position_mode:
-                return
-
             all_success = True
             msg = ""
             for trading_pair in self.trading_pairs:

--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_derivative.py
@@ -773,21 +773,25 @@ class BybitPerpetualDerivative(PerpetualDerivativePyBase):
 
     async def _execute_set_position_mode(self, mode: PositionMode):
         """Bybit sets position mode per-symbol, so we must loop over all trading pairs."""
-        all_success = True
-        msg = ""
-        for trading_pair in self.trading_pairs:
-            success, msg = await self._trading_pair_position_mode_set(mode, trading_pair)
-            if not success:
-                all_success = False
-                self.logger().network(f"Error switching {trading_pair} mode to {mode}: {msg}")
-                break
+        async with self._set_position_mode_lock:
+            if mode == self._perpetual_trading.position_mode:
+                return
 
-        if all_success:
-            self._perpetual_trading.set_position_mode(mode)
-            self.logger().info(f"Position mode switched to {mode}.")
-        else:
-            self.logger().error(f"Failed to set position mode to {mode}: {msg}")
-        self._fire_position_mode_events(mode, success=all_success, message=msg)
+            all_success = True
+            msg = ""
+            for trading_pair in self.trading_pairs:
+                success, msg = await self._trading_pair_position_mode_set(mode, trading_pair)
+                if not success:
+                    all_success = False
+                    self.logger().network(f"Error switching {trading_pair} mode to {mode}: {msg}")
+                    break
+
+            if all_success:
+                self._perpetual_trading.set_position_mode(mode)
+                self.logger().info(f"Position mode switched to {mode}.")
+            else:
+                self.logger().error(f"Failed to set position mode to {mode}: {msg}")
+            self._fire_position_mode_events(mode, success=all_success, message=msg)
 
     async def _trading_pair_position_mode_set(self, mode: PositionMode, trading_pair: str) -> Tuple[bool, str]:
         msg = ""

--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_derivative.py
@@ -771,6 +771,24 @@ class BybitPerpetualDerivative(PerpetualDerivativePyBase):
         price = float(resp_json["result"]["list"][0]["lastPrice"])
         return price
 
+    async def _execute_set_position_mode(self, mode: PositionMode):
+        """Bybit sets position mode per-symbol, so we must loop over all trading pairs."""
+        all_success = True
+        msg = ""
+        for trading_pair in self.trading_pairs:
+            success, msg = await self._trading_pair_position_mode_set(mode, trading_pair)
+            if not success:
+                all_success = False
+                self.logger().network(f"Error switching {trading_pair} mode to {mode}: {msg}")
+                break
+
+        if all_success:
+            self._perpetual_trading.set_position_mode(mode)
+            self.logger().info(f"Position mode switched to {mode}.")
+        else:
+            self.logger().error(f"Failed to set position mode to {mode}: {msg}")
+        self._fire_position_mode_events(mode, success=all_success, message=msg)
+
     async def _trading_pair_position_mode_set(self, mode: PositionMode, trading_pair: str) -> Tuple[bool, str]:
         msg = ""
         success = True

--- a/hummingbot/connector/derivative/gate_io_perpetual/gate_io_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/gate_io_perpetual/gate_io_perpetual_derivative.py
@@ -727,36 +727,19 @@ class GateIoPerpetualDerivative(PerpetualDerivativePyBase):
             else:
                 self._perpetual_trading.remove_position(pos_key)
 
-    async def _get_position_mode(self) -> Optional[PositionMode]:
-        if self._position_mode is None:
-            response = await self._api_get(
-                path_url=CONSTANTS.POSITION_INFORMATION_URL,
-                is_auth_required=True,
-                limit_id=CONSTANTS.POSITION_INFORMATION_URL
-            )
-            self._position_mode = PositionMode.ONEWAY if response[0]["mode"] == 'single' else PositionMode.HEDGE
+    async def _fetch_account_position_mode(self) -> Optional[PositionMode]:
+        response = await self._api_get(
+            path_url=CONSTANTS.POSITION_INFORMATION_URL,
+            is_auth_required=True,
+            limit_id=CONSTANTS.POSITION_INFORMATION_URL
+        )
+        self._position_mode = PositionMode.ONEWAY if response[0]["mode"] == 'single' else PositionMode.HEDGE
         return self._position_mode
 
-    async def _execute_set_position_mode_for_pairs(
-            # To-do: ensure there's no active order or contract before changing position mode
-            self, mode: PositionMode, trading_pairs: List[str]
-    ) -> Tuple[bool, List[str], str]:
-        successful_pairs = []
-        success = True
-        msg = ""
-
-        for trading_pair in trading_pairs:
-            initial_mode = await self._get_position_mode()
-            if mode != initial_mode:
-                success, msg = await self._trading_pair_position_mode_set(mode, trading_pair)
-                self._position_mode = mode
-            if success:
-                successful_pairs.append(trading_pair)
-            else:
-                self.logger().network(f"Error switching {trading_pair} mode to {mode}: {msg}")
-                break
-
-        return success, successful_pairs, msg
+    async def _get_position_mode(self) -> Optional[PositionMode]:
+        if self._position_mode is None:
+            await self._fetch_account_position_mode()
+        return self._position_mode
 
     async def _trading_pair_position_mode_set(self, mode: PositionMode, trading_pair: str) -> Tuple[bool, str]:
         msg = ""

--- a/hummingbot/connector/derivative/okx_perpetual/okx_perpetual_constants.py
+++ b/hummingbot/connector/derivative/okx_perpetual/okx_perpetual_constants.py
@@ -110,6 +110,8 @@ REST_GET_INSTRUMENTS = {METHOD: GET,
 # REST API Private General Endpoints
 REST_GET_WALLET_BALANCE = {METHOD: GET,
                            ENDPOINT: f"/api/{REST_API_VERSION}/account/balance"}
+REST_GET_ACCOUNT_CONFIG = {METHOD: GET,
+                           ENDPOINT: f"/api/{REST_API_VERSION}/account/config"}
 REST_SET_POSITION_MODE = {METHOD: POST,
                           ENDPOINT: f"/api/{REST_API_VERSION}/account/set-position-mode"}
 
@@ -174,6 +176,7 @@ RATE_LIMIT_SET_LEVERAGE = 20  # per 2 seconds
 RATE_LIMIT_USER_TRADE_RECORDS = 120  # per 60 seconds
 RATE_LIMIT_GET_POSITIONS = 10  # per 2 seconds
 RATE_LIMIT_GET_WALLET_BALANCE = 10  # per 2 seconds
+RATE_LIMIT_GET_ACCOUNT_CONFIG = 5  # per 2 seconds
 RATE_LIMIT_SET_POSITION_MODE = 5  # per 2 seconds
 RATE_LIMIT_BILLS_DETAILS = 5  # per 1 second
 RET_CODE_TIMESTAMP_HEADER_INVALID = "50112"

--- a/hummingbot/connector/derivative/okx_perpetual/okx_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/okx_perpetual/okx_perpetual_derivative.py
@@ -19,7 +19,6 @@ from hummingbot.connector.perpetual_derivative_py_base import PerpetualDerivativ
 from hummingbot.connector.trading_rule import TradingRule
 from hummingbot.connector.utils import combine_to_hb_trading_pair
 from hummingbot.core.api_throttler.data_types import RateLimit
-from hummingbot.core.clock import Clock
 from hummingbot.core.data_type.common import OrderType, PositionAction, PositionMode, PositionSide, TradeType
 from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState, OrderUpdate, TradeUpdate
 from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
@@ -185,11 +184,6 @@ class OkxPerpetualDerivative(PerpetualDerivativePyBase):
     def get_sell_collateral_token(self, trading_pair: str) -> str:
         trading_rule: TradingRule = self._trading_rules[trading_pair]
         return trading_rule.sell_order_collateral_token
-
-    def start(self, clock: Clock, timestamp: float):
-        super().start(clock, timestamp)
-        if self._domain == CONSTANTS.DEFAULT_DOMAIN and self.is_trading_required:
-            self.set_position_mode(PositionMode.HEDGE)
 
     async def start_network(self):
         """
@@ -782,6 +776,17 @@ class OkxPerpetualDerivative(PerpetualDerivativePyBase):
                                                                         quote=symbol_data["settleCcy"])
         self._set_trading_pair_symbol_map(mapping)
 
+    async def _fetch_account_position_mode(self) -> Optional[PositionMode]:
+        response = await self._api_get(
+            path_url=CONSTANTS.REST_GET_ACCOUNT_CONFIG[CONSTANTS.ENDPOINT],
+            is_auth_required=True,
+        )
+        if response.get("code") == CONSTANTS.RET_CODE_OK and response.get("data"):
+            pos_mode = response["data"][0].get("posMode")
+            reverse_map = {v: k for k, v in CONSTANTS.POSITION_MODE_MAP.items()}
+            return reverse_map.get(pos_mode)
+        return None
+
     async def _trading_pair_position_mode_set(self, mode: PositionMode, trading_pair: str) -> Tuple[bool, str]:
         msg = ""
         success = True
@@ -799,8 +804,7 @@ class OkxPerpetualDerivative(PerpetualDerivativePyBase):
         response_code = response["code"]
 
         if response_code != CONSTANTS.RET_CODE_OK:
-            formatted_ret_code = self._format_ret_code_for_print(response_code)
-            msg = f"{formatted_ret_code} - {response['msg']}"
+            msg = response['msg']
             success = False
 
         return success, msg

--- a/hummingbot/connector/derivative/okx_perpetual/okx_perpetual_web_utils.py
+++ b/hummingbot/connector/derivative/okx_perpetual/okx_perpetual_web_utils.py
@@ -274,6 +274,12 @@ def _build_private_general_rate_limits() -> List[RateLimit]:
             time_interval=CONSTANTS.TWO_SECONDS,
         ),
         RateLimit(
+            limit_id=get_rest_api_limit_id_for_endpoint(method=CONSTANTS.REST_GET_ACCOUNT_CONFIG[CONSTANTS.METHOD],
+                                                        endpoint=CONSTANTS.REST_GET_ACCOUNT_CONFIG[CONSTANTS.ENDPOINT]),
+            limit=CONSTANTS.RATE_LIMIT_GET_ACCOUNT_CONFIG,
+            time_interval=CONSTANTS.TWO_SECONDS,
+        ),
+        RateLimit(
             limit_id=get_rest_api_limit_id_for_endpoint(method=CONSTANTS.REST_SET_POSITION_MODE[CONSTANTS.METHOD],
                                                         endpoint=CONSTANTS.REST_SET_POSITION_MODE[CONSTANTS.ENDPOINT]),
             limit=CONSTANTS.RATE_LIMIT_SET_POSITION_MODE,

--- a/hummingbot/connector/perpetual_derivative_py_base.py
+++ b/hummingbot/connector/perpetual_derivative_py_base.py
@@ -330,54 +330,42 @@ class PerpetualDerivativePyBase(ExchangePyBase, ABC):
         )
 
     async def _execute_set_position_mode(self, mode: PositionMode):
-        success, successful_pairs, msg = await self._execute_set_position_mode_for_pairs(
-            mode=mode, trading_pairs=self.trading_pairs
-        )
+        try:
+            current_mode = await self._fetch_account_position_mode()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            current_mode = None
 
-        if not success:
-            await self._execute_set_position_mode_for_pairs(
-                mode=self._perpetual_trading.position_mode, trading_pairs=successful_pairs
-            )
-            for trading_pair in self.trading_pairs:
-                self.trigger_event(
-                    AccountEvent.PositionModeChangeFailed,
-                    PositionModeChangeEvent(
-                        self.current_timestamp,
-                        trading_pair,
-                        mode,
-                        msg,
-                    ),
-                )
-        else:
+        if current_mode == mode:
             self._perpetual_trading.set_position_mode(mode)
-            for trading_pair in self.trading_pairs:
-                self.trigger_event(
-                    AccountEvent.PositionModeChangeSucceeded,
-                    PositionModeChangeEvent(
-                        self.current_timestamp,
-                        trading_pair,
-                        mode,
-                    )
-                )
-            self.logger().debug(f"Position mode switched to {mode}.")
+            self._fire_position_mode_events(mode, success=True)
+            self.logger().info(f"Position mode already set to {mode}.")
+            return
 
-    async def _execute_set_position_mode_for_pairs(
-        self, mode: PositionMode, trading_pairs: List[str]
-    ) -> Tuple[bool, List[str], str]:
-        successful_pairs = []
-        success = True
-        msg = ""
+        if not self.trading_pairs:
+            return
 
-        for trading_pair in trading_pairs:
-            if mode != self._perpetual_trading.position_mode:
-                success, msg = await self._trading_pair_position_mode_set(mode, trading_pair)
-            if success:
-                successful_pairs.append(trading_pair)
-            else:
-                self.logger().network(f"Error switching {trading_pair} mode to {mode}: {msg}")
-                break
+        success, msg = await self._trading_pair_position_mode_set(mode, self.trading_pairs[0])
 
-        return success, successful_pairs, msg
+        if success:
+            self._perpetual_trading.set_position_mode(mode)
+            self._fire_position_mode_events(mode, success=True)
+            self.logger().info(f"Position mode switched to {mode}.")
+        else:
+            self._fire_position_mode_events(mode, success=False, message=msg)
+            self.logger().error(f"Failed to set position mode to {mode}: {msg}")
+
+    def _fire_position_mode_events(self, mode: PositionMode, success: bool, message: str = ""):
+        event_tag = (
+            AccountEvent.PositionModeChangeSucceeded if success
+            else AccountEvent.PositionModeChangeFailed
+        )
+        for trading_pair in self.trading_pairs:
+            self.trigger_event(
+                event_tag,
+                PositionModeChangeEvent(self.current_timestamp, trading_pair, mode, message),
+            )
 
     async def _execute_set_leverage(self, trading_pair: str, leverage: int):
         success, msg = await self._set_trading_pair_leverage(trading_pair, leverage)

--- a/hummingbot/connector/perpetual_derivative_py_base.py
+++ b/hummingbot/connector/perpetual_derivative_py_base.py
@@ -38,6 +38,7 @@ class PerpetualDerivativePyBase(ExchangePyBase, ABC):
         self._orderbook_ds: PerpetualAPIOrderBookDataSource = self._orderbook_ds  # for type-hinting
 
         self._budget_checker = PerpetualBudgetChecker(self)
+        self._set_position_mode_lock = asyncio.Lock()
 
     @property
     @abstractmethod
@@ -330,31 +331,22 @@ class PerpetualDerivativePyBase(ExchangePyBase, ABC):
         )
 
     async def _execute_set_position_mode(self, mode: PositionMode):
-        try:
-            current_mode = await self._fetch_account_position_mode()
-        except asyncio.CancelledError:
-            raise
-        except Exception:
-            current_mode = None
+        async with self._set_position_mode_lock:
+            if mode == self._perpetual_trading.position_mode:
+                return
 
-        if current_mode == mode:
-            self._perpetual_trading.set_position_mode(mode)
-            self._fire_position_mode_events(mode, success=True)
-            self.logger().info(f"Position mode already set to {mode}.")
-            return
+            if not self.trading_pairs:
+                return
 
-        if not self.trading_pairs:
-            return
+            success, msg = await self._trading_pair_position_mode_set(mode, self.trading_pairs[0])
 
-        success, msg = await self._trading_pair_position_mode_set(mode, self.trading_pairs[0])
-
-        if success:
-            self._perpetual_trading.set_position_mode(mode)
-            self._fire_position_mode_events(mode, success=True)
-            self.logger().info(f"Position mode switched to {mode}.")
-        else:
-            self._fire_position_mode_events(mode, success=False, message=msg)
-            self.logger().error(f"Failed to set position mode to {mode}: {msg}")
+            if success:
+                self._perpetual_trading.set_position_mode(mode)
+                self._fire_position_mode_events(mode, success=True)
+                self.logger().info(f"Position mode switched to {mode}.")
+            else:
+                self._fire_position_mode_events(mode, success=False, message=msg)
+                self.logger().error(f"Failed to set position mode to {mode}: {msg}")
 
     def _fire_position_mode_events(self, mode: PositionMode, success: bool, message: str = ""):
         event_tag = (

--- a/hummingbot/connector/perpetual_derivative_py_base.py
+++ b/hummingbot/connector/perpetual_derivative_py_base.py
@@ -121,7 +121,9 @@ class PerpetualDerivativePyBase(ExchangePyBase, ABC):
             mode = await self._fetch_account_position_mode()
             if mode is not None:
                 self._perpetual_trading.set_position_mode(mode)
-                self.logger().debug(f"Initialized position mode to {mode} from exchange.")
+                self.logger().info(f"Position mode initialized to {mode} from exchange.")
+            else:
+                self.logger().warning("Exchange returned None for position mode. Using default.")
         except asyncio.CancelledError:
             raise
         except Exception:
@@ -332,10 +334,27 @@ class PerpetualDerivativePyBase(ExchangePyBase, ABC):
 
     async def _execute_set_position_mode(self, mode: PositionMode):
         async with self._set_position_mode_lock:
-            if mode == self._perpetual_trading.position_mode:
+            current_mode = self._perpetual_trading.position_mode
+            self.logger().info(
+                f"Setting position mode: requested={mode}, current_local={current_mode}")
+
+            try:
+                exchange_mode = await self._fetch_account_position_mode()
+                self.logger().info(f"Position mode on exchange: {exchange_mode}")
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                self.logger().warning(f"Could not fetch position mode from exchange: {e}")
+                exchange_mode = None
+
+            if exchange_mode == mode:
+                self._perpetual_trading.set_position_mode(mode)
+                self._fire_position_mode_events(mode, success=True)
+                self.logger().info(f"Position mode already set to {mode} on exchange.")
                 return
 
             if not self.trading_pairs:
+                self.logger().warning("No trading pairs configured, cannot set position mode.")
                 return
 
             success, msg = await self._trading_pair_position_mode_set(mode, self.trading_pairs[0])
@@ -346,7 +365,8 @@ class PerpetualDerivativePyBase(ExchangePyBase, ABC):
                 self.logger().info(f"Position mode switched to {mode}.")
             else:
                 self._fire_position_mode_events(mode, success=False, message=msg)
-                self.logger().error(f"Failed to set position mode to {mode}: {msg}")
+                self.logger().error(
+                    f"Failed to set position mode to {mode} (exchange is {exchange_mode}): {msg}")
 
     def _fire_position_mode_events(self, mode: PositionMode, success: bool, message: str = ""):
         event_tag = (

--- a/hummingbot/connector/perpetual_derivative_py_base.py
+++ b/hummingbot/connector/perpetual_derivative_py_base.py
@@ -117,20 +117,21 @@ class PerpetualDerivativePyBase(ExchangePyBase, ABC):
         Fetches the current position mode from the exchange and syncs local state.
         Called during start_network to ensure the local position mode reflects reality.
         """
-        try:
-            mode = await self._fetch_account_position_mode()
-            if mode is not None:
-                self._perpetual_trading.set_position_mode(mode)
-                self.logger().info(f"Position mode initialized to {mode} from exchange.")
-            else:
-                self.logger().warning("Exchange returned None for position mode. Using default.")
-        except asyncio.CancelledError:
-            raise
-        except Exception:
-            self.logger().warning(
-                "Could not fetch position mode from exchange. Using default.",
-                exc_info=True,
-            )
+        async with self._set_position_mode_lock:
+            try:
+                mode = await self._fetch_account_position_mode()
+                if mode is not None:
+                    self._perpetual_trading.set_position_mode(mode)
+                    self.logger().info(f"Position mode initialized to {mode} from exchange.")
+                else:
+                    self.logger().warning("Exchange returned None for position mode. Using default.")
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                self.logger().warning(
+                    "Could not fetch position mode from exchange. Using default.",
+                    exc_info=True,
+                )
 
     async def _fetch_account_position_mode(self) -> Optional[PositionMode]:
         """
@@ -334,18 +335,16 @@ class PerpetualDerivativePyBase(ExchangePyBase, ABC):
 
     async def _execute_set_position_mode(self, mode: PositionMode):
         async with self._set_position_mode_lock:
-            current_mode = self._perpetual_trading.position_mode
-            self.logger().info(
-                f"Setting position mode: requested={mode}, current_local={current_mode}")
-
             try:
                 exchange_mode = await self._fetch_account_position_mode()
-                self.logger().info(f"Position mode on exchange: {exchange_mode}")
             except asyncio.CancelledError:
                 raise
             except Exception as e:
                 self.logger().warning(f"Could not fetch position mode from exchange: {e}")
                 exchange_mode = None
+
+            self.logger().info(
+                f"Setting position mode: requested={mode}, current_exchange={exchange_mode}")
 
             if exchange_mode == mode:
                 self._perpetual_trading.set_position_mode(mode)

--- a/hummingbot/connector/perpetual_derivative_py_base.py
+++ b/hummingbot/connector/perpetual_derivative_py_base.py
@@ -366,7 +366,7 @@ class PerpetualDerivativePyBase(ExchangePyBase, ABC):
             else:
                 self._fire_position_mode_events(mode, success=False, message=msg)
                 self.logger().error(
-                    f"Failed to set position mode to {mode} (exchange is {exchange_mode}): {msg}")
+                    f"Failed to set position mode to {mode}: {msg}")
 
     def _fire_position_mode_events(self, mode: PositionMode, success: bool, message: str = ""):
         event_tag = (

--- a/hummingbot/connector/test_support/perpetual_derivative_test.py
+++ b/hummingbot/connector/test_support/perpetual_derivative_test.py
@@ -586,8 +586,8 @@ class AbstractPerpetualDerivativeTests:
 
             self.assertTrue(
                 self.is_logged(
-                    log_level="NETWORK",
-                    message=f"Error switching {self.trading_pair} mode to {PositionMode.HEDGE}: {error_msg}"
+                    log_level="ERROR",
+                    message=f"Failed to set position mode to {PositionMode.HEDGE}: {error_msg}"
                 )
             )
 
@@ -604,7 +604,7 @@ class AbstractPerpetualDerivativeTests:
 
             self.assertTrue(
                 self.is_logged(
-                    log_level="DEBUG",
+                    log_level="INFO",
                     message=f"Position mode switched to {PositionMode.HEDGE}.",
                 )
             )
@@ -620,7 +620,7 @@ class AbstractPerpetualDerivativeTests:
 
             self.assertTrue(
                 self.is_logged(
-                    log_level="DEBUG",
+                    log_level="INFO",
                     message=f"Position mode switched to {PositionMode.ONEWAY}.",
                 )
             )

--- a/hummingbot/strategy_v2/backtesting/backtesting_engine_base.py
+++ b/hummingbot/strategy_v2/backtesting/backtesting_engine_base.py
@@ -45,68 +45,107 @@ class BacktestPositionHold:
         self.connector_name = connector_name
         self.trading_pair = trading_pair
         self.source_executor_ids: set = set()
+
+        # Net position tracking (positive = long, negative = short)
+        self.net_amount_base = Decimal("0")
+        self.avg_entry_price = Decimal("0")
+
+        # Accumulated metrics
+        self.realized_pnl_quote = Decimal("0")
+        self.cum_fees_quote = Decimal("0")
+        self.volume_traded_quote = Decimal("0")
+
+        # Separate tracking for buys and sells (for logging/diagnostics)
         self.buy_amount_base = Decimal("0")
         self.buy_amount_quote = Decimal("0")
         self.sell_amount_base = Decimal("0")
         self.sell_amount_quote = Decimal("0")
-        self.cum_fees_quote = Decimal("0")
-        self.volume_traded_quote = Decimal("0")
+
+    def _process_order(self, is_buy: bool, amount_base: Decimal, amount_quote: Decimal):
+        """Process an order incrementally: realize PnL when reducing, update avg entry when adding."""
+        if amount_base == 0:
+            return
+
+        order_price = amount_quote / amount_base
+        is_reducing = (self.net_amount_base > 0 and not is_buy) or (self.net_amount_base < 0 and is_buy)
+
+        if is_reducing:
+            abs_net = abs(self.net_amount_base)
+            matched = min(amount_base, abs_net)
+
+            if self.net_amount_base > 0:
+                self.realized_pnl_quote += (order_price - self.avg_entry_price) * matched
+            else:
+                self.realized_pnl_quote += (self.avg_entry_price - order_price) * matched
+
+            excess = amount_base - matched
+            if excess > 0:
+                self.net_amount_base = excess if is_buy else -excess
+                self.avg_entry_price = order_price
+            elif matched == abs_net:
+                self.net_amount_base = Decimal("0")
+                self.avg_entry_price = Decimal("0")
+            else:
+                if self.net_amount_base > 0:
+                    self.net_amount_base -= matched
+                else:
+                    self.net_amount_base += matched
+        else:
+            if self.net_amount_base == 0:
+                self.net_amount_base = amount_base if is_buy else -amount_base
+                self.avg_entry_price = order_price
+            else:
+                abs_net = abs(self.net_amount_base)
+                total_cost = self.avg_entry_price * abs_net + amount_quote
+                new_abs = abs_net + amount_base
+                self.avg_entry_price = total_cost / new_abs
+                self.net_amount_base = new_abs if is_buy else -new_abs
 
     def add_executor(self, executor_info: ExecutorInfo, entry_price: Decimal):
         """Add an executor's filled position to this hold."""
         self.source_executor_ids.add(executor_info.config.id)
         amount_base = executor_info.filled_amount_quote / entry_price
-        if executor_info.side == TradeType.BUY:
+        amount_quote = executor_info.filled_amount_quote
+        is_buy = executor_info.side == TradeType.BUY
+
+        # Update buy/sell totals (for logging/diagnostics)
+        if is_buy:
             self.buy_amount_base += amount_base
-            self.buy_amount_quote += executor_info.filled_amount_quote
+            self.buy_amount_quote += amount_quote
         else:
             self.sell_amount_base += amount_base
-            self.sell_amount_quote += executor_info.filled_amount_quote
+            self.sell_amount_quote += amount_quote
         self.cum_fees_quote += executor_info.cum_fees_quote
-        self.volume_traded_quote += executor_info.filled_amount_quote
+        self.volume_traded_quote += amount_quote
 
-    @property
-    def net_amount_base(self) -> Decimal:
-        return self.buy_amount_base - self.sell_amount_base
+        # Process for incremental PnL calculation
+        self._process_order(is_buy, amount_base, amount_quote)
 
     @property
     def is_closed(self) -> bool:
         return self.net_amount_base == 0
 
     def get_position_summary(self, mid_price: Decimal) -> PositionSummary:
-        """Calculate position summary with buy/sell netting, mirroring PositionHold.get_position_summary."""
-        buy_breakeven = self.buy_amount_quote / self.buy_amount_base if self.buy_amount_base > 0 else Decimal("0")
-        sell_breakeven = self.sell_amount_quote / self.sell_amount_base if self.sell_amount_base > 0 else Decimal("0")
-
-        matched_base = min(self.buy_amount_base, self.sell_amount_base)
-        realized_pnl = (sell_breakeven - buy_breakeven) * matched_base if matched_base > 0 else Decimal("0")
-
-        net_base = self.buy_amount_base - self.sell_amount_base
-        is_net_long = net_base >= 0
+        """Calculate position summary using incremental PnL tracking."""
+        abs_amount = abs(self.net_amount_base)
+        is_net_long = self.net_amount_base >= 0
 
         unrealized_pnl = Decimal("0")
-        breakeven_price = Decimal("0")
-        if net_base != 0:
+        if abs_amount > 0:
             if is_net_long:
-                remaining_base = net_base
-                remaining_quote = self.buy_amount_quote - (matched_base * buy_breakeven)
-                breakeven_price = remaining_quote / remaining_base if remaining_base > 0 else Decimal("0")
-                unrealized_pnl = (mid_price - breakeven_price) * remaining_base
+                unrealized_pnl = (mid_price - self.avg_entry_price) * abs_amount
             else:
-                remaining_base = abs(net_base)
-                remaining_quote = self.sell_amount_quote - (matched_base * sell_breakeven)
-                breakeven_price = remaining_quote / remaining_base if remaining_base > 0 else Decimal("0")
-                unrealized_pnl = (breakeven_price - mid_price) * remaining_base
+                unrealized_pnl = (self.avg_entry_price - mid_price) * abs_amount
 
         return PositionSummary(
             connector_name=self.connector_name,
             trading_pair=self.trading_pair,
             volume_traded_quote=self.volume_traded_quote,
-            amount=abs(net_base),
+            amount=abs_amount,
             side=TradeType.BUY if is_net_long else TradeType.SELL,
-            breakeven_price=breakeven_price,
+            breakeven_price=self.avg_entry_price,
             unrealized_pnl_quote=unrealized_pnl,
-            realized_pnl_quote=realized_pnl,
+            realized_pnl_quote=self.realized_pnl_quote,
             cum_fees_quote=self.cum_fees_quote,
         )
 

--- a/hummingbot/strategy_v2/executors/executor_orchestrator.py
+++ b/hummingbot/strategy_v2/executors/executor_orchestrator.py
@@ -40,25 +40,86 @@ class PositionHold:
         # Store only client order IDs
         self.order_ids = set()
 
-        # Pre-calculated metrics
+        # Net position tracking (positive = long, negative = short)
+        self.net_amount_base = Decimal("0")
+        self.avg_entry_price = Decimal("0")
+
+        # Accumulated metrics
+        self.realized_pnl_quote = Decimal("0")
         self.volume_traded_quote = Decimal("0")
         self.cum_fees_quote = Decimal("0")
 
-        # Separate tracking for buys and sells
+        # Separate tracking for buys and sells (for logging/diagnostics)
         self.buy_amount_base = Decimal("0")
         self.buy_amount_quote = Decimal("0")
         self.sell_amount_base = Decimal("0")
         self.sell_amount_quote = Decimal("0")
 
+    def _process_order(self, is_buy: bool, amount_base: Decimal, amount_quote: Decimal):
+        """
+        Process an order incrementally: realize PnL when reducing position,
+        update avg_entry_price when adding to position.
+        """
+        if amount_base == 0:
+            return
+
+        order_price = amount_quote / amount_base
+        is_reducing = (self.net_amount_base > 0 and not is_buy) or (self.net_amount_base < 0 and is_buy)
+
+        if is_reducing:
+            abs_net = abs(self.net_amount_base)
+            matched = min(amount_base, abs_net)
+
+            # Realize PnL on matched portion
+            if self.net_amount_base > 0:
+                self.realized_pnl_quote += (order_price - self.avg_entry_price) * matched
+            else:
+                self.realized_pnl_quote += (self.avg_entry_price - order_price) * matched
+
+            excess = amount_base - matched
+            if excess > 0:
+                # Position flipped to opposite side
+                self.net_amount_base = excess if is_buy else -excess
+                self.avg_entry_price = order_price
+            elif matched == abs_net:
+                # Position fully closed
+                self.net_amount_base = Decimal("0")
+                self.avg_entry_price = Decimal("0")
+            else:
+                # Position partially reduced, avg_entry_price stays the same
+                if self.net_amount_base > 0:
+                    self.net_amount_base -= matched
+                else:
+                    self.net_amount_base += matched
+        else:
+            # Adding to position or first order
+            if self.net_amount_base == 0:
+                self.net_amount_base = amount_base if is_buy else -amount_base
+                self.avg_entry_price = order_price
+            else:
+                abs_net = abs(self.net_amount_base)
+                total_cost = self.avg_entry_price * abs_net + amount_quote
+                new_abs = abs_net + amount_base
+                self.avg_entry_price = total_cost / new_abs
+                self.net_amount_base = new_abs if is_buy else -new_abs
+
     def add_orders_from_executor(self, executor: ExecutorInfo):
         custom_info = executor.custom_info
         if "held_position_orders" not in custom_info or len(custom_info["held_position_orders"]) == 0:
+            logging.getLogger(__name__).warning(
+                f"PositionHold.add_orders: executor {executor.id[:8]} has no held_position_orders. "
+                f"close_type={executor.close_type} side={executor.config.side} "
+                f"level_id={custom_info.get('level_id', 'N/A')}"
+            )
             return
 
         for order in custom_info["held_position_orders"]:
             # Skip if we've already processed this order
             order_id = order.get("client_order_id")
             if order_id in self.order_ids:
+                logging.getLogger(__name__).debug(
+                    f"PositionHold.add_orders: skipping duplicate order {order_id}"
+                )
                 continue
 
             # Add the order ID to our set
@@ -69,11 +130,16 @@ class PositionHold:
             executed_amount_quote = Decimal(str(order.get("executed_amount_quote", 0)))
 
             is_buy = order.get("trade_type") == "BUY"
+            order_type_label = order.get("order_type", "N/A")
+            position_action = order.get("position", "N/A")
+
+            # Snapshot before
+            prev_net = self.net_amount_base
 
             # Update volume traded in quote
             self.volume_traded_quote += executed_amount_quote
 
-            # Update buy/sell amounts
+            # Update buy/sell totals (for logging/diagnostics)
             if is_buy:
                 self.buy_amount_base += executed_amount_base
                 self.buy_amount_quote += executed_amount_quote
@@ -84,48 +150,51 @@ class PositionHold:
             # Update fees (tx fees paid)
             self.cum_fees_quote += Decimal(str(order.get("cumulative_fee_paid_quote", 0)))
 
+            # Process order for incremental PnL calculation
+            self._process_order(is_buy, executed_amount_base, executed_amount_quote)
+
+            logging.getLogger(__name__).info(
+                f"PositionHold.add_orders: {self.trading_pair} | "
+                f"order={order_id[:12] if order_id else 'N/A'} | "
+                f"trade_type={'BUY' if is_buy else 'SELL'} | "
+                f"order_type={order_type_label} | position_action={position_action} | "
+                f"amount_base={executed_amount_base} amount_quote={executed_amount_quote:.2f} | "
+                f"executor_side={executor.config.side} level={custom_info.get('level_id', 'N/A')} | "
+                f"net_before={prev_net} -> net_after={self.net_amount_base} | "
+                f"avg_entry={self.avg_entry_price:.4f} realized_pnl={self.realized_pnl_quote:.4f} | "
+                f"buy_total={self.buy_amount_base} sell_total={self.sell_amount_base}"
+            )
+
     def get_position_summary(self, mid_price: Decimal):
-        # Calculate buy and sell breakeven prices
-        buy_breakeven_price = self.buy_amount_quote / self.buy_amount_base if self.buy_amount_base > 0 else Decimal("0")
-        sell_breakeven_price = self.sell_amount_quote / self.sell_amount_base if self.sell_amount_base > 0 else Decimal("0")
+        abs_amount = abs(self.net_amount_base)
+        is_net_long = self.net_amount_base >= 0
 
-        # Calculate matched volume (minimum of buy and sell base amounts)
-        matched_amount_base = min(self.buy_amount_base, self.sell_amount_base)
-
-        # Calculate realized PnL from matched volume
-        realized_pnl_quote = (sell_breakeven_price - buy_breakeven_price) * matched_amount_base if matched_amount_base > 0 else Decimal("0")
-
-        # Calculate net position amount and direction
-        net_amount_base = self.buy_amount_base - self.sell_amount_base
-        is_net_long = net_amount_base >= 0
-
-        # Calculate unrealized PnL for the remaining unmatched volume
+        # Calculate unrealized PnL for remaining open position
         unrealized_pnl_quote = Decimal("0")
-        breakeven_price = Decimal("0")
-        if net_amount_base != 0:
+        if abs_amount > 0:
             if is_net_long:
-                # Long position: remaining buy amount
-                remaining_base = net_amount_base
-                remaining_quote = self.buy_amount_quote - (matched_amount_base * buy_breakeven_price)
-                breakeven_price = remaining_quote / remaining_base if remaining_base != 0 else Decimal("0")
-                unrealized_pnl_quote = (mid_price - breakeven_price) * remaining_base
+                unrealized_pnl_quote = (mid_price - self.avg_entry_price) * abs_amount
             else:
-                # Short position: remaining sell amount
-                remaining_base = abs(net_amount_base)
-                remaining_quote = self.sell_amount_quote - (matched_amount_base * sell_breakeven_price)
-                breakeven_price = remaining_quote / remaining_base if remaining_base != 0 else Decimal("0")
-                unrealized_pnl_quote = (breakeven_price - mid_price) * remaining_base
+                unrealized_pnl_quote = (self.avg_entry_price - mid_price) * abs_amount
 
-        return PositionSummary(
+        summary = PositionSummary(
             connector_name=self.connector_name,
             trading_pair=self.trading_pair,
             volume_traded_quote=self.volume_traded_quote,
-            amount=abs(net_amount_base),
+            amount=abs_amount,
             side=TradeType.BUY if is_net_long else TradeType.SELL,
-            breakeven_price=breakeven_price,
+            breakeven_price=self.avg_entry_price,
             unrealized_pnl_quote=unrealized_pnl_quote,
-            realized_pnl_quote=realized_pnl_quote,
+            realized_pnl_quote=self.realized_pnl_quote,
             cum_fees_quote=self.cum_fees_quote)
+
+        logging.getLogger(__name__).debug(
+            f"PositionHold.summary: {self.trading_pair} | "
+            f"net={'LONG' if is_net_long else 'SHORT'} {abs_amount} @ entry={self.avg_entry_price:.4f} | "
+            f"unrealized_pnl={unrealized_pnl_quote:.4f} realized_pnl={self.realized_pnl_quote:.4f} | "
+            f"mid_price={mid_price:.4f} orders={len(self.order_ids)}"
+        )
+        return summary
 
 
 class ExecutorOrchestrator:
@@ -227,20 +296,18 @@ class ExecutorOrchestrator:
         position_hold.volume_traded_quote = db_position.volume_traded_quote
         position_hold.cum_fees_quote = db_position.cum_fees_quote
 
-        # Since the database stores the net position, we need to reconstruct the buy/sell amounts
-        # We assume this represents the remaining unmatched position after any realized trades
+        # Restore net position and avg entry price from database
         if db_position.side == "BUY":
-            # This is a net long position
+            position_hold.net_amount_base = db_position.amount
             position_hold.buy_amount_base = db_position.amount
             position_hold.buy_amount_quote = db_position.amount * db_position.breakeven_price
-            position_hold.sell_amount_base = Decimal("0")
-            position_hold.sell_amount_quote = Decimal("0")
         else:
-            # This is a net short position
+            position_hold.net_amount_base = -db_position.amount
             position_hold.sell_amount_base = db_position.amount
             position_hold.sell_amount_quote = db_position.amount * db_position.breakeven_price
-            position_hold.buy_amount_base = Decimal("0")
-            position_hold.buy_amount_quote = Decimal("0")
+        position_hold.avg_entry_price = db_position.breakeven_price
+        # Restore realized PnL if available
+        position_hold.realized_pnl_quote = getattr(db_position, 'realized_pnl_quote', Decimal("0"))
 
         # Add to positions held
         self.positions_held[controller_id].append(position_hold)
@@ -280,21 +347,16 @@ class ExecutorOrchestrator:
                     position_config.side
                 )
 
-                # Set amounts based on side
+                # Set net position and avg entry price
                 if position_config.side == TradeType.BUY:
+                    position_hold.net_amount_base = position_config.amount
                     position_hold.buy_amount_base = position_config.amount
                     position_hold.buy_amount_quote = quote_amount
-                    position_hold.sell_amount_base = Decimal("0")
-                    position_hold.sell_amount_quote = Decimal("0")
                 else:
+                    position_hold.net_amount_base = -position_config.amount
                     position_hold.sell_amount_base = position_config.amount
                     position_hold.sell_amount_quote = quote_amount
-                    position_hold.buy_amount_base = Decimal("0")
-                    position_hold.buy_amount_quote = Decimal("0")
-
-                # Set fees and volume to 0 (as specified - this is a fresh start)
-                position_hold.volume_traded_quote = Decimal("0")
-                position_hold.cum_fees_quote = Decimal("0")
+                position_hold.avg_entry_price = mid_price
 
                 # Add to positions held
                 self.positions_held[controller_id].append(position_hold)
@@ -469,17 +531,46 @@ class ExecutorOrchestrator:
                 # Determine position side (handling perpetual markets)
                 position_side = self._determine_position_side(executor_info)
 
+                held_orders = executor_info.custom_info.get("held_position_orders", [])
+                held_summary = [
+                    f"{o.get('trade_type')}:{o.get('executed_amount_base')}@{o.get('position', 'N/A')}"
+                    for o in held_orders
+                ]
+
+                self.logger().info(
+                    f"Processing POSITION_HOLD executor: {executor_info.id[:8]} | "
+                    f"controller={controller_id} | side={executor_info.config.side} | "
+                    f"level={executor_info.custom_info.get('level_id', 'N/A')} | "
+                    f"position_side_resolved={position_side} | "
+                    f"held_orders({len(held_orders)}): {held_summary} | "
+                    f"existing_positions={len(positions)}"
+                )
+
                 # Find or create position
                 existing_position = self._find_existing_position(positions, executor_info, position_side)
 
                 if existing_position:
+                    prev_net = existing_position.net_amount_base
+                    self.logger().info(
+                        f"  -> MATCHED existing position: side={existing_position.side} "
+                        f"net_before={prev_net} avg_entry={existing_position.avg_entry_price:.4f}"
+                    )
                     existing_position.add_orders_from_executor(executor_info)
+                    self.logger().info(
+                        f"  -> After merge: net={existing_position.net_amount_base} "
+                        f"avg_entry={existing_position.avg_entry_price:.4f} "
+                        f"realized_pnl={existing_position.realized_pnl_quote:.4f}"
+                    )
                 else:
                     # Create new position (handles both spot/perp and LP)
+                    assigned_side = position_side if position_side else executor_info.config.side
+                    self.logger().info(
+                        f"  -> NO existing position found. Creating NEW PositionHold with side={assigned_side}"
+                    )
                     position = PositionHold(
                         executor_info.connector_name,
                         executor_info.trading_pair,
-                        position_side if position_side else executor_info.config.side
+                        assigned_side
                     )
                     position.add_orders_from_executor(executor_info)
                     positions.append(position)

--- a/hummingbot/strategy_v2/executors/executor_orchestrator.py
+++ b/hummingbot/strategy_v2/executors/executor_orchestrator.py
@@ -563,7 +563,7 @@ class ExecutorOrchestrator:
                     )
                 else:
                     # Create new position (handles both spot/perp and LP)
-                    assigned_side = position_side if position_side else executor_info.config.side
+                    assigned_side = position_side
                     self.logger().info(
                         f"  -> NO existing position found. Creating NEW PositionHold with side={assigned_side}"
                     )
@@ -583,11 +583,11 @@ class ExecutorOrchestrator:
         """
         is_perpetual = "_perpetual" in executor_info.connector_name
         if not is_perpetual:
-            return None
+            return executor_info.config.side
 
         market = self.strategy.connectors.get(executor_info.connector_name)
         if not market or not hasattr(market, 'position_mode'):
-            return None
+            return executor_info.config.side
 
         position_mode = market.position_mode
         if position_mode == PositionMode.HEDGE:

--- a/hummingbot/strategy_v2/executors/executor_orchestrator.py
+++ b/hummingbot/strategy_v2/executors/executor_orchestrator.py
@@ -487,6 +487,8 @@ class ExecutorOrchestrator:
     def _determine_position_side(self, executor_info: ExecutorInfo) -> Optional[TradeType]:
         """
         Determine the position side for an executor, handling perpetual markets.
+        In ONEWAY mode, returns None so all orders (buy/sell) are netted into a single position.
+        In HEDGE mode, returns the appropriate side based on position_action.
         """
         is_perpetual = "_perpetual" in executor_info.connector_name
         if not is_perpetual:
@@ -497,11 +499,14 @@ class ExecutorOrchestrator:
             return None
 
         position_mode = market.position_mode
-        if hasattr(executor_info.config, "position_action") and position_mode == PositionMode.HEDGE:
-            opposite_side = TradeType.BUY if executor_info.config.side == TradeType.SELL else TradeType.SELL
-            return opposite_side if executor_info.config.position_action == PositionAction.CLOSE else executor_info.config.side
+        if position_mode == PositionMode.HEDGE:
+            if hasattr(executor_info.config, "position_action"):
+                opposite_side = TradeType.BUY if executor_info.config.side == TradeType.SELL else TradeType.SELL
+                return opposite_side if executor_info.config.position_action == PositionAction.CLOSE else executor_info.config.side
+            return executor_info.config.side
 
-        return executor_info.config.side
+        # ONEWAY: all orders net into a single position, no side filtering
+        return None
 
     def _find_existing_position(self, positions: List[PositionHold],
                                 executor_info: ExecutorInfo,

--- a/hummingbot/strategy_v2/executors/executor_orchestrator.py
+++ b/hummingbot/strategy_v2/executors/executor_orchestrator.py
@@ -153,7 +153,7 @@ class PositionHold:
             # Process order for incremental PnL calculation
             self._process_order(is_buy, executed_amount_base, executed_amount_quote)
 
-            logging.getLogger(__name__).info(
+            logging.getLogger(__name__).debug(
                 f"PositionHold.add_orders: {self.trading_pair} | "
                 f"order={order_id[:12] if order_id else 'N/A'} | "
                 f"trade_type={'BUY' if is_buy else 'SELL'} | "
@@ -537,7 +537,7 @@ class ExecutorOrchestrator:
                     for o in held_orders
                 ]
 
-                self.logger().info(
+                self.logger().debug(
                     f"Processing POSITION_HOLD executor: {executor_info.id[:8]} | "
                     f"controller={controller_id} | side={executor_info.config.side} | "
                     f"level={executor_info.custom_info.get('level_id', 'N/A')} | "
@@ -550,22 +550,16 @@ class ExecutorOrchestrator:
                 existing_position = self._find_existing_position(positions, executor_info, position_side)
 
                 if existing_position:
-                    prev_net = existing_position.net_amount_base
-                    self.logger().info(
-                        f"  -> MATCHED existing position: side={existing_position.side} "
-                        f"net_before={prev_net} avg_entry={existing_position.avg_entry_price:.4f}"
-                    )
                     existing_position.add_orders_from_executor(executor_info)
-                    self.logger().info(
-                        f"  -> After merge: net={existing_position.net_amount_base} "
-                        f"avg_entry={existing_position.avg_entry_price:.4f} "
-                        f"realized_pnl={existing_position.realized_pnl_quote:.4f}"
+                    self.logger().debug(
+                        f"Merged executor {executor_info.id[:8]} into existing position: "
+                        f"net={existing_position.net_amount_base} avg_entry={existing_position.avg_entry_price:.4f}"
                     )
                 else:
                     # Create new position (handles both spot/perp and LP)
                     assigned_side = position_side
-                    self.logger().info(
-                        f"  -> NO existing position found. Creating NEW PositionHold with side={assigned_side}"
+                    self.logger().debug(
+                        f"Creating new PositionHold for executor {executor_info.id[:8]} with side={assigned_side}"
                     )
                     position = PositionHold(
                         executor_info.connector_name,

--- a/hummingbot/strategy_v2/executors/order_executor/order_executor.py
+++ b/hummingbot/strategy_v2/executors/order_executor/order_executor.py
@@ -173,18 +173,32 @@ class OrderExecutor(ExecutorBase):
     def place_open_order(self):
         """
         Place the order based on the execution strategy.
+        Accounts for previously filled amounts so renewals only order the remaining quantity.
         """
+        remaining = self.config.amount - self.executed_amount_base
+        if remaining <= Decimal("0"):
+            self.logger().info(
+                f"Executor {self.config.id}: fully filled ({self.executed_amount_base}/{self.config.amount}). "
+                f"No new order needed."
+            )
+            self._held_position_orders.extend([order.order.to_json() for order in self._partial_filled_orders])
+            self.close_type = CloseType.POSITION_HOLD
+            self.stop()
+            return
         order_id = self.place_order(
             connector_name=self.config.connector_name,
             trading_pair=self.config.trading_pair,
             order_type=self.get_order_type(),
-            amount=self.config.amount,
+            amount=remaining,
             price=self.get_order_price(),
             side=self.config.side,
             position_action=self.config.position_action,
         )
         self._order = TrackedOrder(order_id=order_id)
-        self.logger().debug(f"Executor ID: {self.config.id} - Placing order {order_id}")
+        self.logger().debug(
+            f"Executor ID: {self.config.id} - Placing order {order_id} "
+            f"(remaining: {remaining}, filled: {self.executed_amount_base}/{self.config.amount})"
+        )
 
     def get_order_type(self) -> OrderType:
         """

--- a/test/hummingbot/connector/derivative/architect_perpetual/test_architect_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/architect_perpetual/test_architect_perpetual_derivative.py
@@ -1696,7 +1696,7 @@ class ArchitectPerpetualDerivativeUnitTest(AbstractPerpetualDerivativeTests.Perp
 
         self.assertTrue(
             self.is_logged(
-                log_level="DEBUG",
+                log_level="INFO",
                 message=f"Position mode switched to {PositionMode.ONEWAY}.",
             )
         )

--- a/test/hummingbot/connector/derivative/binance_perpetual/test_binance_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/binance_perpetual/test_binance_perpetual_derivative.py
@@ -448,62 +448,58 @@ class BinancePerpetualDerivativeUnitTest(IsolatedAsyncioWrapperTestCase):
         self.assertEqual(expected_result, linear_connector.supported_position_modes())
 
     @aioresponses()
-    async def test_set_position_mode_initial_mode_is_none(self, mock_api):
+    async def test_set_position_mode_change_successful(self, mock_api):
         self._simulate_trading_rules_initialized()
-        self.assertIsNone(self.exchange._position_mode)
 
         url = web_utils.private_rest_url(CONSTANTS.CHANGE_POSITION_MODE_URL, domain=self.domain)
         regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
-        get_position_mode_response = {"dualSidePosition": False}  # True: Hedge Mode; False: One-way Mode
+        get_position_mode_response = {"dualSidePosition": False}  # One-way Mode
         post_position_mode_response = {"code": 200, "msg": "success"}
         mock_api.get(regex_url, body=json.dumps(get_position_mode_response))
         mock_api.post(regex_url, body=json.dumps(post_position_mode_response))
 
-        await self.exchange._trading_pair_position_mode_set(PositionMode.HEDGE, self.trading_pair)
+        success, msg = await self.exchange._trading_pair_position_mode_set(PositionMode.HEDGE, self.trading_pair)
 
-        self.assertEqual(PositionMode.HEDGE, self.exchange._position_mode)
+        self.assertTrue(success)
 
     @aioresponses()
     async def test_set_position_initial_mode_unchanged(self, mock_api):
-        self.exchange._position_mode = PositionMode.ONEWAY
         url = web_utils.private_rest_url(CONSTANTS.CHANGE_POSITION_MODE_URL, domain=self.domain)
         regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
-        get_position_mode_response = {"dualSidePosition": False}  # True: Hedge Mode; False: One-way Mode
-
+        get_position_mode_response = {"dualSidePosition": False}  # One-way Mode
         mock_api.get(regex_url, body=json.dumps(get_position_mode_response))
-        await self.exchange._trading_pair_position_mode_set(PositionMode.ONEWAY, self.trading_pair)
 
-        self.assertEqual(PositionMode.ONEWAY, self.exchange.position_mode)
+        success, msg = await self.exchange._trading_pair_position_mode_set(PositionMode.ONEWAY, self.trading_pair)
+
+        self.assertTrue(success)
 
     @aioresponses()
     async def test_set_position_mode_diff_initial_mode_change_successful(self, mock_api):
-        self.exchange._position_mode = PositionMode.ONEWAY
         url = web_utils.private_rest_url(CONSTANTS.CHANGE_POSITION_MODE_URL, domain=self.domain)
         regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
-        get_position_mode_response = {"dualSidePosition": False}  # True: Hedge Mode; False: One-way Mode
+        get_position_mode_response = {"dualSidePosition": False}  # One-way Mode
         post_position_mode_response = {"code": 200, "msg": "success"}
 
         mock_api.get(regex_url, body=json.dumps(get_position_mode_response))
         mock_api.post(regex_url, body=json.dumps(post_position_mode_response))
 
-        await self.exchange._trading_pair_position_mode_set(PositionMode.HEDGE, self.trading_pair)
+        success, msg = await self.exchange._trading_pair_position_mode_set(PositionMode.HEDGE, self.trading_pair)
 
-        self.assertEqual(PositionMode.HEDGE, self.exchange._position_mode)
+        self.assertTrue(success)
 
     @aioresponses()
     async def test_set_position_mode_diff_initial_mode_change_fail(self, mock_api):
-        self.exchange._position_mode = PositionMode.ONEWAY
         url = web_utils.private_rest_url(CONSTANTS.CHANGE_POSITION_MODE_URL, domain=self.domain)
         regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
-        get_position_mode_response = {"dualSidePosition": False}  # True: Hedge Mode; False: One-way Mode
+        get_position_mode_response = {"dualSidePosition": False}  # One-way Mode
         post_position_mode_response = {"code": -4059, "msg": "No need to change position side."}
 
         mock_api.get(regex_url, body=json.dumps(get_position_mode_response))
         mock_api.post(regex_url, body=json.dumps(post_position_mode_response))
 
-        await self.exchange._trading_pair_position_mode_set(PositionMode.HEDGE, self.trading_pair)
+        success, msg = await self.exchange._trading_pair_position_mode_set(PositionMode.HEDGE, self.trading_pair)
 
-        self.assertEqual(PositionMode.ONEWAY, self.exchange.position_mode)
+        self.assertFalse(success)
 
     @aioresponses()
     async def test_initialize_position_mode_success(self, mock_api):
@@ -513,7 +509,7 @@ class BinancePerpetualDerivativeUnitTest(IsolatedAsyncioWrapperTestCase):
 
         await self.exchange._initialize_position_mode()
 
-        self.assertEqual(PositionMode.HEDGE, self.exchange._position_mode)
+        self.assertEqual(PositionMode.HEDGE, self.exchange.position_mode)
 
     @aioresponses()
     async def test_initialize_position_mode_exception(self, mock_api):
@@ -523,7 +519,7 @@ class BinancePerpetualDerivativeUnitTest(IsolatedAsyncioWrapperTestCase):
 
         await self.exchange._initialize_position_mode()
 
-        self.assertIsNone(self.exchange._position_mode)
+        self.assertEqual(PositionMode.ONEWAY, self.exchange.position_mode)
         self.assertTrue(
             self._is_logged("WARNING", "Could not fetch position mode from exchange. Using default.")
         )

--- a/test/hummingbot/connector/derivative/derive_perpetual/test_derive_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/derive_perpetual/test_derive_perpetual_derivative.py
@@ -558,7 +558,7 @@ class DerivePerpetualDerivativeTests(AbstractPerpetualDerivativeTests.PerpetualD
         self.async_run_with_timeout(asyncio.sleep(0.5))
         self.assertTrue(
             self.is_logged(
-                log_level="DEBUG",
+                log_level="INFO",
                 message=f"Position mode switched to {PositionMode.ONEWAY}.",
             )
         )

--- a/test/hummingbot/connector/derivative/gate_io_perpetual/test_gate_io_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/gate_io_perpetual/test_gate_io_perpetual_derivative.py
@@ -888,7 +888,7 @@ class GateIoPerpetualDerivativeTests(AbstractPerpetualDerivativeTests.PerpetualD
             "label": "1666",
             "detail": "",
         }
-        mock_api.get(regex_get_position_url, body=json.dumps(get_position_mock_response), callback=callback)
+        mock_api.get(regex_get_position_url, body=json.dumps(get_position_mock_response))
         mock_api.post(regex_url, body=json.dumps(mock_response), callback=callback)
 
         return url, f"{error_msg}"

--- a/test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_derivative.py
@@ -434,7 +434,7 @@ class HyperliquidPerpetualDerivativeTests(AbstractPerpetualDerivativeTests.Perpe
         self.async_run_with_timeout(asyncio.sleep(0.5))
         self.assertTrue(
             self.is_logged(
-                log_level="DEBUG",
+                log_level="INFO",
                 message=f"Position mode switched to {PositionMode.ONEWAY}.",
             )
         )

--- a/test/hummingbot/connector/derivative/okx_perpetual/test_okx_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/okx_perpetual/test_okx_perpetual_derivative.py
@@ -979,7 +979,7 @@ class OkxPerpetualDerivativeTests(
         }
         mock_api.post(regex_url, body=json.dumps(mock_response), callback=callback)
 
-        return url, f"ret_code <{error_code}> - {error_msg}"
+        return url, error_msg
 
     def configure_failed_set_leverage(
         self,

--- a/test/hummingbot/strategy_v2/executors/test_executor_orchestrator.py
+++ b/test/hummingbot/strategy_v2/executors/test_executor_orchestrator.py
@@ -663,6 +663,8 @@ class TestExecutorOrchestrator(unittest.TestCase):
         existing_position = PositionHold("binance", "ETH-USDT", TradeType.BUY)
         existing_position.buy_amount_base = Decimal("2")
         existing_position.buy_amount_quote = Decimal("400")
+        existing_position.net_amount_base = Decimal("2")
+        existing_position.avg_entry_price = Decimal("200")
         existing_position.volume_traded_quote = Decimal("400")
 
         # Create executor that should add to existing position

--- a/test/hummingbot/strategy_v2/executors/test_executor_orchestrator.py
+++ b/test/hummingbot/strategy_v2/executors/test_executor_orchestrator.py
@@ -748,6 +748,154 @@ class TestExecutorOrchestrator(unittest.TestCase):
         orchestrator.initialize_initial_positions()
         self.assertEqual(len(orchestrator.positions_held["test_controller"]), 1)
 
+    def test_position_hold_process_order_open_long(self):
+        """Test _process_order opening a long position"""
+        ph = PositionHold("binance", "ETH-USDT", TradeType.BUY)
+        ph._process_order(is_buy=True, amount_base=Decimal("5"), amount_quote=Decimal("1000"))
+        self.assertEqual(ph.net_amount_base, Decimal("5"))
+        self.assertEqual(ph.avg_entry_price, Decimal("200"))
+
+    def test_position_hold_process_order_open_short(self):
+        """Test _process_order opening a short position"""
+        ph = PositionHold("binance", "ETH-USDT", TradeType.SELL)
+        ph._process_order(is_buy=False, amount_base=Decimal("3"), amount_quote=Decimal("600"))
+        self.assertEqual(ph.net_amount_base, Decimal("-3"))
+        self.assertEqual(ph.avg_entry_price, Decimal("200"))
+
+    def test_position_hold_process_order_add_to_long(self):
+        """Test _process_order adding to an existing long position"""
+        ph = PositionHold("binance", "ETH-USDT", TradeType.BUY)
+        ph._process_order(is_buy=True, amount_base=Decimal("2"), amount_quote=Decimal("400"))
+        ph._process_order(is_buy=True, amount_base=Decimal("3"), amount_quote=Decimal("900"))
+        self.assertEqual(ph.net_amount_base, Decimal("5"))
+        self.assertEqual(ph.avg_entry_price, Decimal("260"))  # (400+900)/5
+
+    def test_position_hold_process_order_partial_close_long(self):
+        """Test _process_order partially closing a long position"""
+        ph = PositionHold("binance", "ETH-USDT", TradeType.BUY)
+        ph._process_order(is_buy=True, amount_base=Decimal("10"), amount_quote=Decimal("2000"))
+        ph._process_order(is_buy=False, amount_base=Decimal("4"), amount_quote=Decimal("1000"))
+        self.assertEqual(ph.net_amount_base, Decimal("6"))
+        self.assertEqual(ph.avg_entry_price, Decimal("200"))
+        self.assertEqual(ph.realized_pnl_quote, Decimal("200"))  # (250-200)*4
+
+    def test_position_hold_process_order_full_close_long(self):
+        """Test _process_order fully closing a long position"""
+        ph = PositionHold("binance", "ETH-USDT", TradeType.BUY)
+        ph._process_order(is_buy=True, amount_base=Decimal("5"), amount_quote=Decimal("1000"))
+        ph._process_order(is_buy=False, amount_base=Decimal("5"), amount_quote=Decimal("1500"))
+        self.assertEqual(ph.net_amount_base, Decimal("0"))
+        self.assertEqual(ph.avg_entry_price, Decimal("0"))
+        self.assertEqual(ph.realized_pnl_quote, Decimal("500"))
+
+    def test_position_hold_process_order_flip_long_to_short(self):
+        """Test _process_order flipping from long to short"""
+        ph = PositionHold("binance", "ETH-USDT", TradeType.BUY)
+        ph._process_order(is_buy=True, amount_base=Decimal("3"), amount_quote=Decimal("600"))
+        ph._process_order(is_buy=False, amount_base=Decimal("5"), amount_quote=Decimal("1250"))
+        self.assertEqual(ph.net_amount_base, Decimal("-2"))
+        self.assertEqual(ph.avg_entry_price, Decimal("250"))
+        self.assertEqual(ph.realized_pnl_quote, Decimal("150"))  # (250-200)*3
+
+    def test_position_hold_process_order_partial_close_short(self):
+        """Test _process_order partially closing a short position"""
+        ph = PositionHold("binance", "ETH-USDT", TradeType.SELL)
+        ph._process_order(is_buy=False, amount_base=Decimal("10"), amount_quote=Decimal("3000"))
+        ph._process_order(is_buy=True, amount_base=Decimal("4"), amount_quote=Decimal("1000"))
+        self.assertEqual(ph.net_amount_base, Decimal("-6"))
+        self.assertEqual(ph.avg_entry_price, Decimal("300"))
+        self.assertEqual(ph.realized_pnl_quote, Decimal("200"))  # (300-250)*4
+
+    def test_position_hold_process_order_zero_amount(self):
+        """Test _process_order with zero amount is a no-op"""
+        ph = PositionHold("binance", "ETH-USDT", TradeType.BUY)
+        ph._process_order(is_buy=True, amount_base=Decimal("0"), amount_quote=Decimal("0"))
+        self.assertEqual(ph.net_amount_base, Decimal("0"))
+
+    def test_position_hold_add_orders_no_held_position_orders(self):
+        """Test add_orders_from_executor with missing held_position_orders logs warning"""
+        ph = PositionHold("binance", "ETH-USDT", TradeType.BUY)
+        config = PositionExecutorConfig(
+            timestamp=1234, trading_pair="ETH-USDT", connector_name="binance",
+            side=TradeType.BUY, amount=Decimal(10), entry_price=Decimal(100),
+        )
+        executor_info = ExecutorInfo(
+            id="abcdefgh", timestamp=1234, type="position_executor",
+            status=RunnableStatus.TERMINATED, config=config,
+            filled_amount_quote=Decimal(0), net_pnl_quote=Decimal(0), net_pnl_pct=Decimal(0),
+            cum_fees_quote=Decimal(0), is_trading=False, is_active=False,
+            custom_info={},
+            close_type=CloseType.POSITION_HOLD,
+        )
+        ph.add_orders_from_executor(executor_info)
+        self.assertEqual(ph.net_amount_base, Decimal("0"))
+
+    def test_position_hold_add_orders_duplicate_order_skipped(self):
+        """Test add_orders_from_executor skips duplicate orders"""
+        ph = PositionHold("binance", "ETH-USDT", TradeType.BUY)
+        config = PositionExecutorConfig(
+            timestamp=1234, trading_pair="ETH-USDT", connector_name="binance",
+            side=TradeType.BUY, amount=Decimal(10), entry_price=Decimal(100),
+        )
+        orders = [{"client_order_id": "dup_order", "executed_amount_base": Decimal("5"),
+                   "executed_amount_quote": Decimal("1000"), "trade_type": "BUY",
+                   "cumulative_fee_paid_quote": Decimal("1")}]
+        executor_info = ExecutorInfo(
+            id="abcdefgh", timestamp=1234, type="position_executor",
+            status=RunnableStatus.TERMINATED, config=config,
+            filled_amount_quote=Decimal(1000), net_pnl_quote=Decimal(0), net_pnl_pct=Decimal(0),
+            cum_fees_quote=Decimal(1), is_trading=False, is_active=False,
+            custom_info={"held_position_orders": orders},
+            close_type=CloseType.POSITION_HOLD,
+        )
+        ph.add_orders_from_executor(executor_info)
+        self.assertEqual(ph.buy_amount_base, Decimal("5"))
+        # Add same executor again - duplicate order should be skipped
+        ph.add_orders_from_executor(executor_info)
+        self.assertEqual(ph.buy_amount_base, Decimal("5"))  # unchanged
+
+    def test_get_all_reports_oneway_position_mode(self):
+        """Test that ONEWAY position mode returns None for position side (line 600)"""
+        from hummingbot.core.data_type.common import PositionMode
+
+        config = PositionExecutorConfig(
+            timestamp=1234, trading_pair="ETH-USDT", connector_name="binance_perpetual",
+            side=TradeType.BUY, amount=Decimal(10), entry_price=Decimal(100),
+        )
+        config.id = "oneway_executor_id"
+
+        executor = MagicMock()
+        executor.executor_info = ExecutorInfo(
+            id="oneway_executor_id", timestamp=1234, type="position_executor",
+            status=RunnableStatus.TERMINATED, config=config,
+            filled_amount_quote=Decimal(1000), net_pnl_quote=Decimal(50), net_pnl_pct=Decimal(5),
+            cum_fees_quote=Decimal(5), is_trading=False, is_active=False,
+            custom_info={"held_position_orders": [
+                {"client_order_id": "ow_order_1", "executed_amount_base": Decimal("5"),
+                 "executed_amount_quote": Decimal("1000"), "trade_type": "BUY",
+                 "cumulative_fee_paid_quote": Decimal("5")}
+            ]},
+            close_type=CloseType.POSITION_HOLD,
+            connector_name="binance_perpetual",
+            trading_pair="ETH-USDT"
+        )
+
+        mock_market = MagicMock()
+        mock_market.position_mode = PositionMode.ONEWAY
+        self.mock_strategy.connectors = {"binance_perpetual": mock_market}
+
+        self.orchestrator.active_executors = {"oneway_ctrl": [executor]}
+        self.orchestrator.positions_held = {"oneway_ctrl": []}
+        self.orchestrator.executors_ids_position_held = []
+        self.orchestrator.cached_performance = {"oneway_ctrl": PerformanceReport()}
+
+        self.orchestrator.get_all_reports()
+
+        # Position should be created with side=None (no side filtering in ONEWAY)
+        self.assertEqual(len(self.orchestrator.positions_held["oneway_ctrl"]), 1)
+        position = self.orchestrator.positions_held["oneway_ctrl"][0]
+        self.assertIsNone(position.side)
+
     def test_get_all_reports_comprehensive_controller_aggregation(self):
         """Test get_all_reports aggregating controllers from different sources"""
         # This tests lines 545,548-549,552,557 comprehensively


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] Tests all pass
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
# Position Mode Setting Flow — Changes & Test Plan

## Summary of Changes

### Problem

1. The base class (`PerpetualDerivativePyBase`) looped over all trading pairs calling `_trading_pair_position_mode_set` for each one — making redundant identical API calls (e.g. Binance with 5 pairs = 5 identical POSTs).
2. Binance's `_fetch_account_position_mode` used `return_err=True`, which swallowed errors silently.
3. Gate.io didn't implement `_fetch_account_position_mode` at all.
4. Rollback logic on failure was fragile (rollback could also fail, leaving inconsistent state).

### Changes

#### 1. `hummingbot/connector/perpetual_derivative_py_base.py`

- **Deleted** `_execute_set_position_mode_for_pairs` (the per-pair loop with rollback).
- **Rewrote** `_execute_set_position_mode`:
  1. Fetches current mode via `_fetch_account_position_mode()`
  2. Short-circuits if already in desired mode (no API call)
  3. Calls `_trading_pair_position_mode_set(mode, trading_pairs[0])` **once**
  4. Fires events for all pairs
- **Added** `_fire_position_mode_events` helper to DRY event firing across base and overrides.
- **Improved logging**: `info` on success/already-set, `error` on failure (was `debug`/silent).

#### 2. `hummingbot/connector/derivative/binance_perpetual/binance_perpetual_derivative.py`

- **Removed** `return_err=True` from `_fetch_account_position_mode` — errors now propagate correctly.

#### 3. `hummingbot/connector/derivative/gate_io_perpetual/gate_io_perpetual_derivative.py`

- **Added** `_fetch_account_position_mode` — queries the positions endpoint and returns current mode.
- Previous `_execute_set_position_mode_for_pairs` override removed (method no longer exists in base).

#### 4. `hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_derivative.py`

- **Added** `_execute_set_position_mode` override — loops over all trading pairs because Bybit sets position mode per-symbol (sends `symbol` in the POST body).

#### 5. `hummingbot/connector/derivative/bitget_perpetual/bitget_perpetual_derivative.py`

- **Added** `_execute_set_position_mode` override — loops over all trading pairs because Bitget derives `productType` from the trading pair.

### What stays unchanged

- `_trading_pair_position_mode_set` — signature and all 18 connector implementations untouched.
- `_fetch_account_position_mode` in base class (abstract).
- `_initialize_position_mode` in base class.
- `PerpetualTrading` class, strategy layer, all other connectors.

---

## Manual Test Plan

### Prerequisites

- A controller config (e.g. `pmm_mister`) that can be configured with `position_mode: HEDGE` or `position_mode: ONEWAY`.
- API keys configured for each exchange.
- No open positions on the account (some exchanges reject mode change with open positions).

### How to test

For each exchange below:
1. Set the controller's `position_mode` to **HEDGE**, start the bot.
2. Check logs for `Position mode switched to PositionMode.HEDGE` or `Position mode already set to PositionMode.HEDGE`.
3. Stop the bot, change `position_mode` to **ONEWAY**, restart.
4. Check logs for `Position mode switched to PositionMode.ONEWAY`.
5. Verify no errors in logs related to position mode.
6. Confirm only **1 API call** was made to set position mode (except Bybit/Bitget — 1 per pair).

### Tier 1 — Dual mode exchanges (support ONEWAY + HEDGE)

These exchanges support switching between modes. Test both directions.

| Exchange | Position Mode Setting | Expected API calls | Notes |
|---|---|---|---|
| **Binance Perpetual** | Account-level (base class) | 1 call total | Most common. Verify no `return_err` swallowing. |
| **Gate.io Perpetual** | Account-level (base class) | 1 call total | New `_fetch_account_position_mode`. Verify it reads mode correctly. |
| **Bybit Perpetual** | Per-symbol (override) | 1 call per trading pair | Only linear perpetuals. Inverse pairs will fail with clear error. |
| **Bitget Perpetual** | Per-product-type (override) | 1 call per trading pair | Derives `productType` from pair. Fails if positions exist. |
| **OKX Perpetual** | Account-level (base class) | 1 call total | |
| **BitMart Perpetual** | Account-level (base class) | 1 call total | |

#### Test matrix for each Tier 1 exchange

| # | Test | Controller config | Expected log | Pass? |
|---|---|---|---|---|
| 1 | Start with HEDGE when account is ONEWAY | `position_mode: HEDGE` | `Position mode switched to PositionMode.HEDGE` | |
| 2 | Start with HEDGE when account is already HEDGE | `position_mode: HEDGE` | `Position mode already set to PositionMode.HEDGE` | |
| 3 | Start with ONEWAY when account is HEDGE | `position_mode: ONEWAY` | `Position mode switched to PositionMode.ONEWAY` | |
| 4 | Start with ONEWAY when account is already ONEWAY | `position_mode: ONEWAY` | `Position mode already set to PositionMode.ONEWAY` | |
| 5 | Fail to switch (open positions exist) | `position_mode: HEDGE` | `Failed to set position mode to PositionMode.HEDGE: <error>` | |
| 6 | Multiple trading pairs configured | any mode | Binance/Gate.io/OKX: 1 API call. Bybit/Bitget: N calls. | |

### Tier 2 — ONEWAY-only exchanges (no mode switching needed)

These only support `ONEWAY`. The base class `_initialize_position_mode` should set ONEWAY without calling the exchange API. No manual testing needed beyond confirming startup works.

| Exchange | Supported Modes |
|---|---|
| KuCoin Perpetual | ONEWAY only |
| Hyperliquid Perpetual | ONEWAY only |
| dYdX v4 Perpetual | ONEWAY only |
| Aevo Perpetual | ONEWAY only |
| Derive Perpetual | ONEWAY only |
| Injective v2 Perpetual | ONEWAY only |
| Architect Perpetual | ONEWAY only |
| Backpack Perpetual | ONEWAY only |
| Evedex Perpetual | ONEWAY only |
| Decibel Perpetual | ONEWAY only |
| GRVT Perpetual | ONEWAY only |
| Pacifica Perpetual | ONEWAY only |

#### Quick sanity check for Tier 2

| # | Test | Expected | Pass? |
|---|---|---|---|
| 1 | Start bot with default config | Bot starts, no position mode errors | |
| 2 | Set `position_mode: HEDGE` | Should fail or be rejected (not in `supported_position_modes`) | |

### What to watch for (all exchanges)

- **No redundant API calls**: With N trading pairs, account-level exchanges should make exactly 1 POST (not N).
- **Short-circuit works**: If the account is already in the desired mode, no POST should be made — only a GET to fetch current mode.
- **Error messages are visible**: On failure, `error` level log appears with the exchange error message.
- **Events fire for all pairs**: Even with a single API call, `PositionModeChangeSucceeded` / `PositionModeChangeFailed` events should fire for every configured trading pair.

---

## Unit Tests

Existing tests already pass:

```bash
python -m pytest test/hummingbot/connector/derivative/binance_perpetual/test_binance_perpetual_derivative.py -v
# 47 passed
```

Additional test files to verify (if they exist):

```bash
python -m pytest test/hummingbot/connector/derivative/gate_io_perpetual/ -v
python -m pytest test/hummingbot/connector/derivative/bybit_perpetual/ -v
python -m pytest test/hummingbot/connector/derivative/bitget_perpetual/ -v
```



**Tests performed by the developer**:



**Tips for QA testing**:
