### PR TITLE
feat / add message timeout for websocket connections to improve stabi…

### DIFF
--- a/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_api_order_book_data_source.py
+++ b/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_api_order_book_data_source.py
@@ -151,7 +151,11 @@ class HyperliquidPerpetualAPIOrderBookDataSource(PerpetualAPIOrderBookDataSource
     async def _connected_websocket_assistant(self) -> WSAssistant:
         url = f"{web_utils.wss_url(self._domain)}"
         ws: WSAssistant = await self._api_factory.get_ws_assistant()
-        await ws.connect(ws_url=url, ping_timeout=CONSTANTS.HEARTBEAT_TIME_INTERVAL)
+        await ws.connect(
+            ws_url=url,
+            ping_timeout=CONSTANTS.HEARTBEAT_TIME_INTERVAL,
+            message_timeout=CONSTANTS.WS_MESSAGE_TIMEOUT,
+        )
         return ws
 
     async def _subscribe_channels(self, ws: WSAssistant):

--- a/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_constants.py
+++ b/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_constants.py
@@ -90,6 +90,10 @@ ORDER_STATE = {
 }
 
 HEARTBEAT_TIME_INTERVAL = 30.0
+# Max time to wait for a websocket message before assuming the connection is half-open (no data, no close
+# frame) and forcing a keepalive ping / reconnection. Set above HEARTBEAT_TIME_INTERVAL so the periodic ping
+# (and its pong) keeps a healthy connection from timing out.
+WS_MESSAGE_TIMEOUT = 60.0
 
 MAX_REQUEST = 1_200
 ALL_ENDPOINTS_LIMIT = "All"

--- a/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_user_stream_data_source.py
+++ b/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_user_stream_data_source.py
@@ -41,6 +41,7 @@ class HyperliquidPerpetualUserStreamDataSource(UserStreamTrackerDataSource):
         self._listen_for_user_stream_task = None
         self._last_listen_key_ping_ts = None
         self._trading_pairs: List[str] = trading_pairs
+        self._ping_task: Optional[asyncio.Task] = None
 
         self.token = None
 
@@ -61,8 +62,12 @@ class HyperliquidPerpetualUserStreamDataSource(UserStreamTrackerDataSource):
         """
         ws: WSAssistant = await self._get_ws_assistant()
         url = f"{web_utils.wss_url(self._domain)}"
-        await ws.connect(ws_url=url, ping_timeout=self.HEARTBEAT_TIME_INTERVAL)
-        safe_ensure_future(self._ping_thread(ws))
+        await ws.connect(
+            ws_url=url,
+            ping_timeout=self.HEARTBEAT_TIME_INTERVAL,
+            message_timeout=CONSTANTS.WS_MESSAGE_TIMEOUT,
+        )
+        self._ping_task = safe_ensure_future(self._ping_thread(ws))
         return ws
 
     async def _subscribe_channels(self, websocket_assistant: WSAssistant):
@@ -102,6 +107,18 @@ class HyperliquidPerpetualUserStreamDataSource(UserStreamTrackerDataSource):
         except Exception:
             self.logger().exception("Unexpected error occurred subscribing to user streams...")
             raise
+
+    async def _on_user_stream_interruption(self, websocket_assistant: Optional[WSAssistant]):
+        # Cancel the keepalive ping task tied to this connection so it does not outlive the websocket and
+        # leak across reconnections.
+        if self._ping_task is not None:
+            self._ping_task.cancel()
+            try:
+                await self._ping_task
+            except asyncio.CancelledError:
+                pass
+            self._ping_task = None
+        await super()._on_user_stream_interruption(websocket_assistant=websocket_assistant)
 
     async def _process_event_message(self, event_message: Dict[str, Any], queue: asyncio.Queue):
         if event_message.get("error") is not None:

--- a/hummingbot/connector/exchange/hyperliquid/hyperliquid_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/hyperliquid/hyperliquid_api_order_book_data_source.py
@@ -71,7 +71,11 @@ class HyperliquidAPIOrderBookDataSource(OrderBookTrackerDataSource):
     async def _connected_websocket_assistant(self) -> WSAssistant:
         url = f"{web_utils.wss_url(self._domain)}"
         ws: WSAssistant = await self._api_factory.get_ws_assistant()
-        await ws.connect(ws_url=url, ping_timeout=CONSTANTS.HEARTBEAT_TIME_INTERVAL)
+        await ws.connect(
+            ws_url=url,
+            ping_timeout=CONSTANTS.HEARTBEAT_TIME_INTERVAL,
+            message_timeout=CONSTANTS.WS_MESSAGE_TIMEOUT,
+        )
         return ws
 
     async def _subscribe_channels(self, ws: WSAssistant):

--- a/hummingbot/connector/exchange/hyperliquid/hyperliquid_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/hyperliquid/hyperliquid_api_user_stream_data_source.py
@@ -42,6 +42,7 @@ class HyperliquidAPIUserStreamDataSource(UserStreamTrackerDataSource):
         self._listen_for_user_stream_task = None
         self._last_listen_key_ping_ts = None
         self._trading_pairs: List[str] = trading_pairs
+        self._ping_task: Optional[asyncio.Task] = None
 
         self.token = None
 
@@ -62,8 +63,12 @@ class HyperliquidAPIUserStreamDataSource(UserStreamTrackerDataSource):
         """
         ws: WSAssistant = await self._get_ws_assistant()
         url = f"{web_utils.wss_url(self._domain)}"
-        await ws.connect(ws_url=url, ping_timeout=self.HEARTBEAT_TIME_INTERVAL)
-        safe_ensure_future(self._ping_thread(ws))
+        await ws.connect(
+            ws_url=url,
+            ping_timeout=self.HEARTBEAT_TIME_INTERVAL,
+            message_timeout=CONSTANTS.WS_MESSAGE_TIMEOUT,
+        )
+        self._ping_task = safe_ensure_future(self._ping_thread(ws))
         return ws
 
     async def _subscribe_channels(self, websocket_assistant: WSAssistant):
@@ -103,6 +108,18 @@ class HyperliquidAPIUserStreamDataSource(UserStreamTrackerDataSource):
         except Exception:
             self.logger().exception("Unexpected error occurred subscribing to user streams...")
             raise
+
+    async def _on_user_stream_interruption(self, websocket_assistant: Optional[WSAssistant]):
+        # Cancel the keepalive ping task tied to this connection so it does not outlive the websocket and
+        # leak across reconnections.
+        if self._ping_task is not None:
+            self._ping_task.cancel()
+            try:
+                await self._ping_task
+            except asyncio.CancelledError:
+                pass
+            self._ping_task = None
+        await super()._on_user_stream_interruption(websocket_assistant=websocket_assistant)
 
     async def _process_event_message(self, event_message: Dict[str, Any], queue: asyncio.Queue):
         if event_message.get("error") is not None:

--- a/hummingbot/connector/exchange/hyperliquid/hyperliquid_constants.py
+++ b/hummingbot/connector/exchange/hyperliquid/hyperliquid_constants.py
@@ -67,6 +67,10 @@ ORDER_STATE = {
 }
 
 HEARTBEAT_TIME_INTERVAL = 30.0
+# Max time to wait for a websocket message before assuming the connection is half-open (no data, no close
+# frame) and forcing a keepalive ping / reconnection. Set above HEARTBEAT_TIME_INTERVAL so the periodic ping
+# (and its pong) keeps a healthy connection from timing out.
+WS_MESSAGE_TIMEOUT = 60.0
 
 MAX_REQUEST = 1_200
 ALL_ENDPOINTS_LIMIT = "All"


### PR DESCRIPTION
This pull request improves the reliability and resource management of the Hyperliquid connectors by introducing a websocket message timeout, enhancing keepalive ping task handling, and ensuring proper cleanup on user stream interruptions. These changes help prevent stale websocket connections and avoid leaking background tasks during reconnections.

**Websocket Connection Improvements:**

* Added a new `WS_MESSAGE_TIMEOUT` constant (set to 60 seconds) in both `hyperliquid_constants.py` and `hyperliquid_perpetual_constants.py` to specify the maximum time to wait for a websocket message before considering the connection stale. [[1]](diffhunk://#diff-22c00ea063aa495808b98eb95d42edc931acae1120ef44ef2dae0b4fb57d0a2aR70-R73) [[2]](diffhunk://#diff-4710e79171ae36eb8cd1f14cfa8217efc9ade85927ef6915c62d58695f872ac5R93-R96)
* Updated all websocket connection code in order book and user stream data sources to use the new `message_timeout` parameter, improving detection and handling of half-open connections. [[1]](diffhunk://#diff-3c45c54d8557fe3c30870e37c2616020711fe3322520506d7c7a89a9c28845beL74-R78) [[2]](diffhunk://#diff-3ee5e49a1ec70b7ae5feb3356d3e0f52def68f2358fc5653fae7da607c4b1670L154-R158) [[3]](diffhunk://#diff-3f9103cf2f4ed6542de33dfe9045707f65c033b48e9bca1ba1e87da05a1c8ebdL65-R71) [[4]](diffhunk://#diff-a0c0d485ad309edc5fdcb9ded183195e2ee88380613a48a9afd61647979d2537L64-R70)

**Keepalive Ping Task Management:**

* Added a `_ping_task` attribute to user stream data source classes to track the keepalive ping task, replacing the previous approach where the task could leak across reconnections. [[1]](diffhunk://#diff-3f9103cf2f4ed6542de33dfe9045707f65c033b48e9bca1ba1e87da05a1c8ebdR45) [[2]](diffhunk://#diff-a0c0d485ad309edc5fdcb9ded183195e2ee88380613a48a9afd61647979d2537R44)
* Modified connection logic to store the created ping task in `_ping_task` for proper management. [[1]](diffhunk://#diff-3f9103cf2f4ed6542de33dfe9045707f65c033b48e9bca1ba1e87da05a1c8ebdL65-R71) [[2]](diffhunk://#diff-a0c0d485ad309edc5fdcb9ded183195e2ee88380613a48a9afd61647979d2537L64-R70)
* Implemented `_on_user_stream_interruption` to cancel and clean up the keepalive ping task when a websocket connection is interrupted, preventing task leaks and ensuring resources are freed correctly. [[1]](diffhunk://#diff-3f9103cf2f4ed6542de33dfe9045707f65c033b48e9bca1ba1e87da05a1c8ebdR112-R123) [[2]](diffhunk://#diff-a0c0d485ad309edc5fdcb9ded183195e2ee88380613a48a9afd61647979d2537R111-R122)…lity

**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] Tests all pass
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:



**Tests performed by the developer**:



**Tips for QA testing**:
