### PR TITLE
fix / parse decimal position values in OKX perpetual connector

### DIFF
--- a/hummingbot/connector/derivative/okx_perpetual/okx_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/okx_perpetual/okx_perpetual_derivative.py
@@ -656,7 +656,7 @@ class OkxPerpetualDerivative(PerpetualDerivativePyBase):
     @staticmethod
     def get_position_side(position_msg: Dict[str, Any]) -> PositionSide:
         if position_msg.get("posSide") == "net":
-            position_side = PositionSide.LONG if int(position_msg["pos"]) > 0 else PositionSide.SHORT
+            position_side = PositionSide.LONG if Decimal(position_msg["pos"]) > 0 else PositionSide.SHORT
         else:
             position_side = PositionSide.LONG if position_msg.get("posSide") == "long" else PositionSide.SHORT
         return position_side

--- a/test/hummingbot/connector/derivative/okx_perpetual/test_okx_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/okx_perpetual/test_okx_perpetual_derivative.py
@@ -16,7 +16,7 @@ from hummingbot.connector.derivative.okx_perpetual.okx_perpetual_derivative impo
 from hummingbot.connector.test_support.perpetual_derivative_test import AbstractPerpetualDerivativeTests
 from hummingbot.connector.trading_rule import TradingRule
 from hummingbot.core.data_type.cancellation_result import CancellationResult
-from hummingbot.core.data_type.common import OrderType, PositionAction, PositionMode, TradeType
+from hummingbot.core.data_type.common import OrderType, PositionAction, PositionMode, PositionSide, TradeType
 from hummingbot.core.data_type.funding_info import FundingInfo
 from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState
 from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee, TokenAmount, TradeFeeBase
@@ -2574,3 +2574,38 @@ class OkxPerpetualDerivativeTests(
         mock_api.get(self.latest_prices_url, body=json.dumps(self.latest_prices_request_mock_response))
         lastprice_response = self.run_async_with_timeout(self.exchange._get_last_traded_price(self.trading_pair))
         self.assertEqual(lastprice_response, 9999.9)
+
+    def test_get_position_side_decimal_long(self):
+        position_msg = {"pos": "0.02", "posSide": "net"}
+        result = OkxPerpetualDerivative.get_position_side(position_msg)
+        self.assertEqual(result, PositionSide.LONG)
+
+    def test_get_position_side_decimal_short(self):
+        position_msg = {"pos": "-0.04", "posSide": "net"}
+        result = OkxPerpetualDerivative.get_position_side(position_msg)
+        self.assertEqual(result, PositionSide.SHORT)
+
+    def test_get_position_side_integer_long(self):
+        position_msg = {"pos": "1", "posSide": "net"}
+        result = OkxPerpetualDerivative.get_position_side(position_msg)
+        self.assertEqual(result, PositionSide.LONG)
+
+    def test_get_position_side_integer_short(self):
+        position_msg = {"pos": "-3", "posSide": "net"}
+        result = OkxPerpetualDerivative.get_position_side(position_msg)
+        self.assertEqual(result, PositionSide.SHORT)
+
+    def test_get_position_side_explicit_long(self):
+        position_msg = {"pos": "0.02", "posSide": "long"}
+        result = OkxPerpetualDerivative.get_position_side(position_msg)
+        self.assertEqual(result, PositionSide.LONG)
+
+    def test_get_position_side_explicit_short(self):
+        position_msg = {"pos": "0.02", "posSide": "short"}
+        result = OkxPerpetualDerivative.get_position_side(position_msg)
+        self.assertEqual(result, PositionSide.SHORT)
+
+    def test_get_position_side_zero_position(self):
+        position_msg = {"pos": "0", "posSide": "net"}
+        result = OkxPerpetualDerivative.get_position_side(position_msg)
+        self.assertEqual(result, PositionSide.SHORT)


### PR DESCRIPTION
## Summary

- Fix `ValueError` crash in `get_position_side()` when OKX API returns fractional position sizes (e.g. `"0.02"`) instead of integer strings
- Replace `int()` with `Decimal()` for parsing position values, consistent with the rest of the connector
- Add 7 unit tests covering decimal, integer, zero, and explicit `posSide` cases

## Problem

When running `perpetual_market_making` on OKX perpetual with fractional order sizes, filled positions crash the connector because `int("0.02")` raises `ValueError`. This breaks both the user stream listener and status polling loops, making the connector unresponsive.

Traceback and reproduction confirmed by @rapcmia in #8248.

## Changes

**`okx_perpetual_derivative.py`** (1 line):
- `get_position_side()`: `int(position_msg["pos"])` -> `Decimal(position_msg["pos"])`

**`test_okx_perpetual_derivative.py`** (35 lines):
- `test_get_position_side_decimal_long` - decimal positive -> LONG
- `test_get_position_side_decimal_short` - decimal negative -> SHORT
- `test_get_position_side_integer_long` - integer positive -> LONG (regression)
- `test_get_position_side_integer_short` - integer negative -> SHORT (regression)
- `test_get_position_side_explicit_long` - explicit posSide "long"
- `test_get_position_side_explicit_short` - explicit posSide "short"
- `test_get_position_side_zero_position` - zero pos -> SHORT (existing behavior)

## Test plan

- [ ] New unit tests pass for `get_position_side()` with decimal, integer, and zero values
- [ ] Existing `test_update_positions` continues to pass
- [ ] flake8 and isort pass on changed files
- [ ] diff-cover >= 80% on changed lines

Fixes #8248