### PR TITLE
feat / allow disabling stop_loss and take_profit in market making controllers

### DIFF
--- a/hummingbot/strategy_v2/controllers/market_making_controller_base.py
+++ b/hummingbot/strategy_v2/controllers/market_making_controller_base.py
@@ -79,15 +79,15 @@ class MarketMakingControllerConfigBase(ControllerConfigBase):
     )
     # Triple Barrier Configuration
     stop_loss: Optional[Decimal] = Field(
-        default=Decimal("0.03"), gt=0,
+        default=Decimal("0.03"),
         json_schema_extra={
-            "prompt": "Enter the stop loss (as a decimal, e.g., 0.03 for 3%): ",
+            "prompt": "Enter the stop loss (as a decimal, e.g., 0.03 for 3%). Leave empty to disable: ",
             "prompt_on_new": True, "is_updatable": True}
     )
     take_profit: Optional[Decimal] = Field(
-        default=Decimal("0.02"), gt=0,
+        default=Decimal("0.02"),
         json_schema_extra={
-            "prompt": "Enter the take profit (as a decimal, e.g., 0.02 for 2%): ",
+            "prompt": "Enter the take profit (as a decimal, e.g., 0.02 for 2%). Leave empty to disable: ",
             "prompt_on_new": True, "is_updatable": True}
     )
     time_limit: Optional[int] = Field(
@@ -131,7 +131,7 @@ class MarketMakingControllerConfigBase(ControllerConfigBase):
     @classmethod
     def validate_target(cls, v):
         if isinstance(v, str):
-            if v == "":
+            if v == "" or v.lower() == "none":
                 return None
             return Decimal(v)
         return v

--- a/test/hummingbot/strategy_v2/controllers/test_market_making_controller_base.py
+++ b/test/hummingbot/strategy_v2/controllers/test_market_making_controller_base.py
@@ -116,6 +116,8 @@ class TestMarketMakingControllerBase(IsolatedAsyncioWrapperTestCase):
     def test_validate_target(self):
         self.assertEqual(None, self.mock_controller_config.validate_target(""))
         self.assertEqual(Decimal("2.0"), self.mock_controller_config.validate_target("2.0"))
+        self.assertEqual(None, self.mock_controller_config.validate_target("None"))
+        self.assertEqual(None, self.mock_controller_config.validate_target("none"))
 
     def test_parse_trailing_stop(self):
         self.assertEqual(None, self.mock_controller_config.parse_trailing_stop(""))
@@ -436,3 +438,87 @@ class TestMarketMakingControllerBase(IsolatedAsyncioWrapperTestCase):
 
         # Should not include any rebalance actions
         self.assertEqual(len(actions), 0)
+
+    def test_config_with_disabled_stop_loss(self):
+        config = MarketMakingControllerConfigBase(
+            id="test",
+            controller_name="test_controller",
+            connector_name="binance_perpetual",
+            trading_pair="ETH-USDT",
+            total_amount_quote=Decimal(100),
+            buy_spreads=[0.01],
+            sell_spreads=[0.01],
+            stop_loss=None,
+            take_profit=Decimal("0.02"),
+        )
+        self.assertIsNone(config.stop_loss)
+        self.assertEqual(config.take_profit, Decimal("0.02"))
+        triple_barrier = config.triple_barrier_config
+        self.assertIsNone(triple_barrier.stop_loss)
+        self.assertEqual(triple_barrier.take_profit, Decimal("0.02"))
+
+    def test_config_with_disabled_take_profit(self):
+        config = MarketMakingControllerConfigBase(
+            id="test",
+            controller_name="test_controller",
+            connector_name="binance_perpetual",
+            trading_pair="ETH-USDT",
+            total_amount_quote=Decimal(100),
+            buy_spreads=[0.01],
+            sell_spreads=[0.01],
+            stop_loss=Decimal("0.03"),
+            take_profit=None,
+        )
+        self.assertEqual(config.stop_loss, Decimal("0.03"))
+        self.assertIsNone(config.take_profit)
+        triple_barrier = config.triple_barrier_config
+        self.assertEqual(triple_barrier.stop_loss, Decimal("0.03"))
+        self.assertIsNone(triple_barrier.take_profit)
+
+    def test_config_with_both_disabled(self):
+        config = MarketMakingControllerConfigBase(
+            id="test",
+            controller_name="test_controller",
+            connector_name="binance_perpetual",
+            trading_pair="ETH-USDT",
+            total_amount_quote=Decimal(100),
+            buy_spreads=[0.01],
+            sell_spreads=[0.01],
+            stop_loss=None,
+            take_profit=None,
+        )
+        self.assertIsNone(config.stop_loss)
+        self.assertIsNone(config.take_profit)
+        triple_barrier = config.triple_barrier_config
+        self.assertIsNone(triple_barrier.stop_loss)
+        self.assertIsNone(triple_barrier.take_profit)
+
+    def test_config_stop_loss_from_empty_string(self):
+        config = MarketMakingControllerConfigBase(
+            id="test",
+            controller_name="test_controller",
+            connector_name="binance_perpetual",
+            trading_pair="ETH-USDT",
+            total_amount_quote=Decimal(100),
+            buy_spreads=[0.01],
+            sell_spreads=[0.01],
+            stop_loss="",
+            take_profit="",
+        )
+        self.assertIsNone(config.stop_loss)
+        self.assertIsNone(config.take_profit)
+
+    def test_config_stop_loss_from_none_string(self):
+        config = MarketMakingControllerConfigBase(
+            id="test",
+            controller_name="test_controller",
+            connector_name="binance_perpetual",
+            trading_pair="ETH-USDT",
+            total_amount_quote=Decimal(100),
+            buy_spreads=[0.01],
+            sell_spreads=[0.01],
+            stop_loss="None",
+            take_profit="none",
+        )
+        self.assertIsNone(config.stop_loss)
+        self.assertIsNone(config.take_profit)


### PR DESCRIPTION
## Summary

- Remove `gt=0` constraint from `stop_loss` and `take_profit` fields in `MarketMakingControllerConfigBase`, allowing them to be set to `None`
- Update `validate_target` to accept `"None"`/`"none"` string values from YAML config files
- Update prompt text to indicate users can leave the field empty to disable

## Problem

Users cannot disable `stop_loss` and `take_profit` in PMM_simple and other market making controllers. This is problematic for low-liquidity pairs where prices can be manipulated to trigger stop loss traps. The `gt=0` Pydantic constraint prevents setting these fields to `None`.

The downstream code (`TripleBarrierConfig`, position executor) already handles `None` values correctly, so the only barrier was the config validation.

## Changes

**`market_making_controller_base.py`** (3 changes):
- Remove `gt=0` from `stop_loss` field definition
- Remove `gt=0` from `take_profit` field definition
- `validate_target()`: handle `"None"`/`"none"` strings as `None`

**`test_market_making_controller_base.py`** (6 new tests):
- `test_config_with_disabled_stop_loss` - stop_loss=None, take_profit set
- `test_config_with_disabled_take_profit` - take_profit=None, stop_loss set
- `test_config_with_both_disabled` - both None, verify triple_barrier_config propagation
- `test_config_stop_loss_from_empty_string` - empty string -> None
- `test_config_stop_loss_from_none_string` - "None"/"none" string -> None
- `test_validate_target` - extended with "None"/"none" cases

## Usage

Users can now set in their YAML config:
```yaml
stop_loss:        # empty = disabled
take_profit: ~    # YAML null = disabled
```

Or when prompted interactively, leave the field empty to disable.

## Test plan

- [ ] New unit tests pass for disabled stop_loss/take_profit combinations
- [ ] Existing tests continue to pass (default values unchanged)
- [ ] flake8 and isort pass on changed files
- [ ] diff-cover >= 80% on changed lines

Fixes #7203