### PR TITLE
fix: clamp Kraken start_time instead of raising ValueError (fixes #8208)

### DIFF
--- a/hummingbot/data_feed/candles_feed/kraken_spot_candles/kraken_spot_candles.py
+++ b/hummingbot/data_feed/candles_feed/kraken_spot_candles/kraken_spot_candles.py
@@ -102,11 +102,18 @@ class KrakenSpotCandles(CandlesBase):
         For API documentation, please refer to:
         https://docs.kraken.com/rest/#tag/Spot-Market-Data/operation/getOHLCData
 
-        This endpoint allows you to return up to 3600 candles ago.
+        This endpoint returns up to MAX_CANDLES_AGO (720) candles. If the requested
+        start_time is older than the maximum supported lookback, clamp it to the
+        oldest retrievable timestamp rather than raising an exception.  Raising
+        caused the candle-fill loop to abort permanently for short intervals (e.g.
+        5 m) when _is_first_candle_not_included_in_rest_request == True pushed the
+        requested since value one interval beyond the 720-candle boundary.
+        See: https://github.com/hummingbot/hummingbot/issues/8208
         """
-        candles_ago = (int(time.time()) - start_time) // self.interval_in_seconds
-        if candles_ago > CONSTANTS.MAX_CANDLES_AGO:
-            raise ValueError("Kraken REST API does not support fetching more than 720 candles ago.")
+        if start_time is not None:
+            max_lookback_start = int(time.time()) - CONSTANTS.MAX_CANDLES_AGO * self.interval_in_seconds
+            if start_time < max_lookback_start:
+                start_time = max_lookback_start
         return {"pair": self._ex_trading_pair, "interval": CONSTANTS.INTERVALS[self.interval],
                 "since": start_time}
 

--- a/test/hummingbot/data_feed/candles_feed/kraken_spot_candles/test_kraken_spot_candles.py
+++ b/test/hummingbot/data_feed/candles_feed/kraken_spot_candles/test_kraken_spot_candles.py
@@ -98,19 +98,50 @@ class TestKrakenSpotCandles(TestCandlesBase):
         }
         return data
 
-    @aioresponses()
-    def test_fetch_candles_raises_exception(self, mock_api):
-        regex_url = re.compile(f"^{self.data_feed.candles_url}".replace(".", r"\.").replace("?", r"\?"))
-        data_mock = self.get_candles_rest_data_mock()
-        mock_api.get(url=regex_url, body=json.dumps(data_mock))
-        start_time = self._time - self._interval_in_seconds * 100000
-        end_time = self._time
+    def test_get_rest_candles_params_clamps_ancient_start_time(self):
+        """
+        Regression test for https://github.com/hummingbot/hummingbot/issues/8208.
 
-        config = HistoricalCandlesConfig(start_time=start_time, end_time=end_time, interval=self.interval,
-                                         connector_name=self.data_feed.name, trading_pair=self.trading_pair)
-        with self.assertRaises(ValueError,
-                               msg="Kraken REST API does not support fetching more than 720 candles ago."):
-            self.run_async_with_timeout(self.data_feed.get_historical_candles(config))
+        Previously _get_rest_candles_params raised ValueError when start_time was
+        older than MAX_CANDLES_AGO intervals ago.  The bug surfaced for 5-minute
+        candles when _is_first_candle_not_included_in_rest_request == True caused
+        the base class to subtract one extra interval, pushing candles_ago from
+        720 to 721 and killing the fill loop permanently.
+
+        The fix silently clamps start_time to the oldest supported value instead
+        of raising, so the fill loop can recover and return the most candles
+        available.
+        """
+        interval = "5m"
+        feed_5m = KrakenSpotCandles(trading_pair=self.trading_pair, interval=interval)
+        interval_in_seconds = feed_5m.interval_in_seconds  # 300
+
+        # A start_time that is 721 intervals in the past (one beyond the limit)
+        ancient_start = int(time.time()) - 721 * interval_in_seconds
+        params = feed_5m._get_rest_candles_params(start_time=ancient_start)
+
+        max_lookback = int(time.time()) - CONSTANTS.MAX_CANDLES_AGO * interval_in_seconds
+        # The clamped since must be >= max_lookback (allow 1-second tolerance for test timing)
+        self.assertGreaterEqual(params["since"], max_lookback - 1,
+                                "start_time should be clamped to oldest supported value, not the ancient input")
+        self.assertLess(ancient_start, max_lookback,
+                        "Pre-condition: ancient_start must be older than max_lookback for this test to be meaningful")
+
+    def test_get_rest_candles_params_does_not_alter_recent_start_time(self):
+        """A start_time within the supported window must be passed through unchanged."""
+        interval = "5m"
+        feed_5m = KrakenSpotCandles(trading_pair=self.trading_pair, interval=interval)
+        interval_in_seconds = feed_5m.interval_in_seconds
+
+        # 100 intervals ago — well within the 720-candle window
+        recent_start = int(time.time()) - 100 * interval_in_seconds
+        params = feed_5m._get_rest_candles_params(start_time=recent_start)
+        self.assertEqual(recent_start, params["since"])
+
+    def test_get_rest_candles_params_handles_none_start_time(self):
+        """Passing start_time=None must not raise and must pass None through to 'since'."""
+        params = self.data_feed._get_rest_candles_params(start_time=None)
+        self.assertIsNone(params["since"])
 
     @aioresponses()
     def test_fetch_candles(self, mock_api):


### PR DESCRIPTION
## Summary

Fixes #8208 — Kraken 5-minute candle feed crashes permanently on startup with `ValueError: Kraken REST API does not support fetching more than 720 candles ago.`

## Root Cause

`_get_rest_candles_params` computed `candles_ago` and raised `ValueError` if it exceeded `MAX_CANDLES_AGO` (720). This guard was too aggressive because of an interaction with the base class:

1. `KrakenSpotCandles._is_first_candle_not_included_in_rest_request = True`
2. The base class subtracts one extra `interval_in_seconds` from `start_time` when this flag is set
3. For the 5 m interval with `max_records=720`, when the first WebSocket candle arrives for a just-closed bar (`end_time ≈ now − 300 s`), the base class computes `since = now − 720 × 300 − 300`
4. This yields `candles_ago = 721 > 720` → `ValueError` is raised **on the very first REST request**
5. The exception propagates out of the fill loop, which does not retry — the feed remains permanently empty

## Fix

Replace the `raise` with a silent clamp. When `start_time` is older than the oldest supported timestamp, it is adjusted to that boundary. The REST call succeeds and returns the maximum available history.

## Tests

- **Updated** existing `test_fetch_candles_raises_exception` → now correctly tests the clamp behaviour (regression for #8208, 5 m at 721-interval boundary)
- **Added** `test_get_rest_candles_params_does_not_alter_recent_start_time`: recent start_time passes through unchanged
- **Added** `test_get_rest_candles_params_handles_none_start_time`: `start_time=None` is safe

## Files Changed

| File | Change |
|---|---|
| `hummingbot/data_feed/candles_feed/kraken_spot_candles/kraken_spot_candles.py` | Replace raise with clamp in `_get_rest_candles_params` |
| `test/hummingbot/data_feed/candles_feed/kraken_spot_candles/test_kraken_spot_candles.py` | Update existing test + add 3 regression tests |