### PR TITLE
fix: resolve connector aliases for balance lookups

### DIFF
--- a/hummingbot/core/connector_manager.py
+++ b/hummingbot/core/connector_manager.py
@@ -162,7 +162,19 @@ class ConnectorManager:
 
     def get_connector(self, connector_name: str) -> Optional[ExchangeBase]:
         """Get a connector by name."""
-        return self.connectors.get(connector_name)
+        connector = self.connectors.get(connector_name)
+        if connector is not None:
+            return connector
+
+        matches = [
+            connector
+            for connector in self.connectors.values()
+            if connector_name in {
+                getattr(connector, "name", None),
+                getattr(connector, "display_name", None),
+            }
+        ]
+        return matches[0] if len(matches) == 1 else None
 
     def get_all_connectors(self) -> Dict[str, ExchangeBase]:
         """Get all active connectors."""

--- a/hummingbot/core/trading_core.py
+++ b/hummingbot/core/trading_core.py
@@ -702,8 +702,9 @@ class TradingCore:
         return self.connector_manager.get_order_book(connector_name, trading_pair)
 
     async def get_current_balances(self, connector_name: str):
-        if connector_name in self.connector_manager.connectors and self.connector_manager.connectors[connector_name].ready:
-            return self.connector_manager.connectors[connector_name].get_all_balances()
+        connector = self.connector_manager.get_connector(connector_name)
+        if connector is not None and connector.ready:
+            return connector.get_all_balances()
         elif "Paper" in connector_name:
             paper_balances = self.client_config_map.paper_trade.paper_trade_account_balance
             if paper_balances is None:

--- a/test/hummingbot/core/test_connector_manager.py
+++ b/test/hummingbot/core/test_connector_manager.py
@@ -210,6 +210,30 @@ class ConnectorManagerTest(IsolatedAsyncioWrapperTestCase):
         connector = self.connector_manager.get_connector("nonexistent")
         self.assertIsNone(connector)
 
+    def test_get_connector_by_unambiguous_connector_name_alias(self):
+        """Test getting a connector by emitted connector name."""
+        self.mock_connector.name = "binance_perpetual"
+        self.mock_connector.display_name = "binance_perpetual"
+        self.connector_manager.connectors["binance_perpetual_testnet"] = self.mock_connector
+
+        connector = self.connector_manager.get_connector("binance_perpetual")
+
+        self.assertEqual(connector, self.mock_connector)
+
+    def test_get_connector_by_ambiguous_connector_name_alias_returns_none(self):
+        """Test ambiguous emitted connector names are not resolved."""
+        self.mock_connector.name = "binance_perpetual"
+        self.mock_connector.display_name = "binance_perpetual"
+        mock_connector2 = Mock(spec=ExchangeBase)
+        mock_connector2.name = "binance_perpetual"
+        mock_connector2.display_name = "binance_perpetual"
+        self.connector_manager.connectors["binance_perpetual_testnet"] = self.mock_connector
+        self.connector_manager.connectors["binance_perpetual_devnet"] = mock_connector2
+
+        connector = self.connector_manager.get_connector("binance_perpetual")
+
+        self.assertIsNone(connector)
+
     def test_get_all_connectors(self):
         """Test getting all connectors"""
         # Add multiple connectors
@@ -340,6 +364,18 @@ class ConnectorManagerTest(IsolatedAsyncioWrapperTestCase):
         await self.connector_manager.update_connector_balances("binance")
 
         # Verify _update_balances was called
+        mock_update_balances.assert_called_once()
+
+    async def test_update_connector_balances_by_unambiguous_connector_name_alias(self):
+        """Test updating balances through an emitted connector name alias."""
+        mock_update_balances = AsyncMock()
+        self.mock_connector.name = "binance_perpetual"
+        self.mock_connector.display_name = "binance_perpetual"
+        self.mock_connector._update_balances = mock_update_balances
+        self.connector_manager.connectors["binance_perpetual_testnet"] = self.mock_connector
+
+        await self.connector_manager.update_connector_balances("binance_perpetual")
+
         mock_update_balances.assert_called_once()
 
     async def test_update_connector_balances_nonexistent(self):

--- a/test/hummingbot/core/test_trading_core.py
+++ b/test/hummingbot/core/test_trading_core.py
@@ -534,6 +534,21 @@ class TradingCoreTest(IsolatedAsyncioWrapperTestCase):
         self.assertEqual(balances["USDT"], Decimal("5000.0"))
         self.mock_connector.get_all_balances.assert_called_once()
 
+    async def test_get_current_balances_with_ready_connector_alias(self):
+        """Test get_current_balances resolves emitted connector names."""
+        self.mock_connector.name = "binance_perpetual"
+        self.mock_connector.display_name = "binance_perpetual"
+        self.mock_connector.ready = True
+        self.mock_connector.get_all_balances.return_value = {
+            "USDT": Decimal("5000.0")
+        }
+        self.trading_core.connector_manager.connectors["binance_perpetual_testnet"] = self.mock_connector
+
+        balances = await self.trading_core.get_current_balances("binance_perpetual")
+
+        self.assertEqual(balances["USDT"], Decimal("5000.0"))
+        self.mock_connector.get_all_balances.assert_called_once()
+
     async def test_get_current_balances_paper_trade(self):
         """Test get_current_balances for paper trade"""
         # Set up paper trade balances
@@ -669,6 +684,34 @@ class TradingCoreTest(IsolatedAsyncioWrapperTestCase):
 
             # Verify PerformanceMetrics.create was called correctly
             self.assertEqual(mock_perf_metrics_class.create.call_count, 2)
+
+    @patch("hummingbot.core.trading_core.PerformanceMetrics")
+    async def test_calculate_performance_metrics_resolves_trade_fill_market_alias(self, mock_perf_metrics_class):
+        """Test performance metrics resolve emitted connector names from trade fills."""
+        self.mock_connector.name = "binance_perpetual"
+        self.mock_connector.display_name = "binance_perpetual"
+        self.mock_connector.ready = True
+        self.mock_connector.get_all_balances.return_value = {
+            "USDT": Decimal("5000.0")
+        }
+        self.trading_core.connector_manager.connectors["binance_perpetual_testnet"] = self.mock_connector
+
+        trade = Mock(spec=TradeFill)
+        trade.market = "binance_perpetual"
+        trade.symbol = "BTC-USDT"
+
+        mock_perf = Mock()
+        mock_perf_metrics_class.create = AsyncMock(return_value=mock_perf)
+
+        result = await self.trading_core.calculate_performance_metrics_by_connector_pair([trade])
+
+        self.assertEqual([mock_perf], result)
+        self.mock_connector.get_all_balances.assert_called_once()
+        mock_perf_metrics_class.create.assert_awaited_once_with(
+            "BTC-USDT",
+            [trade],
+            {"USDT": Decimal("5000.0")},
+        )
 
     @patch("hummingbot.core.trading_core.PerformanceMetrics")
     async def test_calculate_performance_metrics_timeout(self, mock_perf_metrics_class):


### PR DESCRIPTION
**A description of the changes proposed in the pull request**:

Fixes #7893.

This update lets `ConnectorManager.get_connector()` resolve an active connector by its configured key first, then by a unique emitted `name` / `display_name`. This handles cases where a running connector is keyed as a domain connector such as `binance_perpetual_testnet`, while recorded trade fills refer to the parent connector name `binance_perpetual`.

`TradingCore.get_current_balances()` now uses that resolver before reading balances, so performance/trade-monitor balance lookups do not fail with `Connector binance_perpetual not found` when the active connector is the testnet domain.

**Tests performed by the developer**:

- Added connector manager coverage for unambiguous and ambiguous alias resolution.
- Added trading core coverage for direct balance lookup through an alias.
- Added regression coverage for performance metrics using a trade fill market alias against a `binance_perpetual_testnet` active connector.
- Ran `py_compile` for touched files.
- Ran `git diff --check`.

Full `make test` was not run locally because this machine does not have Conda installed, and the project installer exits with `Conda is not found in PATH`.