### PR TITLE
fix / Update KuCoin perpetuals connector

### DIFF
--- a/hummingbot/connector/derivative/kucoin_perpetual/kucoin_perpetual_api_order_book_data_source.py
+++ b/hummingbot/connector/derivative/kucoin_perpetual/kucoin_perpetual_api_order_book_data_source.py
@@ -48,12 +48,20 @@ class KucoinPerpetualAPIOrderBookDataSource(PerpetualAPIOrderBookDataSource):
             symbol_info = funding_info_response["data"]
         else:
             symbol_info = funding_info_response["data"][0]
+
+        # KuCoin's contract-detail endpoint now returns "predictedFundingFeeRate": null; use the
+        # current "fundingFeeRate" instead. Parsing the null value raised decimal.InvalidOperation,
+        # which blocked funding-info init and left the connector stuck in "not ready" (issue #8256).
+        rate = symbol_info.get("predictedFundingFeeRate")
+        if rate is None:
+            rate = symbol_info["fundingFeeRate"]
+
         funding_info = FundingInfo(
             trading_pair=trading_pair,
             index_price=Decimal(str(symbol_info["indexPrice"])),
             mark_price=Decimal(str(symbol_info["markPrice"])),
             next_funding_utc_timestamp=int(pd.Timestamp(symbol_info["nextFundingRateTime"]).timestamp()),
-            rate=Decimal(str(symbol_info["predictedFundingFeeRate"])),
+            rate=Decimal(str(rate)),
         )
         return funding_info
 

--- a/hummingbot/connector/derivative/kucoin_perpetual/kucoin_perpetual_auth.py
+++ b/hummingbot/connector/derivative/kucoin_perpetual/kucoin_perpetual_auth.py
@@ -29,7 +29,7 @@ class KucoinPerpetualAuth(AuthBase):
     def keysort(dictionary: Dict[str, str]) -> Dict[str, str]:
         return OrderedDict(sorted(dictionary.items(), key=lambda t: t[0]))
 
-    async def rest_authenticate(self, request: RESTRequest, use_time_provider=0) -> RESTRequest:
+    async def rest_authenticate(self, request: RESTRequest) -> RESTRequest:
         """
         Adds the server time and the signature to the request, required for authenticated interactions. It also adds
         the required parameter in the request header.
@@ -40,7 +40,7 @@ class KucoinPerpetualAuth(AuthBase):
         headers = {}
         if request.headers is not None:
             headers.update(request.headers)
-        headers.update(self.authentication_headers(request=request, use_time_provider=use_time_provider))
+        headers.update(self.authentication_headers(request=request))
         request.headers = headers
 
         return request
@@ -104,11 +104,11 @@ class KucoinPerpetualAuth(AuthBase):
         }
         return third_party
 
-    def authentication_headers(self, request: RESTRequest, use_time_provider) -> Dict[str, Any]:
-        if use_time_provider == 1 and self._time_provider.time() > 0:
-            timestamp = self._time_provider.time()
-        else:
-            timestamp = int(self._get_timestamp())
+    def authentication_headers(self, request: RESTRequest) -> Dict[str, Any]:
+        # Sign with the server-synchronized time (in milliseconds), like the spot connector. Signing
+        # with the local clock caused intermittent 400002 "Invalid KC-API-TIMESTAMP" errors whenever
+        # the machine clock drifted from KuCoin's server time.
+        timestamp = int(self._time_provider.time() * 1e3)
 
         header = {
             "KC-API-KEY": self._api_key,

--- a/hummingbot/connector/derivative/kucoin_perpetual/kucoin_perpetual_constants.py
+++ b/hummingbot/connector/derivative/kucoin_perpetual/kucoin_perpetual_constants.py
@@ -10,6 +10,12 @@ DEFAULT_DOMAIN = "kucoin_perpetual_main"
 
 DEFAULT_TIME_IN_FORCE = "GTC"
 
+# KuCoin made margin mode a per-symbol setting (ISOLATED/CROSS). An order whose "marginMode" does
+# not match the symbol's selected mode is rejected at runtime (observed error code 330005), so the
+# connector reads the symbol's mode and sends a matching value. This is only the fallback used
+# before the per-symbol mode has been read.
+DEFAULT_MARGIN_MODE = "ISOLATED"
+
 REST_URLS = {"kucoin_perpetual_main": "https://api-futures.kucoin.com/"}
 WSS_PUBLIC_URLS = {"kucoin_perpetual_main": "wss://stream.kucoin.com/realtime_public"}
 WSS_PRIVATE_URLS = {"kucoin_perpetual_main": "wss://stream.kucoin.com/realtime_private"}
@@ -60,6 +66,8 @@ GET_WALLET_BALANCE_PATH_URL = f"{REST_API_VERSION}/account-overview?currency={{c
 GET_POSITIONS_PATH_URL = f"{REST_API_VERSION}/positions"
 QUERY_ACTIVE_ORDER_PATH_URL = f"{REST_API_VERSION}/orders?status=active"
 QUERY_ALL_ORDER_PATH_URL = f"{REST_API_VERSION}/orders"
+# Margin mode is read per symbol from API v2 (the connector follows the user's setting)
+GET_MARGIN_MODE_PATH_URL = "api/v2/position/getMarginMode?symbol={symbol}"
 
 # Websocket
 PUBLIC_WS_DATA_PATH_URL = f"{REST_API_VERSION}/bullet-public"
@@ -99,6 +107,7 @@ RET_CODE_OK = "200000"
 RET_CODE_PARAMS_ERROR = "100001"
 RET_CODE_API_KEY_INVALID = "400001"
 RET_CODE_ORDER_NOT_EXISTS = "20001"
+RET_CODE_ORDER_CANNOT_BE_CANCELED = "100004"
 RET_CODE_MODE_POSITION_NOT_EMPTY = "30082"
 RET_CODE_MODE_NOT_MODIFIED = "300010"
 RET_CODE_LEVERAGE_NOT_MODIFIED = "300016"
@@ -129,4 +138,5 @@ RATE_LIMITS = [
     RateLimit(limit_id=GET_RECENT_FILLS_INFO_PATH_URL, limit=9, time_interval=3),
     RateLimit(limit_id=GET_FUNDING_HISTORY_PATH_URL, limit=9, time_interval=3),
     RateLimit(limit_id=GET_RISK_LIMIT_LEVEL_PATH_URL, limit=9, time_interval=3),
+    RateLimit(limit_id=GET_MARGIN_MODE_PATH_URL, limit=9, time_interval=3),
 ]

--- a/hummingbot/connector/derivative/kucoin_perpetual/kucoin_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/kucoin_perpetual/kucoin_perpetual_derivative.py
@@ -57,6 +57,9 @@ class KucoinPerpetualDerivative(PerpetualDerivativePyBase):
         self._trading_pairs = trading_pairs
         self._domain = domain
         self._last_trade_history_timestamp = None
+        # Per-trading-pair margin mode (ISOLATED/CROSS) as configured by the user on KuCoin, cached
+        # at leverage setup so orders can send a matching "marginMode".
+        self._margin_modes: Dict[str, str] = {}
 
         super().__init__(balance_asset_limit, rate_limits_share_pct)
 
@@ -166,8 +169,6 @@ class KucoinPerpetualDerivative(PerpetualDerivativePyBase):
         response_code = cancel_result["code"]
 
         if response_code != CONSTANTS.RET_CODE_OK:
-            if response_code == CONSTANTS.RET_CODE_ORDER_NOT_EXISTS:
-                await self._order_tracker.process_order_not_found(order_id)
             formatted_ret_code = self._format_ret_code_for_print(response_code)
             raise IOError(f"{formatted_ret_code} - {cancel_result['msg']}")
 
@@ -194,6 +195,10 @@ class KucoinPerpetualDerivative(PerpetualDerivativePyBase):
             "reduceOnly": position_action == PositionAction.CLOSE,
             "type": CONSTANTS.ORDER_TYPE_MAP[order_type],
             "leverage": str(self.get_leverage(trading_pair)),
+            # Match the symbol's selected margin mode (read from KuCoin and cached at leverage
+            # setup). "marginMode" is optional but defaults to ISOLATED, so it must be sent
+            # explicitly for a CROSS symbol; a mismatch is rejected at runtime (error 330005).
+            "marginMode": self._margin_modes.get(trading_pair, CONSTANTS.DEFAULT_MARGIN_MODE),
         }
         if order_type.is_limit_type():
             data["price"] = float(price)
@@ -382,6 +387,12 @@ class KucoinPerpetualDerivative(PerpetualDerivativePyBase):
         for resp, active_order in zip(raw_responses, active_orders):
             if not isinstance(resp, Exception) and "data" in resp:
                 parsed_status_responses.append(resp["data"])
+            elif not isinstance(resp, Exception) and self._is_order_not_found_during_status_update_error(
+                    IOError(str(resp))):
+                # KuCoin returns "orderNotExist" once an order is no longer active (filled and
+                # purged, or already canceled). Reconcile it as not-found, but quietly — it is an
+                # expected lifecycle response, not a fetch failure worth a network warning.
+                await self._order_tracker.process_order_not_found(active_order.client_order_id)
             else:
                 self.logger().network(
                     f"Error fetching status update for the order {active_order.client_order_id}: {resp}.",
@@ -420,6 +431,19 @@ class KucoinPerpetualDerivative(PerpetualDerivativePyBase):
                 self._account_balances[currency] = Decimal(str(wallet_balance["data"]["marginBalance"]))
                 self._account_available_balances[currency] = Decimal(str(wallet_balance["data"]["availableBalance"]))
 
+    def _position_leverage(self, trading_pair: str, position_data: Dict[str, Any]) -> Decimal:
+        # KuCoin omits "realLeverage" on CROSS-margin positions (it is only present on ISOLATED
+        # positions); CROSS positions report "leverage" instead. Confirmed by toggling one symbol
+        # between modes: ISOLATED -> {realLeverage, leverage}; CROSS -> {leverage} only. Read
+        # "realLeverage", then "leverage", then the leverage configured for the pair, so the
+        # status-polling / user-stream loop never crashes with a KeyError.
+        raw_leverage = position_data.get("realLeverage")
+        if raw_leverage is None:
+            raw_leverage = position_data.get("leverage")
+        if raw_leverage is not None:
+            return Decimal(str(raw_leverage))
+        return Decimal(self.get_leverage(trading_pair))
+
     async def _update_positions(self):
         """
         Retrieves all positions using the REST API.
@@ -451,7 +475,7 @@ class KucoinPerpetualDerivative(PerpetualDerivativePyBase):
             position_side = PositionSide.SHORT if amount < 0 else PositionSide.LONG
             unrealized_pnl = Decimal(str(data["unrealisedPnl"]))
             entry_price = Decimal(str(data["avgEntryPrice"]))
-            leverage = Decimal(str(data["realLeverage"]))
+            leverage = self._position_leverage(hb_trading_pair, data)
             pos_key = self._perpetual_trading.position_key(hb_trading_pair, position_side)
             if amount != s_decimal_0:
                 position = Position(
@@ -499,6 +523,11 @@ class KucoinPerpetualDerivative(PerpetualDerivativePyBase):
     async def _request_order_status(self, tracked_order: InFlightOrder) -> OrderUpdate:
         try:
             order_status_data = await self._request_order_status_data(tracked_order=tracked_order)
+            if order_status_data.get("code") != CONSTANTS.RET_CODE_OK or "data" not in order_status_data:
+                # e.g. a 200 response carrying {"code": "100001", "msg": "...orderNotExist"}; raise so
+                # _is_order_not_found_during_status_update_error can recognize it (lost-order path).
+                raise IOError(f"{self._format_ret_code_for_print(order_status_data.get('code'))} "
+                              f"- {order_status_data.get('msg')}")
             order_msg = order_status_data["data"]
             client_order_id = str(order_msg["clientOid"])
 
@@ -609,7 +638,7 @@ class KucoinPerpetualDerivative(PerpetualDerivativePyBase):
             amount = self.get_value_of_contracts(trading_pair, int(position_msg["currentQty"]))
             position_side = PositionSide.SHORT if amount < 0 else PositionSide.LONG
             entry_price = Decimal(str(position_msg["avgEntryPrice"]))
-            leverage = Decimal(str(position_msg["realLeverage"]))
+            leverage = self._position_leverage(trading_pair, position_msg)
             unrealized_pnl = Decimal(str(position_msg["unrealisedPnl"]))
             pos_key = self._perpetual_trading.position_key(trading_pair, position_side)
             if amount != s_decimal_0:
@@ -700,13 +729,17 @@ class KucoinPerpetualDerivative(PerpetualDerivativePyBase):
         is_active = order_msg["isActive"]
         client_order_id = str(order_msg["clientOid"])
         updatable_order = self._order_tracker.all_updatable_orders.get(client_order_id)
-        new_state = updatable_order.current_state
-        if ordered_canceled:
-            new_state = OrderState.CANCELED
-        elif not is_active:
-            new_state = OrderState.FILLED
 
+        # The order-status poll can return orders that are not tracked (e.g. stale orders from a
+        # previous session). Guard before reading attributes, otherwise the whole status-polling
+        # cycle crashes with AttributeError and balance/position updates are skipped that round.
         if updatable_order is not None:
+            new_state = updatable_order.current_state
+            if ordered_canceled:
+                new_state = OrderState.CANCELED
+            elif not is_active:
+                new_state = OrderState.FILLED
+
             new_order_update: OrderUpdate = OrderUpdate(
                 trading_pair=updatable_order.trading_pair,
                 update_timestamp=self.current_timestamp,
@@ -861,7 +894,34 @@ class KucoinPerpetualDerivative(PerpetualDerivativePyBase):
         if leverage > max_leverage:
             self.logger().error(f"Max leverage for {trading_pair} is {max_leverage}.")
             return False, f"Max leverage for {trading_pair} is {max_leverage}."
+        # Cache the symbol's margin mode (as configured by the user on KuCoin) so each order can
+        # send a matching "marginMode"; KuCoin rejects an order whose mode differs from the symbol's
+        # selected one. The connector follows the user's choice and does not change it.
+        await self._update_margin_mode(exchange_symbol, trading_pair)
         return True, ""
+
+    async def _update_margin_mode(self, exchange_symbol: str, trading_pair: str):
+        """
+        Reads the symbol's current margin mode (ISOLATED/CROSS) from KuCoin and caches it.
+
+        The connector follows the user's per-symbol setting rather than changing it; the cached
+        value is sent as "marginMode" on each order so it matches the symbol's selected mode (a
+        mismatch is rejected with code 330005). Best-effort: on error the cache is left untouched
+        and order placement falls back to the default margin mode. Cached after the first success
+        so the repeated leverage-setup calls at startup don't re-fetch it.
+        """
+        if trading_pair in self._margin_modes:
+            return
+        try:
+            response = await self._api_get(
+                path_url=CONSTANTS.GET_MARGIN_MODE_PATH_URL.format(symbol=exchange_symbol),
+                is_auth_required=True,
+                trading_pair=trading_pair,
+                limit_id=CONSTANTS.GET_MARGIN_MODE_PATH_URL,
+            )
+            self._margin_modes[trading_pair] = response["data"]["marginMode"]
+        except Exception as exception:
+            self.logger().warning(f"Could not fetch margin mode for {trading_pair}: {exception}")
 
     async def _fetch_last_fee_payment(self, trading_pair: str) -> Tuple[int, Decimal, Decimal]:
         exchange_symbol = await self.exchange_symbol_associated_to_pair(trading_pair)
@@ -927,18 +987,19 @@ class KucoinPerpetualDerivative(PerpetualDerivativePyBase):
         return resp
 
     def _is_order_not_found_during_status_update_error(self, status_update_exception: Exception) -> bool:
-        # TODO: implement this method correctly for the connector
-        # The default implementation was added when the functionality to detect not found orders was introduced in the
-        # ExchangePyBase class. Also fix the unit test test_lost_order_removed_if_not_found_during_order_status_update
-        # when replacing the dummy implementation
-        return False
+        # KuCoin returns "orderNotExist" (or code 20001) once an order is no longer queryable —
+        # filled and purged, or canceled. Treat it as not-found so the order is reconciled instead
+        # of being retried indefinitely (lost-order path) or logged as a fetch error (active path).
+        error = str(status_update_exception)
+        return CONSTANTS.RET_CODE_ORDER_NOT_EXISTS in error or "orderNotExist" in error
 
     def _is_order_not_found_during_cancelation_error(self, cancelation_exception: Exception) -> bool:
-        # TODO: implement this method correctly for the connector
-        # The default implementation was added when the functionality to detect not found orders was introduced in the
-        # ExchangePyBase class. Also fix the unit test test_cancel_order_not_found_in_the_exchange when replacing the
-        # dummy implementation
-        return False
+        # 20001: the order does not exist; 100004: the order cannot be canceled (already filled or
+        # canceled). Both mean the order is no longer active, so the cancelation is treated as
+        # "order not found" (a benign race) instead of a hard error with a noisy traceback.
+        error = str(cancelation_exception)
+        return (CONSTANTS.RET_CODE_ORDER_NOT_EXISTS in error
+                or CONSTANTS.RET_CODE_ORDER_CANNOT_BE_CANCELED in error)
 
     @staticmethod
     def _format_ret_code_for_print(ret_code: Union[str, int]) -> str:

--- a/hummingbot/connector/derivative/kucoin_perpetual/kucoin_perpetual_web_utils.py
+++ b/hummingbot/connector/derivative/kucoin_perpetual/kucoin_perpetual_web_utils.py
@@ -59,7 +59,11 @@ async def get_current_server_time(
     )
     server_time = response["data"]
 
-    return server_time * 1e-3
+    # KuCoin returns the server time in milliseconds, which is what TimeSynchronizer expects
+    # (it computes the offset against perf_counter * 1e3). Returning seconds here corrupted the
+    # offset (~1000x off), making signed timestamps invalid (400002) once the auth started using
+    # the synchronizer. Mirror the spot connector and return milliseconds unchanged.
+    return server_time
 
 
 def endpoint_from_message(message: Dict[str, Any]) -> Optional[str]:

--- a/test/hummingbot/connector/derivative/kucoin_perpetual/test_kucoin_perpetual_auth.py
+++ b/test/hummingbot/connector/derivative/kucoin_perpetual/test_kucoin_perpetual_auth.py
@@ -51,18 +51,18 @@ class KucoinPerpetualAuthTests(TestCase):
             throttler_limit_id="/api/endpoint"
         )
 
-        self.async_run_with_timeout(self.auth.rest_authenticate(request, use_time_provider=1))
+        self.async_run_with_timeout(self.auth.rest_authenticate(request))
 
         self.assertEqual(self.api_key, request.headers["KC-API-KEY"])
-        self.assertEqual("1000000", request.headers["KC-API-TIMESTAMP"])
+        self.assertEqual("1000000000", request.headers["KC-API-TIMESTAMP"])
         self.assertEqual("2", request.headers["KC-API-KEY-VERSION"])
-        expected_signature = self._sign("1000000" + "GET" + request.throttler_limit_id, key=self.secret_key)
+        expected_signature = self._sign("1000000000" + "GET" + request.throttler_limit_id, key=self.secret_key)
         self.assertEqual(expected_signature, request.headers["KC-API-SIGN"])
         expected_passphrase = self._sign(self.passphrase, key=self.secret_key)
         self.assertEqual(expected_passphrase, request.headers["KC-API-PASSPHRASE"])
 
         self.assertEqual(CONSTANTS.HB_PARTNER_ID, request.headers["KC-API-PARTNER"])
-        expected_partner_signature = self._sign("1000000" + CONSTANTS.HB_PARTNER_ID + self.api_key,
+        expected_partner_signature = self._sign("1000000000" + CONSTANTS.HB_PARTNER_ID + self.api_key,
                                                 key=CONSTANTS.HB_PARTNER_KEY)
         self.assertEqual(expected_partner_signature, request.headers["KC-API-PARTNER-SIGN"])
 
@@ -75,19 +75,19 @@ class KucoinPerpetualAuthTests(TestCase):
             throttler_limit_id="/api/endpoint"
         )
 
-        self.async_run_with_timeout(self.auth.rest_authenticate(request, use_time_provider=1))
+        self.async_run_with_timeout(self.auth.rest_authenticate(request))
 
         self.assertEqual(self.api_key, request.headers["KC-API-KEY"])
-        self.assertEqual("1000000", request.headers["KC-API-TIMESTAMP"])
+        self.assertEqual("1000000000", request.headers["KC-API-TIMESTAMP"])
         self.assertEqual("2", request.headers["KC-API-KEY-VERSION"])
         full_endpoint = f"{request.throttler_limit_id}?param1=value1&param2=value2"
-        expected_signature = self._sign("1000000" + "GET" + full_endpoint, key=self.secret_key)
+        expected_signature = self._sign("1000000000" + "GET" + full_endpoint, key=self.secret_key)
         self.assertEqual(expected_signature, request.headers["KC-API-SIGN"])
         expected_passphrase = self._sign(self.passphrase, key=self.secret_key)
         self.assertEqual(expected_passphrase, request.headers["KC-API-PASSPHRASE"])
 
         self.assertEqual(CONSTANTS.HB_PARTNER_ID, request.headers["KC-API-PARTNER"])
-        expected_partner_signature = self._sign("1000000" + CONSTANTS.HB_PARTNER_ID + self.api_key,
+        expected_partner_signature = self._sign("1000000000" + CONSTANTS.HB_PARTNER_ID + self.api_key,
                                                 key=CONSTANTS.HB_PARTNER_KEY)
         self.assertEqual(expected_partner_signature, request.headers["KC-API-PARTNER-SIGN"])
 
@@ -101,19 +101,19 @@ class KucoinPerpetualAuthTests(TestCase):
             throttler_limit_id="/api/endpoint"
         )
 
-        self.async_run_with_timeout(self.auth.rest_authenticate(request, use_time_provider=1))
+        self.async_run_with_timeout(self.auth.rest_authenticate(request))
 
         self.assertEqual(self.api_key, request.headers["KC-API-KEY"])
-        self.assertEqual("1000000", request.headers["KC-API-TIMESTAMP"])
+        self.assertEqual("1000000000", request.headers["KC-API-TIMESTAMP"])
         self.assertEqual("2", request.headers["KC-API-KEY-VERSION"])
-        expected_signature = self._sign("1000000" + "POST" + request.throttler_limit_id + json.dumps(body),
+        expected_signature = self._sign("1000000000" + "POST" + request.throttler_limit_id + json.dumps(body),
                                         key=self.secret_key)
         self.assertEqual(expected_signature, request.headers["KC-API-SIGN"])
         expected_passphrase = self._sign(self.passphrase, key=self.secret_key)
         self.assertEqual(expected_passphrase, request.headers["KC-API-PASSPHRASE"])
 
         self.assertEqual(CONSTANTS.HB_PARTNER_ID, request.headers["KC-API-PARTNER"])
-        expected_partner_signature = self._sign("1000000" + CONSTANTS.HB_PARTNER_ID + self.api_key,
+        expected_partner_signature = self._sign("1000000000" + CONSTANTS.HB_PARTNER_ID + self.api_key,
                                                 key=CONSTANTS.HB_PARTNER_KEY)
         self.assertEqual(expected_partner_signature, request.headers["KC-API-PARTNER-SIGN"])
 

--- a/test/hummingbot/connector/derivative/kucoin_perpetual/test_kucoin_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/kucoin_perpetual/test_kucoin_perpetual_derivative.py
@@ -612,6 +612,8 @@ class KucoinPerpetualDerivativeTests(AbstractPerpetualDerivativeTests.PerpetualD
         self.assertEqual(order.client_order_id, request_data["clientOid"])
         self.assertIn("clientOid", request_data)
         self.assertEqual(order.order_type.name.lower(), request_data["type"])
+        # Orders carry the symbol's margin mode (cached at leverage setup; the default before it's read)
+        self.assertEqual(CONSTANTS.DEFAULT_MARGIN_MODE, request_data["marginMode"])
 
     def validate_order_cancelation_request(self, order: InFlightOrder, request_call: RequestCall):
         request_data = json.loads(request_call.kwargs["data"])
@@ -908,6 +910,15 @@ class KucoinPerpetualDerivativeTests(AbstractPerpetualDerivativeTests.PerpetualD
         }
 
         mock_api.get(regex_url, body=json.dumps(mock_response), callback=callback)
+
+        # _set_trading_pair_leverage also ensures ISOLATED margin mode; mock the symbol as already
+        # ISOLATED so _set_margin_mode short-circuits without a changeMarginMode call.
+        margin_mode_url = web_utils.get_rest_url_for_endpoint(
+            endpoint=CONSTANTS.GET_MARGIN_MODE_PATH_URL.format(symbol=self.exchange_trading_pair))
+        margin_mode_regex = re.compile(f"^{margin_mode_url}".replace(".", r"\.").replace("?", r"\?"))
+        mock_api.get(margin_mode_regex, body=json.dumps(
+            {"code": "200000",
+             "data": {"symbol": self.exchange_trading_pair, "marginMode": CONSTANTS.DEFAULT_MARGIN_MODE}}))
 
         return url
 
@@ -1237,6 +1248,75 @@ class KucoinPerpetualDerivativeTests(AbstractPerpetualDerivativeTests.PerpetualD
 
     @aioresponses()
     @patch("asyncio.Queue.get")
+    def test_funding_info_initializes_when_predicted_rate_is_null(self, mock_api, mock_queue_get):
+        # Regression for issue #8256: KuCoin's contract-detail endpoint now returns
+        # "predictedFundingFeeRate": null, which raised decimal.InvalidOperation and left the
+        # connector stuck in "not ready". The rate must fall back to the current "fundingFeeRate"
+        # instead of crashing funding-info initialization.
+        response = deepcopy(self.funding_info_mock_response)
+        response["data"][0]["predictedFundingFeeRate"] = None
+        response["data"][0]["fundingFeeRate"] = 0.00005
+
+        url = web_utils.get_rest_url_for_endpoint(
+            endpoint=CONSTANTS.GET_CONTRACT_INFO_PATH_URL.format(symbol=self.exchange_trading_pair))
+        regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
+        mock_api.get(regex_url, body=json.dumps(response))
+
+        mock_queue_get.side_effect = [asyncio.CancelledError]
+        try:
+            self.async_run_with_timeout(self.exchange._listen_for_funding_info())
+        except asyncio.CancelledError:
+            pass
+
+        funding_info: FundingInfo = self.exchange.get_funding_info(self.trading_pair)
+        self.assertEqual(self.trading_pair, funding_info.trading_pair)
+        self.assertEqual(Decimal("0.00005"), funding_info.rate)
+
+    @aioresponses()
+    def test_update_margin_mode_caches_symbol_setting(self, mock_api):
+        # Regression for issue #8256: the connector follows the user's per-symbol margin mode. It
+        # reads the symbol's mode from KuCoin and caches it (without changing it) so orders can send
+        # a matching "marginMode" and avoid the 330005 rejection.
+        get_url = web_utils.get_rest_url_for_endpoint(
+            endpoint=CONSTANTS.GET_MARGIN_MODE_PATH_URL.format(symbol=self.exchange_trading_pair))
+        get_regex = re.compile(f"^{get_url}".replace(".", r"\.").replace("?", r"\?"))
+        mock_api.get(get_regex, body=json.dumps(
+            {"code": "200000", "data": {"symbol": self.exchange_trading_pair, "marginMode": "CROSS"}}))
+
+        self.async_run_with_timeout(
+            self.exchange._update_margin_mode(self.exchange_trading_pair, self.trading_pair))
+
+        self.assertEqual("CROSS", self.exchange._margin_modes.get(self.trading_pair))
+
+    def test_process_order_event_message_ignores_untracked_order(self):
+        # Regression for issue #8256: the order-status poll can return an order that is not tracked
+        # (e.g. a stale order from a previous session). Reading its state used to crash the whole
+        # status-polling cycle with AttributeError; it must now be ignored safely.
+        order_msg = {
+            "id": "451270029397291010",
+            "clientOid": "an-untracked-client-order-id",
+            "cancelExist": False,
+            "isActive": True,
+        }
+        self.exchange._process_order_event_message(order_msg)  # must not raise
+        self.assertEqual(0, len(self.exchange.in_flight_orders))
+
+    def test_position_leverage_falls_back_when_real_leverage_missing(self):
+        # Regression for issue #8256: KuCoin omits "realLeverage" on CROSS-margin positions (it
+        # reports "leverage" instead); ISOLATED positions report both. _update_positions / the
+        # user-stream position handler must use whichever is present instead of crashing on KeyError.
+        self.exchange._perpetual_trading.set_leverage(self.trading_pair, 7)
+        # realLeverage present (ISOLATED) -> used as-is
+        self.assertEqual(Decimal("5"), self.exchange._position_leverage(self.trading_pair, {"realLeverage": "5"}))
+        # realLeverage absent but "leverage" present (CROSS) -> uses "leverage"
+        self.assertEqual(Decimal("6"), self.exchange._position_leverage(self.trading_pair, {"leverage": "6"}))
+        # neither field present -> falls back to the configured leverage (no KeyError)
+        self.assertEqual(Decimal("7"), self.exchange._position_leverage(self.trading_pair, {}))
+        # null -> falls back to the configured leverage
+        self.assertEqual(Decimal("7"), self.exchange._position_leverage(self.trading_pair, {"realLeverage": None}))
+
+    @aioresponses()
+    @patch("asyncio.Queue.get")
     def test_listen_for_funding_info_update_updates_funding_info(self, mock_api, mock_queue_get):
         url = self.funding_info_url
 
@@ -1453,28 +1533,27 @@ class KucoinPerpetualDerivativeTests(AbstractPerpetualDerivativeTests.PerpetualD
             self, order: InFlightOrder, mock_api: aioresponses,
             callback: Optional[Callable] = lambda *args, **kwargs: None
     ) -> str:
-        # Implement the expected not found response when enabling test_cancel_order_not_found_in_the_exchange
-        raise NotImplementedError
+        url = web_utils.get_rest_url_for_endpoint(
+            endpoint=CONSTANTS.CANCEL_ORDER_PATH_URL.format(orderid=order.exchange_order_id)
+        )
+        regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?") + ".*")
+        response = {
+            "code": CONSTANTS.RET_CODE_ORDER_CANNOT_BE_CANCELED,
+            "msg": "The order cannot be canceled.",
+        }
+        mock_api.delete(regex_url, body=json.dumps(response), callback=callback)
+        return url
 
     def configure_order_not_found_error_order_status_response(
             self, order: InFlightOrder, mock_api: aioresponses,
             callback: Optional[Callable] = lambda *args, **kwargs: None
     ) -> List[str]:
-        # Implement the expected not found response when enabling
-        # test_lost_order_removed_if_not_found_during_order_status_update
-        raise NotImplementedError
-
-    @aioresponses()
-    def test_cancel_order_not_found_in_the_exchange(self, mock_api):
-        # Disabling this test because the connector has not been updated yet to validate
-        # order not found during cancellation (check _is_order_not_found_during_cancelation_error)
-        pass
-
-    @aioresponses()
-    def test_lost_order_removed_if_not_found_during_order_status_update(self, mock_api):
-        # Disabling this test because the connector has not been updated yet to validate
-        # order not found during status update (check _is_order_not_found_during_status_update_error)
-        pass
+        url = web_utils.get_rest_url_for_endpoint(
+            endpoint=CONSTANTS.QUERY_ORDER_BY_EXCHANGE_ORDER_ID_PATH_URL.format(orderid=order.exchange_order_id)
+        )
+        response = {"code": "100001", "msg": "error.getOrder.orderNotExist"}
+        mock_api.get(url, body=json.dumps(response), callback=callback)
+        return [url]
 
     @aioresponses()
     def test_create_buy_limit_maker_order_successfully(self, mock_api):


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] Tests all pass
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

This is the changeset for this bounty: https://github.com/hummingbot/hummingbot/issues/8256

The KuCoin **Perpetual** connector was stuck on `kucoin_perpetual is not ready` and couldn't trade against the current KuCoin Futures API. Root-caused live and fixed (classic `api-futures.kucoin.com` API):

- **Not ready** -- `GET /api/v1/contracts/{symbol}` now returns `predictedFundingFeeRate: null`, which crashed funding-info init (`Decimal(None)`); fall back to `fundingFeeRate`.
- **Order rejection `330005`** -- KuCoin made margin mode per-symbol; read & cache the symbol's mode once and send a matching `marginMode` on orders (we follow the user's setting, not force it).
- **`400002 Invalid KC-API-TIMESTAMP`** -- sign with the server-synchronized time (like Spot) and fix `get_current_server_time` to return ms (it returned seconds, which corrupted the time offset).
- **Cancel error `100004`** -- treat an already-filled/canceled order as "not found" instead of a hard error + traceback.
- **Status-poll crash** -- guard `_process_order_event_message` against untracked orders.

**Spot:** audited -- no changes required.

**UTA:** out of scope (classic API has no deprecation notice; bounty says "no unnecessary refactors/rewrite").

Tests: all KuCoin unit tests pass. Live-validated on KuCoin Futures -- orders place/cancel,
leverage, funding, balances, positions.

**Tests performed by the developer**:

Run the bot on Kucoin Futures (perp) DOGE/USDT pair

**Tips for QA testing**:

N/A