### PR TITLE
fix: validate DCA executor levels

### DIFF
--- a/hummingbot/strategy_v2/executors/dca_executor/dca_executor.py
+++ b/hummingbot/strategy_v2/executors/dca_executor/dca_executor.py
@@ -35,6 +35,12 @@ class DCAExecutor(ExecutorBase):
         # validate amounts and prices
         if len(config.amounts_quote) != len(config.prices):
             raise ValueError("Amounts and prices lists must have the same length")
+        if not config.amounts_quote:
+            raise ValueError("DCA executor must define at least one order level")
+        if any(amount <= Decimal("0") for amount in config.amounts_quote):
+            raise ValueError("DCA amounts_quote values must be greater than zero")
+        if any(price <= Decimal("0") for price in config.prices):
+            raise ValueError("DCA price values must be greater than zero")
 
         # Initialize super class
         super().__init__(strategy=strategy, connectors=[config.connector_name], config=config,

--- a/test/hummingbot/strategy_v2/executors/dca_executor/test_dca_executor.py
+++ b/test/hummingbot/strategy_v2/executors/dca_executor/test_dca_executor.py
@@ -48,6 +48,33 @@ class TestDCAExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         self.set_loggers(loggers=[executor.logger()])
         return executor
 
+    def test_dca_executor_rejects_empty_levels(self):
+        config = DCAExecutorConfig(id="test", timestamp=123, side=TradeType.BUY, connector_name="binance",
+                                   trading_pair="ETH-USDT",
+                                   amounts_quote=[],
+                                   prices=[])
+
+        with self.assertRaisesRegex(ValueError, "at least one order level"):
+            self.get_dca_executor_from_config(config)
+
+    def test_dca_executor_rejects_zero_amount_quote(self):
+        config = DCAExecutorConfig(id="test", timestamp=123, side=TradeType.BUY, connector_name="binance",
+                                   trading_pair="ETH-USDT",
+                                   amounts_quote=[Decimal("0")],
+                                   prices=[Decimal("100")])
+
+        with self.assertRaisesRegex(ValueError, "amounts_quote values must be greater than zero"):
+            self.get_dca_executor_from_config(config)
+
+    def test_dca_executor_rejects_zero_price(self):
+        config = DCAExecutorConfig(id="test", timestamp=123, side=TradeType.BUY, connector_name="binance",
+                                   trading_pair="ETH-USDT",
+                                   amounts_quote=[Decimal("10")],
+                                   prices=[Decimal("0")])
+
+        with self.assertRaisesRegex(ValueError, "price values must be greater than zero"):
+            self.get_dca_executor_from_config(config)
+
     @patch.object(DCAExecutor, "get_price", MagicMock(return_value=Decimal("120")))
     async def test_control_task_open_orders(self):
         config = DCAExecutorConfig(id="test", timestamp=123, side=TradeType.BUY, connector_name="binance",


### PR DESCRIPTION
**A description of the changes proposed in the pull request**:

Fixes #8109.

This update validates DCA executor levels before the executor starts. A DCA config with empty levels, zero quote amounts, or zero prices now raises a clear `ValueError` during initialization instead of allowing later calculations such as `amount / price` or weighted-average price computation to raise `ZeroDivisionError` inside the strategy loop.

The goal is to fail fast for invalid DCA parameters and avoid the reported non-responsive runtime behavior when DCA-related values are set to `0`.

**Tests performed by the developer**:

- Added regression tests for empty DCA levels, zero `amounts_quote`, and zero `prices`.
- Ran `python3 -m py_compile` for the touched DCA executor and test file with `PYTHONPYCACHEPREFIX=/private/tmp/hummingbot-pycache`.
- Ran `git diff --check`.

The focused unittest command could not complete locally because this machine only has Python 3.9, while Hummingbot's test helpers require newer Python syntax (`str | List[str]`). `pytest` is also not installed in this local environment.