### PR TITLE
fix: pass trading pair to order book lookup

### DIFF
--- a/hummingbot/strategy_v2/executors/executor_base.py
+++ b/hummingbot/strategy_v2/executors/executor_base.py
@@ -350,7 +350,7 @@ class ExecutorBase(RunnableBase):
         :param trading_pair: The trading pair.
         :return: The order book.
         """
-        return self.connectors[connector_name].get_order_book(connector_name, trading_pair)
+        return self.connectors[connector_name].get_order_book(trading_pair)
 
     def get_balance(self, connector_name: str, asset: str):
         """

--- a/test/hummingbot/strategy_v2/executors/test_executor_base.py
+++ b/test/hummingbot/strategy_v2/executors/test_executor_base.py
@@ -160,6 +160,7 @@ class TestExecutorBase(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
     def test_get_order_book(self):
         order_book = self.component.get_order_book("connector1", "ETH-USDT")
         self.assertEqual(order_book.last_diff_uid, 0)
+        self.strategy.connectors["connector1"].get_order_book.assert_called_once_with("ETH-USDT")
 
     def test_get_total_and_available_balance(self):
         balance = self.component.get_balance("connector1", "ETH")


### PR DESCRIPTION
**A description of the changes proposed in the pull request**:

Fixes #7505.

`ExecutorBase.get_order_book()` accepted both a connector name and trading pair, but forwarded both values to the connector's `get_order_book()` method. Connector implementations such as `ExchangePyBase.get_order_book()` expect only the trading pair, so this caused `TypeError: ... takes 2 positional arguments but 3 were given` when executors called through the wrapper.

This update passes only `trading_pair` to the connector and tightens the existing executor-base test so it verifies the forwarded call signature.

**Tests performed by the developer**:

- Added an assertion covering the connector `get_order_book("ETH-USDT")` call signature.
- Ran `PYTHONPYCACHEPREFIX=/private/tmp/hb-pycache python3 -m py_compile hummingbot/strategy_v2/executors/executor_base.py test/hummingbot/strategy_v2/executors/test_executor_base.py`.
- Ran `git diff --check`.

The focused unittest could not be run locally because the system Python is 3.9.6 and the repository's test harness uses Python 3.10+ type-union syntax.