### PR TITLE
fix: propagate cancelled user stream events

### DIFF
--- a/hummingbot/connector/derivative/aevo_perpetual/aevo_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/aevo_perpetual/aevo_perpetual_derivative.py
@@ -696,7 +696,7 @@ class AevoPerpetualDerivative(PerpetualDerivativePyBase):
                 if isinstance(event_message, dict):
                     channel: str = event_message.get("channel", None)
                     results = event_message.get("data", None)
-                elif event_message is asyncio.CancelledError:
+                elif event_message is asyncio.CancelledError or isinstance(event_message, asyncio.CancelledError):
                     raise asyncio.CancelledError
                 else:
                     raise Exception(event_message)

--- a/hummingbot/connector/derivative/derive_perpetual/derive_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/derive_perpetual/derive_perpetual_derivative.py
@@ -614,7 +614,7 @@ class DerivePerpetualDerivative(PerpetualDerivativePyBase):
                         else:
                             channel = "none"
 
-                elif event_message is asyncio.CancelledError:
+                elif event_message is asyncio.CancelledError or isinstance(event_message, asyncio.CancelledError):
                     raise asyncio.CancelledError
                 else:
                     raise Exception(event_message)

--- a/hummingbot/connector/derivative/gate_io_perpetual/gate_io_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/gate_io_perpetual/gate_io_perpetual_derivative.py
@@ -549,7 +549,7 @@ class GateIoPerpetualDerivative(PerpetualDerivativePyBase):
                 if isinstance(event_message, dict):
                     channel: str = event_message.get("channel", None)
                     results: List[Dict[str, Any]] = event_message.get("result", None)
-                elif event_message is asyncio.CancelledError:
+                elif event_message is asyncio.CancelledError or isinstance(event_message, asyncio.CancelledError):
                     raise asyncio.CancelledError
                 else:
                     raise Exception(event_message)

--- a/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_derivative.py
@@ -762,7 +762,7 @@ class HyperliquidPerpetualDerivative(PerpetualDerivativePyBase):
                 if isinstance(event_message, dict):
                     channel: str = event_message.get("channel", None)
                     results = event_message.get("data", None)
-                elif event_message is asyncio.CancelledError:
+                elif event_message is asyncio.CancelledError or isinstance(event_message, asyncio.CancelledError):
                     raise asyncio.CancelledError
                 else:
                     raise Exception(event_message)

--- a/hummingbot/connector/exchange/derive/derive_exchange.py
+++ b/hummingbot/connector/exchange/derive/derive_exchange.py
@@ -527,7 +527,7 @@ class DeriveExchange(ExchangePyBase):
                 if isinstance(event_message, dict):
                     channel: str = event_message.get("channel", None)
                     results = event_message.get("data", None)
-                elif event_message is asyncio.CancelledError:
+                elif event_message is asyncio.CancelledError or isinstance(event_message, asyncio.CancelledError):
                     raise asyncio.CancelledError
                 else:
                     raise Exception(event_message)

--- a/hummingbot/connector/exchange/hyperliquid/hyperliquid_exchange.py
+++ b/hummingbot/connector/exchange/hyperliquid/hyperliquid_exchange.py
@@ -461,7 +461,7 @@ class HyperliquidExchange(ExchangePyBase):
                 if isinstance(event_message, dict):
                     channel: str = event_message.get("channel", None)
                     results = event_message.get("data", None)
-                elif event_message is asyncio.CancelledError:
+                elif event_message is asyncio.CancelledError or isinstance(event_message, asyncio.CancelledError):
                     raise asyncio.CancelledError
                 else:
                     raise Exception(event_message)

--- a/hummingbot/connector/exchange/kraken/kraken_exchange.py
+++ b/hummingbot/connector/exchange/kraken/kraken_exchange.py
@@ -455,7 +455,7 @@ class KrakenExchange(ExchangePyBase):
                         self._process_trade_message(results)
                     elif channel == CONSTANTS.USER_ORDERS_ENDPOINT_NAME:
                         self._process_order_message(event_message)
-                elif event_message is asyncio.CancelledError:
+                elif event_message is asyncio.CancelledError or isinstance(event_message, asyncio.CancelledError):
                     raise asyncio.CancelledError
                 else:
                     raise Exception(event_message)

--- a/test/hummingbot/connector/derivative/aevo_perpetual/test_aevo_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/aevo_perpetual/test_aevo_perpetual_derivative.py
@@ -761,6 +761,15 @@ class AevoPerpetualDerivativeAsyncTests(IsolatedAsyncioWrapperTestCase):
 
         self.assertTrue(self._is_logged("ERROR", "Unexpected message in user stream: {'channel': 'unknown', 'data': {}}."))
 
+    async def test_user_stream_event_listener_raises_cancelled_error_instance(self):
+        async def message_generator():
+            yield asyncio.CancelledError()
+
+        self.connector._iter_user_event_queue = message_generator
+
+        with self.assertRaises(asyncio.CancelledError):
+            await self.connector._user_stream_event_listener()
+
     async def test_get_last_traded_price_uses_mark_price(self):
         self.connector.exchange_symbol_associated_to_pair = AsyncMock(return_value=self.ex_trading_pair)
         self.connector._api_get = AsyncMock(return_value={"mark_price": "10", "index_price": "9"})


### PR DESCRIPTION
**A description of the changes proposed in the pull request**:

While sweeping the repo for small mistakes, I found several user-stream listeners that special-cased `asyncio.CancelledError` only when the stream yielded the exception class object itself:

```python
elif event_message is asyncio.CancelledError:
```

That preserves cancellation when the class sentinel is yielded, but it treats an actual `asyncio.CancelledError()` instance as an unexpected message. The listener then logs it and sleeps instead of propagating cancellation.

This PR keeps the existing class-sentinel behavior and also propagates `CancelledError` instances across the affected spot and perpetual connectors:

- Aevo perpetual
- Derive spot
- Derive perpetual
- Gate.io perpetual
- Hyperliquid spot
- Hyperliquid perpetual
- Kraken spot

It also adds a focused Aevo regression test that yields a `CancelledError()` instance directly from the event iterator.

**Tests performed by the developer**:

- Ran `git diff --check`.
- Ran `PYTHONPYCACHEPREFIX=/private/tmp/hb-pycache python3 -m py_compile` for the modified connector files and the modified Aevo test file.

The focused unittest could not be run locally because this machine's system Python is 3.9.6, while the repository test harness imports Python 3.10+ type-union syntax.