### PR TITLE
docs: fix connector domain docstrings

### DIFF
--- a/hummingbot/connector/exchange/bitrue/bitrue_web_utils.py
+++ b/hummingbot/connector/exchange/bitrue/bitrue_web_utils.py
@@ -13,7 +13,7 @@ def public_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> st
     """
     Creates a full URL for provided public REST endpoint
     :param path_url: a public REST endpoint
-    :param domain: the Binance domain to connect to ("com" or "us"). The default value is "com"
+    :param domain: connector domain parameter kept for compatibility. The default value is an empty string
     :return: the full URL to the endpoint
     """
     return CONSTANTS.REST_URL.format(domain) + CONSTANTS.API_VERSION + path_url
@@ -23,7 +23,7 @@ def private_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> s
     """
     Creates a full URL for provided private REST endpoint
     :param path_url: a private REST endpoint
-    :param domain: the Binance domain to connect to ("com" or "us"). The default value is "com"
+    :param domain: connector domain parameter kept for compatibility. The default value is an empty string
     :return: the full URL to the endpoint
     """
     return CONSTANTS.REST_URL.format(domain) + CONSTANTS.API_VERSION + path_url

--- a/hummingbot/connector/exchange/cube/cube_web_utils.py
+++ b/hummingbot/connector/exchange/cube/cube_web_utils.py
@@ -11,7 +11,7 @@ def public_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> st
     """
     Creates a full URL for provided public REST endpoint
     :param path_url: a public REST endpoint
-    :param domain: the Binance domain to connect to ("com" or "us"). The default value is "com"
+    :param domain: the Cube domain to connect to ("live" or "staging"). The default value is "live"
     :return: the full URL to the endpoint
     """
     return CONSTANTS.REST_URL.get(domain) + path_url
@@ -21,7 +21,7 @@ def private_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> s
     """
     Creates a full URL for provided private REST endpoint
     :param path_url: a private REST endpoint
-    :param domain: the Binance domain to connect to ("com" or "us"). The default value is "com"
+    :param domain: the Cube domain to connect to ("live" or "staging"). The default value is "live"
     :return: the full URL to the endpoint
     """
     return CONSTANTS.REST_URL.get(domain) + path_url

--- a/hummingbot/connector/exchange/ndax/ndax_web_utils.py
+++ b/hummingbot/connector/exchange/ndax/ndax_web_utils.py
@@ -13,7 +13,7 @@ def public_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> st
     """
     Creates a full URL for provided public REST endpoint
     :param path_url: a public REST endpoint
-    :param domain: the Mexc domain to connect to ("com" or "us"). The default value is "com"
+    :param domain: the NDAX domain to connect to. Unknown values fall back to the main NDAX endpoint
     :return: the full URL to the endpoint
     """
     return CONSTANTS.REST_URLS.get(domain, CONSTANTS.REST_URLS["ndax_main"]) + path_url
@@ -23,7 +23,7 @@ def private_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> s
     """
     Creates a full URL for provided private REST endpoint
     :param path_url: a private REST endpoint
-    :param domain: the Mexc domain to connect to ("com" or "us"). The default value is "com"
+    :param domain: the NDAX domain to connect to. Unknown values fall back to the main NDAX endpoint
     :return: the full URL to the endpoint
     """
     return CONSTANTS.REST_URLS.get(domain, CONSTANTS.REST_URLS["ndax_main"]) + path_url


### PR DESCRIPTION
## Summary

- Correct copied domain descriptions in NDAX, Cube, and Bitrue web utility docstrings.
- Keep runtime behavior unchanged; this only fixes misleading source documentation.

## Testing

- `git diff --check`
- `env PYTHONPYCACHEPREFIX=/private/tmp/hummingbot-pycache python3 -m py_compile hummingbot/connector/exchange/ndax/ndax_web_utils.py hummingbot/connector/exchange/cube/cube_web_utils.py hummingbot/connector/exchange/bitrue/bitrue_web_utils.py`