### PR TITLE
fix/removed require_kwargs_on_init which is causing HAPI to fail

### DIFF
--- a/hummingbot/connector/exchange/xrpl/xrpl_utils.py
+++ b/hummingbot/connector/exchange/xrpl/xrpl_utils.py
@@ -16,7 +16,6 @@ from xrpl.asyncio.transaction import XRPLReliableSubmissionException
 from xrpl.asyncio.transaction.main import _LEDGER_OFFSET, _calculate_fee_per_transaction_type, _tx_needs_networkID
 from xrpl.models import Currency, IssuedCurrency, Request, Response, ServerInfo, Transaction, TransactionMetadata, Tx
 from xrpl.models.requests.request import LookupByLedgerRequest, RequestMethod
-from xrpl.models.utils import require_kwargs_on_init
 from xrpl.utils.txn_parser.utils import NormalizedNode, normalize_nodes
 from xrpl.utils.txn_parser.utils.order_book_parser import (
     _get_change_amount,
@@ -162,8 +161,7 @@ def represent_xrpl_market(dumper, data):
 SafeRepresenter.add_representer(XRPLMarket, represent_xrpl_market)
 
 
-@require_kwargs_on_init
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class Ledger(Request, LookupByLedgerRequest):
     """
     Retrieve information about the public ledger.


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] Tests all pass
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
- Removed `require_kwargs_on_init` which is the cause for this issue https://github.com/hummingbot/hummingbot-api/issues/172


**Tests performed by the developer**:
- Run `make test` to retest the whole codebase


**Tips for QA testing**:
- Check if HAPI fail or not