### PR TITLE
(fix) cap xrpl-py to <5 so pip wheel installs stay importable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ def main():
         "ujson>=5.7.0",
         "urllib3>=1.26.15,<2.0",
         "web3",
-        "xrpl-py>=4.4.0",
+        "xrpl-py>=4.4.0,<5",
         "PyYaml>=0.2.5",
     ]
 


### PR DESCRIPTION
Hi, and thanks for maintaining Hummingbot.

This fixes #8280. `setup.py` pins `xrpl-py>=4.4.0` with no upper bound, so pip installs of the wheel resolve to xrpl-py 5.x. The XRPL connector imports `require_kwargs_on_init` from `xrpl.models.utils`, which xrpl-py 5.0.0 removed, so connector enumeration crashes at import time. Anything calling `AllConnectorSettings.get_connector_settings()` hits it, including the API Docker image (full traceback in #8280).

`setup/environment.yml` already pins `xrpl-py==4.4.0`, so conda and source installs are unaffected. This change brings `setup.py` in line by capping the upper bound to `"xrpl-py>=4.4.0,<5"`.

I confirmed in a clean venv that `from xrpl.models.utils import require_kwargs_on_init` imports fine on 4.4.0 and raises ImportError on 5.0.0, so `<5` is the correct bound. I did not run the full suite locally (conda/cython build), so I verified the dependency behavior directly.

This is the minimal fix suggested in the issue. The longer term option is to migrate the connector off `require_kwargs_on_init` and widen the bound again, which I can do in a separate PR if you prefer.

Rene