### PR TITLE
fix(ci): cap aiohttp<3.14 — 3.14 breaks connector tests (failures + hangs)

### DIFF
--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - pytest-asyncio>=0.16.0
   - setuptools==80.8.0
   ### Packages used within HB and helping reduce the footprint of pip-installed packages
-  - aiohttp>=3.8.5
+  - aiohttp>=3.8.5,<3.14
   - asyncssh>=2.13.2
   - aioprocessing>=2.0.1
   - aioresponses>=0.7.4

--- a/setup/environment_dydx.yml
+++ b/setup/environment_dydx.yml
@@ -18,7 +18,7 @@ dependencies:
   - pytest-asyncio>=0.16.0
   - setuptools>=75.7.0
   ### Packages used within HB and helping reduce the footprint of pip-installed packages
-  - aiohttp>=3.8.5
+  - aiohttp>=3.8.5,<3.14
   - asyncssh>=2.13.2
   - aioprocessing>=2.0.1
   - aioresponses>=0.7.4


### PR DESCRIPTION
## Problem

The **Hummingbot build + stable tests** CI job has been hitting the **6h job timeout** (`The job has exceeded the maximum execution time of 6h0m0s`) with no diagnostic output — the suite stalls at ~4% in the perpetual connector tests.

## Root cause

The CI conda env is rebuilt from the **loose pin `aiohttp>=3.8.5`**. A fresh solve now resolves **aiohttp 3.14.x**, which was released *after* the last green run (that run used a cached 3.13.x env). aiohttp 3.14 is **not compatible with the current test mocking stack** (`aioresponses==0.7.8`): many async connector tests fail, and several **deadlock on an idle event loop** (an `await` that never resolves — confirmed via a faulthandler thread dump showing `MainThread` parked in `selector.poll`).

This is **not** specific to any one connector or PR — it hits `architect`, `backpack`, `derive`, `gate_io_perpetual`, `hyperliquid_perpetual`, `kucoin` perpetual tests, each costing the per-test budget, which is what stalls the whole suite.

## Reproduction (deterministic A/B)

Same machine, same Python 3.13, only aiohttp changed:

| aiohttp | architect + backpack tests |
|---|---|
| **3.14.1** | mass failures + **hang** (killed at 120s) — matches CI exactly |
| **3.13.5** | **189 passed in 4.4s** |

## Fix

Cap `aiohttp>=3.8.5,<3.14` in `setup/environment.yml` and `setup/environment_dydx.yml`. The 3.13.x line is API/behaviour-compatible and known-good; `<3.14` is the surgical constraint that excludes exactly the breaking release while staying solver-friendly (no exact pin on a central transitive dep). Revisit once `aioresponses` / the connector tests gain aiohttp 3.14 support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)