### PR TITLE
fix(ci): stop push-event runs failing on get-diff-action ref resolution

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -16,15 +16,19 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+      # get-diff-action diffs against a pull/<n>/merge ref that only exists for pull_request
+      # events; on a push (e.g. post-merge to master/development) that ref is absent and the
+      # action exits 128, failing this gate and skipping the build. Only run the file-change
+      # filter for PRs; on push always build, since post-merge runs should exercise the suite.
       - uses: technote-space/get-diff-action@v6
+        if: github.event_name == 'pull_request'
         with:
           PATTERNS: |
             **/*.+(py|pyx|pyd|yml)
       - name: Check if client files are modified
         id: check_files
-        if: env.GIT_DIFF
+        if: github.event_name == 'push' || env.GIT_DIFF
         run: |
-          echo ${{ env.GIT_DIFF }}
           echo "is_set=true" >> $GITHUB_OUTPUT
 
   build_hummingbot:


### PR DESCRIPTION
## Problem

The post-merge `push` CI runs on `development`/`master` go red even when the PR that was merged passed all checks. Example: [run 27359558988](https://github.com/hummingbot/hummingbot/actions/runs/27359558988) (the merge of #8265).

The `Check if client files changed` gate fails at the `technote-space/get-diff-action@v6` step:

```
command [git diff] exited with code 128.
fatal: ambiguous argument 'get-diff-action/staging...get-diff-action/pull/8290/merge':
unknown revision or path not in the working tree.
```

`get-diff-action` diffs against a `pull/<n>/merge` ref. That ref only exists for **`pull_request`** events — on a **`push`** event (the merge commit landing on the branch) it's absent, so `git diff` exits 128. That fails the gate job, and because `build_hummingbot` has `needs: run_client`, the build + stable tests job is **skipped**. Re-running doesn't help — the failure is deterministic, not flaky.

## Fix

Only run the file-change filter for `pull_request` events; on `push`, always set `is_set=true` so the post-merge run exercises the full suite.

- **PR events:** unchanged — `get-diff-action` still gates the build so it's skipped when no `py/pyx/pyd/yml` files changed.
- **Push events:** skip `get-diff-action` entirely (no merge ref to resolve) and build unconditionally.

## Verification

- YAML parses cleanly; pre-commit hooks pass.
- Logic: on push, the `get-diff-action` step is skipped, `check_files` runs via `github.event_name == 'push'`, sets `is_set=true`, gate passes, build runs. On PR, behaviour is identical to today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)