### PR TITLE
(feat) Migrate remote_iface MQTT bridge from commlib-py to aiomqtt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ test:
  	--ignore="test/mock" \
  	--ignore="test/hummingbot/connector/exchange/ndax/" \
  	--ignore="test/hummingbot/connector/derivative/dydx_v4_perpetual/" \
- 	--ignore="test/hummingbot/remote_iface/" \
  	--ignore="test/connector/utilities/oms_connector/" \
  	--ignore="test/hummingbot/strategy/amm_arb/" \
  	--ignore="test/hummingbot/strategy/cross_exchange_market_making/" \

--- a/hummingbot/client/command/mqtt_command.py
+++ b/hummingbot/client/command/mqtt_command.py
@@ -74,8 +74,9 @@ class MQTTCommand:
                         self.logger().error(
                             f'Failed to connect MQTT Bridge: {str(e)}')
                         self.notify('MQTT Bridge failed to connect to the broker.')
-                    self._mqtt.stop()
-                    self._mqtt = None
+                    if self._mqtt is not None:
+                        self._mqtt.stop()
+                        self._mqtt = None
 
                     if self.client_config_map.mqtt_bridge.mqtt_autostart:
                         await asyncio.sleep(self._mqtt_sleep_rate_autostart_retry)

--- a/hummingbot/remote_iface/messages.py
+++ b/hummingbot/remote_iface/messages.py
@@ -1,11 +1,36 @@
 from typing import Any, Dict, List, Optional, Tuple
 
-from commlib.msg import PubSubMessage, RPCMessage
+from pydantic import BaseModel
 
 
 class MQTT_STATUS_CODE:
     ERROR: int = 400
     SUCCESS: int = 200
+
+
+class PubSubMessage(BaseModel):
+    """Base class for pub/sub messages.
+
+    Local replacement for ``commlib.msg.PubSubMessage`` (a bare pydantic
+    ``BaseModel``). Kept so the wire format and field semantics are identical
+    after dropping the commlib dependency.
+    """
+    pass
+
+
+class RPCMessage(BaseModel):
+    """Namespace base for RPC request/response messages.
+
+    Local replacement for ``commlib.msg.RPCMessage``: a ``BaseModel`` exposing
+    nested ``Request``/``Response`` ``BaseModel`` classes for subclasses to
+    extend.
+    """
+
+    class Request(BaseModel):
+        pass
+
+    class Response(BaseModel):
+        pass
 
 
 class NotifyMessage(PubSubMessage):

--- a/hummingbot/remote_iface/mqtt.py
+++ b/hummingbot/remote_iface/mqtt.py
@@ -11,6 +11,9 @@ from datetime import datetime
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 
+import aiomqtt
+import ujson
+
 from hummingbot import get_logging_conf
 from hummingbot.client.config.config_helpers import ClientConfigAdapter
 from hummingbot.client.config.config_var import ConfigVar
@@ -20,9 +23,6 @@ from hummingbot.logger import HummingbotLogger
 if TYPE_CHECKING:  # pragma: no cover
     from hummingbot.client.hummingbot_application import HummingbotApplication  # noqa: F401
     from hummingbot.core.event.event_listener import EventListener  # noqa: F401
-
-from commlib.node import Node, NodeState
-from commlib.transports.mqtt import ConnectionParameters as MQTTConnectionParameters
 
 from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee, DeductedFromReturnsTradeFee
 from hummingbot.core.event import events
@@ -50,6 +50,34 @@ from hummingbot.remote_iface.messages import (
 mqtts_logger: HummingbotLogger = None
 
 
+def _make_primitive(val: Any) -> Any:
+    """Convert a value into JSON-serializable primitives.
+
+    Faithful port of ``commlib.serializer.JSONSerializer.make_primitive_value``
+    so the wire format is byte-compatible after dropping the commlib dependency
+    (Decimals/floats -> float, non-digit/unknown values -> str, etc.).
+    """
+    if isinstance(val, dict):
+        return {k: _make_primitive(v) for k, v in val.items()}
+    elif isinstance(val, (list, tuple)):
+        return [_make_primitive(v) for v in val]
+    elif isinstance(val, (Decimal, float)):
+        return float(val)
+    elif isinstance(val, int) and str(val).isdigit():
+        return int(val)
+    elif isinstance(val, bool):
+        return bool(val)
+    elif val is None:
+        return None
+    else:
+        return str(val)
+
+
+def mqtt_serialize(payload: Dict[str, Any]) -> str:
+    """Serialize an MQTT payload exactly as commlib did (ujson + primitives)."""
+    return ujson.dumps(_make_primitive(payload))
+
+
 class CommandTopicSpecs:
     START: str = '/start'
     STOP: str = '/stop'
@@ -69,24 +97,25 @@ class TopicSpecs:
     NOTIFICATIONS: str = '/notify'
     STATUS_UPDATES: str = '/status_updates'
     HEARTBEATS: str = '/hb'
-    EXTERNAL_EVENTS: str = '/external/event/*'
+    # MQTT multi-level wildcard ('#'); commlib used '*' and converted it internally.
+    EXTERNAL_EVENTS: str = '/external/event/#'
 
 
 class MQTTCommands:
     def __init__(self,
                  hb_app: "HummingbotApplication",
-                 node: Node):
+                 gateway: "MQTTGateway"):
         if threading.current_thread() != threading.main_thread():  # pragma: no cover
             raise EnvironmentError(
                 "MQTTCommands can only be initialized from the main thread."
             )
         self._hb_app = hb_app
-        self._node = node
+        self._gateway = gateway
         self.logger = self._hb_app.logger
         self._ev_loop: asyncio.AbstractEventLoop = self._hb_app.ev_loop
 
         topic_prefix = TopicSpecs.PREFIX.format(
-            namespace=self._node.namespace,
+            namespace=self._gateway.namespace,
             instance_id=self._hb_app.instance_id
         )
         self._start_uri = f'{topic_prefix}{TopicSpecs.COMMANDS.START}'
@@ -101,46 +130,22 @@ class MQTTCommands:
         self._init_commands()
 
     def _init_commands(self):
-        self._node.create_rpc(
-            rpc_name=self._start_uri,
-            msg_type=StartCommandMessage,
-            on_request=self._on_cmd_start
-        )
-        self._node.create_rpc(
-            rpc_name=self._stop_uri,
-            msg_type=StopCommandMessage,
-            on_request=self._on_cmd_stop
-        )
-        self._node.create_rpc(
-            rpc_name=self._config_uri,
-            msg_type=ConfigCommandMessage,
-            on_request=self._on_cmd_config
-        )
-        self._node.create_rpc(
-            rpc_name=self._import_uri,
-            msg_type=ImportCommandMessage,
-            on_request=self._on_cmd_import
-        )
-        self._node.create_rpc(
-            rpc_name=self._status_uri,
-            msg_type=StatusCommandMessage,
-            on_request=self._on_cmd_status
-        )
-        self._node.create_rpc(
-            rpc_name=self._history_uri,
-            msg_type=HistoryCommandMessage,
-            on_request=self._on_cmd_history
-        )
-        self._node.create_rpc(
-            rpc_name=self._balance_limit_uri,
-            msg_type=BalanceLimitCommandMessage,
-            on_request=self._on_cmd_balance_limit
-        )
-        self._node.create_rpc(
-            rpc_name=self._balance_paper_uri,
-            msg_type=BalancePaperCommandMessage,
-            on_request=self._on_cmd_balance_paper
-        )
+        self._gateway.register_command(
+            self._start_uri, StartCommandMessage, self._on_cmd_start)
+        self._gateway.register_command(
+            self._stop_uri, StopCommandMessage, self._on_cmd_stop)
+        self._gateway.register_command(
+            self._config_uri, ConfigCommandMessage, self._on_cmd_config)
+        self._gateway.register_command(
+            self._import_uri, ImportCommandMessage, self._on_cmd_import)
+        self._gateway.register_command(
+            self._status_uri, StatusCommandMessage, self._on_cmd_status)
+        self._gateway.register_command(
+            self._history_uri, HistoryCommandMessage, self._on_cmd_history)
+        self._gateway.register_command(
+            self._balance_limit_uri, BalanceLimitCommandMessage, self._on_cmd_balance_limit)
+        self._gateway.register_command(
+            self._balance_paper_uri, BalancePaperCommandMessage, self._on_cmd_balance_paper)
 
     def _on_cmd_start(self, msg: StartCommandMessage.Request):
         response = StartCommandMessage.Response()
@@ -343,6 +348,22 @@ class MQTTCommands:
 
 
 class MQTTMarketEventForwarder:
+    # Hoisted to a class attribute so it is built once, not per event (PERF-001).
+    EVENT_TYPES: Dict[int, str] = {
+        events.MarketEvent.BuyOrderCreated.value: "BuyOrderCreated",
+        events.MarketEvent.BuyOrderCompleted.value: "BuyOrderCompleted",
+        events.MarketEvent.SellOrderCreated.value: "SellOrderCreated",
+        events.MarketEvent.SellOrderCompleted.value: "SellOrderCompleted",
+        events.MarketEvent.OrderFilled.value: "OrderFilled",
+        events.MarketEvent.OrderCancelled.value: "OrderCancelled",
+        events.MarketEvent.OrderExpired.value: "OrderExpired",
+        events.MarketEvent.OrderFailure.value: "OrderFailure",
+        events.MarketEvent.FundingPaymentCompleted.value: "FundingPaymentCompleted",
+        events.MarketEvent.RangePositionLiquidityAdded.value: "RangePositionLiquidityAdded",
+        events.MarketEvent.RangePositionLiquidityRemoved.value: "RangePositionLiquidityRemoved",
+        events.MarketEvent.RangePositionUpdateFailure.value: "RangePositionUpdateFailure",
+    }
+
     @classmethod
     def logger(cls) -> HummingbotLogger:
         global mqtts_logger
@@ -352,18 +373,18 @@ class MQTTMarketEventForwarder:
 
     def __init__(self,
                  hb_app: "HummingbotApplication",
-                 node: Node):
+                 gateway: "MQTTGateway"):
         if threading.current_thread() != threading.main_thread():  # pragma: no cover
             raise EnvironmentError(
                 "MQTTMarketEventForwarder can only be initialized from the main thread."
             )
         self._hb_app = hb_app
-        self._node = node
+        self._gateway = gateway
         self._ev_loop: asyncio.AbstractEventLoop = self._hb_app.ev_loop
         self._markets: List[ConnectorBase] = list(self._hb_app.markets.values())
 
         topic_prefix = TopicSpecs.PREFIX.format(
-            namespace=self._node.namespace,
+            namespace=self._gateway.namespace,
             instance_id=self._hb_app.instance_id
         )
         self._topic = f'{topic_prefix}{TopicSpecs.INTERNAL_EVENTS}'
@@ -385,38 +406,10 @@ class MQTTMarketEventForwarder:
             (events.MarketEvent.RangePositionUpdateFailure, self._mqtt_fowarder),
         ]
 
-        self.event_fw_pub = self._node.create_publisher(
-            topic=self._topic, msg_type=InternalEventMessage
-        )
         self._start_event_listeners()
 
     def _send_mqtt_event(self, event_tag: int, pubsub: PubSub, event):
-        if threading.current_thread() != threading.main_thread():  # pragma: no cover
-            self._ev_loop.call_soon_threadsafe(
-                self._send_mqtt_event,
-                event_tag,
-                pubsub,
-                event
-            )
-            return
-        try:
-            event_types = {
-                events.MarketEvent.BuyOrderCreated.value: "BuyOrderCreated",
-                events.MarketEvent.BuyOrderCompleted.value: "BuyOrderCompleted",
-                events.MarketEvent.SellOrderCreated.value: "SellOrderCreated",
-                events.MarketEvent.SellOrderCompleted.value: "SellOrderCompleted",
-                events.MarketEvent.OrderFilled.value: "OrderFilled",
-                events.MarketEvent.OrderCancelled.value: "OrderCancelled",
-                events.MarketEvent.OrderExpired.value: "OrderExpired",
-                events.MarketEvent.OrderFailure.value: "OrderFailure",
-                events.MarketEvent.FundingPaymentCompleted.value: "FundingPaymentCompleted",
-                events.MarketEvent.RangePositionLiquidityAdded.value: "RangePositionLiquidityAdded",
-                events.MarketEvent.RangePositionLiquidityRemoved.value: "RangePositionLiquidityRemoved",
-                events.MarketEvent.RangePositionUpdateFailure.value: "RangePositionUpdateFailure",
-            }
-            event_type = event_types[event_tag]
-        except KeyError:
-            event_type = "Unknown"
+        event_type = self.EVENT_TYPES.get(event_tag, "Unknown")
 
         if is_dataclass(event):
             event_data = asdict(event)
@@ -435,12 +428,14 @@ class MQTTMarketEventForwarder:
 
         event_data = self._make_event_payload(event_data)
 
-        self.event_fw_pub.publish(
+        self._gateway.publish(
+            self._topic,
             InternalEventMessage(
                 timestamp=int(timestamp),
                 type=event_type,
                 data=event_data
-            )
+            ).model_dump(),
+            qos=0
         )
 
     def _make_event_payload(self, event_data):
@@ -452,17 +447,23 @@ class MQTTMarketEventForwarder:
             event_data['trade_type'] = str(event_data['trade_type'])
 
         for key, val in event_data.items():
-            if isinstance(val, dict):
-                self._make_event_payload(val)
-            elif isinstance(val, Decimal):
-                event_data[key] = float(val)
-            elif isinstance(val, DeductedFromReturnsTradeFee):
-                event_data[key] = val.to_json()
-                self._make_event_payload(event_data[key])
-            elif isinstance(val, AddedToCostTradeFee):
-                event_data[key] = val.to_json()
-                self._make_event_payload(event_data[key])
+            event_data[key] = self._primitivize_event_value(val)
         return event_data
+
+    def _primitivize_event_value(self, val):
+        # Recurse through dicts and lists so nested Decimals/TradeFees are
+        # converted too (CORR-007: the old version skipped list elements).
+        if isinstance(val, dict):
+            for key, inner in val.items():
+                val[key] = self._primitivize_event_value(inner)
+            return val
+        elif isinstance(val, (list, tuple)):
+            return [self._primitivize_event_value(v) for v in val]
+        elif isinstance(val, Decimal):
+            return float(val)
+        elif isinstance(val, (DeductedFromReturnsTradeFee, AddedToCostTradeFee)):
+            return self._primitivize_event_value(val.to_json())
+        return val
 
     def _start_event_listeners(self):
         for market in self._markets:
@@ -481,27 +482,20 @@ class MQTTMarketEventForwarder:
 class MQTTNotifier(NotifierBase):
     def __init__(self,
                  hb_app: "HummingbotApplication",
-                 node: Node) -> None:
+                 gateway: "MQTTGateway") -> None:
         super().__init__()
-        self._node = node
+        self._gateway = gateway
         self._hb_app = hb_app
         self._ev_loop: asyncio.AbstractEventLoop = self._hb_app.ev_loop
 
         topic_prefix = TopicSpecs.PREFIX.format(
-            namespace=self._node.namespace,
+            namespace=self._gateway.namespace,
             instance_id=self._hb_app.instance_id
         )
         self._topic = f'{topic_prefix}{TopicSpecs.NOTIFICATIONS}'
-        self.notify_pub = self._node.create_publisher(
-            topic=self._topic,
-            msg_type=NotifyMessage
-        )
 
     def add_msg_to_queue(self, msg: str):
-        if threading.current_thread() != threading.main_thread():  # pragma: no cover
-            self._ev_loop.call_soon_threadsafe(self.add_msg_to_queue, msg)
-            return
-        self.notify_pub.publish(NotifyMessage(msg=msg))
+        self._gateway.publish(self._topic, NotifyMessage(msg=msg).model_dump(), qos=0)
 
     def start(self) -> None:
         return None
@@ -513,47 +507,38 @@ class MQTTNotifier(NotifierBase):
 class MQTTStatusUpdates:
     def __init__(self,
                  hb_app: "HummingbotApplication",
-                 node: Node) -> None:
-        self._node = node
+                 gateway: "MQTTGateway") -> None:
+        self._gateway = gateway
         self._hb_app = hb_app
         self._ev_loop: asyncio.AbstractEventLoop = self._hb_app.ev_loop
 
         topic_prefix = TopicSpecs.PREFIX.format(
-            namespace=self._node.namespace,
+            namespace=self._gateway.namespace,
             instance_id=self._hb_app.instance_id
         )
         self._topic = f'{topic_prefix}{TopicSpecs.STATUS_UPDATES}'
-        self.status_updates_pub = self._node.create_publisher(
-            topic=self._topic,
-            msg_type=StatusUpdateMessage
-        )
-
-        if self._node.state == NodeState.RUNNING:
-            self.status_updates_pub.run()
 
     def add_msg_to_queue(self, msg: str, msg_type: str = 'hbapp'):
-        if threading.current_thread() != threading.main_thread():  # pragma: no cover
-            self._ev_loop.call_soon_threadsafe(self.add_msg_to_queue, msg, msg_type)
-            return
-
-        self.status_updates_pub.publish(
+        self._gateway.publish(
+            self._topic,
             StatusUpdateMessage(
                 msg=msg,
                 type=msg_type,
                 timestamp=int(time.time() * 1e3)
-            )
+            ).model_dump(),
+            qos=0
         )
 
     def stop(self):
-        self.status_updates_pub.stop()
+        return None
 
 
-class MQTTGateway(Node):
+class MQTTGateway:
     NODE_NAME: str = 'hbot.$instance_id'
     _instance: Optional["MQTTGateway"] = None
-    _INTERVAL_HEALTH_CHECK = 1.0
-    _INTERVAL_RESTART_SHORT = 5.0
-    _INTERVAL_RESTART_LONG = 10.0
+
+    _QOS_COMMAND: int = 1
+    _QOS_PUBSUB: int = 0
 
     @classmethod
     def logger(cls) -> HummingbotLogger:
@@ -570,10 +555,6 @@ class MQTTGateway(Node):
                  hb_app: "HummingbotApplication",
                  *args, **kwargs
                  ):
-        self._health = False
-        self._initial_connection_succeeded = False
-        self._restarting = False
-        self._stop_event_async = asyncio.Event()
         self._notifier: MQTTNotifier = None
         self._status_updates: MQTTStatusUpdates = None
         self._market_events: MQTTMarketEventForwarder = None
@@ -582,7 +563,22 @@ class MQTTGateway(Node):
         self._external_events: MQTTExternalEvents = None
         self._hb_app: "HummingbotApplication" = hb_app
         self._ev_loop = self._hb_app.ev_loop
-        self._params = self._create_mqtt_params_from_conf()
+
+        self._heartbeat_interval: float = 10.0
+        self._reconnect_interval: float = 5.0
+
+        # aiomqtt connection state (all MQTT I/O lives on hb_app.ev_loop).
+        self._client: Optional[aiomqtt.Client] = None
+        self._connected: bool = False
+        self._stopped: asyncio.Event = asyncio.Event()
+        self._run_task: Optional[asyncio.Task] = None
+        self._outgoing: "asyncio.Queue[Tuple[str, Dict[str, Any], int]]" = asyncio.Queue()
+        # RPC handlers keyed by exact command topic.
+        self._command_table: Dict[str, Tuple[Any, Callable]] = {}
+        # Pub/Sub callbacks keyed by topic pattern (supports +/# wildcards).
+        self._sub_callbacks: Dict[str, List[Callable[[str, Dict[str, Any]], None]]] = {}
+
+        self._read_mqtt_params_from_conf()
         self.namespace = self._hb_app.client_config_map.mqtt_bridge.mqtt_namespace
         if self.namespace[-1] in ('/', '.'):
             self.namespace = self.namespace[:-1]
@@ -591,22 +587,235 @@ class MQTTGateway(Node):
             namespace=self.namespace,
             instance_id=self._hb_app.instance_id
         )
-        _hb_topic = f'{self._topic_prefix}{TopicSpecs.HEARTBEATS}'
+        self._hb_topic = f'{self._topic_prefix}{TopicSpecs.HEARTBEATS}'
+        self._node_name = self.NODE_NAME.replace('$instance_id', hb_app.instance_id)
 
-        super().__init__(
-            node_name=self.NODE_NAME.replace('$instance_id', hb_app.instance_id),
-            connection_params=self._params,
-            heartbeats=True,
-            heartbeat_uri=_hb_topic,
-            *args,
-            **kwargs
-        )
         MQTTGateway._instance = self
 
     @property
     def health(self):
-        return self._health
+        return self._connected
 
+    # ------------------------------------------------------------------ #
+    # Connection params
+    # ------------------------------------------------------------------ #
+    def _read_mqtt_params_from_conf(self):
+        cfg = self._hb_app.client_config_map.mqtt_bridge
+        self._host = cfg.mqtt_host
+        self._port = int(cfg.mqtt_port)
+        self._username = cfg.mqtt_username
+        self._password = cfg.mqtt_password
+        self._use_ssl = bool(cfg.mqtt_ssl)
+
+    def _create_client(self) -> aiomqtt.Client:
+        # Seam: tests patch this to inject a fake client.
+        tls_params = aiomqtt.TLSParameters() if self._use_ssl else None
+        return aiomqtt.Client(
+            hostname=self._host,
+            port=self._port,
+            username=self._username or None,
+            password=self._password or None,
+            identifier=self._node_name,
+            tls_params=tls_params,
+            keepalive=60,
+        )
+
+    # ------------------------------------------------------------------ #
+    # Connection / reconnection loop
+    # ------------------------------------------------------------------ #
+    async def _run(self):
+        while not self._stopped.is_set():
+            tasks: List[asyncio.Task] = []
+            try:
+                async with self._create_client() as client:
+                    self._client = client
+                    self._connected = True
+                    for topic, qos in self._desired_subscriptions().items():
+                        await client.subscribe(topic, qos=qos)
+                    self._hb_app.logger().debug(
+                        f'Started Heartbeat Publisher <{self._hb_topic}>')
+                    self.broadcast_status_update("online", msg_type="availability")
+                    tasks = [
+                        asyncio.create_task(self._drain_outgoing(client)),
+                        asyncio.create_task(self._heartbeat_loop(client)),
+                        asyncio.create_task(self._dispatch_incoming(client)),
+                    ]
+                    done, _ = await asyncio.wait(
+                        tasks, return_when=asyncio.FIRST_EXCEPTION)
+                    for t in done:
+                        exc = t.exception()
+                        if exc is not None:
+                            raise exc
+            except asyncio.CancelledError:
+                raise
+            except aiomqtt.MqttError as e:
+                self._hb_app.logger().warning(
+                    f'MQTT bridge disconnected: {e}. '
+                    f'Reconnecting in {self._reconnect_interval}s.')
+            except Exception as e:  # pragma: no cover
+                self._hb_app.logger().error(
+                    f'MQTT bridge error: {e}. '
+                    f'Reconnecting in {self._reconnect_interval}s.', exc_info=True)
+            finally:
+                self._connected = False
+                self._client = None
+                for t in tasks:
+                    t.cancel()
+                if tasks:
+                    await asyncio.gather(*tasks, return_exceptions=True)
+            if self._stopped.is_set():
+                break
+            await asyncio.sleep(self._reconnect_interval)
+
+    async def _drain_outgoing(self, client: aiomqtt.Client):
+        while True:
+            topic, payload, qos = await self._outgoing.get()
+            # A publish failure bubbles up to _run to force a reconnect.
+            await client.publish(topic, payload=mqtt_serialize(payload), qos=qos)
+
+    async def _heartbeat_loop(self, client: aiomqtt.Client):
+        while True:
+            ts = int((time.time() + 0.5) * 1000000)
+            await client.publish(
+                self._hb_topic, payload=mqtt_serialize({"ts": ts}), qos=self._QOS_PUBSUB)
+            await asyncio.sleep(self._heartbeat_interval)
+
+    async def _dispatch_incoming(self, client: aiomqtt.Client):
+        async for message in client.messages:
+            topic = str(message.topic)
+            try:
+                payload = ujson.loads(message.payload)
+            except (ValueError, TypeError):  # pragma: no cover
+                continue
+            if topic in self._command_table:
+                self._ev_loop.run_in_executor(None, self._dispatch_rpc, topic, payload)
+                continue
+            for pattern in list(self._sub_callbacks.keys()):
+                if self._topic_matches(pattern, topic):
+                    for cb in list(self._sub_callbacks.get(pattern, [])):
+                        try:
+                            cb(topic, payload)
+                        except Exception:  # pragma: no cover
+                            self._hb_app.logger().error(
+                                f'Error handling MQTT message on {topic}', exc_info=True)
+
+    @staticmethod
+    def _topic_matches(pattern: str, topic: str) -> bool:
+        p_parts = pattern.split('/')
+        t_parts = topic.split('/')
+        for i, seg in enumerate(p_parts):
+            if seg == '#':
+                return True
+            if i >= len(t_parts):
+                return False
+            if seg != '+' and seg != t_parts[i]:
+                return False
+        return len(p_parts) == len(t_parts)
+
+    # ------------------------------------------------------------------ #
+    # RPC server
+    # ------------------------------------------------------------------ #
+    def _dispatch_rpc(self, topic: str, payload: Dict[str, Any]):
+        # Runs in a thread-pool executor (not the event loop) because the
+        # command handlers use call_sync(), which blocks on the loop.
+        try:
+            msg_type, handler = self._command_table[topic]
+        except KeyError:  # pragma: no cover
+            return
+        header = payload.get("header", {}) if isinstance(payload, dict) else {}
+        data = payload.get("data", {}) if isinstance(payload, dict) else {}
+        reply_to = header.get("reply_to") if isinstance(header, dict) else None
+        try:
+            request = msg_type.Request(**(data or {}))
+            response = handler(request)
+        except Exception:  # pragma: no cover
+            self._hb_app.logger().error(
+                f'Error processing MQTT command {topic}', exc_info=True)
+            return
+        if reply_to:
+            self.publish(reply_to, self._wrap_response(response), qos=self._QOS_COMMAND)
+
+    def _wrap_response(self, response) -> Dict[str, Any]:
+        # Mirrors commlib RPCService reply envelope byte-for-byte.
+        return {
+            "header": {
+                "reply_to": "",
+                "timestamp": int(time.time() * 1000),
+                "content_type": "json",
+                "encoding": "utf8",
+                "agent": "commlib",
+            },
+            "data": response.model_dump(),
+        }
+
+    def register_command(self, topic: str, msg_type: Any, handler: Callable):
+        self._command_table[topic] = (msg_type, handler)
+
+    # ------------------------------------------------------------------ #
+    # Publish / Subscribe primitives
+    # ------------------------------------------------------------------ #
+    def publish(self, topic: str, payload: Dict[str, Any], qos: int = 0):
+        """Enqueue a publish from any thread; drained on the event loop."""
+        try:
+            self._ev_loop.call_soon_threadsafe(
+                self._outgoing.put_nowait, (topic, payload, qos))
+        except RuntimeError:  # pragma: no cover - loop already closed
+            pass
+
+    def subscribe(self, topic: str, callback: Callable[[str, Dict[str, Any]], None]):
+        self._sub_callbacks.setdefault(topic, [])
+        self._sub_callbacks[topic].append(callback)
+        self._schedule_subscribe(topic, self._QOS_PUBSUB)
+
+    def unsubscribe(self,
+                    topic: str,
+                    callback: Optional[Callable[[str, Dict[str, Any]], None]] = None):
+        cbs = self._sub_callbacks.get(topic)
+        if cbs is None:
+            return
+        if callback is None:
+            cbs.clear()
+        elif callback in cbs:
+            cbs.remove(callback)
+        if not cbs:
+            self._sub_callbacks.pop(topic, None)
+            self._schedule_unsubscribe(topic)
+
+    def _desired_subscriptions(self) -> Dict[str, int]:
+        subs = {topic: self._QOS_COMMAND for topic in self._command_table}
+        for topic in self._sub_callbacks:
+            subs.setdefault(topic, self._QOS_PUBSUB)
+        return subs
+
+    def _schedule_subscribe(self, topic: str, qos: int):
+        if not self._connected or self._client is None:
+            return
+        client = self._client
+
+        async def _do():
+            try:
+                await client.subscribe(topic, qos=qos)
+            except aiomqtt.MqttError:  # pragma: no cover
+                pass
+        self._ev_loop.call_soon_threadsafe(
+            lambda: safe_ensure_future(_do(), loop=self._ev_loop))
+
+    def _schedule_unsubscribe(self, topic: str):
+        if not self._connected or self._client is None:
+            return
+        client = self._client
+
+        async def _do():
+            try:
+                await client.unsubscribe(topic)
+            except aiomqtt.MqttError:  # pragma: no cover
+                pass
+        self._ev_loop.call_soon_threadsafe(
+            lambda: safe_ensure_future(_do(), loop=self._ev_loop))
+
+    # ------------------------------------------------------------------ #
+    # Logging handler patching
+    # ------------------------------------------------------------------ #
     def _safe_get_log_handlers(self, max_tries=3):  # pragma: no cover
         current_try = 0
         while current_try < max_tries:
@@ -669,6 +878,9 @@ class MQTTGateway(Node):
     def add_log_handler(self, logger: HummingbotLogger):
         logger.addHandler(self._logh)
 
+    # ------------------------------------------------------------------ #
+    # Sub-component lifecycle
+    # ------------------------------------------------------------------ #
     def _init_notifier(self):
         if self._hb_app.client_config_map.mqtt_bridge.mqtt_notifier:
             self._notifier = MQTTNotifier(self._hb_app, self)
@@ -699,8 +911,6 @@ class MQTTGateway(Node):
         # Markets must be initialized via TradingCore before calling this method
         if self._hb_app.client_config_map.mqtt_bridge.mqtt_events:
             self._market_events = MQTTMarketEventForwarder(self._hb_app, self)
-            if self.state == NodeState.RUNNING:
-                self._market_events.event_fw_pub.run()
 
     def _remove_market_event_listeners(self):
         if self._market_events is not None:
@@ -726,154 +936,54 @@ class MQTTGateway(Node):
         else:
             self._external_events.remove_listener(event_name, callback)
 
-    def _create_mqtt_params_from_conf(self):
-        host = self._hb_app.client_config_map.mqtt_bridge.mqtt_host
-        port = self._hb_app.client_config_map.mqtt_bridge.mqtt_port
-        username = self._hb_app.client_config_map.mqtt_bridge.mqtt_username
-        password = self._hb_app.client_config_map.mqtt_bridge.mqtt_password
-        ssl = self._hb_app.client_config_map.mqtt_bridge.mqtt_ssl
-        conn_params = MQTTConnectionParameters(
-            host=host,
-            port=int(port),
-            username=username,
-            password=password,
-            ssl=ssl
-        )
-        return conn_params
-
-    def _check_connections(self) -> bool:
-        if self._restarting:
-            return False
-        for c in self._publishers:
-            if not c._transport.is_connected:
-                return False
-        for c in self._rpc_services:
-            if not c._transport.is_connected:
-                return False
-        # Will use if subscribtions are integrated
-        for c in self._subscribers:
-            if not c._transport.is_connected:
-                return False
-        # Will use if rpc clients are integrated
-        # for c in self._rpc_clients:
-        #     if not c._transport.is_connected:
-        #         return False
-        return True
-
-    def _start_health_monitoring_loop(self):
-        if threading.current_thread() != threading.main_thread():  # pragma: no cover
-            self._ev_loop.call_soon_threadsafe(self._start_health_monitoring_loop)
-            return
-        self._stop_event_async.clear()
-        safe_ensure_future(self._monitor_health_loop(),
-                           loop=self._ev_loop)
-
-    async def _monitor_health_loop(self):
-        while not self._stop_event_async.is_set():
-            # Maybe we can include more checks here to determine the health!
-            self._health = await self._ev_loop.run_in_executor(
-                None, self._check_connections)
-            if self.health:
-                if not self._initial_connection_succeeded:
-                    self._initial_connection_succeeded = True
-                    self._hb_app.logger().debug('Monitoring MQTT Gateway health for disconnections.')
-
-                await asyncio.sleep(self._INTERVAL_HEALTH_CHECK)
-            elif self._initial_connection_succeeded and not self._stop_event_async.is_set():
-                await self._restart_gateway()
-
-    async def _restart_gateway(self):
-        self._hb_app.logger().warning('MQTT Gateway is disconnected, attempting to reconnect.')
-
-        try:
-            self._restarting = True
-            self.stop(False)
-            await asyncio.sleep(self._INTERVAL_RESTART_SHORT)
-
-            self._publishers = []
-            self._subscribers = []
-            self._rpc_services = []
-            # self._rpc_clients = []
-
-            self.start(False)
-            if self._hb_app.strategy is not None:
-                self.start_market_events_fw()
-
-            await asyncio.sleep(self._INTERVAL_RESTART_SHORT)
-
-            self._restarting = False
-
-            self._health = await self._ev_loop.run_in_executor(
-                None, self._check_connections)
-
-            if self._health:
-                self._hb_app.logger().warning('MQTT Gateway successfully reconnected.')
-
-        except Exception as e:
-            self._hb_app.logger().error(f'MQTT Gateway failed to reconnect: {e}. Sleeping 10 seconds before retry.')
-
-        await asyncio.sleep(self._INTERVAL_RESTART_LONG)
-
-    def _stop_health_monitoring_loop(self):
-        self._stop_event_async.set()
-
-    def start(self, with_health: bool = True) -> None:
+    # ------------------------------------------------------------------ #
+    # Start / Stop
+    # ------------------------------------------------------------------ #
+    def start(self) -> None:
+        self._stopped.clear()
         self._init_logger()
         self._init_notifier()
         self._init_status_updates()
         self._init_commands()
         self._init_external_events()
+        self._run_task = safe_ensure_future(self._run(), loop=self._ev_loop)
 
-        if with_health:
-            self._start_health_monitoring_loop()
-
-        self.run()
-        self.broadcast_status_update("online", msg_type="availability")
-
-    def stop(self, with_health: bool = True):
+    def stop(self):
+        # Best-effort offline notice (may not flush if we are mid-disconnect).
         self.broadcast_status_update("offline", msg_type="availability")
-        super().stop()
-        if self._hb_thread:
-            self._hb_thread.stop()
+        self._stopped.set()
+        self._connected = False
+        if self._run_task is not None:
+            self._run_task.cancel()
+            self._run_task = None
         self._remove_status_updates()
         self._remove_notifier()
         self._remove_log_handlers()
         self._remove_market_event_listeners()
 
-        if with_health:
-            self._stop_health_monitoring_loop()
-
-    def __del__(self):
-        self.stop()
-
 
 class MQTTLogHandler(logging.Handler):
     def __init__(self,
                  hb_app: "HummingbotApplication",
-                 node: Node):
+                 gateway: "MQTTGateway"):
         if threading.current_thread() != threading.main_thread():  # pragma: no cover
             raise EnvironmentError(
                 "MQTTLogHandler can only be initialized from the main thread."
             )
         self._hb_app = hb_app
-        self._node = node
+        self._gateway = gateway
         self._ev_loop: asyncio.AbstractEventLoop = self._hb_app.ev_loop
 
         topic_prefix = TopicSpecs.PREFIX.format(
-            namespace=self._node.namespace,
+            namespace=self._gateway.namespace,
             instance_id=self._hb_app.instance_id
         )
         self._topic = f'{topic_prefix}{TopicSpecs.LOGS}'
 
         super().__init__()
         self.name = self.__class__.__name__
-        self.log_pub = self._node.create_publisher(topic=self._topic,
-                                                   msg_type=LogMessage)
 
     def emit(self, record: logging.LogRecord):
-        if threading.current_thread() != threading.main_thread():  # pragma: no cover
-            self._ev_loop.call_soon_threadsafe(self.emit, record)
-            return
         msg_str = self.format(record)
         msg = LogMessage(
             timestamp=time.time(),
@@ -883,33 +993,39 @@ class MQTTLogHandler(logging.Handler):
             logger_name=record.name
 
         )
-        self.log_pub.publish(msg)
+        self._gateway.publish(self._topic, msg.model_dump(), qos=self._gateway._QOS_PUBSUB)
 
 
 class MQTTExternalEvents:
     def __init__(self,
                  hb_app: "HummingbotApplication",
-                 node: Node
+                 gateway: "MQTTGateway"
                  ):
-        self._node: Node = node
+        self._gateway: "MQTTGateway" = gateway
         self._hb_app: 'HummingbotApplication' = hb_app
         self._ev_loop: asyncio.AbstractEventLoop = self._hb_app.ev_loop
 
         topic_prefix = TopicSpecs.PREFIX.format(
-            namespace=self._node.namespace,
+            namespace=self._gateway.namespace,
             instance_id=self._hb_app.instance_id
         )
         self._topic = f'{topic_prefix}{TopicSpecs.EXTERNAL_EVENTS}'
 
-        self._node.create_psubscriber(
-            topic=self._topic,
-            msg_type=ExternalEventMessage,
-            on_message=self._on_event_arrived
-        )
+        self._gateway.subscribe(self._topic, self._on_message)
         self._listeners: Dict[
             str,
             List[Callable[[ExternalEventMessage], str], None]
         ] = {'*': []}
+
+    def _on_message(self, topic: str, payload: Dict[str, Any]) -> None:
+        # Reconstruct the ExternalEventMessage so listeners keep receiving an
+        # object with a `.data` attribute (commlib msg_type behaviour).
+        try:
+            msg = ExternalEventMessage(**payload) if isinstance(payload, dict) \
+                else ExternalEventMessage()
+        except Exception:  # pragma: no cover
+            msg = ExternalEventMessage()
+        self._on_event_arrived(msg, topic)
 
     def _event_uri_to_name(self, topic: str) -> str:
         return topic.split('event/')[1].replace('/', '.')
@@ -918,10 +1034,6 @@ class MQTTExternalEvents:
                           msg: ExternalEventMessage,
                           topic: str
                           ) -> None:
-        if threading.current_thread() != threading.main_thread():  # pragma: no cover
-            self._ev_loop.call_soon_threadsafe(self._on_event_arrived,
-                                               msg, topic)
-            return
         event_name = self._event_uri_to_name(topic)
         self._hb_app.logger().debug(
             f'Received external event {event_name} -> {msg} - '
@@ -972,25 +1084,25 @@ class ETopicListener:
                  on_message: Callable[[Dict[str, Any], str], None],
                  use_bot_prefix: Optional[bool] = True
                  ):
-        self._node = MQTTGateway.main()
-        if self._node is None:
+        self._gateway = MQTTGateway.main()
+        if self._gateway is None:
             raise Exception('MQTT Gateway not yet initialized')
         topic_prefix = TopicSpecs.PREFIX.format(
-            namespace=self._node.namespace,
-            instance_id=self._node._hb_app.instance_id
+            namespace=self._gateway.namespace,
+            instance_id=self._gateway._hb_app.instance_id
         )
         if use_bot_prefix:
             self._topic = f'{topic_prefix}/{topic}'
         else:
             self._topic = topic
         self._on_message = on_message
-        self._sub = self._node.create_psubscriber(topic=self._topic,
-                                                  on_message=self._on_message)
-        if self._node.state == NodeState.RUNNING:
-            self._sub.run()
+        self._gateway.subscribe(self._topic, self._on_message_wrapper)
+
+    def _on_message_wrapper(self, topic: str, payload: Dict[str, Any]):
+        self._on_message(payload, topic)
 
     def stop(self):
-        self._sub.stop()
+        self._gateway.unsubscribe(self._topic, self._on_message_wrapper)
 
 
 class EEventQueueFactory:
@@ -1124,26 +1236,20 @@ class ETopicPublisher:
     def __init__(self,
                  topic: str,
                  use_bot_prefix: Optional[bool] = False):
-        self._node = MQTTGateway.main()
-        if self._node is None:
+        self._gateway = MQTTGateway.main()
+        if self._gateway is None:
             raise Exception('MQTT Gateway not yet initialized')
         self._topic_prefix = TopicSpecs.PREFIX.format(
-            namespace=self._node.namespace,
-            instance_id=self._node._hb_app.instance_id
+            namespace=self._gateway.namespace,
+            instance_id=self._gateway._hb_app.instance_id
         )
         if use_bot_prefix:
             self._topic = f'{self._topic_prefix}/{topic}'
         else:
             self._topic = topic
-        self._pub = self._node.create_mpublisher()
-        if self._node.state == NodeState.RUNNING:
-            self._pub.run()
 
     def send(self, msg: Dict[str, Any]):
-        if threading.current_thread() != threading.main_thread():  # pragma: no cover
-            asyncio.get_event_loop().call_soon_threadsafe(self.send, msg)
-            return
-        self._pub.publish(msg, self._topic)
+        self._gateway.publish(self._topic, msg, qos=self._gateway._QOS_PUBSUB)
 
     def __call__(self, msg: Dict[str, Any]):
         self.send(msg)
@@ -1153,24 +1259,16 @@ class EMTopicPublisher:
     def __init__(self,
                  use_bot_prefix: Optional[bool] = False):
         self._use_bot_prefix = use_bot_prefix
-        self._node = MQTTGateway.main()
-        if self._node is None:
+        self._gateway = MQTTGateway.main()
+        if self._gateway is None:
             raise Exception('MQTT Gateway not yet initialized')
         self._topic_prefix = TopicSpecs.PREFIX.format(
-            namespace=self._node.namespace,
-            instance_id=self._node._hb_app.instance_id
+            namespace=self._gateway.namespace,
+            instance_id=self._gateway._hb_app.instance_id
         )
 
-        self._pub = self._node.create_mpublisher()
-        if self._node.state == NodeState.RUNNING:
-            self._pub.run()
-
     def send(self, topic: str, msg: Dict[str, Any]):
-        if threading.current_thread() != threading.main_thread():  # pragma: no cover
-            asyncio.get_event_loop().call_soon_threadsafe(self.send, msg)
-            return
-        _topic = self._make_topic(topic)
-        self._pub.publish(msg, _topic)
+        self._gateway.publish(self._make_topic(topic), msg, qos=self._gateway._QOS_PUBSUB)
 
     def _make_topic(self, topic: str):
         if self._use_bot_prefix:

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ def main():
     }
     install_requires = [
         "aiohttp>=3.8.5",
+        "aiomqtt>=2.0.0",
         "asyncssh>=2.13.2",
         "aioprocessing>=2.0.1",
         "aioresponses>=0.7.4",
@@ -52,7 +53,6 @@ def main():
         "bidict>=0.22.1",
         "bip-utils",
         "cachetools>=5.3.1",
-        "commlib-py>=0.11",
         "cryptography>=41.0.2",
         "decibel-python-sdk==0.2.1",
         "eth-account>=0.13.0",

--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -27,7 +27,6 @@ dependencies:
   - bidict>=0.22.1
   - bip-utils
   - cachetools>=5.3.1
-  - commlib-py==0.11.5
   - cryptography>=41.0.2
   - eth-account>=0.13.0
 #  - injective-py==1.12.*
@@ -65,6 +64,7 @@ dependencies:
   - yaml>=0.2.5
   - zlib>=1.2.13
   - pip:
+    - aiomqtt>=2.0.0
     - injective-py==1.14.*
     - decibel-python-sdk==0.2.1
     - aptos-sdk>=0.8.0

--- a/setup/environment_dydx.yml
+++ b/setup/environment_dydx.yml
@@ -20,6 +20,7 @@ dependencies:
   - setuptools>=75.7.0
   ### Packages used within HB and helping reduce the footprint of pip-installed packages
   - aiohttp>=3.8.5,<3.14  # aiohttp 3.14 requires a stream_writer arg that aioresponses 0.7.8 doesn't pass, breaking HTTP-mocked tests
+  - aiomqtt>=2.0.0
   - asyncssh>=2.13.2
   - aioprocessing>=2.0.1
   - aioresponses>=0.7.4
@@ -28,7 +29,6 @@ dependencies:
   - bidict>=0.22.1
   - bip-utils
   - cachetools>=5.3.1
-  - commlib-py==0.11.5
   - cryptography>=41.0.2
   - dydxprotocol-v4-proto-py
   - eth-account >=0.13.0

--- a/test/hummingbot/client/command/test_mqtt_command.py
+++ b/test/hummingbot/client/command/test_mqtt_command.py
@@ -11,9 +11,6 @@ from hummingbot.client.config.config_helpers import ClientConfigAdapter
 from hummingbot.client.hummingbot_application import HummingbotApplication
 
 
-@patch("hummingbot.remote_iface.mqtt.MQTTGateway._INTERVAL_HEALTH_CHECK", 0.0)
-@patch("hummingbot.remote_iface.mqtt.MQTTGateway._INTERVAL_RESTART_LONG", 0.0)
-@patch("hummingbot.remote_iface.mqtt.MQTTGateway._INTERVAL_RESTART_SHORT", 0.0)
 class RemoteIfaceMQTTTests(IsolatedAsyncioWrapperTestCase):
     # logging.Level required to receive logs from the exchange
     level = 0
@@ -44,13 +41,16 @@ class RemoteIfaceMQTTTests(IsolatedAsyncioWrapperTestCase):
         self.resume_test_event = asyncio.Event()
         self.hbapp.logger().setLevel(1)
         self.hbapp.logger().addHandler(self)
-        # MQTT Transport Patcher
-        self.mqtt_transport_patcher = patch(
-            'commlib.transports.mqtt.MQTTTransport'
+        # Inject the fake aiomqtt client transport.
+
+        def _fake_create_client(gw):
+            return self.fake_mqtt_broker.create_client()
+        self.create_client_patcher = patch(
+            'hummingbot.remote_iface.mqtt.MQTTGateway._create_client',
+            _fake_create_client
         )
-        self.addCleanup(self.mqtt_transport_patcher.stop)
-        self.mqtt_transport_mock = self.mqtt_transport_patcher.start()
-        self.mqtt_transport_mock.side_effect = self.fake_mqtt_broker.create_transport
+        self.addCleanup(self.create_client_patcher.stop)
+        self.create_client_patcher.start()
         # MQTT Patch Loggers Patcher
         self.patch_loggers_patcher = patch(
             'hummingbot.remote_iface.mqtt.MQTTGateway.patch_loggers'
@@ -68,7 +68,7 @@ class RemoteIfaceMQTTTests(IsolatedAsyncioWrapperTestCase):
         # self.ev_loop.run_until_complete(self.hbapp.stop_mqtt_async())
         # self.ev_loop.run_until_complete(asyncio.sleep(0.1))
         self.fake_mqtt_broker.clear()
-        self.mqtt_transport_patcher.stop()
+        self.create_client_patcher.stop()
         self.patch_loggers_patcher.stop()
         super().tearDown()
 

--- a/test/hummingbot/client/command/test_mqtt_command.py
+++ b/test/hummingbot/client/command/test_mqtt_command.py
@@ -51,6 +51,14 @@ class RemoteIfaceMQTTTests(IsolatedAsyncioWrapperTestCase):
         )
         self.addCleanup(self.create_client_patcher.stop)
         self.create_client_patcher.start()
+        # Hard guard: a real broker connection must never be attempted in tests.
+        self.no_network_patcher = patch(
+            'hummingbot.remote_iface.mqtt.aiomqtt.Client',
+            side_effect=AssertionError(
+                "Real aiomqtt.Client instantiated in tests — network access attempted")
+        )
+        self.addCleanup(self.no_network_patcher.stop)
+        self.no_network_patcher.start()
         # MQTT Patch Loggers Patcher
         self.patch_loggers_patcher = patch(
             'hummingbot.remote_iface.mqtt.MQTTGateway.patch_loggers'

--- a/test/hummingbot/remote_iface/test_mqtt.py
+++ b/test/hummingbot/remote_iface/test_mqtt.py
@@ -76,6 +76,16 @@ class RemoteIfaceMQTTTests(TestCase):
         )
         self.addCleanup(self.create_client_patcher.stop)
         self.create_client_patcher.start()
+        # Hard guard: a real broker connection must never be attempted in tests.
+        # If any code path bypasses the _create_client seam, fail loudly instead
+        # of opening a socket (CI runners have no MQTT broker).
+        self.no_network_patcher = patch(
+            'hummingbot.remote_iface.mqtt.aiomqtt.Client',
+            side_effect=AssertionError(
+                "Real aiomqtt.Client instantiated in tests — network access attempted")
+        )
+        self.addCleanup(self.no_network_patcher.stop)
+        self.no_network_patcher.start()
         # MQTT Patch Loggers Patcher
         self.patch_loggers_patcher = patch(
             'hummingbot.remote_iface.mqtt.MQTTGateway.patch_loggers'

--- a/test/hummingbot/remote_iface/test_mqtt.py
+++ b/test/hummingbot/remote_iface/test_mqtt.py
@@ -1,9 +1,10 @@
 import asyncio
+import threading
 from decimal import Decimal
 from test.mock.mock_mqtt_server import FakeMQTTBroker
 from typing import Awaitable
 from unittest import TestCase
-from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from async_timeout import timeout
 
@@ -20,8 +21,6 @@ from hummingbot.model.trade_fill import TradeFill
 from hummingbot.remote_iface.mqtt import MQTTGateway, MQTTMarketEventForwarder
 
 
-@patch("hummingbot.remote_iface.mqtt.MQTTGateway._INTERVAL_HEALTH_CHECK", 0.0)
-@patch("hummingbot.remote_iface.mqtt.MQTTGateway._INTERVAL_RESTART_LONG", 0.0)
 class RemoteIfaceMQTTTests(TestCase):
     # logging.Level required to receive logs from the exchange
     level = 0
@@ -50,7 +49,6 @@ class RemoteIfaceMQTTTests(TestCase):
         cls.HISTORY_URI = 'hbot/$instance_id/history'
         cls.BALANCE_LIMIT_URI = 'hbot/$instance_id/balance/limit'
         cls.BALANCE_PAPER_URI = 'hbot/$instance_id/balance/paper'
-        cls.fake_mqtt_broker = FakeMQTTBroker()
 
     def setUp(self) -> None:
         super().setUp()
@@ -67,33 +65,17 @@ class RemoteIfaceMQTTTests(TestCase):
         self.client_config_map.mqtt_bridge.mqtt_events = 1
 
         self.log_records = []
-        # self.async_run_with_timeout(read_system_configs_from_yml())
-        self.gateway = MQTTGateway(self.hbapp)
-        self.test_market: MockPaperExchange = MockPaperExchange(
-            client_config_map=self.client_config_map)
-        self.hbapp.markets = {
-            "test_market_paper_trade": self.test_market
-        }
-        self.resume_test_event = asyncio.Event()
-        self.hbapp.logger().setLevel(1)
-        self.hbapp.logger().addHandler(self)
-        self.gateway.logger().setLevel(1)
-        self.gateway.logger().addHandler(self)
-        # Restart interval Patcher
-        self.restart_interval_patcher = patch(
-            'hummingbot.remote_iface.mqtt.MQTTGateway._INTERVAL_RESTART_SHORT',
-            new_callable=PropertyMock
+        self.fake_mqtt_broker = FakeMQTTBroker()
+
+        # Inject the fake aiomqtt client transport.
+        def _fake_create_client(gw):
+            return self.fake_mqtt_broker.create_client()
+        self.create_client_patcher = patch(
+            'hummingbot.remote_iface.mqtt.MQTTGateway._create_client',
+            _fake_create_client
         )
-        self.addCleanup(self.restart_interval_patcher.stop)
-        self.restart_interval_mock = self.restart_interval_patcher.start()
-        self.restart_interval_mock.return_value = 0.0
-        # MQTT Transport Patcher
-        self.mqtt_transport_patcher = patch(
-            'commlib.transports.mqtt.MQTTTransport'
-        )
-        self.addCleanup(self.mqtt_transport_patcher.stop)
-        self.mqtt_transport_mock = self.mqtt_transport_patcher.start()
-        self.mqtt_transport_mock.side_effect = self.fake_mqtt_broker.create_transport
+        self.addCleanup(self.create_client_patcher.stop)
+        self.create_client_patcher.start()
         # MQTT Patch Loggers Patcher
         self.patch_loggers_patcher = patch(
             'hummingbot.remote_iface.mqtt.MQTTGateway.patch_loggers'
@@ -102,14 +84,26 @@ class RemoteIfaceMQTTTests(TestCase):
         self.patch_loggers_mock = self.patch_loggers_patcher.start()
         self.patch_loggers_mock.return_value = None
 
+        self.gateway = MQTTGateway(self.hbapp)
+        # Reconnect instantly in tests.
+        self.gateway._reconnect_interval = 0.0
+        self.test_market: MockPaperExchange = MockPaperExchange()
+        self.hbapp.trading_core.connector_manager.connectors["test_market_paper_trade"] = self.test_market
+        # No strategy loaded by default (the app no longer initializes this attribute).
+        self.hbapp.strategy = None
+        self.resume_test_event = asyncio.Event()
+        self.hbapp.logger().setLevel(1)
+        self.hbapp.logger().addHandler(self)
+        self.gateway.logger().setLevel(1)
+        self.gateway.logger().addHandler(self)
+
     def tearDown(self):
         self.async_loop.run_until_complete(asyncio.sleep(0.1))
         self.gateway.stop()
         del self.gateway
         self.async_loop.run_until_complete(asyncio.sleep(0.1))
         self.fake_mqtt_broker.clear()
-        self.restart_interval_patcher.stop()
-        self.mqtt_transport_patcher.stop()
+        self.create_client_patcher.stop()
         self.patch_loggers_patcher.stop()
 
         self.async_loop.stop()
@@ -138,6 +132,16 @@ class RemoteIfaceMQTTTests(TestCase):
     def async_run_with_timeout(self, coroutine: Awaitable, timeout: float = 1):
         ret = self.async_loop.run_until_complete(asyncio.wait_for(coroutine, timeout))
         return ret
+
+    async def wait_for_connected(self):
+        async with timeout(3):
+            while not self.fake_mqtt_broker.is_connected:
+                await asyncio.sleep(0.05)
+
+    async def wait_for_subscriptions(self, count: int):
+        async with timeout(3):
+            while len(self.fake_mqtt_broker.subscriptions) < count:
+                await asyncio.sleep(0.05)
 
     async def _create_exception_and_unlock_test_with_event_async(self, *args, **kwargs):
         self.resume_test_event.set()
@@ -323,8 +327,6 @@ class RemoteIfaceMQTTTests(TestCase):
 
         self.fake_mqtt_broker.publish_to_subscription(self.get_topic_for(self.BALANCE_LIMIT_URI), msg)
 
-        self.async_run_with_timeout(self.resume_test_event.wait())
-
         topic = f"test_reply/hbot/{self.instance_id}/balance/limit"
         msg = {'status': 400, 'msg': self.fake_err_msg, 'data': ''}
         self.async_run_with_timeout(self.wait_for_rcv(topic, msg, msg_key='data'), timeout=10)
@@ -345,8 +347,6 @@ class RemoteIfaceMQTTTests(TestCase):
         }
 
         self.fake_mqtt_broker.publish_to_subscription(self.get_topic_for(self.BALANCE_PAPER_URI), msg)
-
-        self.async_run_with_timeout(self.resume_test_event.wait())
 
         topic = f"test_reply/hbot/{self.instance_id}/balance/paper"
         msg = {'status': 400, 'msg': self.fake_err_msg, 'data': ''}
@@ -386,8 +386,6 @@ class RemoteIfaceMQTTTests(TestCase):
 
         self.fake_mqtt_broker.publish_to_subscription(self.get_topic_for(self.CONFIG_URI), {})
 
-        self.async_run_with_timeout(self.resume_test_event.wait())
-
         topic = f"test_reply/hbot/{self.instance_id}/config"
         msg = {'changes': [], 'config': {}, 'status': 400, 'msg': self.fake_err_msg}
         self.async_run_with_timeout(self.wait_for_rcv(topic, msg, msg_key='data'), timeout=10)
@@ -402,8 +400,6 @@ class RemoteIfaceMQTTTests(TestCase):
         self.start_mqtt()
 
         self.fake_mqtt_broker.publish_to_subscription(self.get_topic_for(self.HISTORY_URI), {})
-
-        self.async_run_with_timeout(self.resume_test_event.wait())
 
         topic = f"test_reply/hbot/{self.instance_id}/history"
         msg = {'status': 400, 'msg': self.fake_err_msg, 'trades': []}
@@ -525,12 +521,34 @@ class RemoteIfaceMQTTTests(TestCase):
 
         self.fake_mqtt_broker.publish_to_subscription(self.get_topic_for(self.STOP_URI), {})
 
-        self.async_run_with_timeout(self.resume_test_event.wait())
-
         topic = f"test_reply/hbot/{self.instance_id}/stop"
         msg = {'status': 400, 'msg': self.fake_err_msg}
         self.async_run_with_timeout(self.wait_for_rcv(topic, msg, msg_key='data'), timeout=10)
         self.assertTrue(self.is_msg_received(topic, msg, msg_key='data'))
+
+    def test_mqtt_rpc_response_envelope_is_wire_compatible(self):
+        # A failing balance command exercises the full request -> handler ->
+        # reply_to round-trip; assert the response envelope matches commlib.
+        with patch("hummingbot.client.command.balance_command.BalanceCommand.balance") as balance_mock:
+            balance_mock.side_effect = self._create_exception_and_unlock_test_with_event
+            self.start_mqtt()
+            self.fake_mqtt_broker.publish_to_subscription(
+                self.get_topic_for(self.BALANCE_PAPER_URI),
+                {'exchange': 'binance', 'asset': 'BTC-USD', 'amount': '1.0'})
+            topic = f"test_reply/hbot/{self.instance_id}/balance/paper"
+            expected = {'status': 400, 'msg': self.fake_err_msg, 'data': ''}
+            self.async_run_with_timeout(self.wait_for_rcv(topic, expected, msg_key='data'), timeout=10)
+
+        envelope = self.fake_mqtt_broker.received_msgs[topic][0]
+        self.assertIn('header', envelope)
+        self.assertIn('data', envelope)
+        header = envelope['header']
+        self.assertEqual('', header['reply_to'])
+        self.assertEqual('json', header['content_type'])
+        self.assertEqual('utf8', header['encoding'])
+        self.assertEqual('commlib', header['agent'])
+        self.assertIsInstance(header['timestamp'], int)
+        self.assertEqual(expected, envelope['data'])
 
     def test_mqtt_event_buy_order_created(self):
         self.start_mqtt()
@@ -586,9 +604,53 @@ class RemoteIfaceMQTTTests(TestCase):
     def test_mqtt_subscribed_topics(self):
         self.start_mqtt()
         self.assertTrue(self.gateway is not None)
-        subscribed_mqtt_topics = sorted(list([f"hbot/{self.instance_id}/{topic}"
-                                              for topic in (self.command_topics + ['external/event/*'])]))
-        self.assertEqual(subscribed_mqtt_topics, sorted(list(self.fake_mqtt_broker.subscriptions.keys())))
+        expected_topics = sorted(list([f"hbot/{self.instance_id}/{topic}"
+                                       for topic in (self.command_topics + ['external/event/#'])]))
+        self.async_run_with_timeout(self.wait_for_subscriptions(len(expected_topics)), timeout=10)
+        self.assertEqual(expected_topics, sorted(list(self.fake_mqtt_broker.subscriptions.keys())))
+
+    def test_mqtt_heartbeat_published(self):
+        self.start_mqtt()
+        hb_topic = f"hbot/{self.instance_id}/hb"
+        self.async_run_with_timeout(self.wait_for_rcv(hb_topic), timeout=10)
+        self.assertTrue(self.is_msg_received(hb_topic))
+        self.assertIn('ts', self.fake_mqtt_broker.received_msgs[hb_topic][0])
+
+    def test_mqtt_online_status_update(self):
+        self.start_mqtt()
+        status_topic = f"hbot/{self.instance_id}/status_updates"
+        self.async_run_with_timeout(self.wait_for_rcv(status_topic, 'online'), timeout=10)
+        self.assertTrue(self.is_msg_received(status_topic, 'online'))
+
+    def test_mqtt_reconnects_on_mqtt_error(self):
+        self.start_mqtt()
+        self.async_run_with_timeout(self.wait_for_connected(), timeout=10)
+        self.assertTrue(self.gateway.health)
+        # Force the broker connection to drop.
+        self.fake_mqtt_broker.inject_disconnect()
+        self.async_run_with_timeout(
+            self.wait_for_logged(
+                "WARNING",
+                "MQTT bridge disconnected: Simulated broker disconnect. Reconnecting in 0.0s."),
+            timeout=10)
+        # The single reconnect loop brings it back online by itself.
+        self.async_run_with_timeout(self.wait_for_connected(), timeout=10)
+        self.assertTrue(self.gateway.health)
+
+    def test_mqtt_publish_from_non_main_thread(self):
+        self.start_mqtt()
+        self.async_run_with_timeout(self.wait_for_connected(), timeout=10)
+        topic = f"hbot/{self.instance_id}/threadtest"
+
+        def worker():
+            self.gateway.publish(topic, {"msg": "fromthread"}, 0)
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join()
+
+        self.async_run_with_timeout(self.wait_for_rcv(topic, "fromthread"), timeout=10)
+        self.assertTrue(self.is_msg_received(topic, "fromthread"))
 
     @patch("hummingbot.remote_iface.mqtt.mqtts_logger", None)
     def test_mqtt_eventforwarder_logger(self):
@@ -628,78 +690,12 @@ class RemoteIfaceMQTTTests(TestCase):
         self.assertEqual(self.gateway._notifier.start(), None)
         self.assertEqual(self.gateway._notifier.stop(), None)
 
-    def test_mqtt_gateway_check_health(self):
-        tmp = self.gateway._start_health_monitoring_loop
-        self.gateway._start_health_monitoring_loop = lambda: None
-        self.start_mqtt()
-        self.assertTrue(self.gateway._check_connections())
-        self.gateway._rpc_services[0]._transport._connected = False
-        self.assertFalse(self.gateway._check_connections())
-        self.gateway._rpc_services[0]._transport._connected = True
-        s = self.gateway.create_subscriber(topic='TEST', on_message=lambda x: {})
-        s.run()
-        self.assertTrue(self.gateway._check_connections())
-        s._transport._connected = False
-        self.assertFalse(self.gateway._check_connections())
-        prev_pub = self.gateway._publishers
-        prev__sub = self.gateway._subscribers
-        self.gateway._publishers = []
-        self.gateway._subscribers = []
-        self.gateway._rpc_services[0]._transport._connected = False
-        self.assertFalse(self.gateway._check_connections())
-        self.gateway._publishers = prev_pub
-        self.gateway._subscribers = prev__sub
-        self.gateway._start_health_monitoring_loop = tmp
-
-    @patch("hummingbot.remote_iface.mqtt.MQTTGateway.health", new_callable=PropertyMock)
-    def test_mqtt_gateway_check_health_restarts(
-            self,
-            health_mock: PropertyMock
-    ):
-        health_mock.return_value = True
-        status_topic = f"hbot/{self.instance_id}/status_updates"
-        self.start_mqtt()
-        self.async_run_with_timeout(
-            self.wait_for_logged("DEBUG", f"Started Heartbeat Publisher <hbot/{self.instance_id}/hb>"), timeout=10)
-        self.async_run_with_timeout(self.wait_for_rcv(status_topic, 'online'), timeout=10)
-        self.async_run_with_timeout(self.wait_for_logged("DEBUG", "Monitoring MQTT Gateway health for disconnections."),
-                                    timeout=10)
-        self.log_records.clear()
-        health_mock.return_value = False
-        self.restart_interval_mock.return_value = None
-        self.async_run_with_timeout(
-            self.wait_for_logged("WARNING", "MQTT Gateway is disconnected, attempting to reconnect."), timeout=10)
-        fake_err = "'<=' not supported between instances of 'NoneType' and 'int'"
-        self.async_run_with_timeout(self.wait_for_logged("ERROR",
-                                                         f"MQTT Gateway failed to reconnect: {fake_err}. Sleeping 10 seconds before retry."),
-                                    timeout=10)
-        self.assertFalse(
-            self._is_logged(
-                "WARNING",
-                "MQTT Gateway successfully reconnected.",
-            )
-        )
-        self.assertTrue(self.is_msg_received(status_topic, 'offline'))
-        self.log_records.clear()
-        self.restart_interval_mock.return_value = 0.0
-        self.hbapp.strategy = True
-        self.async_run_with_timeout(
-            self.wait_for_logged("WARNING", "MQTT Gateway is disconnected, attempting to reconnect."), timeout=10)
-        health_mock.return_value = True
-        self.async_run_with_timeout(self.wait_for_logged("WARNING", "MQTT Gateway successfully reconnected."),
-                                    timeout=10)
-        self.assertTrue(
-            self._is_logged(
-                "WARNING",
-                "MQTT Gateway successfully reconnected.",
-            )
-        )
-
     def test_mqtt_gateway_stop(self):
         self.start_mqtt()
-        self.assertTrue(self.gateway._check_connections())
+        self.async_run_with_timeout(self.wait_for_connected(), timeout=10)
+        self.assertTrue(self.gateway.health)
         self.gateway.stop()
-        self.assertFalse(self.gateway._check_connections())
+        self.assertFalse(self.gateway.health)
 
     def test_eevent_queue_factory(self):
         self.start_mqtt()
@@ -801,6 +797,7 @@ class RemoteIfaceMQTTTests(TestCase):
             'd': DeductedFromReturnsTradeFee(),
             'e': AddedToCostTradeFee(),
             'f': {'a': 1},
+            'g': [Decimal('2.0'), {'h': Decimal('3.0')}],
             'type': 'TEST',
             'order_type': 'BUY',
             'trade_type': 'LIMIT',
@@ -813,14 +810,13 @@ class RemoteIfaceMQTTTests(TestCase):
         def clb(msg, topic):
             pass
 
-        listener = ETopicListener('test', clb, use_bot_prefix=False)
-        self.assertTrue(listener is not None)
-        listener = ETopicListener('test', clb, use_bot_prefix=True)
-        self.assertTrue(listener is not None)
-
         self.start_mqtt()
         listener = ETopicListener('test', clb, use_bot_prefix=True)
         self.assertTrue(listener is not None)
+        listener.stop()
+        listener = ETopicListener('test', clb, use_bot_prefix=False)
+        self.assertTrue(listener is not None)
+        listener.stop()
 
         prev_gw = MQTTGateway.main()
         MQTTGateway._instance = None
@@ -906,6 +902,31 @@ class RemoteIfaceMQTTTests(TestCase):
         eevents.add_listener('test_event', clb)
         eevents.remove_listener('test_event', clb)
 
+    def test_mqtt_external_event_delivery_wraps_message(self):
+        from hummingbot.remote_iface.mqtt import ExternalEventFactory
+        self.start_mqtt()
+        self.async_run_with_timeout(self.wait_for_connected(), timeout=10)
+
+        received = []
+
+        def clb(msg, name):
+            received.append((name, msg))
+
+        ExternalEventFactory.create_async('*', clb)
+        event_topic = f"hbot/{self.instance_id}/external/event/order/market"
+        self.fake_mqtt_broker.publish_event(
+            event_topic, {'type': 'eevent', 'data': {'type': 'buy', 'amount': '1'}})
+
+        async def _wait():
+            async with timeout(3):
+                while not received:
+                    await asyncio.sleep(0.05)
+        self.async_run_with_timeout(_wait(), timeout=10)
+        name, msg = received[0]
+        self.assertEqual('order.market', name)
+        # Listeners must receive an ExternalEventMessage object with `.data`.
+        self.assertEqual({'type': 'buy', 'amount': '1'}, msg.data)
+
     def test_mqtt_gateway_health(self):
         health = self.gateway.health
         self.assertFalse(health)
@@ -931,8 +952,9 @@ class RemoteIfaceMQTTTests(TestCase):
         }
         pub = ETopicPublisher('test/a/b', use_bot_prefix=False)
         pub.send(test_msg)
-        self.assertTrue(1)
+        self.async_run_with_timeout(self.wait_for_rcv('test/a/b'), timeout=10)
+        self.assertTrue(self.is_msg_received('test/a/b'))
         pub2 = EMTopicPublisher(use_bot_prefix=False)
-        pub2.send("test/a/b", test_msg)
         pub2.send("test/c/d", test_msg)
-        self.assertTrue(1)
+        self.async_run_with_timeout(self.wait_for_rcv('test/c/d'), timeout=10)
+        self.assertTrue(self.is_msg_received('test/c/d'))

--- a/test/mock/mock_mqtt_server.py
+++ b/test/mock/mock_mqtt_server.py
@@ -1,49 +1,125 @@
+import asyncio
 import logging
-from typing import Any, Dict
+from typing import Any, Optional
 
+import aiomqtt
 import ujson
-from commlib.serializer import JSONSerializer
+
+# Sentinels pushed onto the incoming queue to drive the fake message iterator.
+_DISCONNECT = object()
 
 
-class FakeMQTTMessage(object):
-    def __init__(self,
-                 topic,
-                 payload):
+class FakeMQTTMessage:
+    """Mimics an ``aiomqtt.Message`` (``.topic`` str-able, ``.payload`` bytes).
+
+    ``envelope=True`` wraps the payload in the commlib RPC ``{header, data}``
+    envelope (for command/RPC requests); ``envelope=False`` sends the payload
+    verbatim (for plain pub/sub messages such as external events).
+    """
+
+    def __init__(self, topic: str, payload: Any, envelope: bool = True):
         self.topic = topic
-        fake_payload = {
-            'header': {
-                'reply_to': f"test_reply/{topic}"
-            },
-            'data': payload
-        }
-        self.payload = ujson.dumps(fake_payload)
+        if envelope:
+            payload = {
+                'header': {
+                    'reply_to': f"test_reply/{topic}"
+                },
+                'data': payload
+            }
+        self.payload = ujson.dumps(payload).encode('utf-8')
+
+
+class FakeMQTTClient:
+    """Minimal stand-in for ``aiomqtt.Client`` used as the gateway transport.
+
+    All connection state is delegated to the shared ``FakeMQTTBroker`` so it
+    survives across reconnects (a fresh client is created per ``_run`` cycle).
+    """
+
+    def __init__(self, broker: "FakeMQTTBroker"):
+        self._broker = broker
+
+    async def __aenter__(self) -> "FakeMQTTClient":
+        self._broker._connected = True
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        self._broker._connected = False
+        return False
+
+    async def subscribe(self, topic: str, qos: int = 0, **kwargs):
+        self._broker._subscriptions[topic] = qos
+
+    async def unsubscribe(self, topic: str, **kwargs):
+        self._broker._subscriptions.pop(topic, None)
+
+    async def publish(self, topic: str, payload: Any = None, qos: int = 0, **kwargs):
+        self._broker._record(topic, payload)
+
+    @property
+    def messages(self):
+        return self._message_iterator()
+
+    async def _message_iterator(self):
+        while True:
+            item = await self._broker.incoming.get()
+            if item is _DISCONNECT:
+                raise aiomqtt.MqttError("Simulated broker disconnect")
+            yield item
 
 
 class FakeMQTTBroker:
     def __init__(self):
-        self._transport = None
+        self._connected = False
+        self._subscriptions = {}
+        self._received_msgs = {}
+        self._incoming: Optional[asyncio.Queue] = None
 
-    def create_transport(self, *args, **kwargs):
-        if not self._transport:
-            self._transport = FakeMQTTTransport(*args, **kwargs)
-        return self._transport
+    @property
+    def incoming(self) -> asyncio.Queue:
+        # Created lazily so it binds to the test's current event loop.
+        if self._incoming is None:
+            self._incoming = asyncio.Queue()
+        return self._incoming
 
-    def publish_to_subscription(self, topic, payload):
-        callback = self._transport._subscriptions[topic]
-        msg = FakeMQTTMessage(topic=topic, payload=payload)
-        callback(client=None,
-                 userdata=None,
-                 msg=msg)
+    def create_client(self, *args, **kwargs) -> FakeMQTTClient:
+        return FakeMQTTClient(self)
+
+    def _record(self, topic: str, payload: Any):
+        if isinstance(payload, (bytes, bytearray)):
+            payload = payload.decode('utf-8')
+        if isinstance(payload, str):
+            payload = ujson.loads(payload)
+        logging.info(f"\nFakeMQTT publish on\n> {topic}\n     {payload}\n")
+        if not self._received_msgs.get(topic):
+            self._received_msgs[topic] = []
+        self._received_msgs[topic].append(payload)
+
+    def publish_to_subscription(self, topic: str, payload: Any):
+        """Inject an inbound RPC request (wrapped in the commlib envelope)."""
+        self.incoming.put_nowait(FakeMQTTMessage(topic=topic, payload=payload))
+
+    def publish_event(self, topic: str, payload: Any):
+        """Inject a plain inbound pub/sub message (e.g. an external event)."""
+        self.incoming.put_nowait(FakeMQTTMessage(topic=topic, payload=payload, envelope=False))
+
+    def inject_disconnect(self):
+        """Force the in-flight message iterator to raise ``MqttError``."""
+        self.incoming.put_nowait(_DISCONNECT)
+
+    @property
+    def is_connected(self) -> bool:
+        return self._connected
 
     @property
     def subscriptions(self):
-        return self._transport._subscriptions
+        return self._subscriptions
 
     @property
     def received_msgs(self):
-        return self._transport._received_msgs
+        return self._received_msgs
 
-    def is_msg_received(self, topic, content=None, msg_key = 'msg'):
+    def is_msg_received(self, topic, content=None, msg_key='msg'):
         msg_found = False
         if topic in self.received_msgs:
             if not content:
@@ -56,50 +132,7 @@ class FakeMQTTBroker:
         return msg_found
 
     def clear(self):
-        if self._transport is not None:
-            self._transport._received_msgs = {}
-            self._transport._subscriptions = {}
-
-
-class FakeMQTTTransport:
-
-    def __init__(self, *args, **kwargs):
-        self._subscriptions = {}
         self._received_msgs = {}
+        self._subscriptions = {}
         self._connected = False
-
-    @property
-    def is_connected(self) -> bool:
-        return self._connected
-
-    # def on_connect(self, *args, **kwargs):
-    #     pass
-
-    # def on_disconnect(self, *args, **kwargs):
-    #     pass
-
-    # def on_message(self, *args, **kwargs):
-    #     pass
-
-    def publish(self, topic: str, payload: Dict[str, Any], qos: Any = "", retain: bool = False):
-        logging.info(f"\nFakeMQTT publish on\n> {topic}\n     {payload}\n")
-        payload = ujson.loads(JSONSerializer.serialize(payload))
-        if not self._received_msgs.get(topic):
-            self._received_msgs[topic] = []
-        self._received_msgs[topic].append(payload)
-
-    def subscribe(self, topic: str, callback: Any, *args, **kwargs):
-        self._subscriptions[topic] = callback
-        return topic
-
-    def start(self):
-        self._connected = True
-
-    def connect(self):
-        self._connected = True
-
-    def stop(self):
-        self._connected = False
-
-    def loop_forever(self):
-        self.start()
+        self._incoming = None


### PR DESCRIPTION
## What

Replaces `commlib-py==0.11.5` with `aiomqtt>=2.0.0` across the whole MQTT bridge (`hummingbot/remote_iface/`). `MQTTGateway` no longer inherits `commlib.node.Node`; it owns an `aiomqtt.Client` driven by a single connect/reconnect loop that lives entirely on `hb_app.ev_loop`.

## Why

Today commlib runs paho in its own thread and a broker disconnect raises an **uncatchable** `ConnectionError` from that network thread. With aiomqtt the disconnect surfaces as a catchable `aiomqtt.MqttError` in the event loop, so the bridge reconnects on its own — and the entire home-grown health/restart machinery (`_monitor_health_loop`, `_restart_gateway`, `_check_connections`, `_restarting`/`_health` flags, the paho thread, and `__del__`) is deleted.

## How

- **Transport**: one async `_run()` loop (`async with aiomqtt.Client(...)` + `try/except aiomqtt.MqttError`), mirroring the already-proven client in `hummingbot-api`.
- **Publishers** (notifier, status, log handler, market-event forwarder, `ETopic*`) enqueue onto a thread-safe outgoing queue drained on the loop — no more cross-thread `asyncio.get_event_loop()`/`__del__` publishing.
- **RPC** requests dispatch via `run_in_executor` (handlers use `call_sync` and would deadlock on the loop); the 8 `_on_cmd_*` handlers are **unchanged**.
- **Wire format preserved byte-for-byte**: commlib's `make_primitives` serialization and the `RPCService` reply envelope are ported verbatim; external `event/*` is subscribed as MQTT `#`; heartbeat `ts` stays in microseconds. Existing commlib consumers and the new aiomqtt hummingbot-api client keep working with no changes.
- `messages.py` drops `commlib.msg` for local pydantic `PubSubMessage`/`RPCMessage` bases with identical fields/defaults.
- Folds `PERF-001` (hoist the `event_types` dict) and `CORR-007` (recurse into lists in the event payload); subsumes the code behind `ARCH-001/002`, `CORR-001/002/003/004/006/008`, and `CORR-005`.

## Public surface

Unchanged: `MQTTGateway`, its `.start()/.stop()/.health/.main()`, `start_market_events_fw()`, `broadcast_status_update()`, the external-event listeners, and every factory (`ETopicPublisher`, `EMTopicPublisher`, `ExternalTopicFactory`, `ExternalEventFactory`, …). Consumers (`strategy_v2_base`, `ai_livestream`, `external_events_example`) need no changes.

## Tests

- Rewrote the bridge tests against an aiomqtt-shaped fake injected through the new `MQTTGateway._create_client` seam.
- New coverage: reconnect-on-`MqttError`, the commlib-compatible RPC response envelope, cross-thread publish, heartbeat, and external-event message wrapping.
- `remote_iface` coverage: `mqtt.py` 88%, `messages.py` 100%; 44/44 MQTT tests pass; `pre-commit` clean.

## Note on dependencies

aiomqtt 2.x bumps `paho-mqtt` to 2.x. No hummingbot module imports `paho` directly. A live round-trip against a real broker + the hummingbot-api consumer is recommended before merge to fully close the wire-compat risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)