### PR TITLE
feat: default rate oracle source to gate_io instead of binance

### DIFF
--- a/hummingbot/client/config/client_config_map.py
+++ b/hummingbot/client/config/client_config_map.py
@@ -826,7 +826,7 @@ class ClientConfigMap(BaseClientModel):
         json_schema_extra={"prompt": lambda cm: f"Select the desired metrics mode ({'/'.join(list(METRICS_MODES.keys()))})"},
     )
     rate_oracle_source: Union[tuple(RATE_SOURCE_MODES.values())] = Field(
-        default=BinanceRateSourceMode(),
+        default=GateIoRateSourceMode(),
         description=f"A source for rate oracle, currently {', '.join(RATE_SOURCE_MODES.keys())}",
         json_schema_extra={"prompt": lambda cm: f"Select the desired rate oracle source ({'/'.join(RATE_SOURCE_MODES.keys())})"},
     )

--- a/hummingbot/core/rate_oracle/rate_oracle.py
+++ b/hummingbot/core/rate_oracle/rate_oracle.py
@@ -80,7 +80,7 @@ class RateOracle(NetworkBase):
 
     def __init__(self, source: Optional[RateSourceBase] = None, quote_token: Optional[str] = None):
         super().__init__()
-        self._source: RateSourceBase = source if source is not None else BinanceRateSource()
+        self._source: RateSourceBase = source if source is not None else GateIoRateSource()
         self._prices: Dict[str, Decimal] = {}
         self._fetch_price_task: Optional[asyncio.Task] = None
         self._ready_event = asyncio.Event()

--- a/test/hummingbot/client/command/test_config_command.py
+++ b/test/hummingbot/client/command/test_config_command.py
@@ -75,7 +75,7 @@ class ConfigCommandTest(IsolatedAsyncioWrapperTestCase):
                            "    | ∟ gateway_api_host                | localhost            |\n"
                            "    | ∟ gateway_api_port                | 15888                |\n"
                            "    | ∟ gateway_use_ssl                 | False                |\n"
-                           "    | rate_oracle_source                | binance              |\n"
+                           "    | rate_oracle_source                | gate_io              |\n"
                            "    | global_token                      |                      |\n"
                            "    | ∟ global_token_name               | USDT                 |\n"
                            "    | ∟ global_token_symbol             | $                    |\n"


### PR DESCRIPTION
## Summary

Change the default `rate_oracle_source` from `binance` to `gate_io` in both places the default is materialized:

- `client_config_map.py` — `rate_oracle_source` field default (`BinanceRateSourceMode()` → `GateIoRateSourceMode()`)
- `rate_oracle.py` — `RateOracle.__init__` fallback source when none is injected

## Rationale

Binance's API returns HTTP 451 from geo-restricted locations (including the US). With the current default, a bot instance trading a USDC-quoted pair can't convert USDC→USDT, so:

- **Anonymized trade-volume metrics are never reported**: `TradeVolumeMetricCollector.collect_metrics` skips any fill it can't value via the oracle and only dispatches when total volume > 0 — so the bot trades but reports nothing, silently.
- Any other oracle-dependent valuation (PNL conversion, portfolio value) fails the same way, with only debug-level logging.

Gate.io is globally accessible and lists the same USDT conversion pairs (USDC-USDT etc.), so conversions keep working out of the box regardless of where the bot runs.

Users with an explicit `rate_oracle_source` in `conf_client.yml` are unaffected — this only changes the default for fresh configs and the no-arg `RateOracle()` fallback.

Companion PR for the API server defaults: hummingbot/hummingbot-api#175

## Test plan

- Reproduced from a Binance-geo-blocked location: with the binance default, every oracle request fails with HTTP 451 and a bot filling BP-USDC orders on Backpack reported no volume metrics; with gate_io, USDC-USDT resolves and volume dispatches.
- Existing rate oracle tests pass (they inject their own sources; none assert the binance default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)