### PR TITLE
Fix/ fix LP executor get_net_pnl_pct return value to conform with other executor

### DIFF
--- a/hummingbot/strategy_v2/executors/lp_executor/lp_executor.py
+++ b/hummingbot/strategy_v2/executors/lp_executor/lp_executor.py
@@ -1050,7 +1050,7 @@ class LPExecutor(ExecutorBase):
         return pnl_in_quote - tx_fee_quote
 
     def get_net_pnl_pct(self) -> Decimal:
-        """Returns net P&L as percentage of initial investment.
+        """Returns net P&L ratio relative to initial investment.
 
         Both P&L and initial value are in quote currency.
         Falls back to config values if initial amounts not yet set.
@@ -1079,7 +1079,7 @@ class LPExecutor(ExecutorBase):
         if initial_value_quote == Decimal("0"):
             return Decimal("0")
 
-        return (pnl_quote / initial_value_quote) * Decimal("100")
+        return pnl_quote / initial_value_quote
 
     def get_cum_fees_quote(self) -> Decimal:
         """

--- a/test/hummingbot/client/command/test_config_command.py
+++ b/test/hummingbot/client/command/test_config_command.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from pydantic import Field
 
+from hummingbot.client.config.client_config_map import ClientConfigMap
 from hummingbot.client.config.config_data_types import BaseClientModel
 from hummingbot.client.config.config_helpers import ClientConfigAdapter, read_system_configs_from_yml
 from hummingbot.client.config.config_var import ConfigVar
@@ -19,7 +20,7 @@ class ConfigCommandTest(IsolatedAsyncioWrapperTestCase):
     @patch("hummingbot.client.hummingbot_application.HummingbotApplication.mqtt_start")
     async def asyncSetUp(self, mock_mqtt_start, mock_gateway_start, mock_trading_pair_fetcher):
         await read_system_configs_from_yml()
-        self.app = HummingbotApplication()
+        self.app = HummingbotApplication(client_config_map=ClientConfigAdapter(ClientConfigMap()))
         self.cli_mock_assistant = CLIMockingAssistant(self.app.app)
         self.cli_mock_assistant.start()
 
@@ -79,9 +80,9 @@ class ConfigCommandTest(IsolatedAsyncioWrapperTestCase):
                            "    | global_token                      |                      |\n"
                            "    | ∟ global_token_name               | USDT                 |\n"
                            "    | ∟ global_token_symbol             | $                    |\n"
-                           "    | rate_limits_share_pct             | 100.0                  |\n"
+                           "    | rate_limits_share_pct             | 100                  |\n"
                            "    | commands_timeout                  |                      |\n"
-                           "    | ∟ create_command_timeout          | 10.0                   |\n"
+                           "    | ∟ create_command_timeout          | 10                   |\n"
                            "    | ∟ other_commands_timeout          | 30.0                 |\n"
                            "    | tables_format                     | psql                 |\n"
                            "    | tick_size                         | 1.0                  |\n"

--- a/test/hummingbot/client/command/test_config_command.py
+++ b/test/hummingbot/client/command/test_config_command.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from pydantic import Field
 
+from hummingbot.client.config.client_config_map import ClientConfigMap
 from hummingbot.client.config.config_data_types import BaseClientModel
 from hummingbot.client.config.config_helpers import ClientConfigAdapter, read_system_configs_from_yml
 from hummingbot.client.config.config_var import ConfigVar
@@ -19,7 +20,7 @@ class ConfigCommandTest(IsolatedAsyncioWrapperTestCase):
     @patch("hummingbot.client.hummingbot_application.HummingbotApplication.mqtt_start")
     async def asyncSetUp(self, mock_mqtt_start, mock_gateway_start, mock_trading_pair_fetcher):
         await read_system_configs_from_yml()
-        self.app = HummingbotApplication()
+        self.app = HummingbotApplication(client_config_map=ClientConfigAdapter(ClientConfigMap()))
         self.cli_mock_assistant = CLIMockingAssistant(self.app.app)
         self.cli_mock_assistant.start()
 
@@ -79,9 +80,9 @@ class ConfigCommandTest(IsolatedAsyncioWrapperTestCase):
                            "    | global_token                      |                      |\n"
                            "    | ∟ global_token_name               | USDT                 |\n"
                            "    | ∟ global_token_symbol             | $                    |\n"
-                           "    | rate_limits_share_pct             | 100.0                |\n"
+                           "    | rate_limits_share_pct             | 100                  |\n"
                            "    | commands_timeout                  |                      |\n"
-                           "    | ∟ create_command_timeout          | 10.0                 |\n"
+                           "    | ∟ create_command_timeout          | 10                   |\n"
                            "    | ∟ other_commands_timeout          | 30.0                 |\n"
                            "    | tables_format                     | psql                 |\n"
                            "    | tick_size                         | 1.0                  |\n"

--- a/test/hummingbot/client/command/test_config_command.py
+++ b/test/hummingbot/client/command/test_config_command.py
@@ -6,7 +6,6 @@ from unittest.mock import patch
 
 from pydantic import Field
 
-from hummingbot.client.config.client_config_map import ClientConfigMap
 from hummingbot.client.config.config_data_types import BaseClientModel
 from hummingbot.client.config.config_helpers import ClientConfigAdapter, read_system_configs_from_yml
 from hummingbot.client.config.config_var import ConfigVar
@@ -20,7 +19,7 @@ class ConfigCommandTest(IsolatedAsyncioWrapperTestCase):
     @patch("hummingbot.client.hummingbot_application.HummingbotApplication.mqtt_start")
     async def asyncSetUp(self, mock_mqtt_start, mock_gateway_start, mock_trading_pair_fetcher):
         await read_system_configs_from_yml()
-        self.app = HummingbotApplication(client_config_map=ClientConfigAdapter(ClientConfigMap()))
+        self.app = HummingbotApplication()
         self.cli_mock_assistant = CLIMockingAssistant(self.app.app)
         self.cli_mock_assistant.start()
 
@@ -80,9 +79,9 @@ class ConfigCommandTest(IsolatedAsyncioWrapperTestCase):
                            "    | global_token                      |                      |\n"
                            "    | ∟ global_token_name               | USDT                 |\n"
                            "    | ∟ global_token_symbol             | $                    |\n"
-                           "    | rate_limits_share_pct             | 100                  |\n"
+                           "    | rate_limits_share_pct             | 100.0                |\n"
                            "    | commands_timeout                  |                      |\n"
-                           "    | ∟ create_command_timeout          | 10                   |\n"
+                           "    | ∟ create_command_timeout          | 10.0                 |\n"
                            "    | ∟ other_commands_timeout          | 30.0                 |\n"
                            "    | tables_format                     | psql                 |\n"
                            "    | tick_size                         | 1.0                  |\n"

--- a/test/hummingbot/client/command/test_config_command.py
+++ b/test/hummingbot/client/command/test_config_command.py
@@ -6,7 +6,6 @@ from unittest.mock import patch
 
 from pydantic import Field
 
-from hummingbot.client.config.client_config_map import ClientConfigMap
 from hummingbot.client.config.config_data_types import BaseClientModel
 from hummingbot.client.config.config_helpers import ClientConfigAdapter, read_system_configs_from_yml
 from hummingbot.client.config.config_var import ConfigVar
@@ -20,7 +19,7 @@ class ConfigCommandTest(IsolatedAsyncioWrapperTestCase):
     @patch("hummingbot.client.hummingbot_application.HummingbotApplication.mqtt_start")
     async def asyncSetUp(self, mock_mqtt_start, mock_gateway_start, mock_trading_pair_fetcher):
         await read_system_configs_from_yml()
-        self.app = HummingbotApplication(client_config_map=ClientConfigAdapter(ClientConfigMap()))
+        self.app = HummingbotApplication()
         self.cli_mock_assistant = CLIMockingAssistant(self.app.app)
         self.cli_mock_assistant.start()
 
@@ -80,9 +79,9 @@ class ConfigCommandTest(IsolatedAsyncioWrapperTestCase):
                            "    | global_token                      |                      |\n"
                            "    | ∟ global_token_name               | USDT                 |\n"
                            "    | ∟ global_token_symbol             | $                    |\n"
-                           "    | rate_limits_share_pct             | 100                  |\n"
+                           "    | rate_limits_share_pct             | 100.0                  |\n"
                            "    | commands_timeout                  |                      |\n"
-                           "    | ∟ create_command_timeout          | 10                   |\n"
+                           "    | ∟ create_command_timeout          | 10.0                   |\n"
                            "    | ∟ other_commands_timeout          | 30.0                 |\n"
                            "    | tables_format                     | psql                 |\n"
                            "    | tick_size                         | 1.0                  |\n"

--- a/test/hummingbot/strategy_v2/executors/lp_executor/test_lp_executor.py
+++ b/test/hummingbot/strategy_v2/executors/lp_executor/test_lp_executor.py
@@ -358,8 +358,8 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         executor.lp_position_state.quote_fee = Decimal("1.0")
 
         # Initial = 200, PnL = 2
-        # Pct = (2 / 200) * 100 = 1%
-        self.assertEqual(executor.get_net_pnl_pct(), Decimal("1"))
+        # Pct ratio = 2 / 200 = 0.01 (1%)
+        self.assertEqual(executor.get_net_pnl_pct(), Decimal("0.01"))
 
     def test_get_cum_fees_quote(self):
         """Test get_cum_fees_quote returns tx_fee converted to global token"""
@@ -1132,9 +1132,9 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         executor.lp_position_state.quote_fee = Decimal("1.0")
 
         # Initial = 200, Current = 200, Fees = 2, PnL = 2
-        # Pct = 2/200 * 100 = 1%
+        # Pct ratio = 2 / 200 = 0.01 (1%)
         pct = executor.get_net_pnl_pct()
-        self.assertEqual(pct, Decimal("1"))
+        self.assertEqual(pct, Decimal("0.01"))
 
     def test_get_net_pnl_pct_no_price_with_nonzero_pnl(self):
         """Test get_net_pnl_pct returns 0 when no price but pnl would be non-zero"""


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] Tests all pass
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
- Fixed LP executor `net_pnl_pct` to return a ratio instead of whole percentage points, conforming with other executor return types.
