### PR TITLE
fix: pass position_close to PerpetualOrderCandidate in budget validation (#8305)

### DIFF
--- a/hummingbot/strategy_v2/executors/order_executor/order_executor.py
+++ b/hummingbot/strategy_v2/executors/order_executor/order_executor.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 from typing import Dict, Optional, Union
 
 from hummingbot.connector.connector_base import ConnectorBase
-from hummingbot.core.data_type.common import OrderType, PriceType, TradeType
+from hummingbot.core.data_type.common import OrderType, PositionAction, PriceType, TradeType
 from hummingbot.core.data_type.order_candidate import OrderCandidate, PerpetualOrderCandidate
 from hummingbot.core.event.events import (
     BuyOrderCompletedEvent,
@@ -349,6 +349,7 @@ class OrderExecutor(ExecutorBase):
                 amount=self.config.amount,
                 price=price_for_validation,
                 leverage=Decimal(self.config.leverage),
+                position_close=self.config.position_action == PositionAction.CLOSE,
             )
         else:
             order_candidate = OrderCandidate(

--- a/test/hummingbot/strategy_v2/executors/order_executor/test_order_executor.py
+++ b/test/hummingbot/strategy_v2/executors/order_executor/test_order_executor.py
@@ -375,6 +375,45 @@ class TestOrderExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         self.assertEqual(executor.close_type, CloseType.INSUFFICIENT_BALANCE)
         self.assertEqual(executor.status, RunnableStatus.TERMINATED)
 
+    @patch.object(OrderExecutor, 'current_market_price', new_callable=PropertyMock)
+    @patch.object(OrderExecutor, 'get_trading_rules')
+    @patch.object(OrderExecutor, 'adjust_order_candidates')
+    async def test_validate_sufficient_balance_perpetual_sets_position_close(
+            self, mock_adjust_order_candidates, mock_get_trading_rules, mock_current_market_price):
+        # Regression for #8314: the PerpetualOrderCandidate built for balance validation must carry
+        # position_close reflecting the executor's position_action, else a CLOSE order is budget-
+        # validated as if it were OPENING a position (wrong margin requirement).
+        from hummingbot.core.data_type.common import PositionAction
+
+        trading_rules = TradingRule(trading_pair="ETH-USDT", min_order_size=Decimal("0.1"),
+                                    min_price_increment=Decimal("0.1"), min_base_amount_increment=Decimal("0.1"))
+        mock_get_trading_rules.return_value = trading_rules
+        mock_current_market_price.return_value = Decimal("100")
+
+        for action, expected_close in [(PositionAction.CLOSE, True), (PositionAction.OPEN, False)]:
+            config = OrderExecutorConfig(
+                id="test",
+                timestamp=123,
+                side=TradeType.BUY,
+                connector_name="binance_perpetual",
+                trading_pair="ETH-USDT",
+                amount=Decimal("1"),
+                price=Decimal("100"),
+                execution_strategy=ExecutionStrategy.MARKET,
+                position_action=action,
+            )
+            executor = self.get_order_executor_from_config(config)
+            mock_adjust_order_candidates.return_value = [OrderCandidate(
+                trading_pair="ETH-USDT", is_maker=True, order_type=OrderType.LIMIT,
+                order_side=TradeType.BUY, amount=Decimal("1"), price=Decimal("100"))]
+
+            await executor.validate_sufficient_balance()
+
+            built_candidate = mock_adjust_order_candidates.call_args.args[1][0]
+            self.assertEqual(
+                built_candidate.position_close, expected_close,
+                f"position_close should be {expected_close} for position_action={action}")
+
     @patch.object(OrderExecutor, '_sleep')
     async def test_control_shutdown_process_with_open_order(self, mock_sleep):
         config = OrderExecutorConfig(


### PR DESCRIPTION
## Summary
Fixes #8305. `OrderExecutor.validate_sufficient_balance()` builds the `PerpetualOrderCandidate` without `position_close=True` when the executor config has `position_action=PositionAction.CLOSE`.

## Root cause
`position_close` defaults to `False`, so the budget checker treats a close order as an *opening* order and requires collateral that a close doesn't need. A valid close executor is then terminated with "Not enough budget to open position", leaving the position open.

## Fix
Pass `position_close=(position_action == PositionAction.CLOSE)` into the `PerpetualOrderCandidate` so the budget check reflects that closing frees collateral rather than requiring it.

## Tests
`test/hummingbot/strategy_v2/executors/order_executor/test_order_executor.py` covers the close-order budget path — fails before the fix, passes after.

---
- [x] Code builds clean with no errors/warnings
- [x] Tests pass
- [x] Title uses an approved prefix (`fix:`)
