### PR TITLE
test: fix flaky cancel test by increasing timeout

### DIFF
--- a/test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_derivative.py
@@ -1591,7 +1591,7 @@ class HyperliquidPerpetualDerivativeTests(AbstractPerpetualDerivativeTests.Perpe
             erroneous_order=order2,
             mock_api=mock_api)
 
-        cancellation_results = self.async_run_with_timeout(self.exchange.cancel_all(10))
+        cancellation_results = self.async_run_with_timeout(self.exchange.cancel_all(10), timeout=15)
 
         for url in urls:
             cancel_request = self._all_executed_requests(mock_api, url)[0]

--- a/test/hummingbot/connector/exchange/hyperliquid/test_hyperliquid_exchange.py
+++ b/test/hummingbot/connector/exchange/hyperliquid/test_hyperliquid_exchange.py
@@ -1325,7 +1325,7 @@ class HyperliquidExchangeTests(AbstractExchangeConnectorTests.ExchangeConnectorT
             erroneous_order=order2,
             mock_api=mock_api)
 
-        cancellation_results = self.async_run_with_timeout(self.exchange.cancel_all(10))
+        cancellation_results = self.async_run_with_timeout(self.exchange.cancel_all(10), timeout=15)
 
         for url in urls:
             cancel_request = self._all_executed_requests(mock_api, url)[0]


### PR DESCRIPTION
**Description**

Fixes random CI failures in `test_cancel_two_orders_with_cancel_all_and_one_fails` that affects multiple PRs (#8317, #8316, #8315, #8313).

**Root cause**

`cancel_all(10)` has a 10-second internal timeout, but the test wrapper `async_run_with_timeout()` defaults to 1 second. This causes premature `CancelledError` → `TimeoutError` before `cancel_all` completes.

**Fix**

Explicitly pass `timeout=15` to `async_run_with_timeout()` in both Hyperliquid spot and perpetual test files, giving `cancel_all` sufficient time to complete.

**Files changed**
- `test/hummingbot/connector/exchange/hyperliquid/test_hyperliquid_exchange.py`
- `test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_derivative.py`

**Tests performed**
- Verified timeout parameter is now 15s (> cancel_all's 10s internal timeout)
- No functional changes to test logic

**Impact**
Should eliminate random CI timeouts affecting unrelated PRs.