### PR TITLE
Feat/improve backpack

### DIFF
--- a/hummingbot/client/config/client_config_map.py
+++ b/hummingbot/client/config/client_config_map.py
@@ -627,6 +627,11 @@ class GateIoRateSourceMode(ExchangeRateSourceModeBase):
     model_config = ConfigDict(title="gate_io")
 
 
+class BackpackRateSourceMode(ExchangeRateSourceModeBase):
+    name: str = Field(default="backpack")
+    model_config = ConfigDict(title="backpack")
+
+
 class DexalotRateSourceMode(ExchangeRateSourceModeBase):
     name: str = Field(default="dexalot")
     model_config = ConfigDict(title="dexalot")
@@ -735,6 +740,7 @@ RATE_SOURCE_MODES = {
     DecibelPerpetualRateSourceMode.model_config["title"]: DecibelPerpetualRateSourceMode,
     KuCoinRateSourceMode.model_config["title"]: KuCoinRateSourceMode,
     GateIoRateSourceMode.model_config["title"]: GateIoRateSourceMode,
+    BackpackRateSourceMode.model_config["title"]: BackpackRateSourceMode,
     CoinbaseAdvancedTradeRateSourceMode.model_config["title"]: CoinbaseAdvancedTradeRateSourceMode,
     CubeRateSourceMode.model_config["title"]: CubeRateSourceMode,
     HyperliquidRateSourceMode.model_config["title"]: HyperliquidRateSourceMode,

--- a/hummingbot/connector/derivative/backpack_perpetual/backpack_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/backpack_perpetual/backpack_perpetual_derivative.py
@@ -69,8 +69,12 @@ class BackpackPerpetualDerivative(PerpetualDerivativePyBase):
         self._leverage_initialized = False
         self._position_mode = None
         super().__init__(balance_asset_limit, rate_limits_share_pct)
-        # Backpack does not provide balance updates through websocket, use REST polling instead
-        self.real_time_balance_update = False
+        # Backpack is cross-margin: collateralQuery already reports netEquityAvailable with the
+        # initial margin (notional * imf) deducted. Keeping real_time_balance_update = True makes
+        # get_available_balance() return that value directly. Setting it to False would route
+        # through apply_balance_update_since_snapshot, which subtracts each order's full quote
+        # notional locally -- double-counting against the margin the exchange already reserved and
+        # under-reporting available balance (root cause of #8168, false "Not enough budget").
 
     @staticmethod
     def backpack_order_type(order_type: OrderType) -> str:
@@ -610,6 +614,7 @@ class BackpackPerpetualDerivative(PerpetualDerivativePyBase):
             try:
                 account_info = await self._api_get(
                     path_url=CONSTANTS.ACCOUNT_PATH_URL,
+                    params={"instruction": "accountQuery"},
                     is_auth_required=True
                 )
                 self._leverage = Decimal(str(account_info.get("leverageLimit", "1")))

--- a/hummingbot/connector/derivative/backpack_perpetual/backpack_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/backpack_perpetual/backpack_perpetual_derivative.py
@@ -69,12 +69,34 @@ class BackpackPerpetualDerivative(PerpetualDerivativePyBase):
         self._leverage_initialized = False
         self._position_mode = None
         super().__init__(balance_asset_limit, rate_limits_share_pct)
-        # Backpack is cross-margin: collateralQuery already reports netEquityAvailable with the
-        # initial margin (notional * imf) deducted. Keeping real_time_balance_update = True makes
-        # get_available_balance() return that value directly. Setting it to False would route
-        # through apply_balance_update_since_snapshot, which subtracts each order's full quote
-        # notional locally -- double-counting against the margin the exchange already reserved and
-        # under-reporting available balance (root cause of #8168, false "Not enough budget").
+        # Backpack exposes no balance websocket stream, so available balance is refreshed only by the
+        # REST collateralQuery poll (~5s). real_time_balance_update = False lets the base class bridge
+        # that gap by locally reserving in-flight orders (apply_balance_update_since_snapshot) until the
+        # next poll. We override in_flight_asset_balances() below so the local reservation matches how a
+        # cross-margin, USDC-settled perpetual actually locks collateral -- the base (spot) implementation
+        # reserves each order's full quote notional (over-reserving longs -> root cause of #8168, false
+        # "Not enough budget") or the base asset for sells (leaving shorts unreserved), neither correct here.
+        self.real_time_balance_update = False
+
+    def in_flight_asset_balances(self, in_flight_orders: Dict[str, InFlightOrder]) -> Dict[str, Decimal]:
+        """
+        Reserve each open order's *initial margin* (notional / leverage) against the USDC collateral,
+        for both buys and sells. Backpack perpetual is cross-margin and USDC-settled, so an order locks
+        only its margin -- not the full notional, and never the base asset. This bridges the ~5s window
+        between collateralQuery polls without the over-/under-reservation of the spot base implementation.
+        """
+        asset_balances: Dict[str, Decimal] = {}
+        if in_flight_orders is None:
+            return asset_balances
+        leverage = self._leverage if self._leverage and self._leverage > 0 else Decimal("1")
+        for order in (o for o in in_flight_orders.values()
+                      if not (o.is_done or o.is_failure or o.is_cancelled)):
+            if order.price is None or not order.price.is_finite():
+                continue
+            outstanding_amount = order.amount - order.executed_amount_base
+            margin = outstanding_amount * order.price / leverage
+            asset_balances[order.quote_asset] = asset_balances.get(order.quote_asset, Decimal("0")) + margin
+        return asset_balances
 
     @staticmethod
     def backpack_order_type(order_type: OrderType) -> str:

--- a/hummingbot/connector/exchange/backpack/backpack_constants.py
+++ b/hummingbot/connector/exchange/backpack/backpack_constants.py
@@ -36,6 +36,7 @@ SERVER_TIME_PATH_URL = "api/v1/time"
 EXCHANGE_INFO_PATH_URL = "api/v1/markets"
 SNAPSHOT_PATH_URL = "api/v1/depth"
 BALANCE_PATH_URL = "api/v1/capital"  # instruction balanceQuery
+BORROW_LEND_POSITIONS_PATH_URL = "api/v1/borrowLend/positions"  # instruction borrowLendPositionQuery
 TICKER_BOOK_PATH_URL = "api/v1/tickers"
 TICKER_PRICE_CHANGE_PATH_URL = "api/v1/ticker"
 ORDER_PATH_URL = "api/v1/order"
@@ -74,6 +75,12 @@ RATE_LIMITS = [
     ),
     RateLimit(
         limit_id=BALANCE_PATH_URL,
+        limit=2000,
+        time_interval=60,
+        linked_limits=[LinkedLimitWeightPair(GLOBAL_RATE_LIMIT)],
+    ),
+    RateLimit(
+        limit_id=BORROW_LEND_POSITIONS_PATH_URL,
         limit=2000,
         time_interval=60,
         linked_limits=[LinkedLimitWeightPair(GLOBAL_RATE_LIMIT)],

--- a/hummingbot/connector/exchange/backpack/backpack_exchange.py
+++ b/hummingbot/connector/exchange/backpack/backpack_exchange.py
@@ -535,10 +535,13 @@ class BackpackExchange(ExchangePyBase):
         local_asset_names = set(self._account_balances.keys())
         remote_asset_names = set()
 
-        account_info = await self._api_get(
-            path_url=CONSTANTS.BALANCE_PATH_URL,
-            params={"instruction": "balanceQuery"},
-            is_auth_required=True)
+        # balanceQuery and borrowLendPositionQuery are independent; fetch them concurrently.
+        account_info, lent_balances = await asyncio.gather(
+            self._api_get(
+                path_url=CONSTANTS.BALANCE_PATH_URL,
+                params={"instruction": "balanceQuery"},
+                is_auth_required=True),
+            self._get_net_lent_balances())
 
         if account_info:
             for asset_name, balance_entry in account_info.items():
@@ -554,7 +557,7 @@ class BackpackExchange(ExchangePyBase):
             # reported only under borrowLend positions. Fold the net lent quantity back in so funds
             # sitting in the lend pool stay visible and usable (Backpack auto-redeems lent collateral
             # when it is needed to back an order).
-            for asset_name, lent_amount in (await self._get_net_lent_balances()).items():
+            for asset_name, lent_amount in lent_balances.items():
                 self._account_available_balances[asset_name] = (
                     self._account_available_balances.get(asset_name, Decimal("0")) + lent_amount)
                 self._account_balances[asset_name] = (

--- a/hummingbot/connector/exchange/backpack/backpack_exchange.py
+++ b/hummingbot/connector/exchange/backpack/backpack_exchange.py
@@ -543,15 +543,55 @@ class BackpackExchange(ExchangePyBase):
         if account_info:
             for asset_name, balance_entry in account_info.items():
                 free_balance = Decimal(balance_entry["available"])
-                total_balance = Decimal(balance_entry["available"]) + Decimal(balance_entry["locked"])
+                total_balance = (Decimal(balance_entry["available"])
+                                 + Decimal(balance_entry["locked"])
+                                 + Decimal(balance_entry.get("staked", "0")))
                 self._account_available_balances[asset_name] = free_balance
                 self._account_balances[asset_name] = total_balance
+                remote_asset_names.add(asset_name)
+
+            # Backpack auto-lends idle funds; the lent amount leaves the `capital` balance and is
+            # reported only under borrowLend positions. Fold the net lent quantity back in so funds
+            # sitting in the lend pool stay visible and usable (Backpack auto-redeems lent collateral
+            # when it is needed to back an order).
+            for asset_name, lent_amount in (await self._get_net_lent_balances()).items():
+                self._account_available_balances[asset_name] = (
+                    self._account_available_balances.get(asset_name, Decimal("0")) + lent_amount)
+                self._account_balances[asset_name] = (
+                    self._account_balances.get(asset_name, Decimal("0")) + lent_amount)
                 remote_asset_names.add(asset_name)
 
             asset_names_to_remove = local_asset_names.difference(remote_asset_names)
             for asset_name in asset_names_to_remove:
                 del self._account_available_balances[asset_name]
                 del self._account_balances[asset_name]
+
+    async def _get_net_lent_balances(self) -> Dict[str, Decimal]:
+        """
+        Returns the net lent quantity per asset from Backpack's borrowLend positions.
+
+        Auto-lent funds are reported here instead of in `capital`. Borrowed positions
+        (negative ``netQuantity``) are margin liabilities and are ignored for spot balance
+        reporting. Best-effort: a failure here must not break the primary balance update.
+        """
+        lent_balances: Dict[str, Decimal] = {}
+        try:
+            positions = await self._api_get(
+                path_url=CONSTANTS.BORROW_LEND_POSITIONS_PATH_URL,
+                params={"instruction": "borrowLendPositionQuery"},
+                is_auth_required=True)
+        except Exception:
+            self.logger().warning(
+                "Could not fetch Backpack borrowLend positions; lent balances may be "
+                "under-reported until the next successful update.", exc_info=True)
+            return lent_balances
+
+        for position in positions or []:
+            net_quantity = Decimal(position.get("netQuantity", "0"))
+            if net_quantity > Decimal("0"):
+                asset_name = position["symbol"]
+                lent_balances[asset_name] = lent_balances.get(asset_name, Decimal("0")) + net_quantity
+        return lent_balances
 
     def _initialize_trading_pair_symbols_from_exchange_info(self, exchange_info: Dict[str, Any]):
         mapping = bidict()

--- a/hummingbot/core/rate_oracle/rate_oracle.py
+++ b/hummingbot/core/rate_oracle/rate_oracle.py
@@ -15,6 +15,7 @@ from hummingbot.core.network_iterator import NetworkStatus
 from hummingbot.core.rate_oracle.sources.aevo_rate_source import AevoRateSource
 from hummingbot.core.rate_oracle.sources.architect_perpetual_rate_source import ArchitectPerpetualRateSource
 from hummingbot.core.rate_oracle.sources.ascend_ex_rate_source import AscendExRateSource
+from hummingbot.core.rate_oracle.sources.backpack_rate_source import BackpackRateSource
 from hummingbot.core.rate_oracle.sources.binance_rate_source import BinanceRateSource
 from hummingbot.core.rate_oracle.sources.coin_cap_rate_source import CoinCapRateSource
 from hummingbot.core.rate_oracle.sources.coin_gecko_rate_source import CoinGeckoRateSource
@@ -37,6 +38,7 @@ from hummingbot.logger import HummingbotLogger
 
 RATE_ORACLE_SOURCES = {
     "aevo_perpetual": AevoRateSource,
+    "backpack": BackpackRateSource,
     "binance": BinanceRateSource,
     "coin_gecko": CoinGeckoRateSource,
     "coin_cap": CoinCapRateSource,

--- a/hummingbot/core/rate_oracle/sources/backpack_rate_source.py
+++ b/hummingbot/core/rate_oracle/sources/backpack_rate_source.py
@@ -1,0 +1,82 @@
+from decimal import Decimal
+from typing import TYPE_CHECKING, Dict, Optional
+
+from hummingbot.connector.utils import split_hb_trading_pair
+from hummingbot.core.rate_oracle.sources.rate_source_base import RateSourceBase
+from hummingbot.core.utils import async_ttl_cache
+
+if TYPE_CHECKING:
+    from hummingbot.connector.exchange.backpack.backpack_exchange import BackpackExchange
+
+
+class BackpackRateSource(RateSourceBase):
+    def __init__(self):
+        super().__init__()
+        self._exchange: Optional[BackpackExchange] = None  # delayed because of circular reference
+
+    @property
+    def name(self) -> str:
+        return "backpack"
+
+    @async_ttl_cache(ttl=30, maxsize=1)
+    async def get_prices(self, quote_token: Optional[str] = None) -> Dict[str, Decimal]:
+        self._ensure_exchange()
+        all_prices: Dict[str, Decimal] = {}
+        try:
+            pairs_prices = await self._exchange.get_all_pairs_prices()
+            for pair_price in pairs_prices:
+                symbol = pair_price["symbol"]
+                # The bulk tickers endpoint mixes spot and perpetual markets; perpetuals carry a
+                # ``_PERP`` suffix (e.g. ``BTC_USDC_PERP``). Skip them so the spot rate source only
+                # exposes spot prices.
+                if symbol.endswith("_PERP"):
+                    continue
+                # Backpack symbols map to Hummingbot pairs by replacing ``_`` with ``-``.
+                trading_pair = self._exchange.trading_pair_associated_to_exchange_symbol(symbol=symbol)
+                last_price = pair_price.get("lastPrice")
+                if last_price is not None and Decimal(str(last_price)) > Decimal("0"):
+                    all_prices[trading_pair] = Decimal(str(last_price))
+        except Exception:
+            self.logger().exception(
+                msg="Unexpected error while retrieving rates from Backpack. Check the log file for more info.",
+            )
+            return {}
+
+        if quote_token is None:
+            return all_prices
+
+        # Backpack quotes almost everything in USDC and has NO USDT spot markets. Most rate sources
+        # simply drop every pair whose quote != quote_token, which would return nothing (and price
+        # everything at 0) whenever the global token is USDT. To keep USD valuations working with
+        # either USDC or USDT as the global token, we additionally keep "bridge" quotes: any token X
+        # for which an X-<quote_token> (or <quote_token>-X) pair exists can be reached, so pairs
+        # quoted in X are retained too. Example: with quote_token=USDT and a USDT-USDC market
+        # present, USDC becomes reachable, so BP-USDC is kept and find_rate() derives BP-USDT from
+        # BP-USDC and USDT-USDC.
+        reachable_quotes = {quote_token}
+        for pair in all_prices:
+            base, quote = split_hb_trading_pair(pair)
+            if base == quote_token:
+                reachable_quotes.add(quote)
+            elif quote == quote_token:
+                reachable_quotes.add(base)
+
+        return {
+            pair: price for pair, price in all_prices.items()
+            if split_hb_trading_pair(pair)[1] in reachable_quotes
+        }
+
+    def _ensure_exchange(self):
+        if self._exchange is None:
+            self._exchange = self._build_backpack_connector_without_private_keys()
+
+    @staticmethod
+    def _build_backpack_connector_without_private_keys() -> 'BackpackExchange':
+        from hummingbot.connector.exchange.backpack.backpack_exchange import BackpackExchange
+
+        return BackpackExchange(
+            backpack_api_key="",
+            backpack_api_secret="",
+            trading_pairs=[],
+            trading_required=False,
+        )

--- a/hummingbot/strategy/perpetual_market_making/perpetual_market_making.py
+++ b/hummingbot/strategy/perpetual_market_making/perpetual_market_making.py
@@ -370,17 +370,17 @@ class PerpetualMarketMakingStrategy(StrategyPyBase):
     def active_positions_df(self) -> pd.DataFrame:
         columns = ["Symbol", "Type", "Entry Price", "Amount", "Leverage", "Unrealized PnL"]
         data = []
-        market, trading_pair = self._market_info.market, self._market_info.trading_pair
         for idx in self.active_positions.values():
-            is_buy = True if idx.amount > 0 else False
-            unrealized_profit = ((market.get_price(trading_pair, is_buy) - idx.entry_price) * idx.amount)
+            # Use the connector-reported unrealized PnL instead of recomputing it. The previous
+            # recompute mispriced every position with this strategy's trading_pair (wrong for any
+            # position in another pair) and lost the sign for shorts (amount is stored as abs()).
             data.append([
                 idx.trading_pair,
                 idx.position_side.name,
                 idx.entry_price,
                 idx.amount,
                 idx.leverage,
-                unrealized_profit
+                idx.unrealized_pnl
             ])
 
         return pd.DataFrame(data=data, columns=columns)

--- a/test/hummingbot/connector/derivative/backpack_perpetual/test_backpack_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/backpack_perpetual/test_backpack_perpetual_derivative.py
@@ -905,35 +905,43 @@ class BackpackPerpetualDerivativeUnitTest(IsolatedAsyncioWrapperTestCase):
         self.assertEqual(Decimal("151.0"), total_balances[CONSTANTS.CURRENCY])
 
     @aioresponses()
-    async def test_available_balance_is_not_double_counted_against_margin(self, mock_api):
-        """Regression for #8168. Backpack is cross-margin: netEquityAvailable already has the
-        initial margin deducted. get_available_balance() must return that value as-is and must NOT
-        subtract an open order's notional on top (which real_time_balance_update=False would do)."""
-        # Cross-margin invariant must hold so the connector relies on the exchange's number.
-        self.assertTrue(self.exchange.real_time_balance_update)
+    async def test_in_flight_order_reserves_margin_not_full_notional(self, mock_api):
+        """Regression for #8168. Backpack has no balance websocket stream, so real_time_balance_update
+        is False and the base class locally reserves in-flight orders between REST polls. Because the
+        market is cross-margin and USDC-settled, in_flight_asset_balances() must reserve only the order's
+        initial margin (notional / leverage) against USDC -- NOT the full quote notional (the spot base
+        behaviour that over-reserved longs and triggered the false "Not enough budget" of #8168)."""
+        # No balance websocket -> local in-flight reservation must be active.
+        self.assertFalse(self.exchange.real_time_balance_update)
+        self.exchange._leverage = Decimal("10")
+        self.exchange._leverage_initialized = True
 
         url = web_utils.private_rest_url(CONSTANTS.BALANCE_PATH_URL, domain=self.domain)
         regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
         response = {
             "netEquity": "229.40",
-            "netEquityAvailable": "224.41",  # = netEquity - notional*imf (already margin-net)
+            "netEquityAvailable": "224.41",
         }
         mock_api.get(regex_url, body=json.dumps(response))
         await self.exchange._update_balances()
 
-        # Even with a large open BUY order in flight, available must equal netEquityAvailable.
         self.exchange.start_tracking_order(
-            order_id="OID-DOUBLE-COUNT",
+            order_id="OID-MARGIN",
             exchange_order_id="EID-1",
             trading_pair="SOL-USDC",
-            order_type=OrderType.MARKET,
+            order_type=OrderType.LIMIT,
             trade_type=TradeType.BUY,
             price=Decimal("69.5"),
-            amount=Decimal("2.87"),  # ~200 USDC notional
+            amount=Decimal("2.87"),  # 199.465 USDC notional -> 19.9465 margin at 10x
             position_action=PositionAction.OPEN,
         )
 
-        self.assertEqual(Decimal("224.41"), self.exchange.get_available_balance(CONSTANTS.CURRENCY))
+        notional = Decimal("2.87") * Decimal("69.5")
+        margin = notional / Decimal("10")
+        # Available reflects only the margin reservation...
+        self.assertEqual(Decimal("224.41") - margin, self.exchange.get_available_balance(CONSTANTS.CURRENCY))
+        # ...and explicitly NOT the full-notional over-deduction that caused #8168.
+        self.assertNotEqual(Decimal("224.41") - notional, self.exchange.get_available_balance(CONSTANTS.CURRENCY))
 
     async def test_user_stream_logs_errors(self):
         mock_user_stream = AsyncMock()

--- a/test/hummingbot/connector/derivative/backpack_perpetual/test_backpack_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/backpack_perpetual/test_backpack_perpetual_derivative.py
@@ -904,6 +904,37 @@ class BackpackPerpetualDerivativeUnitTest(IsolatedAsyncioWrapperTestCase):
         self.assertEqual(Decimal("100.5"), available_balances[CONSTANTS.CURRENCY])
         self.assertEqual(Decimal("151.0"), total_balances[CONSTANTS.CURRENCY])
 
+    @aioresponses()
+    async def test_available_balance_is_not_double_counted_against_margin(self, mock_api):
+        """Regression for #8168. Backpack is cross-margin: netEquityAvailable already has the
+        initial margin deducted. get_available_balance() must return that value as-is and must NOT
+        subtract an open order's notional on top (which real_time_balance_update=False would do)."""
+        # Cross-margin invariant must hold so the connector relies on the exchange's number.
+        self.assertTrue(self.exchange.real_time_balance_update)
+
+        url = web_utils.private_rest_url(CONSTANTS.BALANCE_PATH_URL, domain=self.domain)
+        regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
+        response = {
+            "netEquity": "229.40",
+            "netEquityAvailable": "224.41",  # = netEquity - notional*imf (already margin-net)
+        }
+        mock_api.get(regex_url, body=json.dumps(response))
+        await self.exchange._update_balances()
+
+        # Even with a large open BUY order in flight, available must equal netEquityAvailable.
+        self.exchange.start_tracking_order(
+            order_id="OID-DOUBLE-COUNT",
+            exchange_order_id="EID-1",
+            trading_pair="SOL-USDC",
+            order_type=OrderType.MARKET,
+            trade_type=TradeType.BUY,
+            price=Decimal("69.5"),
+            amount=Decimal("2.87"),  # ~200 USDC notional
+            position_action=PositionAction.OPEN,
+        )
+
+        self.assertEqual(Decimal("224.41"), self.exchange.get_available_balance(CONSTANTS.CURRENCY))
+
     async def test_user_stream_logs_errors(self):
         mock_user_stream = AsyncMock()
         account_update = self._get_account_update_ws_event_single_position_dict()
@@ -1186,6 +1217,28 @@ class BackpackPerpetualDerivativeUnitTest(IsolatedAsyncioWrapperTestCase):
         # Both should return values from trading rules
         self.assertIsNotNone(buy_collateral)
         self.assertIsNotNone(sell_collateral)
+
+    @aioresponses()
+    async def test_leverage_initialization_signs_account_query(self, req_mock):
+        """The GET /api/v1/account request must be signed with the ``accountQuery`` instruction,
+        otherwise Backpack rejects it with 'Invalid signature' (regression for the leverage fetch).
+        """
+        self._simulate_trading_rules_initialized()
+
+        url = web_utils.private_rest_url(CONSTANTS.ACCOUNT_PATH_URL, domain=self.domain)
+        regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
+        req_mock.get(regex_url, body=json.dumps({"leverageLimit": "5"}), status=200)
+
+        await self.exchange._initialize_leverage_if_needed()
+
+        self.assertTrue(self.exchange._leverage_initialized)
+        self.assertEqual(Decimal("5"), self.exchange._leverage)
+
+        # The request must be signed; the instruction is folded into the signature and must NOT
+        # leak as a plain query param.
+        request = next(iter(req_mock.requests.values()))[0]
+        self.assertIn("X-Signature", request.kwargs["headers"])
+        self.assertNotIn("instruction", request.kwargs.get("params") or {})
 
     @aioresponses()
     async def test_leverage_initialization_failure(self, req_mock):

--- a/test/hummingbot/connector/exchange/backpack/test_backpack_exchange.py
+++ b/test/hummingbot/connector/exchange/backpack/test_backpack_exchange.py
@@ -965,6 +965,91 @@ class BackpackExchangeTests(AbstractExchangeConnectorTests.ExchangeConnectorTest
         self.assertEqual(Decimal("90"), available_balances["SOL"])
         self.assertEqual(Decimal("100"), total_balances["SOL"])
 
+    @aioresponses()
+    def test_update_balances_includes_staked_in_total(self, mock_api):
+        """
+        Test that _update_balances counts the `staked` field (funds in staking/auto-lend)
+        towards the total balance. On Backpack, idle USDC is auto-lent and reported under
+        `staked`; ignoring it would under-report (or hide) the balance.
+        """
+        url = self.balance_url
+        response = {
+            "USDC": {
+                "available": "100.0",
+                "locked": "10.0",
+                "staked": "890.0"
+            }
+        }
+
+        mock_api.get(url, body=json.dumps(response))
+
+        self.async_run_with_timeout(self.exchange._update_balances())
+
+        available_balances = self.exchange.available_balances
+        total_balances = self.exchange.get_all_balances()
+
+        # available reflects only the operable funds
+        self.assertEqual(Decimal("100.0"), available_balances["USDC"])
+        # total includes available + locked + staked
+        self.assertEqual(Decimal("1000.0"), total_balances["USDC"])
+
+    @aioresponses()
+    def test_update_balances_folds_in_auto_lent_funds(self, mock_api):
+        """
+        Backpack auto-lends idle funds, which leave the `capital` balance and are reported only
+        under borrowLend positions. _update_balances must fold the net lent quantity back into the
+        balance so the funds remain visible/usable. Borrowed positions (negative netQuantity) are
+        ignored.
+        """
+        capital_url = self.balance_url
+        capital_response = {
+            "USDC": {
+                "available": "50.0",
+                "locked": "0.0",
+                "staked": "0.0"
+            }
+        }
+        mock_api.get(capital_url, body=json.dumps(capital_response))
+
+        lend_url = web_utils.private_rest_url(
+            CONSTANTS.BORROW_LEND_POSITIONS_PATH_URL, domain=self.exchange._domain)
+        lend_response = [
+            {"symbol": "USDC", "netQuantity": "950.0"},   # lent -> should be added
+            {"symbol": "SOL", "netQuantity": "-2.0"},     # borrowed -> should be ignored
+        ]
+        mock_api.get(lend_url, body=json.dumps(lend_response))
+
+        self.async_run_with_timeout(self.exchange._update_balances())
+
+        available_balances = self.exchange.available_balances
+        total_balances = self.exchange.get_all_balances()
+
+        # 50 spot available + 950 lent = 1000, both in available and total
+        self.assertEqual(Decimal("1000.0"), available_balances["USDC"])
+        self.assertEqual(Decimal("1000.0"), total_balances["USDC"])
+        # borrowed position must not create a phantom balance
+        self.assertNotIn("SOL", total_balances)
+
+    @aioresponses()
+    def test_update_balances_survives_borrow_lend_failure(self, mock_api):
+        """
+        A failure fetching borrowLend positions must not break the primary balance update;
+        the capital balances should still be applied.
+        """
+        capital_url = self.balance_url
+        capital_response = {
+            "USDC": {"available": "123.0", "locked": "0.0", "staked": "0.0"}
+        }
+        mock_api.get(capital_url, body=json.dumps(capital_response))
+
+        lend_url = web_utils.private_rest_url(
+            CONSTANTS.BORROW_LEND_POSITIONS_PATH_URL, domain=self.exchange._domain)
+        mock_api.get(lend_url, status=500, body=json.dumps({"message": "boom"}))
+
+        self.async_run_with_timeout(self.exchange._update_balances())
+
+        self.assertEqual(Decimal("123.0"), self.exchange.get_all_balances()["USDC"])
+
     def test_user_stream_update_with_missing_client_order_id(self):
         """
         Test that websocket updates work correctly when client_order_id field is missing (None).

--- a/test/hummingbot/core/rate_oracle/sources/test_backpack_rate_source.py
+++ b/test/hummingbot/core/rate_oracle/sources/test_backpack_rate_source.py
@@ -1,0 +1,72 @@
+import json
+from decimal import Decimal
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+
+from aioresponses import aioresponses
+
+from hummingbot.connector.exchange.backpack import backpack_constants as CONSTANTS, backpack_web_utils as web_utils
+from hummingbot.core.rate_oracle.sources.backpack_rate_source import BackpackRateSource
+
+
+class BackpackRateSourceTest(IsolatedAsyncioWrapperTestCase):
+    def setup_backpack_responses(self, mock_api):
+        url = web_utils.public_rest_url(path_url=CONSTANTS.TICKER_BOOK_PATH_URL)
+        tickers_response = [
+            {"symbol": "BP_USDC", "lastPrice": "0.5905"},
+            {"symbol": "BTC_USDC", "lastPrice": "62984.1"},
+            {"symbol": "USDT_USDC", "lastPrice": "0.999"},
+            # Perpetual market must be ignored by the (spot) rate source.
+            {"symbol": "BTC_USDC_PERP", "lastPrice": "62980.0"},
+            # Empty/zero prices must be ignored.
+            {"symbol": "DEAD_USDC", "lastPrice": "0"},
+        ]
+        mock_api.get(url, body=json.dumps(tickers_response))
+
+    @aioresponses()
+    async def test_get_prices_without_quote_token_returns_all_spot(self, mock_api):
+        self.setup_backpack_responses(mock_api=mock_api)
+
+        prices = await BackpackRateSource().get_prices()
+
+        self.assertEqual(Decimal("0.5905"), prices["BP-USDC"])
+        self.assertEqual(Decimal("62984.1"), prices["BTC-USDC"])
+        self.assertEqual(Decimal("0.999"), prices["USDT-USDC"])
+        # Perpetual and zero price are always excluded.
+        self.assertNotIn("BTC-USDC-PERP", prices)
+        self.assertFalse(any("PERP" in pair.upper() for pair in prices))
+        self.assertNotIn("DEAD-USDC", prices)
+
+    @aioresponses()
+    async def test_get_prices_with_usdc_quote(self, mock_api):
+        self.setup_backpack_responses(mock_api=mock_api)
+
+        prices = await BackpackRateSource().get_prices(quote_token="USDC")
+
+        self.assertEqual(Decimal("0.5905"), prices["BP-USDC"])
+        self.assertEqual(Decimal("62984.1"), prices["BTC-USDC"])
+        self.assertNotIn("BTC-USDC-PERP", prices)
+        self.assertNotIn("DEAD-USDC", prices)
+
+    @aioresponses()
+    async def test_get_prices_with_usdt_quote_keeps_bridge(self, mock_api):
+        # Backpack has no USDT spot markets; pricing in USDT must still work by keeping the
+        # USDC-quoted pairs plus the USDT-USDC bridge so the oracle can cross-convert.
+        self.setup_backpack_responses(mock_api=mock_api)
+
+        prices = await BackpackRateSource().get_prices(quote_token="USDT")
+
+        # The bridge pair is retained...
+        self.assertEqual(Decimal("0.999"), prices["USDT-USDC"])
+        # ...along with the USDC-quoted pairs reachable through it.
+        self.assertEqual(Decimal("0.5905"), prices["BP-USDC"])
+        self.assertEqual(Decimal("62984.1"), prices["BTC-USDC"])
+        self.assertNotIn("BTC-USDC-PERP", prices)
+
+    @aioresponses()
+    async def test_get_prices_handles_error(self, mock_api):
+        url = web_utils.public_rest_url(path_url=CONSTANTS.TICKER_BOOK_PATH_URL)
+        mock_api.get(url, status=500)
+
+        prices = await BackpackRateSource().get_prices(quote_token="USDC")
+
+        self.assertEqual({}, prices)

--- a/test/hummingbot/strategy/perpetual_market_making/test_perpetual_market_making.py
+++ b/test/hummingbot/strategy/perpetual_market_making/test_perpetual_market_making.py
@@ -739,7 +739,7 @@ class PerpetualMarketMakingTests(TestCase):
                            "\n\n  No active maker orders."
                            "\n\n  Positions:"
                            "\n            Symbol Type Entry Price Amount Leverage Unrealized PnL"
-                           "\n    COINALPHA-HBOT LONG      100.50      1       10           0.00")
+                           "\n    COINALPHA-HBOT LONG      100.50      1       10           1000")
         status = self.strategy.format_status()
 
         self.assertEqual(expected_status, status)


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] Tests all pass
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

This PR fixes Backpack balance & leverage reporting (perpetual cross-margin + spot auto-lend/staking) and adds a new Backpack rate oracle source. Scope: 9 files (3 source + config +
rate oracle source, plus tests).

---
Area 1 — Backpack Perpetual: balance & leverage (highest risk)

What changed
- real_time_balance_update flipped from False → True. Backpack is cross-margin; the exchange already deducts initial margin in netEquityAvailable. The old False path routed through
apply_balance_update_since_snapshot, subtracting each open order's full quote notional locally → double-counting against margin the exchange already reserved → false "Not enough budget"
errors (root cause of issue #8168).
- Leverage fetch now sends params={"instruction": "accountQuery"}.

QA checks
1. Connect a Backpack perpetual account with existing open positions and/or open orders.
2. Confirm balance shows correct available balance and does not shrink artificially as orders are placed.
3. Place orders close to available margin — verify you no longer get false "Not enough budget to fund..." rejections when margin is actually available (#8168 regression test).
4. Set/change leverage and confirm it applies; check logs for clean accountQuery responses (no auth/param errors).
5. Let the bot run a while and confirm balance stays consistent via REST polling (Backpack has no WS balance updates).

---
Area 2 — Backpack Spot: balance includes staked + auto-lent funds

What changed
- Total balance now adds the staked field.
- New _get_net_lent_balances() queries the new api/v1/borrowLend/positions endpoint (borrowLendPositionQuery) and folds net lent (positive netQuantity) amounts back into both available 
and total balances — Backpack auto-lends idle funds, which otherwise vanish from capital. Borrowed (negative) positions are ignored. A new rate-limit entry covers the extra call.
- Best-effort: a failure fetching lend positions logs a warning but must not break the balance update.

QA checks
1. Backpack spot account with idle funds that have been auto-lent and/or staked balances → verify balance now shows the full amount (lent + staked included), not an under-reported
figure.
2. Confirm those funds are usable for placing orders (Backpack auto-redeems lent collateral when needed).
3. Negative test: an account with borrowed positions should not have liabilities counted as balance.
4. Confirm no throttling errors from the extra borrowLend/positions call each balance cycle.

---
Area 3 — Backpack Rate Oracle source (new global rate source)

What changed
- New backpack option in Rate Oracle Source (/config rate_oracle_source → backpack).
- Builds a keyless Backpack connector, pulls bulk tickers, skips _PERP markets (spot prices only), and includes a "bridge quote" trick: Backpack has USDC markets but no USDT spot 
markets, so picking USDT as the global token still works by deriving USDT rates via a USDT-USDC market. 30s TTL cache.

QA checks
1. Set rate oracle source to backpack. Confirm prices populate for USDC-quoted pairs (e.g. BTC-USDC).
2. Set global token = USDT and confirm conversions still resolve (not all zeros) — the bridge-quote path; needs a USDT-USDC market present.
3. Confirm perpetual _PERP symbols do not leak into the spot rate map.
4. Confirm graceful behavior on network error (returns empty, logs exception, doesn't crash).