### PR TITLE
feat/ Add twofinance exchange connector

### DIFF
--- a/hummingbot/connector/exchange/twofinance/twofinance_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/twofinance/twofinance_api_order_book_data_source.py
@@ -1,0 +1,206 @@
+import asyncio
+import time
+from typing import Any, Dict, List, Optional
+
+from hummingbot.connector.exchange.twofinance import (
+    twofinance_constants as CONSTANTS,
+    twofinance_web_utils as web_utils,
+)
+from hummingbot.connector.exchange.twofinance.twofinance_matchengine_schemas import MatchEngineEvent
+from hummingbot.core.data_type.order_book_message import OrderBookMessage, OrderBookMessageType
+from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod, WSJSONRequest
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+from hummingbot.core.web_assistant.ws_assistant import WSAssistant
+
+
+class TwoFinanceAPIOrderBookDataSource(OrderBookTrackerDataSource):
+    def __init__(
+        self,
+        trading_pairs: List[str],
+        connector,
+        api_factory: WebAssistantsFactory,
+        domain: str = CONSTANTS.DEFAULT_DOMAIN,
+        ws_url: Optional[str] = None,
+        rest_url: Optional[str] = None,
+    ):
+        super().__init__(trading_pairs)
+        self._connector = connector
+        self._api_factory = api_factory
+        self._domain = domain
+        self._ws_url = ws_url
+        self._rest_url = rest_url.rstrip("/") if rest_url is not None else None
+
+    async def get_last_traded_prices(self, trading_pairs: List[str], domain: Optional[str] = None) -> Dict[str, float]:
+        prices: Dict[str, float] = {}
+        for trading_pair in trading_pairs:
+            snapshot = await self._request_snapshot(trading_pair)
+            bids = snapshot.get("bids") or []
+            asks = snapshot.get("asks") or []
+            bid = float(bids[0][0] if isinstance(bids[0], list) else bids[0]["price"]) if bids else None
+            ask = float(asks[0][0] if isinstance(asks[0], list) else asks[0]["price"]) if asks else None
+            if bid is not None and ask is not None:
+                prices[trading_pair] = (bid + ask) / 2
+            elif bid is not None:
+                prices[trading_pair] = bid
+            elif ask is not None:
+                prices[trading_pair] = ask
+        return prices
+
+    async def _parse_trade_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
+        event = MatchEngineEvent.from_payload(raw_message)
+        message_queue.put_nowait(
+            OrderBookMessage(
+                OrderBookMessageType.TRADE,
+                {
+                    "trading_pair": web_utils.normalize_trading_pair(event.market or raw_message.get("trading_pair")),
+                    "trade_type": 1.0 if str(event.payload.get("side", "BUY")).upper() == "BUY" else 2.0,
+                    "trade_id": int(event.payload.get("trade_id") or event.sequence),
+                    "update_id": event.sequence,
+                    "price": str(event.payload.get("price") or "0"),
+                    "amount": str(event.payload.get("quantity") or event.payload.get("amount") or "0"),
+                },
+                self._timestamp(event),
+            )
+        )
+
+    async def _parse_order_book_diff_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
+        event = MatchEngineEvent.from_payload(raw_message)
+        message_queue.put_nowait(
+            OrderBookMessage(
+                OrderBookMessageType.DIFF,
+                {
+                    "trading_pair": web_utils.normalize_trading_pair(event.market or raw_message.get("trading_pair")),
+                    "update_id": event.sequence,
+                    "bids": self._levels(event.payload.get("bids") or []),
+                    "asks": self._levels(event.payload.get("asks") or []),
+                },
+                self._timestamp(event),
+            )
+        )
+
+    async def _parse_order_book_snapshot_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
+        event = MatchEngineEvent.from_payload(raw_message)
+        payload = {
+            **event.payload,
+            "sequence": event.sequence,
+            "market": web_utils.normalize_trading_pair(event.market),
+        }
+        message_queue.put_nowait(self._snapshot_message(payload))
+
+    async def _order_book_snapshot(self, trading_pair: str) -> OrderBookMessage:
+        payload = await self._request_snapshot(trading_pair)
+        payload.setdefault("trading_pair", trading_pair)
+        return self._snapshot_message(payload)
+
+    async def _connected_websocket_assistant(self) -> WSAssistant:
+        ws = await self._api_factory.get_ws_assistant()
+        await ws.connect(ws_url=web_utils.wss_url(self._domain, self._ws_url), ping_timeout=30)
+        return ws
+
+    async def _subscribe_channels(self, ws: WSAssistant):
+        await ws.send(
+            WSJSONRequest(
+                payload={
+                    "type": CONSTANTS.WS_PUBLIC_SUBSCRIBE,
+                    "channels": ["order_book", "trades"],
+                    "trading_pairs": [web_utils.exchange_trading_pair(pair) for pair in self._trading_pairs],
+                }
+            )
+        )
+
+    async def subscribe_to_trading_pair(self, trading_pair: str) -> bool:
+        if self._ws_assistant is None:
+            self.logger().warning("Cannot subscribe: WebSocket connection not established")
+            return False
+        try:
+            await self._ws_assistant.send(
+                WSJSONRequest(
+                    payload={
+                        "type": CONSTANTS.WS_PUBLIC_SUBSCRIBE,
+                        "channels": ["order_book", "trades"],
+                        "trading_pairs": [web_utils.exchange_trading_pair(trading_pair)],
+                    }
+                )
+            )
+            self.add_trading_pair(trading_pair)
+            return True
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self.logger().exception(f"Unexpected error subscribing to 2Finance market data for {trading_pair}.")
+            return False
+
+    async def unsubscribe_from_trading_pair(self, trading_pair: str) -> bool:
+        if self._ws_assistant is None:
+            self.logger().warning("Cannot unsubscribe: WebSocket connection not established")
+            return False
+        try:
+            await self._ws_assistant.send(
+                WSJSONRequest(
+                    payload={
+                        "type": "unsubscribe_public",
+                        "channels": ["order_book", "trades"],
+                        "trading_pairs": [web_utils.exchange_trading_pair(trading_pair)],
+                    }
+                )
+            )
+            self.remove_trading_pair(trading_pair)
+            return True
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self.logger().exception(f"Unexpected error unsubscribing from 2Finance market data for {trading_pair}.")
+            return False
+
+    def _channel_originating_message(self, event_message: Dict[str, Any]) -> str:
+        event_type = str(event_message.get("event_type") or event_message.get("type") or "")
+        if event_type in {"TRADE", "TRADE_EXECUTED", "ORDER_TRADE"}:
+            return self._trade_messages_queue_key
+        if event_type in {"ORDER_BOOK_SNAPSHOT", "BOOK_SNAPSHOT"}:
+            return self._snapshot_messages_queue_key
+        if event_type in {"ORDER_BOOK_DIFF", "BOOK_DIFF", "LEVEL_UPDATED"}:
+            return self._diff_messages_queue_key
+        return ""
+
+    async def _request_snapshot(self, trading_pair: str) -> Dict[str, Any]:
+        rest = await self._api_factory.get_rest_assistant()
+        path = CONSTANTS.ORDER_BOOK_PATH_URL.format(trading_pair=web_utils.exchange_trading_pair(trading_pair))
+        url = f"{self._rest_url}{path}" if self._rest_url is not None else web_utils.public_rest_url(path, self._domain)
+        payload = await rest.execute_request(
+            url=url,
+            method=RESTMethod.GET,
+            throttler_limit_id=CONSTANTS.ORDER_BOOK_PATH_URL,
+        )
+        if isinstance(payload, dict) and "data" in payload:
+            payload = payload["data"]
+        return payload if isinstance(payload, dict) else {}
+
+    def _snapshot_message(self, payload: Dict[str, Any]) -> OrderBookMessage:
+        update_id = int(payload.get("sequence") or payload.get("update_id") or 0)
+        return OrderBookMessage(
+            OrderBookMessageType.SNAPSHOT,
+            {
+                "trading_pair": web_utils.normalize_trading_pair(payload.get("trading_pair") or payload.get("market")),
+                "update_id": update_id,
+                "bids": self._levels(payload.get("bids") or []),
+                "asks": self._levels(payload.get("asks") or []),
+            },
+            float(payload.get("timestamp") or time.time()),
+        )
+
+    @staticmethod
+    def _levels(levels: List[Any]) -> List[List[str]]:
+        normalized = []
+        for level in levels:
+            if isinstance(level, dict):
+                normalized.append([str(level.get("price")), str(level.get("quantity") or level.get("amount"))])
+            elif isinstance(level, (list, tuple)) and len(level) >= 2:
+                normalized.append([str(level[0]), str(level[1])])
+        return normalized
+
+    @staticmethod
+    def _timestamp(event: MatchEngineEvent) -> float:
+        if event.timestamp_ns is not None:
+            return event.timestamp_ns / 1_000_000_000
+        return float(event.payload.get("timestamp") or time.time())

--- a/hummingbot/connector/exchange/twofinance/twofinance_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/twofinance/twofinance_api_order_book_data_source.py
@@ -101,11 +101,7 @@ class TwoFinanceAPIOrderBookDataSource(OrderBookTrackerDataSource):
     async def _subscribe_channels(self, ws: WSAssistant):
         await ws.send(
             WSJSONRequest(
-                payload={
-                    "type": CONSTANTS.WS_PUBLIC_SUBSCRIBE,
-                    "channels": ["order_book", "trades"],
-                    "trading_pairs": [web_utils.exchange_trading_pair(pair) for pair in self._trading_pairs],
-                }
+                payload=self._subscription_payload("subscribe", self._trading_pairs)
             )
         )
 
@@ -116,11 +112,7 @@ class TwoFinanceAPIOrderBookDataSource(OrderBookTrackerDataSource):
         try:
             await self._ws_assistant.send(
                 WSJSONRequest(
-                    payload={
-                        "type": CONSTANTS.WS_PUBLIC_SUBSCRIBE,
-                        "channels": ["order_book", "trades"],
-                        "trading_pairs": [web_utils.exchange_trading_pair(trading_pair)],
-                    }
+                    payload=self._subscription_payload("subscribe", [trading_pair])
                 )
             )
             self.add_trading_pair(trading_pair)
@@ -138,11 +130,7 @@ class TwoFinanceAPIOrderBookDataSource(OrderBookTrackerDataSource):
         try:
             await self._ws_assistant.send(
                 WSJSONRequest(
-                    payload={
-                        "type": "unsubscribe_public",
-                        "channels": ["order_book", "trades"],
-                        "trading_pairs": [web_utils.exchange_trading_pair(trading_pair)],
-                    }
+                    payload=self._subscription_payload("unsubscribe", [trading_pair])
                 )
             )
             self.remove_trading_pair(trading_pair)
@@ -204,3 +192,17 @@ class TwoFinanceAPIOrderBookDataSource(OrderBookTrackerDataSource):
         if event.timestamp_ns is not None:
             return event.timestamp_ns / 1_000_000_000
         return float(event.payload.get("timestamp") or time.time())
+
+    def _subscription_payload(self, method: str, trading_pairs: List[str]) -> Dict[str, Any]:
+        params: List[str] = []
+        for trading_pair in trading_pairs:
+            symbol_id = self._symbol_id_for_pair(trading_pair)
+            params.extend([f"{symbol_id}@BOOK", f"{symbol_id}@TRADE", f"{symbol_id}@LEVEL"])
+        return {"method": method, "params": params}
+
+    def _symbol_id_for_pair(self, trading_pair: str) -> int:
+        metadata = getattr(self._connector, "_symbol_metadata", {}).get(trading_pair, {})
+        symbol_id = metadata.get("symbol_id")
+        if symbol_id is None:
+            raise KeyError(f"missing 2Finance symbol_id for {trading_pair}")
+        return int(symbol_id)

--- a/hummingbot/connector/exchange/twofinance/twofinance_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/twofinance/twofinance_api_user_stream_data_source.py
@@ -42,10 +42,8 @@ class TwoFinanceAPIUserStreamDataSource(UserStreamTrackerDataSource):
         await websocket_assistant.send(
             WSJSONRequest(
                 payload={
-                    "type": CONSTANTS.WS_PRIVATE_SUBSCRIBE,
-                    "channels": ["orders", "trades", "balances"],
-                    "engine_id": self._engine_id,
-                    "wallet_id": self._wallet_id,
+                    "method": "subscribe",
+                    "params": [f"{self._wallet_id}@WALLET"],
                 },
                 is_auth_required=False,
             )

--- a/hummingbot/connector/exchange/twofinance/twofinance_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/twofinance/twofinance_api_user_stream_data_source.py
@@ -1,0 +1,58 @@
+import asyncio
+from typing import Optional
+
+from hummingbot.connector.exchange.twofinance import (
+    twofinance_constants as CONSTANTS,
+    twofinance_web_utils as web_utils,
+)
+from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
+from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+from hummingbot.core.web_assistant.ws_assistant import WSAssistant
+
+
+class TwoFinanceAPIUserStreamDataSource(UserStreamTrackerDataSource):
+    def __init__(
+        self,
+        api_factory: WebAssistantsFactory,
+        auth_headers: dict[str, str],
+        engine_id: str,
+        wallet_id: int,
+        domain: str = CONSTANTS.DEFAULT_DOMAIN,
+        ws_url: Optional[str] = None,
+    ):
+        super().__init__()
+        self._api_factory = api_factory
+        self._auth_headers = auth_headers
+        self._engine_id = engine_id
+        self._wallet_id = wallet_id
+        self._domain = domain
+        self._ws_url = ws_url
+
+    async def _connected_websocket_assistant(self) -> WSAssistant:
+        ws = await self._api_factory.get_ws_assistant()
+        await ws.connect(
+            ws_url=web_utils.wss_url(self._domain, self._ws_url),
+            ws_headers=self._auth_headers,
+            ping_timeout=30,
+        )
+        return ws
+
+    async def _subscribe_channels(self, websocket_assistant: WSAssistant):
+        await websocket_assistant.send(
+            WSJSONRequest(
+                payload={
+                    "type": CONSTANTS.WS_PRIVATE_SUBSCRIBE,
+                    "channels": ["orders", "trades", "balances"],
+                    "engine_id": self._engine_id,
+                    "wallet_id": self._wallet_id,
+                },
+                is_auth_required=False,
+            )
+        )
+
+    async def _process_websocket_messages(self, websocket_assistant: WSAssistant, queue: asyncio.Queue):
+        async for ws_response in websocket_assistant.iter_messages():
+            data = ws_response.data
+            if isinstance(data, dict):
+                queue.put_nowait(data)

--- a/hummingbot/connector/exchange/twofinance/twofinance_auth.py
+++ b/hummingbot/connector/exchange/twofinance/twofinance_auth.py
@@ -1,0 +1,25 @@
+from hummingbot.core.web_assistant.auth import AuthBase
+from hummingbot.core.web_assistant.connections.data_types import RESTRequest, WSRequest
+
+
+class TwoFinanceAuth(AuthBase):
+    def __init__(self, bearer_token: str = ""):
+        self._bearer_token = bearer_token.strip()
+
+    @property
+    def authorization_header(self) -> str:
+        if not self._bearer_token:
+            return ""
+        if self._bearer_token.lower().startswith("bearer "):
+            return self._bearer_token
+        return f"Bearer {self._bearer_token}"
+
+    async def rest_authenticate(self, request: RESTRequest) -> RESTRequest:
+        if self.authorization_header:
+            headers = dict(request.headers or {})
+            headers["Authorization"] = self.authorization_header
+            request.headers = headers
+        return request
+
+    async def ws_authenticate(self, request: WSRequest) -> WSRequest:
+        return request

--- a/hummingbot/connector/exchange/twofinance/twofinance_constants.py
+++ b/hummingbot/connector/exchange/twofinance/twofinance_constants.py
@@ -1,0 +1,100 @@
+from decimal import Decimal
+
+from hummingbot.core.api_throttler.data_types import LinkedLimitWeightPair, RateLimit
+from hummingbot.core.data_type.in_flight_order import OrderState
+
+DEFAULT_DOMAIN = "twofinance"
+TESTNET_DOMAIN = "twofinance_testnet"
+
+HBOT_ORDER_ID_PREFIX = "HBOT-2F-"
+MAX_ORDER_ID_LEN = 64
+
+REST_URL = "http://127.0.0.1:8080/api/v1"
+WSS_URL = "ws://127.0.0.1:10000"
+TESTNET_REST_URL = REST_URL
+TESTNET_WSS_URL = WSS_URL
+
+SYMBOLS_PATH_URL = "/symbols"
+TRADING_RULES_PATH_URL = "/trading-rules"
+BALANCES_PATH_URL = "/balances"
+ORDER_BOOK_PATH_URL = "/order-book/{trading_pair}"
+ORDER_STATUS_PATH_URL = "/orders/{client_order_id}"
+ORDER_TRADES_PATH_URL = "/orders/{client_order_id}/trades"
+EVENTS_PATH_URL = "/events"
+PING_PATH_URL = "/health"
+
+WS_PUBLIC_SUBSCRIBE = "subscribe_public"
+WS_PRIVATE_SUBSCRIBE = "subscribe_private"
+
+MATCHENGINE_ORDER_COMMAND_SCHEMA = "matchengine.order_command.v1"
+MATCHENGINE_EVENT_SCHEMA = "matchengine.event.v1"
+
+IP_REQUEST_WEIGHT = "IP_REQUEST_WEIGHT"
+UID_REQUEST_WEIGHT = "UID_REQUEST_WEIGHT"
+ONE_SECOND = 1
+ONE_MINUTE = 60
+MAX_REQUEST = 300
+
+RATE_LIMITS = [
+    RateLimit(limit_id=IP_REQUEST_WEIGHT, limit=MAX_REQUEST, time_interval=ONE_MINUTE),
+    RateLimit(limit_id=UID_REQUEST_WEIGHT, limit=MAX_REQUEST, time_interval=ONE_MINUTE),
+    RateLimit(
+        limit_id=SYMBOLS_PATH_URL,
+        limit=MAX_REQUEST,
+        time_interval=ONE_MINUTE,
+        linked_limits=[LinkedLimitWeightPair(IP_REQUEST_WEIGHT, 1)],
+    ),
+    RateLimit(
+        limit_id=TRADING_RULES_PATH_URL,
+        limit=MAX_REQUEST,
+        time_interval=ONE_MINUTE,
+        linked_limits=[LinkedLimitWeightPair(IP_REQUEST_WEIGHT, 1)],
+    ),
+    RateLimit(
+        limit_id=BALANCES_PATH_URL,
+        limit=MAX_REQUEST,
+        time_interval=ONE_MINUTE,
+        linked_limits=[LinkedLimitWeightPair(UID_REQUEST_WEIGHT, 1)],
+    ),
+    RateLimit(
+        limit_id=ORDER_BOOK_PATH_URL,
+        limit=MAX_REQUEST,
+        time_interval=ONE_MINUTE,
+        linked_limits=[LinkedLimitWeightPair(IP_REQUEST_WEIGHT, 1)],
+    ),
+    RateLimit(
+        limit_id=ORDER_STATUS_PATH_URL,
+        limit=MAX_REQUEST,
+        time_interval=ONE_MINUTE,
+        linked_limits=[LinkedLimitWeightPair(UID_REQUEST_WEIGHT, 1)],
+    ),
+    RateLimit(
+        limit_id=ORDER_TRADES_PATH_URL,
+        limit=MAX_REQUEST,
+        time_interval=ONE_MINUTE,
+        linked_limits=[LinkedLimitWeightPair(UID_REQUEST_WEIGHT, 1)],
+    ),
+    RateLimit(
+        limit_id=PING_PATH_URL,
+        limit=MAX_REQUEST,
+        time_interval=ONE_MINUTE,
+        linked_limits=[LinkedLimitWeightPair(IP_REQUEST_WEIGHT, 1)],
+    ),
+    RateLimit(limit_id=WSS_URL, limit=20, time_interval=ONE_SECOND),
+]
+
+ORDER_STATE = {
+    "OPEN": OrderState.OPEN,
+    "NEW": OrderState.OPEN,
+    "ACCEPTED": OrderState.OPEN,
+    "PARTIAL": OrderState.PARTIALLY_FILLED,
+    "PARTIALLY_FILLED": OrderState.PARTIALLY_FILLED,
+    "FILLED": OrderState.FILLED,
+    "CANCELED": OrderState.CANCELED,
+    "CANCELLED": OrderState.CANCELED,
+    "REJECTED": OrderState.FAILED,
+    "FAILED": OrderState.FAILED,
+}
+
+DEFAULT_MAKER_FEE = Decimal("0")
+DEFAULT_TAKER_FEE = Decimal("0")

--- a/hummingbot/connector/exchange/twofinance/twofinance_exchange.py
+++ b/hummingbot/connector/exchange/twofinance/twofinance_exchange.py
@@ -1,0 +1,482 @@
+import asyncio
+from decimal import Decimal
+from typing import Any, Dict, List, Optional, Tuple
+
+from bidict import bidict
+
+from hummingbot.connector.constants import s_decimal_NaN
+from hummingbot.connector.exchange.twofinance import (
+    twofinance_constants as CONSTANTS,
+    twofinance_web_utils as web_utils,
+)
+from hummingbot.connector.exchange.twofinance.twofinance_api_order_book_data_source import (
+    TwoFinanceAPIOrderBookDataSource,
+)
+from hummingbot.connector.exchange.twofinance.twofinance_api_user_stream_data_source import (
+    TwoFinanceAPIUserStreamDataSource,
+)
+from hummingbot.connector.exchange.twofinance.twofinance_auth import TwoFinanceAuth
+from hummingbot.connector.exchange.twofinance.twofinance_matchengine_client import MatchEngineClient
+from hummingbot.connector.exchange.twofinance.twofinance_matchengine_schemas import (
+    MatchEngineEvent,
+    OrderCommand,
+    event_order_state,
+    to_decimal,
+)
+from hummingbot.connector.exchange_py_base import ExchangePyBase
+from hummingbot.connector.trading_rule import TradingRule
+from hummingbot.core.data_type.common import OrderType, TradeType
+from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState, OrderUpdate, TradeUpdate
+from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
+from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee, TokenAmount, TradeFeeBase
+from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
+from hummingbot.core.web_assistant.connections.data_types import RESTMethod
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+
+
+class TwoFinanceExchange(ExchangePyBase):
+    UPDATE_ORDER_STATUS_MIN_INTERVAL = 10.0
+    SHORT_POLL_INTERVAL = 10.0
+
+    web_utils = web_utils
+
+    def __init__(
+        self,
+        twofinance_matchengine_bearer_token: str,
+        twofinance_engine_id: str,
+        twofinance_wallet_id: int,
+        twofinance_state_api_url: str = CONSTANTS.REST_URL,
+        twofinance_matchengine_ws_url: str = CONSTANTS.WSS_URL,
+        twofinance_account_id: str = "",
+        balance_asset_limit: Optional[Dict[str, Dict[str, Decimal]]] = None,
+        rate_limits_share_pct: Decimal = Decimal("100"),
+        trading_pairs: Optional[List[str]] = None,
+        trading_required: bool = True,
+        domain: str = CONSTANTS.DEFAULT_DOMAIN,
+        ack_timeout: float = 1.0,
+    ):
+        self._domain = domain
+        self._trading_pairs = trading_pairs or []
+        self._trading_required = trading_required
+        self._state_api_url = twofinance_state_api_url.rstrip("/")
+        self._matchengine_ws_url = twofinance_matchengine_ws_url
+        self._bearer_token = (
+            twofinance_matchengine_bearer_token.get_secret_value()
+            if hasattr(twofinance_matchengine_bearer_token, "get_secret_value")
+            else str(twofinance_matchengine_bearer_token)
+        )
+        self._engine_id = twofinance_engine_id
+        self._wallet_id = int(twofinance_wallet_id)
+        self._account_id = twofinance_account_id
+        self._ack_timeout = ack_timeout
+        self._symbol_metadata: Dict[str, Dict[str, Any]] = {}
+
+        super().__init__(balance_asset_limit, rate_limits_share_pct)
+        self._matchengine_client = MatchEngineClient(
+            api_factory=self._web_assistants_factory,
+            ws_url=self._matchengine_ws_url,
+            auth_headers=self._auth_headers,
+        )
+
+    @property
+    def authenticator(self):
+        return TwoFinanceAuth(self._bearer_token)
+
+    @property
+    def _auth_headers(self) -> Dict[str, str]:
+        auth = self.authenticator.authorization_header
+        return {"Authorization": auth} if auth else {}
+
+    @property
+    def name(self) -> str:
+        return self._domain
+
+    @property
+    def rate_limits_rules(self):
+        return CONSTANTS.RATE_LIMITS
+
+    @property
+    def domain(self):
+        return self._domain
+
+    @property
+    def client_order_id_max_length(self):
+        return CONSTANTS.MAX_ORDER_ID_LEN
+
+    @property
+    def client_order_id_prefix(self):
+        return CONSTANTS.HBOT_ORDER_ID_PREFIX
+
+    @property
+    def trading_rules_request_path(self):
+        return CONSTANTS.TRADING_RULES_PATH_URL
+
+    @property
+    def trading_pairs_request_path(self):
+        return CONSTANTS.SYMBOLS_PATH_URL
+
+    @property
+    def check_network_request_path(self):
+        return CONSTANTS.PING_PATH_URL
+
+    @property
+    def trading_pairs(self):
+        return self._trading_pairs
+
+    @property
+    def is_cancel_request_in_exchange_synchronous(self) -> bool:
+        return False
+
+    @property
+    def is_trading_required(self) -> bool:
+        return self._trading_required
+
+    def supported_order_types(self):
+        return [OrderType.LIMIT, OrderType.LIMIT_MAKER, OrderType.MARKET]
+
+    def _is_request_exception_related_to_time_synchronizer(self, request_exception: Exception):
+        return False
+
+    def _is_order_not_found_during_status_update_error(self, status_update_exception: Exception) -> bool:
+        return "not found" in str(status_update_exception).lower()
+
+    def _is_order_not_found_during_cancelation_error(self, cancelation_exception: Exception) -> bool:
+        return "not found" in str(cancelation_exception).lower()
+
+    def _create_web_assistants_factory(self) -> WebAssistantsFactory:
+        return web_utils.build_api_factory(throttler=self._throttler, auth=self._auth)
+
+    def _create_order_book_data_source(self) -> OrderBookTrackerDataSource:
+        return TwoFinanceAPIOrderBookDataSource(
+            trading_pairs=self._trading_pairs,
+            connector=self,
+            api_factory=self._web_assistants_factory,
+            domain=self._domain,
+            ws_url=self._matchengine_ws_url,
+            rest_url=self._state_api_url,
+        )
+
+    def _create_user_stream_data_source(self) -> UserStreamTrackerDataSource:
+        return TwoFinanceAPIUserStreamDataSource(
+            api_factory=self._web_assistants_factory,
+            auth_headers=self._auth_headers,
+            engine_id=self._engine_id,
+            wallet_id=self._wallet_id,
+            domain=self._domain,
+            ws_url=self._matchengine_ws_url,
+        )
+
+    def _get_fee(
+        self,
+        base_currency: str,
+        quote_currency: str,
+        order_type: OrderType,
+        order_side: TradeType,
+        amount: Decimal,
+        price: Decimal = s_decimal_NaN,
+        is_maker: Optional[bool] = None,
+    ) -> AddedToCostTradeFee:
+        return AddedToCostTradeFee(percent=Decimal("0"))
+
+    async def _place_order(
+        self,
+        order_id: str,
+        trading_pair: str,
+        amount: Decimal,
+        trade_type: TradeType,
+        order_type: OrderType,
+        price: Decimal,
+        **kwargs,
+    ) -> Tuple[str, float]:
+        command = await self._build_order_command(
+            order_id=order_id,
+            trading_pair=trading_pair,
+            amount=amount,
+            trade_type=trade_type,
+            order_type=order_type,
+            price=price,
+            time_in_force=kwargs.get("time_in_force"),
+        )
+        await self._matchengine_client.send_command(command)
+        response = await self._matchengine_client.wait_for_ack(order_id, self._ack_timeout)
+        if response is not None and not response.accepted:
+            raise IOError(response.reason or f"2Finance rejected order {order_id}")
+        exchange_order_id = response.order_id if response is not None and response.order_id is not None else None
+        if exchange_order_id is None:
+            exchange_order_id = self._matchengine_client.orders[order_id].exchange_order_id
+        return exchange_order_id or f"UNKNOWN:{order_id}", self.current_timestamp
+
+    async def _place_cancel(self, order_id: str, tracked_order: InFlightOrder):
+        exchange_order_id = await tracked_order.get_exchange_order_id()
+        metadata = await self._metadata_for_pair(tracked_order.trading_pair)
+        command = OrderCommand(
+            client_order_id=order_id,
+            engine_id=self._engine_id,
+            symbol_id=int(metadata["symbol_id"]),
+            market=tracked_order.trading_pair,
+            wallet_id=self._wallet_id,
+            side="BUY",
+            order_type="LIMIT",
+            quantity="0",
+            operation="DELETE",
+            order_id=exchange_order_id,
+            idempotency_key=f"{order_id}:cancel",
+        )
+        await self._matchengine_client.send_command(command)
+        return True
+
+    async def _user_stream_event_listener(self):
+        async for event_message in self._iter_user_event_queue():
+            try:
+                event = MatchEngineEvent.from_payload(event_message)
+                self._matchengine_client.apply_event(event)
+                if event.event_type in {"TRADE", "TRADE_EXECUTED", "ORDER_TRADE"}:
+                    trade_update = self._trade_update_from_event(event)
+                    if trade_update is not None:
+                        self._order_tracker.process_trade_update(trade_update)
+                order_update = self._order_update_from_event(event)
+                if order_update is not None:
+                    self._order_tracker.process_order_update(order_update)
+                self._process_balance_event(event)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                self.logger().exception("Unexpected error processing 2Finance user stream event.")
+
+    async def _format_trading_rules(self, exchange_info_dict: Dict[str, Any]) -> List[TradingRule]:
+        data = (
+            exchange_info_dict.get("data", exchange_info_dict)
+            if isinstance(exchange_info_dict, dict)
+            else exchange_info_dict
+        )
+        if isinstance(data, dict) and "trading_rules" in data:
+            data = data["trading_rules"]
+        rules = data.items() if isinstance(data, dict) else enumerate(data if isinstance(data, list) else [])
+        trading_rules = []
+        for key, item in rules:
+            rule = item if isinstance(item, dict) else {}
+            trading_pair = web_utils.normalize_trading_pair(
+                rule.get("symbol") or rule.get("trading_pair") or rule.get("market") or rule.get("name") or key
+            )
+            if not trading_pair:
+                continue
+            trading_rules.append(
+                TradingRule(
+                    trading_pair=trading_pair,
+                    min_order_size=to_decimal(rule.get("min_order_size") or rule.get("min_base_amount") or "0"),
+                    min_price_increment=to_decimal(rule.get("tick_size") or rule.get("min_price_increment") or "0"),
+                    min_base_amount_increment=to_decimal(
+                        rule.get("step_size") or rule.get("min_base_amount_increment") or "0"
+                    ),
+                    min_notional_size=to_decimal(rule.get("min_notional_size") or rule.get("min_notional") or "0"),
+                )
+            )
+        return trading_rules
+
+    async def _update_balances(self):
+        payload = await self._api_get(path_url=CONSTANTS.BALANCES_PATH_URL, is_auth_required=True)
+        data = payload.get("data", payload) if isinstance(payload, dict) else payload
+        if isinstance(data, dict) and "balances" in data:
+            data = data["balances"]
+        local_asset_names = set(self._account_balances.keys())
+        remote_asset_names = set()
+        iterable = data.items() if isinstance(data, dict) else enumerate(data if isinstance(data, list) else [])
+        for asset, balance_payload in iterable:
+            balance = balance_payload if isinstance(balance_payload, dict) else {}
+            total = to_decimal(balance.get("total") or balance.get("balance") or balance.get("quantity") or "0")
+            locked = to_decimal(balance.get("locked") or balance.get("lock_balance") or "0")
+            available = to_decimal(balance.get("available") or (total - locked))
+            asset_name = str(balance.get("asset") or balance.get("asset_id") or asset)
+            self._account_balances[asset_name] = total
+            self._account_available_balances[asset_name] = available
+            remote_asset_names.add(asset_name)
+        for asset_name in local_asset_names.difference(remote_asset_names):
+            self._account_balances.pop(asset_name, None)
+            self._account_available_balances.pop(asset_name, None)
+
+    async def _all_trade_updates_for_order(self, order: InFlightOrder) -> List[TradeUpdate]:
+        payload = await self._api_get(
+            path_url=CONSTANTS.ORDER_TRADES_PATH_URL.format(client_order_id=order.client_order_id),
+            is_auth_required=True,
+        )
+        data = payload.get("data", payload) if isinstance(payload, dict) else payload
+        if isinstance(data, dict) and "trades" in data:
+            data = data["trades"]
+        updates = []
+        for item in data if isinstance(data, list) else []:
+            updates.append(self._trade_update_from_payload(item, order))
+        return updates
+
+    async def _request_order_status(self, tracked_order: InFlightOrder) -> OrderUpdate:
+        payload = await self._api_get(
+            path_url=CONSTANTS.ORDER_STATUS_PATH_URL.format(client_order_id=tracked_order.client_order_id),
+            is_auth_required=True,
+        )
+        data = payload.get("data", payload) if isinstance(payload, dict) else payload
+        state = CONSTANTS.ORDER_STATE.get(str(data.get("status") or "OPEN").upper(), OrderState.OPEN)
+        return OrderUpdate(
+            client_order_id=tracked_order.client_order_id,
+            exchange_order_id=str(data.get("order_id") or tracked_order.exchange_order_id),
+            trading_pair=tracked_order.trading_pair,
+            update_timestamp=self.current_timestamp,
+            new_state=state,
+            misc_updates=data,
+        )
+
+    async def _update_trading_fees(self):
+        return None
+
+    def _initialize_trading_pair_symbols_from_exchange_info(self, exchange_info: Dict[str, Any]):
+        data = exchange_info.get("data", exchange_info) if isinstance(exchange_info, dict) else exchange_info
+        if isinstance(data, dict) and "symbols" in data:
+            data = data["symbols"]
+        items = data.items() if isinstance(data, dict) else enumerate(data if isinstance(data, list) else [])
+        mapping = bidict()
+        self._symbol_metadata.clear()
+        for key, item in items:
+            symbol = item if isinstance(item, dict) else {}
+            trading_pair = web_utils.normalize_trading_pair(
+                symbol.get("symbol") or symbol.get("trading_pair") or symbol.get("market") or symbol.get("name") or key
+            )
+            if not trading_pair:
+                continue
+            exchange_symbol = str(
+                symbol.get("exchange_symbol") or symbol.get("name") or symbol.get("symbol_id") or trading_pair
+            )
+            mapping[exchange_symbol] = trading_pair
+            self._symbol_metadata[trading_pair] = {
+                **symbol,
+                "exchange_symbol": exchange_symbol,
+                "symbol_id": int(symbol.get("symbol_id") or symbol.get("id") or 0),
+            }
+        self._set_trading_pair_symbol_map(mapping)
+
+    async def _api_request_url(self, path_url: str, is_auth_required: bool = False) -> str:
+        return self._state_api_url + path_url
+
+    async def _api_get(self, *args, **kwargs):
+        kwargs["method"] = RESTMethod.GET
+        return await self._api_request(*args, **kwargs)
+
+    async def _api_post(self, *args, **kwargs):
+        kwargs["method"] = RESTMethod.POST
+        return await self._api_request(*args, **kwargs)
+
+    async def _metadata_for_pair(self, trading_pair: str) -> Dict[str, Any]:
+        if trading_pair not in self._symbol_metadata:
+            await self._initialize_trading_pair_symbol_map()
+        if trading_pair not in self._symbol_metadata:
+            raise KeyError(f"2Finance symbol metadata not found for {trading_pair}")
+        return self._symbol_metadata[trading_pair]
+
+    async def _build_order_command(
+        self,
+        order_id: str,
+        trading_pair: str,
+        amount: Decimal,
+        trade_type: TradeType,
+        order_type: OrderType,
+        price: Decimal,
+        time_in_force: Optional[str],
+    ) -> OrderCommand:
+        metadata = await self._metadata_for_pair(trading_pair)
+        return OrderCommand(
+            client_order_id=order_id,
+            engine_id=self._engine_id,
+            symbol_id=int(metadata["symbol_id"]),
+            market=trading_pair,
+            wallet_id=self._wallet_id,
+            side="BUY" if trade_type is TradeType.BUY else "SELL",
+            order_type="MARKET" if order_type is OrderType.MARKET else "LIMIT",
+            quantity=amount,
+            price=None if order_type is OrderType.MARKET else price,
+            time_in_force=time_in_force if time_in_force in {"GTC", "IOC", "FOK", "AON"} else None,
+            idempotency_key=order_id,
+        )
+
+    def _order_update_from_event(self, event: MatchEngineEvent) -> Optional[OrderUpdate]:
+        new_state = event_order_state(event)
+        if new_state is None:
+            return None
+        client_order_id = event.payload.get("client_order_id")
+        exchange_order_id = event.payload.get("order_id") or event.payload.get("new_order_id")
+        if client_order_id is None and exchange_order_id is not None:
+            client_order_id = self._matchengine_client.orders_by_exchange_id.get(str(exchange_order_id))
+        if client_order_id is None:
+            return None
+        return OrderUpdate(
+            trading_pair=web_utils.normalize_trading_pair(event.market or event.payload.get("market")),
+            update_timestamp=self._timestamp(event),
+            new_state=new_state,
+            client_order_id=str(client_order_id),
+            exchange_order_id=str(exchange_order_id) if exchange_order_id is not None else None,
+            misc_updates={"event_id": event.event_id, "sequence": event.sequence, **event.payload},
+        )
+
+    def _trade_update_from_event(self, event: MatchEngineEvent) -> Optional[TradeUpdate]:
+        exchange_order_id = (
+            event.payload.get("order_id") or event.payload.get("taker_order_id") or event.payload.get("maker_order_id")
+        )
+        client_order_id = event.payload.get("client_order_id")
+        if client_order_id is None and exchange_order_id is not None:
+            client_order_id = self._matchengine_client.orders_by_exchange_id.get(str(exchange_order_id))
+        if client_order_id is None or exchange_order_id is None:
+            return None
+        tracked_order = self._order_tracker.all_fillable_orders.get(str(client_order_id))
+        trading_pair = web_utils.normalize_trading_pair(
+            event.market or (tracked_order.trading_pair if tracked_order is not None else "")
+        )
+        return TradeUpdate(
+            trade_id=str(event.payload.get("trade_id") or event.event_id),
+            client_order_id=str(client_order_id),
+            exchange_order_id=str(exchange_order_id),
+            trading_pair=trading_pair,
+            fill_timestamp=self._timestamp(event),
+            fill_price=to_decimal(event.payload.get("price") or "0"),
+            fill_base_amount=to_decimal(event.payload.get("quantity") or event.payload.get("amount") or "0"),
+            fill_quote_amount=to_decimal(event.payload.get("quote_quantity") or "0")
+            or to_decimal(event.payload.get("quantity") or event.payload.get("amount") or "0")
+            * to_decimal(event.payload.get("price") or "0"),
+            fee=self._fee_from_payload(event.payload),
+        )
+
+    def _trade_update_from_payload(self, payload: Dict[str, Any], order: InFlightOrder) -> TradeUpdate:
+        quantity = to_decimal(payload.get("quantity") or payload.get("amount") or "0")
+        price = to_decimal(payload.get("price") or "0")
+        return TradeUpdate(
+            trade_id=str(payload.get("trade_id") or payload.get("id")),
+            client_order_id=order.client_order_id,
+            exchange_order_id=str(payload.get("order_id") or order.exchange_order_id),
+            trading_pair=order.trading_pair,
+            fill_timestamp=float(payload.get("timestamp") or self.current_timestamp),
+            fill_price=price,
+            fill_base_amount=quantity,
+            fill_quote_amount=to_decimal(payload.get("quote_quantity") or quantity * price),
+            fee=self._fee_from_payload(payload),
+        )
+
+    def _fee_from_payload(self, payload: Dict[str, Any]) -> TradeFeeBase:
+        fee_amount = to_decimal(payload.get("fee_amount") or payload.get("fee") or "0")
+        fee_asset = payload.get("fee_asset") or payload.get("asset")
+        flat_fees = [TokenAmount(str(fee_asset), fee_amount)] if fee_asset and fee_amount > Decimal("0") else []
+        return AddedToCostTradeFee(percent=Decimal("0"), flat_fees=flat_fees)
+
+    def _process_balance_event(self, event: MatchEngineEvent):
+        if event.event_type not in {"BALANCE_UPDATED", "BALANCE_SNAPSHOT"}:
+            return
+        asset = event.payload.get("asset") or event.payload.get("asset_id")
+        if asset is None:
+            return
+        total = to_decimal(
+            event.payload.get("total") or event.payload.get("balance") or self._account_balances.get(str(asset), "0")
+        )
+        locked = to_decimal(event.payload.get("locked") or event.payload.get("lock_balance") or "0")
+        available = to_decimal(event.payload.get("available") or (total - locked))
+        self._account_balances[str(asset)] = total
+        self._account_available_balances[str(asset)] = available
+
+    @staticmethod
+    def _timestamp(event: MatchEngineEvent) -> float:
+        if event.timestamp_ns is not None:
+            return event.timestamp_ns / 1_000_000_000
+        return float(event.payload.get("timestamp") or 0)

--- a/hummingbot/connector/exchange/twofinance/twofinance_exchange.py
+++ b/hummingbot/connector/exchange/twofinance/twofinance_exchange.py
@@ -203,7 +203,7 @@ class TwoFinanceExchange(ExchangePyBase):
             raise IOError(response.reason or f"2Finance rejected order {order_id}")
         exchange_order_id = response.order_id if response is not None and response.order_id is not None else None
         if exchange_order_id is None:
-            exchange_order_id = self._matchengine_client.orders[order_id].exchange_order_id
+            exchange_order_id = await self._matchengine_client.wait_for_exchange_order_id(order_id, self._ack_timeout)
         return exchange_order_id or f"UNKNOWN:{order_id}", self.current_timestamp
 
     async def _place_cancel(self, order_id: str, tracked_order: InFlightOrder):

--- a/hummingbot/connector/exchange/twofinance/twofinance_matchengine_client.py
+++ b/hummingbot/connector/exchange/twofinance/twofinance_matchengine_client.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+from hummingbot.connector.exchange.twofinance.twofinance_matchengine_schemas import (
+    CommandResponse,
+    MatchEngineEvent,
+    OrderCommand,
+    is_command_response,
+    parse_command_response,
+)
+from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+
+
+@dataclass
+class MatchEngineOrderEntry:
+    client_order_id: str
+    command: OrderCommand
+    exchange_order_id: str | None = None
+    last_response: CommandResponse | None = None
+    last_event: MatchEngineEvent | None = None
+
+
+@dataclass
+class MatchEngineClient:
+    api_factory: WebAssistantsFactory
+    ws_url: str
+    auth_headers: dict[str, str] = field(default_factory=dict)
+    orders: dict[str, MatchEngineOrderEntry] = field(default_factory=dict)
+    orders_by_exchange_id: dict[str, str] = field(default_factory=dict)
+    last_sequence: int = 0
+    _ws_assistant: Any | None = None
+
+    async def send_command(self, command: OrderCommand) -> None:
+        self.orders.setdefault(command.client_order_id, MatchEngineOrderEntry(command.client_order_id, command))
+        ws = await self._connected_ws_assistant()
+        await ws.send(WSJSONRequest(payload=command.to_payload()))
+
+    async def receive_once(self) -> CommandResponse | MatchEngineEvent:
+        ws = await self._connected_ws_assistant()
+        response = await ws.receive()
+        if response is None:
+            raise ConnectionError("MatchEngine WebSocket disconnected")
+        data = response.data
+        if not isinstance(data, dict):
+            raise ValueError("MatchEngine WebSocket payload must be a JSON object")
+        if is_command_response(data):
+            command_response = parse_command_response(data)
+            self.apply_command_response(command_response)
+            return command_response
+        event = MatchEngineEvent.from_payload(data)
+        self.apply_event(event)
+        return event
+
+    async def wait_for_ack(self, client_order_id: str, timeout_seconds: float) -> CommandResponse | None:
+        deadline = asyncio.get_running_loop().time() + timeout_seconds
+        while True:
+            entry = self.orders.get(client_order_id)
+            if entry is not None and entry.last_response is not None:
+                return entry.last_response
+            remaining = deadline - asyncio.get_running_loop().time()
+            if remaining <= 0:
+                return None
+            try:
+                await asyncio.wait_for(self.receive_once(), timeout=min(remaining, 0.1))
+            except asyncio.TimeoutError:
+                await asyncio.sleep(0)
+
+    def apply_command_response(self, response: CommandResponse) -> None:
+        if response.client_order_id is None:
+            return
+        entry = self.orders.get(response.client_order_id)
+        if entry is None:
+            return
+        entry.last_response = response
+        if response.order_id is not None:
+            entry.exchange_order_id = response.order_id
+            self.orders_by_exchange_id[response.order_id] = response.client_order_id
+
+    def apply_event(self, event: MatchEngineEvent) -> None:
+        if event.sequence > self.last_sequence:
+            self.last_sequence = event.sequence
+        client_order_id = event.payload.get("client_order_id")
+        exchange_order_id = event.payload.get("order_id") or event.payload.get("new_order_id")
+        if client_order_id is None and exchange_order_id is not None:
+            client_order_id = self.orders_by_exchange_id.get(str(exchange_order_id))
+        if client_order_id is None:
+            return
+        entry = self.orders.get(str(client_order_id))
+        if entry is None:
+            return
+        entry.last_event = event
+        if exchange_order_id is not None:
+            entry.exchange_order_id = str(exchange_order_id)
+            self.orders_by_exchange_id[str(exchange_order_id)] = str(client_order_id)
+
+    async def close(self) -> None:
+        if self._ws_assistant is not None:
+            await self._ws_assistant.disconnect()
+            self._ws_assistant = None
+
+    async def _connected_ws_assistant(self):
+        if self._ws_assistant is None:
+            self._ws_assistant = await self.api_factory.get_ws_assistant()
+        if not self._ws_assistant._connection.connected:
+            await self._ws_assistant.connect(ws_url=self.ws_url, ws_headers=self.auth_headers)
+        return self._ws_assistant

--- a/hummingbot/connector/exchange/twofinance/twofinance_matchengine_client.py
+++ b/hummingbot/connector/exchange/twofinance/twofinance_matchengine_client.py
@@ -33,9 +33,11 @@ class MatchEngineClient:
     orders_by_exchange_id: dict[str, str] = field(default_factory=dict)
     last_sequence: int = 0
     _ws_assistant: Any | None = None
+    _pending_command_ids: list[str] = field(default_factory=list)
 
     async def send_command(self, command: OrderCommand) -> None:
         self.orders.setdefault(command.client_order_id, MatchEngineOrderEntry(command.client_order_id, command))
+        self._pending_command_ids.append(command.client_order_id)
         ws = await self._connected_ws_assistant()
         await ws.send(WSJSONRequest(payload=command.to_payload()))
 
@@ -69,16 +71,37 @@ class MatchEngineClient:
             except asyncio.TimeoutError:
                 await asyncio.sleep(0)
 
+    async def wait_for_exchange_order_id(self, client_order_id: str, timeout_seconds: float) -> str | None:
+        deadline = asyncio.get_running_loop().time() + timeout_seconds
+        while True:
+            entry = self.orders.get(client_order_id)
+            if entry is not None and entry.exchange_order_id is not None:
+                return entry.exchange_order_id
+            remaining = deadline - asyncio.get_running_loop().time()
+            if remaining <= 0:
+                return None
+            try:
+                await asyncio.wait_for(self.receive_once(), timeout=min(remaining, 0.1))
+            except asyncio.TimeoutError:
+                await asyncio.sleep(0)
+
     def apply_command_response(self, response: CommandResponse) -> None:
-        if response.client_order_id is None:
+        client_order_id = response.client_order_id
+        simple_ack_without_ids = response.accepted and client_order_id is None and response.order_id is None
+        if client_order_id is None and self._pending_command_ids:
+            client_order_id = self._pending_command_ids.pop(0)
+        if client_order_id is None:
             return
-        entry = self.orders.get(response.client_order_id)
+        if client_order_id in self._pending_command_ids and not simple_ack_without_ids:
+            self._pending_command_ids.remove(client_order_id)
+        entry = self.orders.get(client_order_id)
         if entry is None:
             return
         entry.last_response = response
         if response.order_id is not None:
             entry.exchange_order_id = response.order_id
-            self.orders_by_exchange_id[response.order_id] = response.client_order_id
+            if entry.command.operation != "DELETE" or response.order_id not in self.orders_by_exchange_id:
+                self.orders_by_exchange_id[response.order_id] = client_order_id
 
     def apply_event(self, event: MatchEngineEvent) -> None:
         if event.sequence > self.last_sequence:

--- a/hummingbot/connector/exchange/twofinance/twofinance_matchengine_schemas.py
+++ b/hummingbot/connector/exchange/twofinance/twofinance_matchengine_schemas.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+from enum import Enum
+from typing import Any, Literal, Optional
+
+from hummingbot.connector.exchange.twofinance import twofinance_constants as CONSTANTS
+
+OrderSide = Literal["BUY", "SELL"]
+MatchEngineOrderType = Literal["MARKET", "LIMIT", "STOP", "STOP_LIMIT"]
+TimeInForce = Literal["GTC", "IOC", "FOK", "AON"]
+CommandOperation = Literal["ADD", "DELETE", "REPLACE", "MODIFY"]
+
+
+class CommandStatus(str, Enum):
+    ACCEPTED_TO_QUEUE = "accepted-to-queue"
+    REJECTED_BY_PARSER = "rejected-by-parser"
+    REJECTED_BY_RISK = "rejected-by-risk"
+    DUPLICATE = "duplicate"
+    UNAVAILABLE = "unavailable"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class OrderCommand:
+    client_order_id: str
+    engine_id: str
+    symbol_id: int
+    market: str
+    wallet_id: int
+    side: OrderSide
+    order_type: MatchEngineOrderType
+    quantity: Decimal | str
+    price: Decimal | str | None = None
+    time_in_force: TimeInForce | None = None
+    idempotency_key: str | None = None
+    operation: CommandOperation = "ADD"
+    order_id: int | str | None = None
+
+    def to_payload(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema": CONSTANTS.MATCHENGINE_ORDER_COMMAND_SCHEMA,
+            "message_type": "ORDER",
+            "operation": self.operation,
+            "client_order_id": self.client_order_id,
+            "idempotency_key": self.idempotency_key or self.client_order_id,
+            "engine_id": self.engine_id,
+            "market": self.market,
+            "wallet_id": self.wallet_id,
+            "symbol_id": self.symbol_id,
+        }
+        if self.operation == "ADD":
+            payload.update(
+                {
+                    "side": self.side,
+                    "order_type": self.order_type,
+                    "quantity": decimal_to_str(self.quantity),
+                }
+            )
+            if self.price is not None:
+                payload["price"] = decimal_to_str(self.price)
+            if self.time_in_force is not None:
+                payload["time_in_force"] = self.time_in_force
+        elif self.operation == "DELETE":
+            payload["order_id"] = require_order_id(self.order_id)
+        elif self.operation in {"REPLACE", "MODIFY"}:
+            payload["order_id"] = require_order_id(self.order_id)
+            payload["quantity"] = decimal_to_str(self.quantity)
+            if self.price is not None:
+                payload["price"] = decimal_to_str(self.price)
+        return payload
+
+
+@dataclass(frozen=True)
+class CommandResponse:
+    status: CommandStatus
+    client_order_id: str | None = None
+    order_id: str | None = None
+    reason: str | None = None
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def accepted(self) -> bool:
+        return self.status in {CommandStatus.ACCEPTED_TO_QUEUE, CommandStatus.DUPLICATE}
+
+
+@dataclass(frozen=True)
+class MatchEngineEvent:
+    event_type: str
+    sequence: int
+    event_id: str
+    symbol_id: int | None = None
+    market: str | None = None
+    timestamp_ns: int | None = None
+    payload: dict[str, Any] = field(default_factory=dict)
+    schema: str = CONSTANTS.MATCHENGINE_EVENT_SCHEMA
+    engine_id: str | None = None
+
+    @classmethod
+    def from_payload(cls, data: dict[str, Any]) -> "MatchEngineEvent":
+        payload = data.get("payload")
+        if not isinstance(payload, dict):
+            payload = {
+                key: value
+                for key, value in data.items()
+                if key
+                not in {
+                    "schema",
+                    "engine_id",
+                    "sequence",
+                    "event_id",
+                    "event_type",
+                    "symbol_id",
+                    "market",
+                    "timestamp_ns",
+                }
+            }
+        return cls(
+            schema=str(data.get("schema", CONSTANTS.MATCHENGINE_EVENT_SCHEMA)),
+            engine_id=optional_str(data.get("engine_id")),
+            sequence=int(data.get("sequence", 0)),
+            event_id=str(data.get("event_id") or data.get("sequence") or ""),
+            event_type=str(data.get("event_type") or data.get("type") or ""),
+            symbol_id=optional_int(data.get("symbol_id")),
+            market=optional_str(data.get("market")),
+            timestamp_ns=optional_int(data.get("timestamp_ns")),
+            payload=payload,
+        )
+
+
+def parse_command_response(data: dict[str, Any]) -> CommandResponse:
+    status_value = str(data.get("status") or data.get("Status") or "").lower().replace("_", "-")
+    error_code = data.get("error_code") if data.get("error_code") is not None else data.get("ErrorCode")
+    error_code_value = str(error_code or "")
+    if status_value in {"ok", "accepted", "accepted-to-queue", "queued"} or error_code_value in {"OK", "0"}:
+        status = CommandStatus.ACCEPTED_TO_QUEUE
+    elif status_value == "duplicate" or error_code_value == "ORDER_DUPLICATE":
+        status = CommandStatus.DUPLICATE
+    elif status_value in {"timeout", "unavailable"}:
+        status = CommandStatus.UNAVAILABLE
+    elif error_code_value in {"BALANCE_INSUFICIENT", "WALLET_NOT_FOUND"} or status_value.startswith("rejected-by-risk"):
+        status = CommandStatus.REJECTED_BY_RISK
+    elif status_value.startswith("rejected") or (error_code_value and error_code_value != "0"):
+        status = CommandStatus.REJECTED_BY_PARSER
+    else:
+        status = CommandStatus.UNKNOWN
+    return CommandResponse(
+        status=status,
+        client_order_id=optional_str(data.get("client_order_id") or data.get("ClientOrderId")),
+        order_id=optional_str(data.get("order_id") or data.get("OrderId")),
+        reason=optional_str(data.get("reason") or data.get("message") or data.get("Message") or error_code_value),
+        raw=data,
+    )
+
+
+def is_command_response(payload: dict[str, Any]) -> bool:
+    message_type = str(payload.get("message_type") or payload.get("MessageType") or payload.get("type") or "").upper()
+    return message_type in {"ACK", "ERROR", "12", "15"} or "error_code" in payload or "ErrorCode" in payload
+
+
+def event_order_state(event: MatchEngineEvent):
+    state = {
+        "ORDER_ACCEPTED": CONSTANTS.ORDER_STATE["OPEN"],
+        "ORDER_UPDATED": CONSTANTS.ORDER_STATE["OPEN"],
+        "ORDER_MODIFIED": CONSTANTS.ORDER_STATE["OPEN"],
+        "ORDER_REPLACED": CONSTANTS.ORDER_STATE["OPEN"],
+        "ORDER_EXECUTED": CONSTANTS.ORDER_STATE["PARTIALLY_FILLED"],
+        "ORDER_CANCELED": CONSTANTS.ORDER_STATE["CANCELED"],
+        "ORDER_REJECTED": CONSTANTS.ORDER_STATE["REJECTED"],
+    }.get(event.event_type)
+    raw_status = event.payload.get("order_status") or event.payload.get("status")
+    if raw_status is not None:
+        if isinstance(raw_status, int):
+            state = {
+                0: CONSTANTS.ORDER_STATE["CANCELED"],
+                1: CONSTANTS.ORDER_STATE["OPEN"],
+                2: CONSTANTS.ORDER_STATE["FILLED"],
+                3: CONSTANTS.ORDER_STATE["PARTIALLY_FILLED"],
+            }.get(raw_status, state)
+        else:
+            state = CONSTANTS.ORDER_STATE.get(str(raw_status).upper(), state)
+    return state
+
+
+def decimal_to_str(value: Decimal | str) -> str:
+    return format(to_decimal(value), "f")
+
+
+def to_decimal(value: Any) -> Decimal:
+    if isinstance(value, Decimal):
+        return value
+    return Decimal(str(value))
+
+
+def optional_int(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    return int(value)
+
+
+def optional_str(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    return str(value)
+
+
+def require_order_id(value: int | str | None) -> int | str:
+    if value is None:
+        raise ValueError("order_id is required")
+    return value

--- a/hummingbot/connector/exchange/twofinance/twofinance_matchengine_schemas.py
+++ b/hummingbot/connector/exchange/twofinance/twofinance_matchengine_schemas.py
@@ -130,10 +130,17 @@ class MatchEngineEvent:
 
 
 def parse_command_response(data: dict[str, Any]) -> CommandResponse:
+    message_type = str(data.get("message_type") or data.get("MessageType") or data.get("type") or "").upper()
     status_value = str(data.get("status") or data.get("Status") or "").lower().replace("_", "-")
     error_code = data.get("error_code") if data.get("error_code") is not None else data.get("ErrorCode")
+    if error_code is None:
+        error_code = data.get("reason_code")
     error_code_value = str(error_code or "")
-    if status_value in {"ok", "accepted", "accepted-to-queue", "queued"} or error_code_value in {"OK", "0"}:
+    if message_type in {"ACK", "12"} and status_value not in {"timeout", "unavailable"}:
+        status = CommandStatus.ACCEPTED_TO_QUEUE
+    elif message_type == "REJECT":
+        status = CommandStatus.REJECTED_BY_PARSER
+    elif status_value in {"ok", "accepted", "accepted-to-queue", "queued"} or error_code_value in {"OK", "0"}:
         status = CommandStatus.ACCEPTED_TO_QUEUE
     elif status_value == "duplicate" or error_code_value == "ORDER_DUPLICATE":
         status = CommandStatus.DUPLICATE
@@ -149,14 +156,14 @@ def parse_command_response(data: dict[str, Any]) -> CommandResponse:
         status=status,
         client_order_id=optional_str(data.get("client_order_id") or data.get("ClientOrderId")),
         order_id=optional_str(data.get("order_id") or data.get("OrderId")),
-        reason=optional_str(data.get("reason") or data.get("message") or data.get("Message") or error_code_value),
+        reason=optional_str(data.get("reason") or data.get("reason_code") or data.get("message") or data.get("Message") or error_code_value),
         raw=data,
     )
 
 
 def is_command_response(payload: dict[str, Any]) -> bool:
     message_type = str(payload.get("message_type") or payload.get("MessageType") or payload.get("type") or "").upper()
-    return message_type in {"ACK", "ERROR", "12", "15"} or "error_code" in payload or "ErrorCode" in payload
+    return message_type in {"ACK", "ERROR", "REJECT", "12", "15"} or "error_code" in payload or "ErrorCode" in payload
 
 
 def event_order_state(event: MatchEngineEvent):

--- a/hummingbot/connector/exchange/twofinance/twofinance_utils.py
+++ b/hummingbot/connector/exchange/twofinance/twofinance_utils.py
@@ -1,0 +1,77 @@
+from decimal import Decimal
+from typing import Any, Dict
+
+from pydantic import ConfigDict, Field, SecretStr
+
+from hummingbot.client.config.config_data_types import BaseConnectorConfigMap
+from hummingbot.core.data_type.trade_fee import TradeFeeSchema
+
+CENTRALIZED = False
+EXAMPLE_PAIR = "BTC-USDT"
+
+DEFAULT_FEES = TradeFeeSchema(
+    maker_percent_fee_decimal=Decimal("0"),
+    taker_percent_fee_decimal=Decimal("0"),
+)
+
+
+def is_exchange_information_valid(exchange_info: Dict[str, Any]) -> bool:
+    return bool(exchange_info.get("symbol") or exchange_info.get("trading_pair") or exchange_info.get("market"))
+
+
+class TwoFinanceConfigMap(BaseConnectorConfigMap):
+    connector: str = "twofinance"
+    twofinance_state_api_url: str = Field(
+        default="http://127.0.0.1:8080/api/v1",
+        json_schema_extra={
+            "prompt": "Enter the 2Finance State API URL",
+            "prompt_on_new": True,
+            "is_connect_key": True,
+        },
+    )
+    twofinance_matchengine_ws_url: str = Field(
+        default="ws://127.0.0.1:10000",
+        json_schema_extra={
+            "prompt": "Enter the 2Finance MatchEngine WebSocket URL",
+            "prompt_on_new": True,
+            "is_connect_key": True,
+        },
+    )
+    twofinance_matchengine_bearer_token: SecretStr = Field(
+        default=...,
+        json_schema_extra={
+            "prompt": "Enter the 2Finance MatchEngine bearer token",
+            "is_secure": True,
+            "is_connect_key": True,
+            "prompt_on_new": True,
+        },
+    )
+    twofinance_engine_id: str = Field(
+        default="engine-btc-usdt",
+        json_schema_extra={"prompt": "Enter the 2Finance engine id", "prompt_on_new": True},
+    )
+    twofinance_wallet_id: int = Field(
+        default=1,
+        json_schema_extra={"prompt": "Enter the 2Finance wallet id", "prompt_on_new": True},
+    )
+    twofinance_account_id: str = Field(
+        default="",
+        json_schema_extra={"prompt": "Enter the optional 2Finance account id", "prompt_on_new": False},
+    )
+    model_config = ConfigDict(title="twofinance")
+
+
+KEYS = TwoFinanceConfigMap.model_construct()
+
+OTHER_DOMAINS = ["twofinance_testnet"]
+OTHER_DOMAINS_PARAMETER = {"twofinance_testnet": "twofinance_testnet"}
+OTHER_DOMAINS_EXAMPLE_PAIR = {"twofinance_testnet": "BTC-USDT"}
+OTHER_DOMAINS_DEFAULT_FEES = {"twofinance_testnet": [0, 0]}
+
+
+class TwoFinanceTestnetConfigMap(TwoFinanceConfigMap):
+    connector: str = "twofinance_testnet"
+    model_config = ConfigDict(title="twofinance_testnet")
+
+
+OTHER_DOMAINS_KEYS = {"twofinance_testnet": TwoFinanceTestnetConfigMap.model_construct()}

--- a/hummingbot/connector/exchange/twofinance/twofinance_web_utils.py
+++ b/hummingbot/connector/exchange/twofinance/twofinance_web_utils.py
@@ -1,0 +1,51 @@
+import time
+from typing import Optional
+
+from hummingbot.connector.exchange.twofinance import twofinance_constants as CONSTANTS
+from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from hummingbot.core.web_assistant.auth import AuthBase
+from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
+
+_REST_URLS = {
+    CONSTANTS.DEFAULT_DOMAIN: CONSTANTS.REST_URL,
+    CONSTANTS.TESTNET_DOMAIN: CONSTANTS.TESTNET_REST_URL,
+}
+_WSS_URLS = {
+    CONSTANTS.DEFAULT_DOMAIN: CONSTANTS.WSS_URL,
+    CONSTANTS.TESTNET_DOMAIN: CONSTANTS.TESTNET_WSS_URL,
+}
+
+
+def private_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:
+    return rest_url(path_url=path_url, domain=domain)
+
+
+def public_rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:
+    return rest_url(path_url=path_url, domain=domain)
+
+
+def rest_url(path_url: str, domain: str = CONSTANTS.DEFAULT_DOMAIN) -> str:
+    return _REST_URLS.get(domain, CONSTANTS.REST_URL).rstrip("/") + path_url
+
+
+def wss_url(domain: str = CONSTANTS.DEFAULT_DOMAIN, override_url: Optional[str] = None) -> str:
+    return override_url or _WSS_URLS.get(domain, CONSTANTS.WSS_URL)
+
+
+def normalize_trading_pair(value: str | None) -> str:
+    return str(value or "").replace("/", "-")
+
+
+def exchange_trading_pair(value: str | None) -> str:
+    return str(value or "").replace("-", "/")
+
+
+def build_api_factory(
+    throttler: Optional[AsyncThrottler] = None,
+    auth: Optional[AuthBase] = None,
+) -> WebAssistantsFactory:
+    return WebAssistantsFactory(throttler=throttler, auth=auth)
+
+
+async def get_current_server_time(throttler, domain) -> float:
+    return time.time()

--- a/test/hummingbot/connector/exchange/twofinance/test_twofinance_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/twofinance/test_twofinance_api_order_book_data_source.py
@@ -23,12 +23,19 @@ class FakeAPIFactory:
         return self.ws
 
 
+class FakeConnector:
+    _symbol_metadata = {
+        "BTC-USDT": {"symbol_id": 1},
+        "ETH-USDT": {"symbol_id": 2},
+    }
+
+
 class TwoFinanceAPIOrderBookDataSourceTests(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.api_factory = FakeAPIFactory()
         self.data_source = TwoFinanceAPIOrderBookDataSource(
             trading_pairs=["BTC-USDT"],
-            connector=None,
+            connector=FakeConnector(),
             api_factory=self.api_factory,
         )
 
@@ -104,10 +111,13 @@ class TwoFinanceAPIOrderBookDataSourceTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertTrue(subscribed)
         self.assertTrue(unsubscribed)
-        self.assertEqual(self.api_factory.ws.sent[0]["type"], "subscribe_public")
-        self.assertEqual(self.api_factory.ws.sent[0]["trading_pairs"], ["ETH/USDT"])
-        self.assertEqual(self.api_factory.ws.sent[1]["type"], "unsubscribe_public")
-        self.assertEqual(self.api_factory.ws.sent[1]["trading_pairs"], ["ETH/USDT"])
+        self.assertEqual(self.api_factory.ws.sent[0], {"method": "subscribe", "params": ["2@BOOK", "2@TRADE", "2@LEVEL"]})
+        self.assertEqual(self.api_factory.ws.sent[1], {"method": "unsubscribe", "params": ["2@BOOK", "2@TRADE", "2@LEVEL"]})
+
+    async def test_initial_subscribe_uses_matchengine_symbol_params(self):
+        await self.data_source._subscribe_channels(self.api_factory.ws)
+
+        self.assertEqual(self.api_factory.ws.sent[0], {"method": "subscribe", "params": ["1@BOOK", "1@TRADE", "1@LEVEL"]})
 
 
 if __name__ == "__main__":

--- a/test/hummingbot/connector/exchange/twofinance/test_twofinance_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/twofinance/test_twofinance_api_order_book_data_source.py
@@ -1,0 +1,114 @@
+import asyncio
+import unittest
+
+from hummingbot.connector.exchange.twofinance.twofinance_api_order_book_data_source import (
+    TwoFinanceAPIOrderBookDataSource,
+)
+from hummingbot.core.data_type.order_book_message import OrderBookMessageType
+
+
+class FakeWSAssistant:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, request):
+        self.sent.append(dict(request.payload))
+
+
+class FakeAPIFactory:
+    def __init__(self):
+        self.ws = FakeWSAssistant()
+
+    async def get_ws_assistant(self):
+        return self.ws
+
+
+class TwoFinanceAPIOrderBookDataSourceTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.api_factory = FakeAPIFactory()
+        self.data_source = TwoFinanceAPIOrderBookDataSource(
+            trading_pairs=["BTC-USDT"],
+            connector=None,
+            api_factory=self.api_factory,
+        )
+
+    async def test_parse_snapshot_event_message(self):
+        queue = asyncio.Queue()
+
+        await self.data_source._parse_order_book_snapshot_message(
+            {
+                "schema": "matchengine.event.v1",
+                "sequence": 10,
+                "event_id": "engine:10",
+                "event_type": "ORDER_BOOK_SNAPSHOT",
+                "market": "BTC/USDT",
+                "payload": {
+                    "bids": [["100", "1"]],
+                    "asks": [["101", "2"]],
+                    "timestamp": 123,
+                },
+            },
+            queue,
+        )
+
+        message = queue.get_nowait()
+        self.assertEqual(message.type, OrderBookMessageType.SNAPSHOT)
+        self.assertEqual(message.trading_pair, "BTC-USDT")
+        self.assertEqual(message.update_id, 10)
+        self.assertEqual(message.bids[0].price, 100)
+        self.assertEqual(message.asks[0].amount, 2)
+
+    async def test_parse_diff_and_trade_messages(self):
+        diff_queue = asyncio.Queue()
+        trade_queue = asyncio.Queue()
+
+        await self.data_source._parse_order_book_diff_message(
+            {
+                "schema": "matchengine.event.v1",
+                "sequence": 11,
+                "event_id": "engine:11",
+                "event_type": "ORDER_BOOK_DIFF",
+                "market": "BTC/USDT",
+                "payload": {"bids": [{"price": "100", "quantity": "0"}], "asks": [["101", "3"]]},
+            },
+            diff_queue,
+        )
+        await self.data_source._parse_trade_message(
+            {
+                "schema": "matchengine.event.v1",
+                "sequence": 12,
+                "event_id": "engine:12",
+                "event_type": "TRADE_EXECUTED",
+                "market": "BTC/USDT",
+                "payload": {"trade_id": 44, "side": "SELL", "price": "100.5", "quantity": "0.25"},
+            },
+            trade_queue,
+        )
+
+        diff_message = diff_queue.get_nowait()
+        trade_message = trade_queue.get_nowait()
+        self.assertEqual(diff_message.type, OrderBookMessageType.DIFF)
+        self.assertEqual(diff_message.trading_pair, "BTC-USDT")
+        self.assertEqual(diff_message.update_id, 11)
+        self.assertEqual(diff_message.content["asks"], [["101", "3"]])
+        self.assertEqual(trade_message.type, OrderBookMessageType.TRADE)
+        self.assertEqual(trade_message.trading_pair, "BTC-USDT")
+        self.assertEqual(trade_message.trade_id, 44)
+        self.assertEqual(trade_message.content["trade_type"], 2.0)
+
+    async def test_dynamic_subscribe_and_unsubscribe(self):
+        self.data_source._ws_assistant = self.api_factory.ws
+
+        subscribed = await self.data_source.subscribe_to_trading_pair("ETH-USDT")
+        unsubscribed = await self.data_source.unsubscribe_from_trading_pair("ETH-USDT")
+
+        self.assertTrue(subscribed)
+        self.assertTrue(unsubscribed)
+        self.assertEqual(self.api_factory.ws.sent[0]["type"], "subscribe_public")
+        self.assertEqual(self.api_factory.ws.sent[0]["trading_pairs"], ["ETH/USDT"])
+        self.assertEqual(self.api_factory.ws.sent[1]["type"], "unsubscribe_public")
+        self.assertEqual(self.api_factory.ws.sent[1]["trading_pairs"], ["ETH/USDT"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/hummingbot/connector/exchange/twofinance/test_twofinance_api_user_stream_data_source.py
+++ b/test/hummingbot/connector/exchange/twofinance/test_twofinance_api_user_stream_data_source.py
@@ -1,0 +1,54 @@
+import unittest
+
+from hummingbot.connector.exchange.twofinance.twofinance_api_user_stream_data_source import (
+    TwoFinanceAPIUserStreamDataSource,
+)
+
+
+class FakeWSAssistant:
+    def __init__(self):
+        self.connect_calls = []
+        self.sent_payloads = []
+
+    async def connect(self, ws_url, ws_headers=None, **kwargs):
+        self.connect_calls.append({"ws_url": ws_url, "ws_headers": ws_headers or {}, **kwargs})
+
+    async def send(self, request):
+        self.sent_payloads.append(dict(request.payload))
+
+
+class FakeAPIFactory:
+    def __init__(self):
+        self.ws = FakeWSAssistant()
+
+    async def get_ws_assistant(self):
+        return self.ws
+
+
+class TwoFinanceAPIUserStreamDataSourceTests(unittest.IsolatedAsyncioTestCase):
+    async def test_private_stream_connects_with_bearer_and_subscribes_private_channels(self):
+        api_factory = FakeAPIFactory()
+        data_source = TwoFinanceAPIUserStreamDataSource(
+            api_factory=api_factory,
+            auth_headers={"Authorization": "Bearer private-token"},
+            engine_id="engine-btc-usdt",
+            wallet_id=7,
+            ws_url="ws://matchengine.local:10000",
+        )
+
+        ws = await data_source._connected_websocket_assistant()
+        await data_source._subscribe_channels(ws)
+
+        self.assertEqual(api_factory.ws.connect_calls[0]["ws_url"], "ws://matchengine.local:10000")
+        self.assertEqual(
+            api_factory.ws.connect_calls[0]["ws_headers"],
+            {"Authorization": "Bearer private-token"},
+        )
+        self.assertEqual(api_factory.ws.sent_payloads[0]["type"], "subscribe_private")
+        self.assertEqual(api_factory.ws.sent_payloads[0]["channels"], ["orders", "trades", "balances"])
+        self.assertEqual(api_factory.ws.sent_payloads[0]["engine_id"], "engine-btc-usdt")
+        self.assertEqual(api_factory.ws.sent_payloads[0]["wallet_id"], 7)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/hummingbot/connector/exchange/twofinance/test_twofinance_api_user_stream_data_source.py
+++ b/test/hummingbot/connector/exchange/twofinance/test_twofinance_api_user_stream_data_source.py
@@ -44,10 +44,7 @@ class TwoFinanceAPIUserStreamDataSourceTests(unittest.IsolatedAsyncioTestCase):
             api_factory.ws.connect_calls[0]["ws_headers"],
             {"Authorization": "Bearer private-token"},
         )
-        self.assertEqual(api_factory.ws.sent_payloads[0]["type"], "subscribe_private")
-        self.assertEqual(api_factory.ws.sent_payloads[0]["channels"], ["orders", "trades", "balances"])
-        self.assertEqual(api_factory.ws.sent_payloads[0]["engine_id"], "engine-btc-usdt")
-        self.assertEqual(api_factory.ws.sent_payloads[0]["wallet_id"], 7)
+        self.assertEqual(api_factory.ws.sent_payloads[0], {"method": "subscribe", "params": ["7@WALLET"]})
 
 
 if __name__ == "__main__":

--- a/test/hummingbot/connector/exchange/twofinance/test_twofinance_exchange.py
+++ b/test/hummingbot/connector/exchange/twofinance/test_twofinance_exchange.py
@@ -1,0 +1,160 @@
+import unittest
+from decimal import Decimal
+
+from hummingbot.connector.exchange.twofinance.twofinance_exchange import TwoFinanceExchange
+from hummingbot.connector.exchange.twofinance.twofinance_matchengine_schemas import MatchEngineEvent
+from hummingbot.core.data_type.common import OrderType, TradeType
+from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState
+
+
+class TwoFinanceExchangeTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.exchange = TwoFinanceExchange(
+            twofinance_matchengine_bearer_token="token",
+            twofinance_engine_id="engine-btc-usdt",
+            twofinance_wallet_id=7,
+            trading_pairs=["BTC-USDT"],
+            trading_required=False,
+            ack_timeout=0,
+        )
+        self.exchange._symbol_metadata["BTC-USDT"] = {"symbol_id": 1, "symbol": "BTC-USDT"}
+
+    async def test_build_order_command_maps_hummingbot_order(self):
+        self.exchange._symbol_metadata["BTC-USDT"]["exchange_symbol"] = "BTC/USDT"
+        command = await self.exchange._build_order_command(
+            order_id="HBOT-2F-1",
+            trading_pair="BTC-USDT",
+            amount=Decimal("0.25"),
+            trade_type=TradeType.SELL,
+            order_type=OrderType.LIMIT_MAKER,
+            price=Decimal("100"),
+            time_in_force=None,
+        )
+
+        payload = command.to_payload()
+        self.assertEqual(payload["side"], "SELL")
+        self.assertEqual(payload["order_type"], "LIMIT")
+        self.assertNotIn("time_in_force", payload)
+        self.assertEqual(payload["symbol_id"], 1)
+        self.assertEqual(payload["market"], "BTC-USDT")
+
+    async def test_format_trading_rules(self):
+        rules = await self.exchange._format_trading_rules(
+            {
+                "data": {
+                    "trading_rules": {
+                        "BTC-USDT": {
+                            "symbol": "BTC-USDT",
+                            "min_order_size": "0.001",
+                            "tick_size": "0.01",
+                            "step_size": "0.0001",
+                            "min_notional": "10",
+                        }
+                    }
+                }
+            }
+        )
+
+        self.assertEqual(rules[0].trading_pair, "BTC-USDT")
+        self.assertEqual(rules[0].min_order_size, Decimal("0.001"))
+        self.assertEqual(rules[0].min_price_increment, Decimal("0.01"))
+        self.assertEqual(rules[0].min_base_amount_increment, Decimal("0.0001"))
+        self.assertEqual(rules[0].min_notional_size, Decimal("10"))
+
+    async def test_format_trading_rules_normalizes_exchange_pair(self):
+        rules = await self.exchange._format_trading_rules(
+            {
+                "data": {
+                    "trading_rules": [
+                        {
+                            "name": "BTC/USDT",
+                            "min_order_size": "0.001",
+                            "tick_size": "0.01",
+                            "step_size": "0.0001",
+                            "min_notional": "10",
+                        }
+                    ]
+                }
+            }
+        )
+
+        self.assertEqual(rules[0].trading_pair, "BTC-USDT")
+
+    def test_initialize_trading_pair_symbols_normalizes_state_api_symbols(self):
+        self.exchange._initialize_trading_pair_symbols_from_exchange_info(
+            {
+                "data": {
+                    "symbols": [
+                        {
+                            "symbol_id": 1,
+                            "name": "BTC/USDT",
+                        }
+                    ]
+                }
+            }
+        )
+
+        self.assertEqual(self.exchange._symbol_metadata["BTC-USDT"]["exchange_symbol"], "BTC/USDT")
+
+    def test_order_update_from_event(self):
+        event = MatchEngineEvent.from_payload(
+            {
+                "schema": "matchengine.event.v1",
+                "sequence": 1,
+                "event_id": "engine:1",
+                "event_type": "ORDER_ACCEPTED",
+                "symbol_id": 1,
+                "market": "BTC-USDT",
+                "payload": {"client_order_id": "HBOT-2F-1", "order_id": 99, "order_status": 1},
+            }
+        )
+
+        update = self.exchange._order_update_from_event(event)
+
+        self.assertEqual(update.client_order_id, "HBOT-2F-1")
+        self.assertEqual(update.exchange_order_id, "99")
+        self.assertEqual(update.new_state, OrderState.OPEN)
+
+    def test_trade_update_from_event_uses_exchange_order_mapping(self):
+        order = InFlightOrder(
+            client_order_id="HBOT-2F-1",
+            trading_pair="BTC-USDT",
+            order_type=OrderType.LIMIT,
+            trade_type=TradeType.BUY,
+            amount=Decimal("1"),
+            price=Decimal("100"),
+            exchange_order_id="99",
+            creation_timestamp=1,
+        )
+        self.exchange._order_tracker.start_tracking_order(order)
+        self.exchange._matchengine_client.orders_by_exchange_id["99"] = "HBOT-2F-1"
+        event = MatchEngineEvent.from_payload(
+            {
+                "schema": "matchengine.event.v1",
+                "sequence": 2,
+                "event_id": "engine:2",
+                "event_type": "TRADE_EXECUTED",
+                "symbol_id": 1,
+                "market": "BTC-USDT",
+                "payload": {
+                    "trade_id": "t-1",
+                    "taker_order_id": 99,
+                    "price": "100",
+                    "quantity": "0.5",
+                    "fee_asset": "USDT",
+                    "fee_amount": "0.01",
+                },
+            }
+        )
+
+        trade_update = self.exchange._trade_update_from_event(event)
+
+        self.assertEqual(trade_update.client_order_id, "HBOT-2F-1")
+        self.assertEqual(trade_update.fill_base_amount, Decimal("0.5"))
+        self.assertEqual(trade_update.fill_quote_amount, Decimal("50.0"))
+        self.assertEqual(trade_update.fee.flat_fees[0].token, "USDT")
+        self.assertEqual(trade_update.fee.flat_fees[0].amount, Decimal("0.01"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/hummingbot/connector/exchange/twofinance/test_twofinance_hummingbot_smoke.py
+++ b/test/hummingbot/connector/exchange/twofinance/test_twofinance_hummingbot_smoke.py
@@ -1,0 +1,79 @@
+import os
+import time
+import unittest
+from decimal import Decimal
+
+from hummingbot.client.settings import AllConnectorSettings
+from hummingbot.connector.exchange.twofinance import twofinance_constants as CONSTANTS
+from hummingbot.connector.exchange.twofinance.twofinance_exchange import TwoFinanceExchange
+from hummingbot.core.data_type.common import OrderType, TradeType
+from hummingbot.core.data_type.in_flight_order import InFlightOrder
+
+RUN_SMOKE = os.getenv("TWO_FINANCE_RUN_HUMMINGBOT_SMOKE") == "1"
+
+
+@unittest.skipUnless(RUN_SMOKE, "set TWO_FINANCE_RUN_HUMMINGBOT_SMOKE=1 to run the local 2Finance Hummingbot smoke")
+class TwoFinanceHummingbotSmokeTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.exchange = TwoFinanceExchange(
+            twofinance_matchengine_bearer_token=os.getenv("TWO_FINANCE_MATCHENGINE_BEARER_TOKEN", "valid-order-token"),
+            twofinance_engine_id=os.getenv("TWO_FINANCE_MATCHENGINE_ENGINE_ID", "local-matchengine"),
+            twofinance_wallet_id=int(os.getenv("TWO_FINANCE_MATCHENGINE_WALLET_ID", "1")),
+            twofinance_state_api_url=os.getenv("TWO_FINANCE_STATE_API_URL", "http://127.0.0.1:11080/api/v1"),
+            twofinance_matchengine_ws_url=os.getenv("TWO_FINANCE_MATCHENGINE_WS_URL", CONSTANTS.WSS_URL),
+            trading_pairs=[os.getenv("TWO_FINANCE_TRADING_PAIR", "BTC-USDT")],
+            trading_required=True,
+            ack_timeout=float(os.getenv("TWO_FINANCE_MATCHENGINE_ACK_TIMEOUT", "5")),
+        )
+
+    async def asyncTearDown(self):
+        await self.exchange._matchengine_client.close()
+        await self.exchange._web_assistants_factory.close()
+
+    async def test_connector_loads_market_data_places_and_cancels_order(self):
+        settings = AllConnectorSettings.get_connector_settings()
+        self.assertIn("twofinance", settings)
+        self.assertIn("twofinance_testnet", settings)
+
+        symbols = await self.exchange._api_get(path_url=CONSTANTS.SYMBOLS_PATH_URL)
+        self.exchange._initialize_trading_pair_symbols_from_exchange_info(symbols)
+        self.assertEqual(self.exchange._symbol_metadata["BTC-USDT"]["exchange_symbol"], "BTC/USDT")
+
+        rules_payload = await self.exchange._api_get(path_url=CONSTANTS.TRADING_RULES_PATH_URL)
+        rules = await self.exchange._format_trading_rules(rules_payload)
+        self.assertEqual(rules[0].trading_pair, "BTC-USDT")
+
+        await self.exchange._update_balances()
+        self.assertGreater(self.exchange.get_balance("USDT"), Decimal("0"))
+
+        data_source = self.exchange._create_order_book_data_source()
+        snapshot = await data_source._order_book_snapshot("BTC-USDT")
+        self.assertEqual(snapshot.trading_pair, "BTC-USDT")
+        self.assertGreater(len(snapshot.bids), 0)
+
+        client_order_id = f"HBOT-2F-SMOKE-{int(time.time() * 1000)}"
+        exchange_order_id, _ = await self.exchange._place_order(
+            order_id=client_order_id,
+            trading_pair="BTC-USDT",
+            amount=Decimal(os.getenv("TWO_FINANCE_SMOKE_ORDER_AMOUNT", "1")),
+            trade_type=TradeType.BUY,
+            order_type=OrderType.LIMIT,
+            price=Decimal(os.getenv("TWO_FINANCE_SMOKE_ORDER_PRICE", "100")),
+        )
+        self.assertTrue(exchange_order_id)
+
+        tracked_order = InFlightOrder(
+            client_order_id=client_order_id,
+            trading_pair="BTC-USDT",
+            order_type=OrderType.LIMIT,
+            trade_type=TradeType.BUY,
+            amount=Decimal(os.getenv("TWO_FINANCE_SMOKE_ORDER_AMOUNT", "1")),
+            price=Decimal(os.getenv("TWO_FINANCE_SMOKE_ORDER_PRICE", "100")),
+            exchange_order_id=str(exchange_order_id),
+            creation_timestamp=self.exchange.current_timestamp,
+        )
+        self.assertTrue(await self.exchange._place_cancel(f"{client_order_id}-CANCEL", tracked_order))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/hummingbot/connector/exchange/twofinance/test_twofinance_matchengine_client.py
+++ b/test/hummingbot/connector/exchange/twofinance/test_twofinance_matchengine_client.py
@@ -1,0 +1,104 @@
+import unittest
+
+from hummingbot.connector.exchange.twofinance.twofinance_matchengine_client import MatchEngineClient
+from hummingbot.connector.exchange.twofinance.twofinance_matchengine_schemas import CommandStatus, OrderCommand
+from hummingbot.core.web_assistant.connections.data_types import WSResponse
+
+
+class FakeConnection:
+    def __init__(self):
+        self.connected = False
+
+
+class FakeWSAssistant:
+    def __init__(self):
+        self._connection = FakeConnection()
+        self.connect_calls = []
+        self.sent_payloads = []
+        self.incoming = []
+
+    async def connect(self, ws_url, ws_headers=None, **kwargs):
+        self._connection.connected = True
+        self.connect_calls.append({"ws_url": ws_url, "ws_headers": ws_headers or {}, **kwargs})
+
+    async def send(self, request):
+        self.sent_payloads.append(dict(request.payload))
+
+    async def receive(self):
+        if not self.incoming:
+            return None
+        return WSResponse(self.incoming.pop(0))
+
+
+class FakeAPIFactory:
+    def __init__(self):
+        self.ws = FakeWSAssistant()
+
+    async def get_ws_assistant(self):
+        return self.ws
+
+
+class TwoFinanceMatchEngineClientTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.api_factory = FakeAPIFactory()
+        self.client = MatchEngineClient(
+            api_factory=self.api_factory,
+            ws_url="ws://matchengine.local:10000",
+            auth_headers={"Authorization": "Bearer test-token"},
+        )
+
+    async def test_send_command_connects_with_bearer_header_and_payload(self):
+        command = OrderCommand(
+            client_order_id="HBOT-2F-1",
+            engine_id="engine-btc-usdt",
+            symbol_id=1,
+            market="BTC-USDT",
+            wallet_id=7,
+            side="BUY",
+            order_type="LIMIT",
+            quantity="1",
+            price="100",
+        )
+
+        await self.client.send_command(command)
+
+        self.assertEqual(self.api_factory.ws.connect_calls[0]["ws_url"], "ws://matchengine.local:10000")
+        self.assertEqual(
+            self.api_factory.ws.connect_calls[0]["ws_headers"],
+            {"Authorization": "Bearer test-token"},
+        )
+        self.assertEqual(self.api_factory.ws.sent_payloads[0]["schema"], "matchengine.order_command.v1")
+        self.assertEqual(self.api_factory.ws.sent_payloads[0]["client_order_id"], "HBOT-2F-1")
+        self.assertEqual(self.api_factory.ws.sent_payloads[0]["idempotency_key"], "HBOT-2F-1")
+
+    async def test_receive_ack_tracks_exchange_order_id(self):
+        command = OrderCommand(
+            client_order_id="HBOT-2F-2",
+            engine_id="engine-btc-usdt",
+            symbol_id=1,
+            market="BTC-USDT",
+            wallet_id=7,
+            side="SELL",
+            order_type="LIMIT",
+            quantity="1",
+            price="101",
+        )
+        await self.client.send_command(command)
+        self.api_factory.ws.incoming.append(
+            {
+                "message_type": "ACK",
+                "status": "accepted-to-queue",
+                "client_order_id": "HBOT-2F-2",
+                "order_id": 123,
+            }
+        )
+
+        response = await self.client.receive_once()
+
+        self.assertEqual(response.status, CommandStatus.ACCEPTED_TO_QUEUE)
+        self.assertEqual(self.client.orders["HBOT-2F-2"].exchange_order_id, "123")
+        self.assertEqual(self.client.orders_by_exchange_id["123"], "HBOT-2F-2")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/hummingbot/connector/exchange/twofinance/test_twofinance_matchengine_client.py
+++ b/test/hummingbot/connector/exchange/twofinance/test_twofinance_matchengine_client.py
@@ -99,6 +99,121 @@ class TwoFinanceMatchEngineClientTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(self.client.orders["HBOT-2F-2"].exchange_order_id, "123")
         self.assertEqual(self.client.orders_by_exchange_id["123"], "HBOT-2F-2")
 
+    async def test_simple_ack_is_associated_with_pending_command_without_order_id(self):
+        command = OrderCommand(
+            client_order_id="HBOT-2F-3",
+            engine_id="engine-btc-usdt",
+            symbol_id=1,
+            market="BTC-USDT",
+            wallet_id=7,
+            side="BUY",
+            order_type="LIMIT",
+            quantity="1",
+            price="100",
+        )
+        await self.client.send_command(command)
+        self.api_factory.ws.incoming.append({"type": 12, "timestamp": 123456789})
+
+        response = await self.client.receive_once()
+
+        self.assertEqual(response.status, CommandStatus.ACCEPTED_TO_QUEUE)
+        self.assertIs(self.client.orders["HBOT-2F-3"].last_response, response)
+        self.assertIsNone(self.client.orders["HBOT-2F-3"].exchange_order_id)
+
+        self.api_factory.ws.incoming.append(
+            {
+                "schema": "matchengine.event.v1",
+                "sequence": 1,
+                "event_id": "engine:1",
+                "event_type": "ORDER_ACCEPTED",
+                "symbol_id": 1,
+                "payload": {"client_order_id": "HBOT-2F-3", "order_id": 124, "order_status": 1},
+            }
+        )
+        exchange_order_id = await self.client.wait_for_exchange_order_id("HBOT-2F-3", 1)
+
+        self.assertEqual(exchange_order_id, "124")
+        self.assertEqual(self.client.orders_by_exchange_id["124"], "HBOT-2F-3")
+
+    async def test_cancel_ack_does_not_steal_exchange_order_mapping(self):
+        create_command = OrderCommand(
+            client_order_id="HBOT-2F-OPEN",
+            engine_id="engine-btc-usdt",
+            symbol_id=1,
+            market="BTC-USDT",
+            wallet_id=7,
+            side="BUY",
+            order_type="LIMIT",
+            quantity="1",
+            price="100",
+        )
+        cancel_command = OrderCommand(
+            client_order_id="HBOT-2F-CANCEL",
+            engine_id="engine-btc-usdt",
+            symbol_id=1,
+            market="BTC-USDT",
+            wallet_id=7,
+            side="BUY",
+            order_type="LIMIT",
+            quantity="0",
+            operation="DELETE",
+            order_id="124",
+        )
+        await self.client.send_command(create_command)
+        self.api_factory.ws.incoming.append(
+            {
+                "schema": "matchengine.event.v1",
+                "sequence": 1,
+                "event_id": "engine:1",
+                "event_type": "ORDER_ACCEPTED",
+                "symbol_id": 1,
+                "payload": {"client_order_id": "HBOT-2F-OPEN", "order_id": 124, "order_status": 1},
+            }
+        )
+        await self.client.receive_once()
+
+        await self.client.send_command(cancel_command)
+        self.api_factory.ws.incoming.append(
+            {
+                "message_type": "ACK",
+                "status": "accepted-to-queue",
+                "client_order_id": "HBOT-2F-CANCEL",
+                "order_id": 124,
+            }
+        )
+        await self.client.receive_once()
+
+        self.assertEqual(self.client.orders_by_exchange_id["124"], "HBOT-2F-OPEN")
+
+    async def test_reject_without_client_order_id_fails_pending_command_response(self):
+        command = OrderCommand(
+            client_order_id="HBOT-2F-4",
+            engine_id="engine-btc-usdt",
+            symbol_id=1,
+            market="BTC-USDT",
+            wallet_id=7,
+            side="BUY",
+            order_type="LIMIT",
+            quantity="1",
+            price="100",
+        )
+        await self.client.send_command(command)
+        self.api_factory.ws.incoming.append(
+            {
+                "schema": "matchengine.order_response.v1",
+                "message_type": "REJECT",
+                "status": "rejected",
+                "reason_code": "INVALID_MESSAGE_ORDER_LIMIT",
+                "error_code": 35,
+            }
+        )
+
+        response = await self.client.receive_once()
+
+        self.assertEqual(response.status, CommandStatus.REJECTED_BY_PARSER)
+        self.assertEqual(response.reason, "INVALID_MESSAGE_ORDER_LIMIT")
+        self.assertIs(self.client.orders["HBOT-2F-4"].last_response, response)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/hummingbot/connector/exchange/twofinance/test_twofinance_matchengine_schemas.py
+++ b/test/hummingbot/connector/exchange/twofinance/test_twofinance_matchengine_schemas.py
@@ -47,6 +47,23 @@ class TwoFinanceMatchEngineSchemasTests(unittest.TestCase):
         self.assertEqual(ack.order_id, "42")
         self.assertEqual(reject.status, CommandStatus.REJECTED_BY_RISK)
 
+        simple_ack = parse_command_response({"type": 12, "timestamp": 123456789})
+        real_reject = parse_command_response(
+            {
+                "schema": "matchengine.order_response.v1",
+                "message_type": "REJECT",
+                "status": "rejected",
+                "reason_code": "INVALID_MESSAGE_ORDER_LIMIT",
+                "error_code": 35,
+            }
+        )
+
+        self.assertEqual(simple_ack.status, CommandStatus.ACCEPTED_TO_QUEUE)
+        self.assertIsNone(simple_ack.client_order_id)
+        self.assertIsNone(simple_ack.order_id)
+        self.assertEqual(real_reject.status, CommandStatus.REJECTED_BY_PARSER)
+        self.assertEqual(real_reject.reason, "INVALID_MESSAGE_ORDER_LIMIT")
+
     def test_event_order_state_uses_engine_status(self):
         event = MatchEngineEvent.from_payload(
             {

--- a/test/hummingbot/connector/exchange/twofinance/test_twofinance_matchengine_schemas.py
+++ b/test/hummingbot/connector/exchange/twofinance/test_twofinance_matchengine_schemas.py
@@ -1,0 +1,67 @@
+import unittest
+from decimal import Decimal
+
+from hummingbot.connector.exchange.twofinance.twofinance_matchengine_schemas import (
+    CommandStatus,
+    MatchEngineEvent,
+    OrderCommand,
+    event_order_state,
+    parse_command_response,
+)
+from hummingbot.core.data_type.in_flight_order import OrderState
+
+
+class TwoFinanceMatchEngineSchemasTests(unittest.TestCase):
+    def test_order_command_serializes_canonical_schema(self):
+        command = OrderCommand(
+            client_order_id="HBOT-2F-1",
+            engine_id="engine-btc-usdt",
+            symbol_id=1,
+            market="BTC-USDT",
+            wallet_id=7,
+            side="BUY",
+            order_type="LIMIT",
+            quantity=Decimal("0.1"),
+            price=Decimal("100.50"),
+            time_in_force="GTC",
+        )
+
+        payload = command.to_payload()
+
+        self.assertEqual(payload["schema"], "matchengine.order_command.v1")
+        self.assertEqual(payload["operation"], "ADD")
+        self.assertEqual(payload["client_order_id"], "HBOT-2F-1")
+        self.assertEqual(payload["idempotency_key"], "HBOT-2F-1")
+        self.assertEqual(payload["quantity"], "0.1")
+        self.assertEqual(payload["price"], "100.50")
+
+    def test_command_response_parses_ack_and_reject(self):
+        ack = parse_command_response(
+            {"message_type": "ACK", "status": "accepted-to-queue", "client_order_id": "cid", "order_id": 42}
+        )
+        reject = parse_command_response(
+            {"message_type": "ERROR", "error_code": "BALANCE_INSUFICIENT", "client_order_id": "cid"}
+        )
+
+        self.assertEqual(ack.status, CommandStatus.ACCEPTED_TO_QUEUE)
+        self.assertEqual(ack.order_id, "42")
+        self.assertEqual(reject.status, CommandStatus.REJECTED_BY_RISK)
+
+    def test_event_order_state_uses_engine_status(self):
+        event = MatchEngineEvent.from_payload(
+            {
+                "schema": "matchengine.event.v1",
+                "sequence": 2,
+                "event_id": "engine:2",
+                "event_type": "ORDER_EXECUTED",
+                "symbol_id": 1,
+                "market": "BTC-USDT",
+                "payload": {"order_status": 2, "client_order_id": "cid", "order_id": 99},
+            }
+        )
+
+        self.assertEqual(event_order_state(event), OrderState.FILLED)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] Tests all pass
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

This PR adds the initial `twofinance` exchange connector to Hummingbot.

The connector includes:
- 2Finance exchange integration under `hummingbot/connector/exchange/twofinance`.
- Match engine HTTP client and schemas for order entry, order status, balances, market metadata, and trade updates.
- Connector auth, constants, web utilities, order book data source, and user stream data source.
- Exchange implementation for trading rules, balances, order placement, cancellation, order status tracking, and trade fill handling.
- Unit and smoke tests covering the connector, match engine client, schemas, order book data source, and user stream data source.

**Tests performed by the developer**:

Passed locally:
- `make install`
  - Created/updated the official `hummingbot` conda environment.
  - Built Hummingbot extensions successfully.
- `conda run -n hummingbot pre-commit run --files <PR files>`
  - Result: passed.
- `conda run -n hummingbot python -m pytest test/hummingbot/connector/exchange/twofinance -q`
  - Result: `19 passed, 1 skipped`.

Not fully completed locally:
- `conda run -n hummingbot make test`
  - Started the full stable test suite.
  - Local run stayed silent for several minutes and was interrupted.
  - Full suite should be validated by CI.

Notes:
- Local build/test output includes existing warnings from Hummingbot base modules, including Cython/Pydantic warnings outside the `twofinance` connector.

**Tips for QA testing**:

QA should validate:
- `twofinance` appears as an available exchange connector.
- API credentials can be configured and loaded correctly.
- Trading rules are loaded correctly from the 2Finance match engine API.
- Market metadata, balances, and order status responses are parsed correctly.
- Order creation and cancellation work against a 2Finance test environment.
- Order book snapshots and trade updates are processed correctly.
- User stream events update tracked order state correctly.
- Error handling works for invalid credentials, unavailable APIs, rejected orders, and malformed responses.