### PR TITLE
fix: Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .ONESHELL:
 .PHONY: test run run_coverage report_coverage development-diff-cover uninstall build install setup deploy down
 
+OCI_RUNTIME=podman
 DYDX ?= 0
 ENV_FILE := setup/environment.yml
 ifeq ($(DYDX),1)
@@ -29,7 +30,7 @@ development-diff-cover:
 	diff-cover --compare-branch=origin/development coverage.xml
 
 build:
-	git clean -xdf && make clean && docker build -t hummingbot/hummingbot${TAG} -f Dockerfile .
+	git clean -xdf && make clean && $(OCI_RUNTIME) build -t hummingbot/hummingbot${TAG} -f Dockerfile .
 
 
 uninstall:
@@ -76,7 +77,7 @@ setup:
 
 deploy:
 	@set -a; . ./.compose.env 2>/dev/null || true; set +a; \
-	docker compose up -d
+	$(OCI_RUNTIME) compose up -d
 
 down:
-	docker compose --profile gateway down
+	$(OCI_RUNTIME) compose --profile gateway down

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -1,0 +1,45 @@
+services:
+  hummingbot:
+    container_name: hummingbot
+    image: hummingbot/hummingbot:latest
+    # build: # Uncomment this build section and comment image to build Hummingbot locally
+    #   context: .
+    #   dockerfile: Dockerfile
+    volumes:
+      - ./conf:/home/hummingbot/conf:z
+      - ./conf/connectors:/home/hummingbot/conf/connectors:z
+      - ./conf/strategies:/home/hummingbot/conf/strategies:z
+      - ./conf/controllers:/home/hummingbot/conf/controllers:z
+      - ./conf/scripts:/home/hummingbot/conf/scripts:z
+      - ./logs:/home/hummingbot/logs:z
+      - ./data:/home/hummingbot/data:z
+      - ./certs:/home/hummingbot/certs:z
+      - ./scripts:/home/hummingbot/scripts:z
+      - ./controllers:/home/hummingbot/controllers:z
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "5"
+    tty: true
+    stdin_open: true
+    network_mode: host
+  #  environment:
+  #    - CONFIG_PASSWORD=admin
+  #    - CONFIG_FILE_NAME=v2_with_controllers.py
+  #    - SCRIPT_CONFIG=conf_v2_with_controllers.yml
+
+  gateway:
+   profiles: ["gateway"]
+   restart: always
+   container_name: gateway
+   image: hummingbot/gateway:latest
+   ports:
+     - "15888:15888"
+   volumes:
+     - "./gateway-files/conf:/home/gateway/conf:z"
+     - "./gateway-files/logs:/home/gateway/logs:z"
+     - "./certs:/home/gateway/certs:z"
+   environment:
+     - GATEWAY_PASSPHRASE=admin
+     - DEV=true


### PR DESCRIPTION
- add OCI_RUNTIME variable to switch seamlessly between docker, podman and other oci runtimes.

**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] Tests all pass
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:



**Tests performed by the developer**:



**Tips for QA testing**:
