### PR TITLE
fix/dydx_v4_perpetual sequence not advanced until broadcast confirmed

### DIFF
--- a/hummingbot/connector/derivative/dydx_v4_perpetual/data_sources/dydx_v4_data_source.py
+++ b/hummingbot/connector/derivative/dydx_v4_perpetual/data_sources/dydx_v4_data_source.py
@@ -90,10 +90,8 @@ class DydxPerpetualV4Client:
         future = now + interval
         return int(future.timestamp())
 
-    def get_sequence(self):
-        current_seq = self.sequence
-        self.sequence += 1
-        return current_seq
+    def peek_sequence(self):
+        return self.sequence
 
     def get_number(self):
         return self.number
@@ -101,7 +99,7 @@ class DydxPerpetualV4Client:
     async def trading_account_sequence(self) -> int:
         if not self._is_trading_account_initialized:
             await self.initialize_trading_account()
-        return self.get_sequence()
+        return self.peek_sequence()
 
     async def trading_account_number(self) -> int:
         if not self._is_trading_account_initialized:
@@ -279,10 +277,28 @@ class DydxPerpetualV4Client:
             broadcast_req = BroadcastTxRequest(
                 tx_bytes=tx.tx.SerializeToString(), mode=BroadcastMode.BROADCAST_MODE_SYNC
             )
-            result = await self.send_tx_sync_mode(broadcast_req)
+            try:
+                result = await self.send_tx_sync_mode(broadcast_req)
+            except Exception:
+                # The broadcast call itself failed (network/gRPC error, timeout, etc.),
+                # not just an on-chain rejection. `sequence` was never advanced for this
+                # attempt, so force the next attempt to re-fetch the real on-chain
+                # sequence rather than reusing this one, in case a partial submission
+                # actually landed despite the client-side error.
+                self._is_trading_account_initialized = False
+                raise
+
             err_msg = result.get("raw_log", "")
-            if CONSTANTS.ACCOUNT_SEQUENCE_MISMATCH_ERROR in err_msg:
+            if err_msg and err_msg != "[]":
+                # Any on-chain rejection - not just a sequence mismatch specifically -
+                # means this sequence number was not consumed. Resync from chain instead
+                # of advancing the local counter, so the next transaction doesn't inherit
+                # a stale value that was never actually used.
                 await self.initialize_trading_account()
+            else:
+                # Broadcast accepted: only now is it safe to assume this sequence number
+                # was consumed and advance to the next one.
+                self.sequence += 1
 
             return result
 


### PR DESCRIPTION
**A description of the changes proposed in the pull request**:

`DydxPerpetualV4Client` caches the account's transaction sequence locally
and previously advanced it optimistically in `get_sequence()`, before the
transaction using that sequence was confirmed accepted by the chain. Any
broadcast failure other than the one specific string match already handled
(`ACCOUNT_SEQUENCE_MISMATCH_ERROR` in `raw_log`) - e.g. a generic gRPC/network
exception, a timeout, or any other on-chain rejection reason - left the local
counter permanently ahead of the real chain state with no resync triggered.
Every subsequent transaction built from that drifted counter would then also
fail with "account sequence mismatch," compounding indefinitely since the
existing resync check only reacts to that one specific derived symptom, not
the actual cause.

This PR changes `get_sequence()` to `peek_sequence()` (read-only, no longer
mutates state), and only advances `self.sequence` in
`prepare_and_broadcast_basic_transaction()` after confirming the broadcast
was accepted (empty `raw_log`). On any rejection or client-side exception
during broadcast, it resyncs from chain instead of advancing, so the next
transaction never inherits a sequence value that was never actually consumed.
This preserves the existing fast path (no added RPC call for consecutive
successful transactions).

**Tests performed by the developer**:

- Verified the modified file compiles with no syntax errors, and confirmed
  `get_sequence` (renamed to `peek_sequence`) has no other callers anywhere
  in the codebase - only the two call sites updated in this diff.
- Ran the equivalent of this fix as a live runtime patch against dYdX v4
  mainnet for several hours of `perpetual_market_making` trading with a
  4-25s order refresh interval. Before the fix: a single non-sequence
  broadcast failure triggered the drift described above, causing 100% order
  submission failure for ~2 hours until the process was manually restarted.
  After the fix: zero recurrences of that compounding failure pattern across
  multiple subsequent live sessions.

**Tips for QA testing**:

- To reproduce the original bug: force `send_tx_sync_mode` to raise or
  return a non-empty `raw_log` for a reason unrelated to sequence (e.g. mock
  a generic network exception) on one transaction, then confirm - on master -
  that every subsequent transaction fails with "account sequence mismatch"
  indefinitely. With this fix, confirm the next transaction instead re-syncs
  via `initialize_trading_account()` and succeeds normally.
- Confirm normal operation is unaffected: run `perpetual_market_making`
  against `dydx_v4_perpetual` under regular conditions and verify orders are
  still submitted and filled correctly, with `self.sequence` advancing by
  exactly 1 per successfully broadcast transaction (no behavior change on
  the happy path).
- This does not address the separate, narrower race where two transactions
  submitted in rapid succession can each read a sequence that doesn't yet
  reflect the other's pending-but-not-yet-block-included broadcast (since
  `BROADCAST_MODE_SYNC` only waits for mempool acceptance). That's a distinct,
  already self-healing issue (resolves within 1-2 retries) and isn't in scope
  here.
