### PR TITLE
fix: actionable error for invalid dYdX v4 secret phrase (#7409)

### DIFF
--- a/hummingbot/connector/derivative/dydx_v4_perpetual/data_sources/dydx_v4_data_source.py
+++ b/hummingbot/connector/derivative/dydx_v4_perpetual/data_sources/dydx_v4_data_source.py
@@ -26,6 +26,31 @@ from hummingbot.connector.derivative.dydx_v4_perpetual.data_sources.tx import Si
 
 class DydxPerpetualV4Client:
 
+    # Valid BIP-39 mnemonic lengths (in words).
+    _VALID_MNEMONIC_WORD_COUNTS = (12, 15, 18, 21, 24)
+
+    @classmethod
+    def _validate_secret_phrase(cls, secret_phrase: str) -> str:
+        """Fail fast with an actionable message when the configured secret phrase is
+        missing or not a plausible BIP-39 mnemonic.
+
+        Without this the connector passes an empty/garbled string straight to
+        ``PrivateKey.from_mnemonic`` and dies with the opaque
+        ``ValueError: Mnemonic words count is not valid (0)`` from bip_utils, which gives
+        the user no hint that their ``dydx_v4_perpetual_secret_phrase`` is at fault
+        (see issue #7409).
+        """
+        phrase = (secret_phrase or "").strip()
+        word_count = len(phrase.split())
+        if word_count not in cls._VALID_MNEMONIC_WORD_COUNTS:
+            raise ValueError(
+                "Invalid dYdX v4 secret phrase: expected a BIP-39 mnemonic of "
+                f"{', '.join(map(str, cls._VALID_MNEMONIC_WORD_COUNTS))} words but got "
+                f"{word_count}. Re-enter your 24-word dYdX v4 secret phrase with "
+                "`connect dydx_v4_perpetual`."
+            )
+        return phrase
+
     def __init__(
             self,
             secret_phrase: str,
@@ -33,7 +58,7 @@ class DydxPerpetualV4Client:
             connector,
             subaccount_num=0,
     ):
-        self._private_key = PrivateKey.from_mnemonic(secret_phrase)
+        self._private_key = PrivateKey.from_mnemonic(self._validate_secret_phrase(secret_phrase))
         self._dydx_v4_chain_address = dydx_v4_chain_address
         self._connector = connector
         self._subaccount_num = subaccount_num

--- a/test/hummingbot/connector/derivative/dydx_v4_perpetual/data_sources/test_dydx_v4_data_source.py
+++ b/test/hummingbot/connector/derivative/dydx_v4_perpetual/data_sources/test_dydx_v4_data_source.py
@@ -52,6 +52,28 @@ class DydxPerpetualV4ClientTests(IsolatedAsyncioWrapperTestCase):
         self.async_tasks.append(task)
         return task
 
+    def test_init_with_empty_secret_phrase_raises_actionable_error(self):
+        # Regression for issue #7409: an empty secret phrase must surface a clear,
+        # actionable error naming the config field, not the opaque bip_utils message
+        # "Mnemonic words count is not valid (0)".
+        with self.assertRaises(ValueError) as ctx:
+            DydxPerpetualV4Client("", self._dydx_v4_chain_address, self.exchange)
+        message = str(ctx.exception)
+        self.assertIn("Invalid dYdX v4 secret phrase", message)
+        self.assertIn("connect dydx_v4_perpetual", message)
+        self.assertNotIn("Mnemonic words count", message)
+
+    def test_init_with_wrong_length_secret_phrase_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            DydxPerpetualV4Client("abandon abandon abandon", self._dydx_v4_chain_address, self.exchange)
+        self.assertIn("but got 3", str(ctx.exception))
+
+    def test_init_with_valid_secret_phrase_succeeds(self):
+        # A well-formed 24-word mnemonic must still construct the client (guard is a
+        # gate, not a wall) — this is the same phrase used throughout the suite.
+        client = DydxPerpetualV4Client(self.secret_phrase, self._dydx_v4_chain_address, self.exchange)
+        self.assertIsNotNone(client)
+
     @property
     def _order_cancelation_request_successful_mock_response(self):
         return {"txhash": "79DBF373DE9C534EE2DC9D009F32B850DA8D0C73833FAA0FD52C6AE8989EC659",  # noqa: mock


### PR DESCRIPTION
Fixes #7409.

## Problem
Creating the dYdX v4 perpetual connector with an empty or misconfigured secret phrase dies with the opaque bip_utils error:

```
ValueError: Mnemonic words count is not valid (0)
```

The user has no way to tell that their `dydx_v4_perpetual_secret_phrase` is the cause. This happens because `DydxPerpetualV4Client.__init__` passes the phrase straight to `PrivateKey.from_mnemonic(...)` with no validation.

## Fix
Validate the phrase in `DydxPerpetualV4Client.__init__` **before** calling `from_mnemonic`. If the word count is not a valid BIP-39 length (12/15/18/21/24), raise a `ValueError` that names the config field and tells the user how to fix it:

```
Invalid dYdX v4 secret phrase: expected a BIP-39 mnemonic of 12, 15, 18, 21, 24 words
but got 0. Re-enter your 24-word dYdX v4 secret phrase with `connect dydx_v4_perpetual`.
```

The guard is the first statement of `__init__`, so it fires on the exact path that produced the old opaque error, before any grpc/cert setup — no behavior change beyond the message, no half-constructed object. The real checksum/wordlist validation still runs afterward inside `from_mnemonic`, so this is a gate, not a wall — no valid mnemonic is rejected (BIP-39 lengths are exactly {12,15,18,21,24}, and `str.split()`/`strip()` absorb any extra whitespace).

## Tests
Added to `test_dydx_v4_data_source.py`:
- empty phrase → actionable `ValueError` (and explicitly *not* the old "Mnemonic words count" message)
- wrong length (3 words) → `ValueError` ("but got 3")
- valid 24-word phrase → still constructs

## Scope note
This covers the word-count failure, which is exactly #7409 (count 0). A phrase with a valid length but a bad checksum still yields bip_utils' opaque message; broadening that is intentionally left out to keep the change minimal. If maintainers prefer failing at prompt time instead, this could alternatively be a pydantic field validator on `DydxV4PerpetualConfigMap` in `dydx_v4_perpetual_utils.py` — happy to move it there.