### PR TITLE
feat / MCP server over the hbot CLI (stdio-only, Docker-packaged)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "hummingbot-manager": {
+      "command": "uv",
+      "args": ["run", "--with", "mcp[cli]", "--with", "pyyaml", "python", "mcp_server.py"],
+      "cwd": "/Users/dman/Documents/work/hummingbot"
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "hummingbot": {
       "command": "uv",
-      "args": ["run", "--no-project", "--with", "mcp", "python", "mcp_server.py"]
+      "args": ["run", "--no-project", "--with", "mcp>=1.10", "python", "mcp_server.py"]
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,9 +1,8 @@
 {
   "mcpServers": {
-    "hummingbot-manager": {
+    "hummingbot": {
       "command": "uv",
-      "args": ["run", "--with", "mcp[cli]", "--with", "pyyaml", "python", "mcp_server.py"],
-      "cwd": "/Users/dman/Documents/work/hummingbot"
+      "args": ["run", "--no-project", "--with", "mcp", "python", "mcp_server.py"]
     }
   }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,12 @@ COPY scripts/ scripts-copy/
 COPY setup.py .
 COPY LICENSE .
 COPY README.md .
+COPY mcp_server.py .
+
+# MCP server runtime: a dedicated venv so its deps (mcp/starlette/uvicorn) can never
+# conflict with the trading env. bin/hbot-mcp execs this python when it exists.
+RUN python3 -m venv /opt/mcp-venv && \
+    /opt/mcp-venv/bin/pip install --no-cache-dir "mcp>=1.10"
 
 # activate hummingbot env when entering the CT
 SHELL [ "/bin/bash", "-lc" ]
@@ -71,6 +77,7 @@ WORKDIR /home/hummingbot
 
 # Copy all build artifacts from builder image
 COPY --from=builder /opt/conda/ /opt/conda/
+COPY --from=builder /opt/mcp-venv/ /opt/mcp-venv/
 COPY --from=builder /home/ /home/
 
 # Put the hummingbot env on PATH so non-login shells (e.g. `docker exec … hbot`) find the env's python
@@ -78,7 +85,18 @@ COPY --from=builder /home/ /home/
 # This lets the image run as a single-bot container: `docker run … hbot start <config>`,
 # `docker exec … hbot status`.
 ENV PATH=/opt/conda/envs/hummingbot/bin:$PATH
-RUN ln -sf /home/hummingbot/bin/hbot /opt/conda/envs/hummingbot/bin/hbot
+RUN ln -sf /home/hummingbot/bin/hbot /opt/conda/envs/hummingbot/bin/hbot && \
+    ln -sf /home/hummingbot/bin/hbot-mcp /opt/conda/envs/hummingbot/bin/hbot-mcp
+
+# The MCP server shells out to hbot; point it straight at the env's CLI so it skips the
+# conda-env probe bin/hbot-host would run on every tool call.
+ENV HBOT_BIN=/opt/conda/envs/hummingbot/bin/hbot
+
+# Interactive shells (`docker exec -it … bash`) source /root/.bashrc, whose conda init
+# activates BASE — whose python then shadows the env for `#!/usr/bin/env python` scripts
+# like hbot. Activate the hummingbot env instead. (The builder stage sets this in ITS OWN
+# /root/.bashrc, which is never copied here — this must be done in the release stage.)
+RUN echo "conda activate hummingbot" >> /root/.bashrc
 
 # Setting bash as default shell because we have .bashrc with customized PATH (setting SHELL affects RUN, CMD and ENTRYPOINT, but not manual commands e.g. `docker run image COMMAND`!)
 SHELL [ "/bin/bash", "-lc" ]

--- a/bin/hbot-mcp
+++ b/bin/hbot-mcp
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Launcher for the Hummingbot MCP server (mcp_server.py — a thin wrapper over the `hbot` CLI).
+#
+# Resolution order for a Python that has the `mcp` package:
+#   1. The Docker image's dedicated venv (/opt/mcp-venv) — baked in by the Dockerfile, isolated
+#      from the trading env so the server's deps can never conflict with the bot's.
+#   2. `uv` on a source install — resolves the mcp package on the fly, no env pollution.
+#
+# Pass-through args: `--http` serves streamable HTTP at http://$HBOT_MCP_HOST:$HBOT_MCP_PORT/mcp
+# (default 127.0.0.1:8211); no args = stdio for local MCP clients.
+set -euo pipefail
+
+# Resolve symlinks first: in the Docker image this script is reached via a symlink in the
+# conda env's bin (like `hbot` itself), and dirname of the SYMLINK would point the repo
+# root at /opt/conda/envs/hummingbot instead of /home/hummingbot.
+self="$0"
+while [ -L "$self" ]; do
+    target="$(readlink "$self")"
+    case "$target" in
+        /*) self="$target" ;;
+        *)  self="$(dirname "$self")/$target" ;;
+    esac
+done
+root="$(cd "$(dirname "$self")/.." && pwd)"
+
+if [ -x /opt/mcp-venv/bin/python ]; then
+    exec /opt/mcp-venv/bin/python "$root/mcp_server.py" "$@"
+fi
+
+# Pin a floor: a stale `mcp` in the base interpreter's site-packages would otherwise satisfy
+# a bare `--with mcp` and lack the streamable-http transport.
+if command -v uv >/dev/null 2>&1; then
+    exec uv run --no-project --with "mcp>=1.10" python "$root/mcp_server.py" "$@"
+fi
+
+echo "hbot-mcp: no runtime for the MCP server found." >&2
+echo "  docker: use the hummingbot image (ships /opt/mcp-venv)" >&2
+echo "  source: install uv (https://docs.astral.sh/uv/) and re-run" >&2
+exit 1

--- a/bin/hbot-mcp
+++ b/bin/hbot-mcp
@@ -7,8 +7,8 @@
 #      from the trading env so the server's deps can never conflict with the bot's.
 #   2. `uv` on a source install — resolves the mcp package on the fly, no env pollution.
 #
-# Pass-through args: `--http` serves streamable HTTP at http://$HBOT_MCP_HOST:$HBOT_MCP_PORT/mcp
-# (default 127.0.0.1:8211); no args = stdio for local MCP clients.
+# The server speaks stdio only (its tools trade real money; MCP HTTP ships no auth).
+# From a host harness against the Docker container: `docker exec -i hummingbot hbot-mcp`.
 set -euo pipefail
 
 # Resolve symlinks first: in the Docker image this script is reached via a symlink in the
@@ -29,7 +29,7 @@ if [ -x /opt/mcp-venv/bin/python ]; then
 fi
 
 # Pin a floor: a stale `mcp` in the base interpreter's site-packages would otherwise satisfy
-# a bare `--with mcp` and lack the streamable-http transport.
+# a bare `--with mcp` and break at runtime (the server is developed against 1.10+).
 if command -v uv >/dev/null 2>&1; then
     exec uv run --no-project --with "mcp>=1.10" python "$root/mcp_server.py" "$@"
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,9 +33,15 @@ services:
     # `docker exec -it hummingbot hbot <command>`.
     #   - for one dedicated bot instead:      command: hbot start <config> --foreground
     #   - for the legacy interactive client:  remove this command, then `docker attach hummingbot`
+    #   - to drive it from an MCP client (Claude Desktop & other URL-based clients) instead:
+    #       command: hbot-mcp --http
+    #     then add the connector URL http://localhost:8211/mcp and set HBOT_PASSWORD below.
+    #     Binds loopback only (the server has no auth); `hbot` commands still work via docker exec.
+    #     Requires host networking (Linux, or Docker Desktop with host networking enabled).
     command: tail -f /dev/null
   #  environment:
   #    - HBOT_PASSWORD=admin
+  #    - HBOT_MCP_PORT=8211
 
   gateway:
    profiles: ["gateway"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,15 +33,12 @@ services:
     # `docker exec -it hummingbot hbot <command>`.
     #   - for one dedicated bot instead:      command: hbot start <config> --foreground
     #   - for the legacy interactive client:  remove this command, then `docker attach hummingbot`
-    #   - to drive it from an MCP client (Claude Desktop & other URL-based clients) instead:
-    #       command: hbot-mcp --http
-    #     then add the connector URL http://localhost:8211/mcp and set HBOT_PASSWORD below.
-    #     Binds loopback only (the server has no auth); `hbot` commands still work via docker exec.
-    #     Requires host networking (Linux, or Docker Desktop with host networking enabled).
+    #   - MCP clients (Claude Desktop, etc.) need no changes here: they spawn the server
+    #     inside this container over stdio with `docker exec -i hummingbot hbot-mcp`
+    #     (set HBOT_PASSWORD below so keystore commands work). No port is opened.
     command: tail -f /dev/null
   #  environment:
   #    - HBOT_PASSWORD=admin
-  #    - HBOT_MCP_PORT=8211
 
   gateway:
    profiles: ["gateway"]

--- a/hummingbot/cli/README.md
+++ b/hummingbot/cli/README.md
@@ -327,7 +327,9 @@ transports ship no auth, so trading access stays behind credentials the OS alrea
   ```
 
   The container must be up (`make deploy`), with `HBOT_PASSWORD` set in its environment
-  (`docker-compose.yml`) for keystore commands.
+  (`docker-compose.yml`) for keystore commands. On macOS use the absolute path
+  (`"command": "/usr/local/bin/docker"`) — GUI apps get a minimal `PATH` that may not
+  include docker.
 - The server resolves `hbot` via `bin/hbot-host` (conda env or Docker container both work);
   set `HBOT_BIN` to override (the image presets it).
 - Set `HBOT_PASSWORD` in the server's environment for commands that need the keystore. **No tool

--- a/hummingbot/cli/README.md
+++ b/hummingbot/cli/README.md
@@ -305,14 +305,29 @@ subprocess call and returns `{ok, exit_code, exit_status, data|output, error}` (
 the parsed `--json` payload where the CLI supports it). Same substrate, same one-bot-per-install
 model; MCP is just a second transport.
 
+The transport is **stdio only**, deliberately: the tools trade real money and MCP's HTTP
+transports ship no auth, so trading access stays behind credentials the OS already manages
+(process spawn rights, the Docker socket). No port is ever opened.
+
 - **Claude Code** picks it up automatically from `.mcp.json` when started in the repo root.
-  Other stdio clients: `bin/hbot-mcp` (uses the Docker image's baked-in venv, or `uv` on a
-  source install).
-- **Claude Desktop & other URL-based clients (no shell, no repo checkout):** the Docker image
-  ships the server. Set `command: hbot-mcp --http` in `docker-compose.yml` (plus `HBOT_PASSWORD`),
-  `make deploy`, then add the connector URL `http://localhost:8211/mcp` in the client. The server
-  binds **loopback only** by default — it has no auth and its tools trade real money; set
-  `HBOT_MCP_HOST=0.0.0.0` only if you understand what that exposes.
+  Other stdio clients on a source install: `bin/hbot-mcp`.
+- **Claude Desktop & other shell-less clients (Docker install):** the image ships the server;
+  the client spawns it *inside* the container and speaks stdio through the exec channel.
+  Nothing to install on the host but Docker. In `claude_desktop_config.json`:
+
+  ```json
+  {
+    "mcpServers": {
+      "hummingbot": {
+        "command": "docker",
+        "args": ["exec", "-i", "hummingbot", "hbot-mcp"]
+      }
+    }
+  }
+  ```
+
+  The container must be up (`make deploy`), with `HBOT_PASSWORD` set in its environment
+  (`docker-compose.yml`) for keystore commands.
 - The server resolves `hbot` via `bin/hbot-host` (conda env or Docker container both work);
   set `HBOT_BIN` to override (the image presets it).
 - Set `HBOT_PASSWORD` in the server's environment for commands that need the keystore. **No tool

--- a/hummingbot/cli/README.md
+++ b/hummingbot/cli/README.md
@@ -296,6 +296,28 @@ as a container's command it would exit immediately and stop the container.) Eith
 
 ---
 
+## MCP server (agentic harnesses without a shell)
+
+`hbot` is already agent-friendly over a plain shell, and that is the recommended way to drive it
+from Claude Code or any harness with a Bash tool. For harnesses (or users) that prefer **native MCP
+tools**, the repo root ships `mcp_server.py` — a thin wrapper that runs each tool as one `hbot`
+subprocess call and returns `{ok, exit_code, exit_status, data|output, error}` (with `data` being
+the parsed `--json` payload where the CLI supports it). Same substrate, same one-bot-per-install
+model; MCP is just a second transport.
+
+- **Claude Code** picks it up automatically from `.mcp.json` when started in the repo root.
+  Other MCP clients: run `uv run --no-project --with mcp python mcp_server.py` (stdio).
+- The server resolves `hbot` via `bin/hbot-host` (conda env or Docker container both work);
+  set `HBOT_BIN` to override.
+- Set `HBOT_PASSWORD` in the server's environment for commands that need the keystore. **No tool
+  accepts a password or API key** — key entry stays interactive (`hbot connect <connector>` in
+  your own terminal), so secrets never enter an agent's context.
+- The operating manual (mental model, core loop, health caveats, secrets policy) ships as the
+  server's MCP *instructions*, so every connected harness gets it with the tools — no separate
+  skill required.
+
+---
+
 ## Files & state
 
 ```

--- a/hummingbot/cli/README.md
+++ b/hummingbot/cli/README.md
@@ -306,12 +306,19 @@ the parsed `--json` payload where the CLI supports it). Same substrate, same one
 model; MCP is just a second transport.
 
 - **Claude Code** picks it up automatically from `.mcp.json` when started in the repo root.
-  Other MCP clients: run `uv run --no-project --with mcp python mcp_server.py` (stdio).
+  Other stdio clients: `bin/hbot-mcp` (uses the Docker image's baked-in venv, or `uv` on a
+  source install).
+- **Claude Desktop & other URL-based clients (no shell, no repo checkout):** the Docker image
+  ships the server. Set `command: hbot-mcp --http` in `docker-compose.yml` (plus `HBOT_PASSWORD`),
+  `make deploy`, then add the connector URL `http://localhost:8211/mcp` in the client. The server
+  binds **loopback only** by default — it has no auth and its tools trade real money; set
+  `HBOT_MCP_HOST=0.0.0.0` only if you understand what that exposes.
 - The server resolves `hbot` via `bin/hbot-host` (conda env or Docker container both work);
-  set `HBOT_BIN` to override.
+  set `HBOT_BIN` to override (the image presets it).
 - Set `HBOT_PASSWORD` in the server's environment for commands that need the keystore. **No tool
   accepts a password or API key** — key entry stays interactive (`hbot connect <connector>` in
-  your own terminal), so secrets never enter an agent's context.
+  your own terminal, or `docker exec -it hummingbot hbot connect <connector>`), so secrets never
+  enter an agent's context.
 - The operating manual (mental model, core loop, health caveats, secrets policy) ships as the
   server's MCP *instructions*, so every connected harness gets it with the tools — no separate
   skill required.

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1,0 +1,555 @@
+"""MCP server for managing Hummingbot v2 bots as detached TMUX sessions.
+
+Each bot runs in its own ``tmux`` session named ``hb-<config-stem>``. The server
+exposes MCP tools to deploy controllers, start/stop bots, tail their logs and read
+the live status panel — so an assistant can operate a fleet of bots without a human
+attaching to each terminal.
+
+Configuration via environment variables (all optional):
+
+* ``HB_PYTHON``     — absolute path to the Python interpreter of the ``hummingbot``
+                      conda env. If unset, common conda locations are probed.
+* ``HB_PROJECT_ROOT`` — Hummingbot checkout to operate on. Defaults to this file's dir.
+
+Requirements: ``tmux`` on PATH, and (for ``open_terminal``) macOS with ``osascript``.
+"""
+
+import os
+import platform
+import shlex
+import subprocess
+import time
+from datetime import datetime
+from pathlib import Path
+
+import yaml
+from mcp.server.fastmcp import FastMCP
+
+PROJECT_ROOT = Path(os.environ.get("HB_PROJECT_ROOT", Path(__file__).resolve().parent))
+SESSION_PREFIX = "hb-"
+
+# Timeouts (seconds) for the short, synchronous helper subprocesses.
+TMUX_TIMEOUT = 10
+PGREP_TIMEOUT = 5
+
+# Bounds for log tailing so a tool call never returns an unbounded blob.
+MAX_LOG_LINES = 2000
+
+# Seconds to let the pane's interactive shell finish initializing before we type the
+# launch command. On heavy prompts (oh-my-zsh + git status) send-keys sent too early is
+# silently dropped, so the bot never starts. 0.5s is the empirical floor; 0.75s adds margin.
+SHELL_SETTLE = float(os.environ.get("HB_SHELL_SETTLE", "0.75"))
+
+
+def _resolve_hb_python() -> str:
+    """Locate the hummingbot env interpreter.
+
+    We invoke python by absolute path instead of ``conda run`` because on some setups
+    ``conda run`` does not put the env's python on PATH (it can resolve to an unrelated
+    active venv), and when the env is mounted as ``base`` then ``conda run -n hummingbot``
+    builds a doubled, invalid path. ``HB_PYTHON`` always wins if set.
+    """
+    override = os.environ.get("HB_PYTHON")
+    if override:
+        return override
+    candidates = [
+        Path.home() / "anaconda3" / "envs" / "hummingbot" / "bin" / "python",
+        Path.home() / "miniconda3" / "envs" / "hummingbot" / "bin" / "python",
+        Path.home() / "miniforge3" / "envs" / "hummingbot" / "bin" / "python",
+        Path("/opt/anaconda3/envs/hummingbot/bin/python"),
+        Path("/opt/homebrew/anaconda3/envs/hummingbot/bin/python"),
+        Path("/opt/miniconda3/envs/hummingbot/bin/python"),
+    ]
+    for cand in candidates:
+        if cand.exists():
+            return str(cand)
+    # Fall back to the first well-known location; start_bot surfaces a clear error
+    # if it does not exist, rather than failing opaquely inside tmux.
+    return str(candidates[3])
+
+
+HB_PYTHON = _resolve_hb_python()
+
+mcp = FastMCP("hummingbot-manager")
+
+
+# ── Subprocess helpers ───────────────────────────────────────────────────────
+
+def _run(cmd: list[str], timeout: int) -> subprocess.CompletedProcess:
+    """Run a subprocess, converting environment failures into a CompletedProcess.
+
+    A missing binary or a timeout would otherwise raise and crash the tool call; we
+    surface them as returncode=-1 with a message on stderr so callers stay uniform.
+    """
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except FileNotFoundError:
+        return subprocess.CompletedProcess(cmd, -1, "", f"command not found: {cmd[0]}")
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(cmd, -1, "", f"timed out after {timeout}s: {cmd[0]}")
+
+
+def _run_tmux(*args: str) -> subprocess.CompletedProcess:
+    return _run(["tmux", *args], TMUX_TIMEOUT)
+
+
+def _session_exists(name: str) -> bool:
+    return _run_tmux("has-session", "-t", name).returncode == 0
+
+
+def _get_session_config(name: str) -> str | None:
+    result = _run_tmux("show-environment", "-t", name, "HB_CONFIG")
+    if result.returncode == 0 and "=" in result.stdout:
+        return result.stdout.strip().split("=", 1)[1]
+    return None
+
+
+def _config_to_log_path(config_name: str) -> Path:
+    stem = Path(config_name).stem
+    return PROJECT_ROOT / "logs" / f"logs_{stem}.log"
+
+
+def _capture_pane(name: str, lines: int = 40) -> str:
+    result = _run_tmux("capture-pane", "-t", name, "-p", "-S", f"-{lines}")
+    return result.stdout if result.returncode == 0 else ""
+
+
+def _process_alive(name: str) -> bool:
+    """True if the session's pane shell has a child process (i.e. the bot is running)."""
+    pid_result = _run_tmux("list-panes", "-t", name, "-F", "#{pane_pid}")
+    out = pid_result.stdout.strip().splitlines() if pid_result.returncode == 0 else []
+    pane_pid = out[0].strip() if out else ""
+    if not pane_pid:
+        return False
+    return _run(["pgrep", "-P", pane_pid], PGREP_TIMEOUT).returncode == 0
+
+
+def _safe_stem(name: str) -> str | None:
+    """Return the sanitized stem of a user-supplied name, or None if unsafe.
+
+    Guards the filesystem paths built from run/config names against traversal
+    (``..``) and separators, which would otherwise let a name escape conf/.
+    """
+    stem = Path(name).stem.strip()
+    if not stem or stem in (".", "..") or "/" in name or "\\" in name:
+        return None
+    return stem
+
+
+def _quickstart_cmd(config_file: str, password: str) -> str:
+    """Build the shell command that launches the bot inside the tmux pane.
+
+    The password is passed via the ``CONFIG_PASSWORD`` env var (which quickstart reads)
+    rather than the ``-p`` flag, so it does not appear in the process argv / ``ps`` output.
+    ``VIRTUAL_ENV``/``PYTHONPATH`` are cleared so the absolute-path interpreter is not
+    shadowed by an active venv. Every interpolated value is shell-quoted.
+    """
+    return (
+        f"VIRTUAL_ENV= PYTHONPATH= CONFIG_PASSWORD={shlex.quote(password)} "
+        f"{shlex.quote(HB_PYTHON)} ./bin/hummingbot_quickstart.py "
+        f"--v2 {shlex.quote(config_file)}"
+    )
+
+
+def _start_session(config_file: str, session_name: str, password: str) -> dict:
+    """Create a detached TMUX session and launch the bot in it."""
+    if _session_exists(session_name):
+        return {"status": "error", "error": f"Session '{session_name}' already exists. Stop it first."}
+
+    if not Path(HB_PYTHON).exists():
+        return {
+            "status": "error",
+            "error": f"Hummingbot interpreter not found: {HB_PYTHON}. "
+                     f"Set HB_PYTHON to the conda env's python.",
+        }
+
+    result = _run_tmux("new-session", "-d", "-s", session_name, "-c", str(PROJECT_ROOT))
+    if result.returncode != 0:
+        return {"status": "error", "error": f"Failed to create tmux session: {result.stderr.strip()}"}
+
+    _run_tmux("set-environment", "-t", session_name, "HB_CONFIG", config_file)
+    # Let the interactive shell settle so the launch command is not typed before the
+    # prompt is ready (otherwise send-keys is dropped and the bot never starts).
+    time.sleep(SHELL_SETTLE)
+    _run_tmux("send-keys", "-t", session_name, _quickstart_cmd(config_file, password), "Enter")
+
+    return {
+        "status": "ok",
+        "session_name": session_name,
+        "config_file": config_file,
+        "log_path": str(_config_to_log_path(config_file)),
+    }
+
+
+def _write_deploy_config(
+    controllers: list[str],
+    config_name: str,
+    script_file_name: str,
+    max_global_drawdown_quote: float | None,
+    max_controller_drawdown_quote: float | None,
+) -> dict:
+    if not controllers:
+        return {"status": "error", "error": "Must provide at least one controller config."}
+
+    controllers_dir = PROJECT_ROOT / "conf" / "controllers"
+    normalized = []
+    for c in controllers:
+        if not c.endswith(".yml"):
+            c += ".yml"
+        if _safe_stem(c) is None:
+            return {"status": "error", "error": f"Invalid controller name: {c}"}
+        if not (controllers_dir / c).exists():
+            return {"status": "error", "error": f"Controller config not found: conf/controllers/{c}"}
+        normalized.append(c)
+
+    if _safe_stem(script_file_name) is None or not (PROJECT_ROOT / "scripts" / script_file_name).exists():
+        return {"status": "error", "error": f"Script not found: scripts/{script_file_name}"}
+
+    if not config_name.endswith(".yml"):
+        config_name += ".yml"
+    if _safe_stem(config_name) is None:
+        return {"status": "error", "error": f"Invalid config name: {config_name}"}
+
+    config_data = {
+        "controllers_config": normalized,
+        "script_file_name": script_file_name,
+        "max_global_drawdown_quote": max_global_drawdown_quote,
+        "max_controller_drawdown_quote": max_controller_drawdown_quote,
+    }
+    output_path = PROJECT_ROOT / "conf" / "scripts" / config_name
+    with open(output_path, "w") as f:
+        yaml.dump(config_data, f, default_flow_style=False, sort_keys=False)
+
+    return {"status": "ok", "config_file": config_name, "path": str(output_path), "content": config_data}
+
+
+def _tail(path: Path, n: int) -> list[str]:
+    """Return the last ``n`` lines of a file without reading it fully into memory."""
+    n = max(1, n)
+    with open(path, "rb") as f:
+        f.seek(0, os.SEEK_END)
+        pos = f.tell()
+        data = b""
+        block = 8192
+        while pos > 0 and data.count(b"\n") <= n:
+            read = min(block, pos)
+            pos -= read
+            f.seek(pos)
+            data = f.read(read) + data
+        lines = data.splitlines()[-n:]
+    return [ln.decode("utf-8", "replace") for ln in lines]
+
+
+# ── Deploy / start ─────────────────────────────────────────────────────────
+
+@mcp.tool()
+def deploy(
+    controllers: list[str],
+    run_name: str = "",
+    password: str = "a",
+    max_global_drawdown_quote: float | None = None,
+    max_controller_drawdown_quote: float | None = None,
+    script_file_name: str = "v2_with_controllers.py",
+) -> dict:
+    """Deploy one or more controllers as a new bot run.
+
+    This is the high-level entry point: you say WHICH controllers to run and it
+    builds the v2 deploy config for you with a UNIQUE name, so each run gets its own
+    sqlite DB (data/{config}.sqlite) and log file (logs/logs_{config}.log) — easier to
+    review in isolation. Then it starts the bot in a detached TMUX session.
+
+    Args:
+        controllers: Controller config filenames from conf/controllers/ (e.g. ["pmm_king_wld.yml"]).
+        run_name: Optional label for this run. If omitted, a unique name is auto-generated
+            from the first controller + timestamp (e.g. pmm_king_wld_0604_2103).
+        password: Hummingbot password. Defaults to "a".
+        max_global_drawdown_quote: Max global drawdown in quote. None = no limit.
+        max_controller_drawdown_quote: Max per-controller drawdown in quote. None = no limit.
+        script_file_name: v2 runner script. Defaults to v2_with_controllers.py.
+    """
+    if not controllers:
+        return {"status": "error", "error": "Must provide at least one controller config."}
+
+    if run_name:
+        stem = _safe_stem(run_name)
+        if stem is None:
+            return {"status": "error", "error": f"Invalid run_name: {run_name}"}
+    else:
+        first_stem = _safe_stem(controllers[0]) or "run"
+        stem = f"{first_stem}_{datetime.now().strftime('%m%d_%H%M')}"
+    config_name = f"conf_{stem}.yml"
+    session_name = f"{SESSION_PREFIX}{Path(config_name).stem}"
+
+    created = _write_deploy_config(
+        controllers, config_name, script_file_name,
+        max_global_drawdown_quote, max_controller_drawdown_quote,
+    )
+    if created["status"] != "ok":
+        return created
+
+    started = _start_session(config_name, session_name, password)
+    if started["status"] != "ok":
+        return started
+
+    db_stem = Path(config_name).stem
+    return {
+        "status": "ok",
+        "session_name": session_name,
+        "config_file": config_name,
+        "controllers": created["content"]["controllers_config"],
+        "log_path": str(_config_to_log_path(config_name)),
+        "db_path": str(PROJECT_ROOT / "data" / f"{db_stem}.sqlite"),
+        "note": "Unique DB + logs for this run. Attach with open_terminal, stop with stop_bot.",
+    }
+
+
+@mcp.tool()
+def start_bot(config_file: str, session_name: str = "", password: str = "a") -> dict:
+    """Start a bot from an EXISTING deploy config in conf/scripts/ (low-level).
+
+    Prefer `deploy` for new runs (it builds a uniquely-named config for you). Use this
+    when you want to re-run a specific existing conf/scripts/ file as-is.
+
+    Args:
+        config_file: Config filename in conf/scripts/ (e.g. conf_pmm_king_wld.yml).
+        session_name: TMUX session name. Defaults to hb-{config_stem}.
+        password: Hummingbot password. Defaults to "a".
+    """
+    if not config_file.endswith(".yml"):
+        config_file += ".yml"
+    if _safe_stem(config_file) is None:
+        return {"status": "error", "error": f"Invalid config name: {config_file}"}
+    if not (PROJECT_ROOT / "conf" / "scripts" / config_file).exists():
+        return {"status": "error", "error": f"Config not found: conf/scripts/{config_file}"}
+
+    name = session_name or f"{SESSION_PREFIX}{Path(config_file).stem}"
+    return _start_session(config_file, name, password)
+
+
+# ── Stop / cleanup ─────────────────────────────────────────────────────────
+
+@mcp.tool()
+def stop_bot(session_name: str, force: bool = False, cancel_timeout: int = 25) -> dict:
+    """Stop a bot and ALWAYS clean up its TMUX session.
+
+    Graceful by default: sends the hummingbot `stop` command (which cancels all open
+    orders on the exchange) and waits for confirmation, then `exit`s the app, then
+    kills the TMUX session so nothing is left behind. With force=True it skips the
+    graceful cancel and kills the session immediately (orders may stay open!).
+
+    Args:
+        session_name: TMUX session name (e.g. hb-conf_pmm_king_wld).
+        force: Skip graceful order-cancel and kill the session immediately.
+        cancel_timeout: Seconds to wait for graceful stop confirmation before exiting.
+    """
+    if not _session_exists(session_name):
+        return {"status": "error", "error": f"Session '{session_name}' not found."}
+
+    method = "force-killed"
+    if not force:
+        _run_tmux("send-keys", "-t", session_name, "stop", "Enter")
+        stopped = False
+        for _ in range(max(1, cancel_timeout)):
+            time.sleep(1.0)
+            pane = _capture_pane(session_name, 40).lower()
+            if "stopped successfully" in pane or "no active maker orders" in pane:
+                stopped = True
+                break
+        _run_tmux("send-keys", "-t", session_name, "exit", "Enter")
+        time.sleep(2.0)
+        method = "graceful" if stopped else "graceful-timeout"
+
+    # Guarantee cleanup: the session is always killed.
+    _run_tmux("kill-session", "-t", session_name)
+    return {"status": "ok", "method": method, "session_name": session_name, "cleaned_up": True}
+
+
+@mcp.tool()
+def kill_session(session_name: str) -> dict:
+    """Force-kill a single TMUX session immediately (no graceful stop).
+
+    Use to clean up a dead/zombie session, or one where the bot already crashed.
+    Does NOT cancel exchange orders — use stop_bot for a running bot.
+    """
+    if not _session_exists(session_name):
+        return {"status": "error", "error": f"Session '{session_name}' not found."}
+    _run_tmux("kill-session", "-t", session_name)
+    return {"status": "ok", "session_name": session_name, "killed": True}
+
+
+@mcp.tool()
+def kill_all_bots() -> dict:
+    """Force-kill ALL Hummingbot (hb-) TMUX sessions. Cleanup sweep.
+
+    Does NOT gracefully cancel orders. Use stop_bot per-session if bots are live.
+    """
+    result = _run_tmux("list-sessions", "-F", "#{session_name}")
+    killed = []
+    if result.returncode == 0:
+        for line in result.stdout.strip().splitlines():
+            name = line.strip()
+            if name.startswith(SESSION_PREFIX):
+                _run_tmux("kill-session", "-t", name)
+                killed.append(name)
+    return {"status": "ok", "killed": killed}
+
+
+# ── Inspect ────────────────────────────────────────────────────────────────
+
+@mcp.tool()
+def list_bots() -> dict:
+    """List all Hummingbot TMUX sessions and whether each is actually running."""
+    result = _run_tmux("list-sessions", "-F", "#{session_name}")
+    if result.returncode != 0:
+        return {"status": "ok", "sessions": []}
+
+    sessions = []
+    for line in result.stdout.strip().splitlines():
+        name = line.strip()
+        if not name.startswith(SESSION_PREFIX):
+            continue
+        alive = _process_alive(name)
+        sessions.append({
+            "session_name": name,
+            "config": _get_session_config(name) or "unknown",
+            "process_alive": alive,
+            "state": "running" if alive else "idle/dead",
+        })
+    return {"status": "ok", "sessions": sessions}
+
+
+@mcp.tool()
+def open_terminal(session_name: str) -> dict:
+    """Open a new macOS Terminal window attached to the bot's TMUX session.
+
+    Lets you watch the live hummingbot UI directly. Detach with Ctrl-b then d
+    (this does NOT stop the bot). macOS only.
+
+    Args:
+        session_name: TMUX session name (e.g. hb-conf_pmm_king_wld).
+    """
+    if platform.system() != "Darwin":
+        return {
+            "status": "error",
+            "error": f"open_terminal is macOS-only. Attach manually: tmux attach -t {session_name}",
+        }
+    if not _session_exists(session_name):
+        return {"status": "error", "error": f"Session '{session_name}' not found."}
+    attach_cmd = f"tmux attach -t {shlex.quote(session_name)}"
+    r = _run(
+        [
+            "osascript",
+            "-e", 'tell application "Terminal" to activate',
+            "-e", f'tell application "Terminal" to do script "{attach_cmd}"',
+        ],
+        TMUX_TIMEOUT,
+    )
+    if r.returncode != 0:
+        return {"status": "error", "error": r.stderr.strip() or "osascript failed"}
+    return {"status": "ok", "session_name": session_name, "opened": True}
+
+
+@mcp.tool()
+def read_logs(config_name: str = "", session_name: str = "", lines: int = 50) -> dict:
+    """Read recent log lines from a Hummingbot bot.
+
+    Args:
+        config_name: Config filename to derive log path (e.g. conf_pmm_king_wld).
+        session_name: Alternatively, provide session name to look up config.
+        lines: Number of lines to read from end of log. Defaults to 50 (max 2000).
+    """
+    if not config_name and session_name:
+        config_name = _get_session_config(session_name) or ""
+    if not config_name:
+        return {"status": "error", "error": "Provide config_name or a valid session_name."}
+
+    log_path = _config_to_log_path(config_name)
+    if not log_path.exists():
+        return {"status": "error", "error": f"Log file not found: {log_path}"}
+
+    lines = min(max(1, lines), MAX_LOG_LINES)
+    try:
+        tail = _tail(log_path, lines)
+        return {
+            "status": "ok",
+            "log_path": str(log_path),
+            "lines_returned": len(tail),
+            "content": "\n".join(tail),
+        }
+    except Exception as e:
+        return {"status": "error", "error": str(e)}
+
+
+@mcp.tool()
+def bot_status(session_name: str) -> dict:
+    """Get status of a Hummingbot bot TMUX session.
+
+    Sends the hummingbot `status` command and returns the live strategy panel
+    (curve, target/actual/gap, budgets, held inventory, resting orders) plus whether
+    the process is alive. Requires a running strategy for the status panel to populate.
+
+    Args:
+        session_name: TMUX session name (e.g. hb-conf_pmm_king_wld).
+    """
+    if not _session_exists(session_name):
+        return {"status": "error", "error": f"Session '{session_name}' not found."}
+
+    alive = _process_alive(session_name)
+    if alive:
+        # Trigger a fresh status render, then read it back.
+        _run_tmux("send-keys", "-t", session_name, "status", "Enter")
+        time.sleep(2.0)
+
+    return {
+        "status": "ok",
+        "session_name": session_name,
+        "config": _get_session_config(session_name) or "unknown",
+        "process_alive": alive,
+        "terminal_output": _capture_pane(session_name, 60).strip(),
+    }
+
+
+@mcp.tool()
+def list_controllers() -> dict:
+    """List available controller config files in conf/controllers/."""
+    controllers_dir = PROJECT_ROOT / "conf" / "controllers"
+    if not controllers_dir.exists():
+        return {"status": "error", "error": "conf/controllers/ directory not found."}
+    configs = [f.name for f in sorted(controllers_dir.iterdir()) if f.suffix == ".yml"]
+    return {"status": "ok", "controllers": configs}
+
+
+@mcp.tool()
+def create_config(
+    controllers: list[str],
+    config_name: str = "",
+    script_file_name: str = "v2_with_controllers.py",
+    max_global_drawdown_quote: float | None = None,
+    max_controller_drawdown_quote: float | None = None,
+) -> dict:
+    """Create a deploy config in conf/scripts/ without starting it (low-level).
+
+    Prefer `deploy` for new runs. Use this if you only want to write the config file.
+
+    Args:
+        controllers: Controller config filenames from conf/controllers/ (e.g. ["pmm_3.yml"]).
+        config_name: Output filename in conf/scripts/. Defaults to conf_v2_{first_controller_stem}.yml.
+        script_file_name: Script to use. Defaults to v2_with_controllers.py.
+        max_global_drawdown_quote: Max global drawdown in quote. None = no limit.
+        max_controller_drawdown_quote: Max per-controller drawdown in quote. None = no limit.
+    """
+    if not config_name:
+        if not controllers:
+            return {"status": "error", "error": "Must provide at least one controller config."}
+        first_stem = _safe_stem(controllers[0])
+        if first_stem is None:
+            return {"status": "error", "error": f"Invalid controller name: {controllers[0]}"}
+        config_name = f"conf_v2_{first_stem}.yml"
+    return _write_deploy_config(
+        controllers, config_name, script_file_name,
+        max_global_drawdown_quote, max_controller_drawdown_quote,
+    )
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -75,7 +75,9 @@ Read results like this: every tool returns {ok, exit_code, exit_status, data|out
 otherwise. Branch on ok/exit_status, never on prose.
 
 Health: status() reporting running=true does NOT mean healthy — it includes a recent-errors
-count; check it. history() also fetches balances, so it is the slowest call.
+count; check it. history() also fetches balances, so it is the slowest call. When any tool
+fails unexpectedly (or the user reports breakage), run doctor() FIRST — it pinpoints
+keystore/clock/disk/stale-state problems and each failing check names its fix.
 
 Secrets policy (strict):
 - NEVER ask the user to paste API keys, private keys, or the keystore password into chat,
@@ -150,15 +152,19 @@ def _run_hbot(args: list, stdin_data: Optional[str] = None, json_output: bool = 
         "error": proc.stderr.strip() or None,
     }
     stdout = proc.stdout.strip()
-    if json_output and proc.returncode == 0:
+    if json_output and stdout:
+        # Some commands emit their --json payload AND a nonzero exit (doctor: the checks
+        # table plus health-as-exit-code) — parse whenever stdout parses. A broken payload
+        # on a SUCCESSFUL exit is a broken contract and fails loudly; on a failed exit the
+        # stdout is best-effort and returned as-is.
         try:
             result["data"] = json.loads(stdout)
         except ValueError:
-            # The CLI promised --json and broke it — fail loudly, never degrade silently.
-            result["ok"] = False
-            result["exit_status"] = "PROTOCOL_ERROR"
-            result["output"] = stdout or None
-            result["error"] = f"hbot --json emitted unparseable output: {' '.join(cmd)}"
+            result["output"] = stdout
+            if proc.returncode == 0:
+                result["ok"] = False
+                result["exit_status"] = "PROTOCOL_ERROR"
+                result["error"] = f"hbot --json emitted unparseable output: {' '.join(cmd)}"
     else:
         result["output"] = stdout or None
     return result
@@ -380,6 +386,36 @@ def history(name: str = "", days: Optional[float] = None) -> dict:
     if days is not None:
         args += ["--days", days]
     return _run_hbot(args)
+
+
+# ── maintain ─────────────────────────────────────────────────────────────────
+
+@mcp.tool()
+def doctor() -> dict:
+    """Health-check the install; run this FIRST when any tool fails unexpectedly.
+
+    data.checks rows (install, extensions, keystore, clock skew, disk, stale bot state,
+    dangling loaded config, MCP server) each carry ok/warn/fail/skip plus a one-line fix;
+    data.healthy is the verdict (an unhealthy run also returns exit_status ERROR).
+    """
+    return _run_hbot(["doctor"], json_output=True)
+
+
+@mcp.tool()
+def update(check: bool = True) -> dict:
+    """Update the hbot software itself (source installs: git fast-forward + rebuild).
+
+    check=True (the DEFAULT) only reports whether an update is available — safe anytime.
+    check=False performs the update: refuses while a bot is running, on a diverged branch,
+    and inside Docker (there it returns the host-side `docker compose pull` instructions —
+    a container cannot replace its own image). A real update can take minutes when the
+    compiled extensions rebuild.
+    """
+    args = ["update"]
+    if check:
+        args.append("--check")
+    # A rebuild legitimately runs for minutes; raise the kill ceiling well above it.
+    return _run_hbot(args, json_output=True, op_timeout=900)
 
 
 def _transport_config(argv: list, environ: dict) -> tuple:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -36,8 +36,10 @@ EXIT_NAMES = {
     5: "TIMEOUT",
 }
 
-# Ceiling for one subprocess call; per-command --timeout values stay well under it.
+# Floor for one subprocess call's kill ceiling; commands that take an operation --timeout
+# get that value plus slack, so the CLI's own timeout always fires first (exit code 5).
 SUBPROCESS_TIMEOUT = 300
+TIMEOUT_SLACK = 60
 
 INSTRUCTIONS = """\
 Operate a Hummingbot trading bot through the `hbot` CLI. Real money: prefer small sizes,
@@ -85,23 +87,31 @@ def _hbot_bin() -> str:
     return str(PROJECT_ROOT / "bin" / "hbot-host")
 
 
-def _run_hbot(args: list, stdin_data: Optional[str] = None, json_output: bool = False) -> dict:
+def _run_hbot(args: list, stdin_data: Optional[str] = None, json_output: bool = False,
+              op_timeout: float = 0.0) -> dict:
     """Run one hbot command and map it to the uniform tool result.
 
     ``json_output`` appends ``--json`` and parses stdout into ``data``; otherwise stdout
-    (compact Markdown) is returned verbatim as ``output``.
+    (compact Markdown) is returned verbatim as ``output``. ``op_timeout`` is the command's
+    own --timeout value, used to raise the subprocess kill ceiling above it.
+
+    The child NEVER inherits this process's stdin — that is the MCP JSON-RPC stream, and a
+    stray read would corrupt the session. No piped input means /dev/null.
     """
     cmd = [_hbot_bin(), *[str(a) for a in args]]
     if json_output:
         cmd.append("--json")
+    stdin_kwargs = ({"input": stdin_data} if stdin_data is not None
+                    else {"stdin": subprocess.DEVNULL})
+    kill_after = max(SUBPROCESS_TIMEOUT, op_timeout + TIMEOUT_SLACK)
     try:
         proc = subprocess.run(
             cmd,
-            input=stdin_data,
             capture_output=True,
             text=True,
-            timeout=SUBPROCESS_TIMEOUT,
+            timeout=kill_after,
             cwd=PROJECT_ROOT,
+            **stdin_kwargs,
         )
     except FileNotFoundError:
         return {
@@ -114,7 +124,7 @@ def _run_hbot(args: list, stdin_data: Optional[str] = None, json_output: bool = 
         return {
             "ok": False, "exit_code": -1, "exit_status": "CLIENT_TIMEOUT",
             "data": None, "output": None,
-            "error": f"hbot did not return within {SUBPROCESS_TIMEOUT}s: {' '.join(cmd)}",
+            "error": f"hbot did not return within {kill_after:g}s: {' '.join(cmd)}",
         }
 
     result = {
@@ -143,6 +153,24 @@ def _set_args(values: Optional[dict]) -> tuple:
     return ["--values-stdin"], json.dumps(values)
 
 
+TYPE_FLAGS = {"v1-strategy": "--v1-strategy", "v2-script": "--v2-script", "controller": "--controller"}
+
+
+def _type_args(config_type: str) -> list:
+    """Map a config_type value to the CLI's disambiguation flag; raise on an unknown value."""
+    if not config_type:
+        return []
+    flag = TYPE_FLAGS.get(config_type)
+    if flag is None:
+        raise ValueError(f"config_type must be one of {sorted(TYPE_FLAGS)} (got '{config_type}')")
+    return [flag]
+
+
+def _bad_argument(message: str) -> dict:
+    return {"ok": False, "exit_code": -1, "exit_status": "BAD_ARGUMENT",
+            "data": None, "output": None, "error": message}
+
+
 # ── set up (connectors & funds) ──────────────────────────────────────────────
 
 @mcp.tool()
@@ -151,12 +179,12 @@ def connections(connector: str = "", show_fields: bool = False, show_all: bool =
 
     Read-only. With no arguments: the user's current connections (requires the keystore
     password, i.e. HBOT_PASSWORD). show_all=True: every connectable connector, no keys
-    needed. connector + show_fields=True: which API-key fields that connector requires.
+    needed. Passing a connector shows which API-key fields it requires.
 
     Adding keys is deliberately NOT a tool — never accept keys in chat. Have the user run
     `hbot connect <connector>` interactively in their own terminal instead.
     """
-    if connector and show_fields:
+    if connector:
         return _run_hbot(["connect", connector, "--fields"])
     if show_all:
         return _run_hbot(["connect", "--all"])
@@ -179,16 +207,21 @@ def balance(units_only: bool = False) -> dict:
 
 @mcp.tool()
 def create(strategy: str, values: Optional[dict] = None, name: str = "",
-           with_defaults: bool = False) -> dict:
+           with_defaults: bool = False, config_type: str = "") -> dict:
     """Create a strategy/controller/script config file and load it (without starting).
 
     `values` fills fields ({field: value}); a missing required field fails with the exact
     list of fields needed — use that error for field discovery instead of guessing.
     with_defaults=True scaffolds defaults + blank required fields to fill via config().
-    Prefer deploy() when the goal is a RUNNING bot.
+    config_type ('v1-strategy'|'v2-script'|'controller') is only needed when the strategy
+    name exists under more than one type. Prefer deploy() when the goal is a RUNNING bot.
     """
+    try:
+        type_args = _type_args(config_type)
+    except ValueError as e:
+        return _bad_argument(str(e))
     extra, stdin = _set_args(values)
-    args = ["create", strategy, *extra]
+    args = ["create", strategy, *type_args, *extra]
     if name:
         args += ["--name", name]
     if with_defaults:
@@ -197,10 +230,18 @@ def create(strategy: str, values: Optional[dict] = None, name: str = "",
 
 
 @mcp.tool()
-def import_config(config_file: str) -> dict:
+def import_config(config_file: str, config_type: str = "") -> dict:
     """Load an existing config file (from conf/strategies|scripts|controllers) as the
-    current strategy, so config() can edit it and start() can run it."""
-    return _run_hbot(["import", config_file])
+    current strategy, so config() can edit it and start() can run it.
+
+    config_type ('v1-strategy'|'v2-script'|'controller') is only needed when the file name
+    exists under more than one type — the error will say so.
+    """
+    try:
+        type_args = _type_args(config_type)
+    except ValueError as e:
+        return _bad_argument(str(e))
+    return _run_hbot(["import", config_file, *type_args])
 
 
 @mcp.tool()
@@ -223,37 +264,50 @@ def config(key: str = "", value: str = "") -> dict:
 
 @mcp.tool()
 def deploy(target: str, values: Optional[dict] = None, name: str = "",
-           replace: bool = False, timeout: float = 120.0) -> dict:
+           replace: bool = False, timeout: float = 120.0, config_type: str = "") -> dict:
     """One shot: config → RUNNING bot. The primary way to launch.
 
     `target` is either an existing config file name (deployed as-is, `values` edits it
     first) or a strategy/controller/script name (a ready-to-run config is created; every
     required field must then be in `values` — a miss fails listing the missing fields).
-    replace=True stops a currently running bot first. Verify with status() afterwards.
+    replace=True stops a currently running bot first. config_type
+    ('v1-strategy'|'v2-script'|'controller') disambiguates a name that exists under more
+    than one type. Verify with status() afterwards.
     """
+    try:
+        type_args = _type_args(config_type)
+    except ValueError as e:
+        return _bad_argument(str(e))
     extra, stdin = _set_args(values)
-    args = ["deploy", target, *extra, "--timeout", timeout]
+    args = ["deploy", target, *type_args, *extra, "--timeout", timeout]
     if name:
         args += ["--name", name]
     if replace:
         args.append("--replace")
-    return _run_hbot(args, stdin_data=stdin, json_output=True)
+    return _run_hbot(args, stdin_data=stdin, json_output=True, op_timeout=timeout)
 
 
 @mcp.tool()
-def start(config_file: str = "", replace: bool = False, timeout: float = 120.0) -> dict:
+def start(config_file: str = "", replace: bool = False, timeout: float = 120.0,
+          config_type: str = "") -> dict:
     """Start a bot from a config file (type auto-detected), detached.
 
     With no config_file, runs the currently loaded config (from create/import). Fails if a
-    bot is already running unless replace=True. Verify with status() afterwards.
+    bot is already running unless replace=True. config_type
+    ('v1-strategy'|'v2-script'|'controller') disambiguates a name that exists under more
+    than one type. Verify with status() afterwards.
     """
+    try:
+        type_args = _type_args(config_type)
+    except ValueError as e:
+        return _bad_argument(str(e))
     args = ["start"]
     if config_file:
         args.append(config_file)
-    args += ["--timeout", timeout]
+    args += [*type_args, "--timeout", timeout]
     if replace:
         args.append("--replace")
-    return _run_hbot(args, json_output=True)
+    return _run_hbot(args, json_output=True, op_timeout=timeout)
 
 
 @mcp.tool()
@@ -266,7 +320,7 @@ def stop(force: bool = False, timeout: float = 30.0) -> dict:
     args = ["stop", "--timeout", timeout]
     if force:
         args.append("--force")
-    return _run_hbot(args, json_output=True)
+    return _run_hbot(args, json_output=True, op_timeout=timeout)
 
 
 # ── observe ──────────────────────────────────────────────────────────────────

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -14,13 +14,13 @@ Configuration via environment variables (all optional):
 * ``HBOT_PASSWORD`` — the keystore password, passed through to the CLI's environment.
                       Set it in the MCP server config; it is NEVER a tool argument.
 
-Run: ``uv run --with mcp python mcp_server.py`` (see .mcp.json).
+Run: ``uv run --no-project --with mcp python mcp_server.py`` (see .mcp.json).
 """
 import json
 import os
 import subprocess
 from pathlib import Path
-from typing import Optional
+from typing import Literal, Optional
 
 from mcp.server.fastmcp import FastMCP
 
@@ -38,8 +38,11 @@ EXIT_NAMES = {
 
 # Floor for one subprocess call's kill ceiling; commands that take an operation --timeout
 # get that value plus slack, so the CLI's own timeout always fires first (exit code 5).
+# Tool timeout arguments are rejected above MAX_OP_TIMEOUT so a single MCP call can never
+# block a harness indefinitely.
 SUBPROCESS_TIMEOUT = 300
 TIMEOUT_SLACK = 60
+MAX_OP_TIMEOUT = 600
 
 INSTRUCTIONS = """\
 Operate a Hummingbot trading bot through the `hbot` CLI. Real money: prefer small sizes,
@@ -113,12 +116,15 @@ def _run_hbot(args: list, stdin_data: Optional[str] = None, json_output: bool = 
             cwd=PROJECT_ROOT,
             **stdin_kwargs,
         )
-    except FileNotFoundError:
+    except OSError as e:
+        # Missing binary, no execute bit, HBOT_BIN pointing at a directory, ... — every
+        # spawn failure must come back as the uniform result, never a raw traceback.
         return {
             "ok": False, "exit_code": -1, "exit_status": "NO_CLI",
             "data": None, "output": None,
-            "error": f"hbot executable not found: {cmd[0]}. Set HBOT_BIN or install the CLI "
-                     f"(`make install`, or `make deploy && make link-cli` for Docker).",
+            "error": f"cannot execute hbot ({cmd[0]}): {e}. Set HBOT_BIN to the hbot "
+                     f"executable, or install the CLI (`make install`, or "
+                     f"`make deploy && make link-cli` for Docker).",
         }
     except subprocess.TimeoutExpired:
         return {
@@ -140,7 +146,11 @@ def _run_hbot(args: list, stdin_data: Optional[str] = None, json_output: bool = 
         try:
             result["data"] = json.loads(stdout)
         except ValueError:
+            # The CLI promised --json and broke it — fail loudly, never degrade silently.
+            result["ok"] = False
+            result["exit_status"] = "PROTOCOL_ERROR"
             result["output"] = stdout or None
+            result["error"] = f"hbot --json emitted unparseable output: {' '.join(cmd)}"
     else:
         result["output"] = stdout or None
     return result
@@ -155,6 +165,10 @@ def _set_args(values: Optional[dict]) -> tuple:
 
 TYPE_FLAGS = {"v1-strategy": "--v1-strategy", "v2-script": "--v2-script", "controller": "--controller"}
 
+# Literal in the tool signatures pushes the allowed values into the MCP schema, so clients
+# reject a bad config_type before the call; this is the safety net for direct callers.
+ConfigType = Literal["", "v1-strategy", "v2-script", "controller"]
+
 
 def _type_args(config_type: str) -> list:
     """Map a config_type value to the CLI's disambiguation flag; raise on an unknown value."""
@@ -166,6 +180,13 @@ def _type_args(config_type: str) -> list:
     return [flag]
 
 
+def _timeout_error(timeout: float) -> Optional[dict]:
+    if timeout > MAX_OP_TIMEOUT:
+        return _bad_argument(f"timeout must be <= {MAX_OP_TIMEOUT}s (got {timeout:g}) — "
+                             f"one MCP call may not block the harness longer than that")
+    return None
+
+
 def _bad_argument(message: str) -> dict:
     return {"ok": False, "exit_code": -1, "exit_status": "BAD_ARGUMENT",
             "data": None, "output": None, "error": message}
@@ -174,12 +195,12 @@ def _bad_argument(message: str) -> dict:
 # ── set up (connectors & funds) ──────────────────────────────────────────────
 
 @mcp.tool()
-def connections(connector: str = "", show_fields: bool = False, show_all: bool = False) -> dict:
+def connections(connector: str = "", show_all: bool = False) -> dict:
     """Show connected connectors, list all connectable ones, or a connector's key fields.
 
     Read-only. With no arguments: the user's current connections (requires the keystore
     password, i.e. HBOT_PASSWORD). show_all=True: every connectable connector, no keys
-    needed. Passing a connector shows which API-key fields it requires.
+    needed. Passing a connector shows which API-key fields it requires (also keys-free).
 
     Adding keys is deliberately NOT a tool — never accept keys in chat. Have the user run
     `hbot connect <connector>` interactively in their own terminal instead.
@@ -207,21 +228,17 @@ def balance(units_only: bool = False) -> dict:
 
 @mcp.tool()
 def create(strategy: str, values: Optional[dict] = None, name: str = "",
-           with_defaults: bool = False, config_type: str = "") -> dict:
+           with_defaults: bool = False, config_type: ConfigType = "") -> dict:
     """Create a strategy/controller/script config file and load it (without starting).
 
     `values` fills fields ({field: value}); a missing required field fails with the exact
     list of fields needed — use that error for field discovery instead of guessing.
     with_defaults=True scaffolds defaults + blank required fields to fill via config().
-    config_type ('v1-strategy'|'v2-script'|'controller') is only needed when the strategy
-    name exists under more than one type. Prefer deploy() when the goal is a RUNNING bot.
+    config_type is only needed when the strategy name exists under more than one type.
+    Prefer deploy() when the goal is a RUNNING bot.
     """
-    try:
-        type_args = _type_args(config_type)
-    except ValueError as e:
-        return _bad_argument(str(e))
     extra, stdin = _set_args(values)
-    args = ["create", strategy, *type_args, *extra]
+    args = ["create", strategy, *_type_args(config_type), *extra]
     if name:
         args += ["--name", name]
     if with_defaults:
@@ -230,32 +247,30 @@ def create(strategy: str, values: Optional[dict] = None, name: str = "",
 
 
 @mcp.tool()
-def import_config(config_file: str, config_type: str = "") -> dict:
+def import_config(config_file: str, config_type: ConfigType = "") -> dict:
     """Load an existing config file (from conf/strategies|scripts|controllers) as the
     current strategy, so config() can edit it and start() can run it.
 
-    config_type ('v1-strategy'|'v2-script'|'controller') is only needed when the file name
-    exists under more than one type — the error will say so.
+    config_type is only needed when the file name exists under more than one type — the
+    error will say so.
     """
-    try:
-        type_args = _type_args(config_type)
-    except ValueError as e:
-        return _bad_argument(str(e))
-    return _run_hbot(["import", config_file, *type_args])
+    return _run_hbot(["import", config_file, *_type_args(config_type)])
 
 
 @mcp.tool()
-def config(key: str = "", value: str = "") -> dict:
+def config(key: Optional[str] = None, value: Optional[str] = None) -> dict:
     """View or set configuration — global client settings plus the loaded strategy's fields.
 
     No args: show everything. key only: read one field. key + value: set it (global keys
     win over strategy keys). On a RUNNING controller, live-updatable fields apply in ~10s;
     the reply says when a change takes effect.
     """
+    if value is not None and key is None:
+        return _bad_argument("a value requires a key — pass key and value to set a field")
     args = ["config"]
-    if key:
+    if key is not None:
         args.append(key)
-        if value:
+        if value is not None:
             args.append(value)
     return _run_hbot(args, json_output=True)
 
@@ -264,22 +279,19 @@ def config(key: str = "", value: str = "") -> dict:
 
 @mcp.tool()
 def deploy(target: str, values: Optional[dict] = None, name: str = "",
-           replace: bool = False, timeout: float = 120.0, config_type: str = "") -> dict:
+           replace: bool = False, timeout: float = 120.0, config_type: ConfigType = "") -> dict:
     """One shot: config → RUNNING bot. The primary way to launch.
 
     `target` is either an existing config file name (deployed as-is, `values` edits it
     first) or a strategy/controller/script name (a ready-to-run config is created; every
     required field must then be in `values` — a miss fails listing the missing fields).
-    replace=True stops a currently running bot first. config_type
-    ('v1-strategy'|'v2-script'|'controller') disambiguates a name that exists under more
-    than one type. Verify with status() afterwards.
+    replace=True stops a currently running bot first. config_type disambiguates a name
+    that exists under more than one type. Verify with status() afterwards.
     """
-    try:
-        type_args = _type_args(config_type)
-    except ValueError as e:
-        return _bad_argument(str(e))
+    if err := _timeout_error(timeout):
+        return err
     extra, stdin = _set_args(values)
-    args = ["deploy", target, *type_args, *extra, "--timeout", timeout]
+    args = ["deploy", target, *_type_args(config_type), *extra, "--timeout", timeout]
     if name:
         args += ["--name", name]
     if replace:
@@ -289,22 +301,19 @@ def deploy(target: str, values: Optional[dict] = None, name: str = "",
 
 @mcp.tool()
 def start(config_file: str = "", replace: bool = False, timeout: float = 120.0,
-          config_type: str = "") -> dict:
+          config_type: ConfigType = "") -> dict:
     """Start a bot from a config file (type auto-detected), detached.
 
     With no config_file, runs the currently loaded config (from create/import). Fails if a
-    bot is already running unless replace=True. config_type
-    ('v1-strategy'|'v2-script'|'controller') disambiguates a name that exists under more
-    than one type. Verify with status() afterwards.
+    bot is already running unless replace=True. config_type disambiguates a name that
+    exists under more than one type. Verify with status() afterwards.
     """
-    try:
-        type_args = _type_args(config_type)
-    except ValueError as e:
-        return _bad_argument(str(e))
+    if err := _timeout_error(timeout):
+        return err
     args = ["start"]
     if config_file:
         args.append(config_file)
-    args += [*type_args, "--timeout", timeout]
+    args += [*_type_args(config_type), "--timeout", timeout]
     if replace:
         args.append("--replace")
     return _run_hbot(args, json_output=True, op_timeout=timeout)
@@ -317,6 +326,8 @@ def stop(force: bool = False, timeout: float = 30.0) -> dict:
     force=True SIGKILLs if still alive after `timeout` seconds (open orders may survive on
     the exchange — check afterwards). exit_status NOT_RUNNING means it was already stopped.
     """
+    if err := _timeout_error(timeout):
+        return err
     args = ["stop", "--timeout", timeout]
     if force:
         args.append("--force")

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -14,7 +14,15 @@ Configuration via environment variables (all optional):
 * ``HBOT_PASSWORD`` — the keystore password, passed through to the CLI's environment.
                       Set it in the MCP server config; it is NEVER a tool argument.
 
-Run: ``uv run --no-project --with mcp python mcp_server.py`` (see .mcp.json).
+Transports:
+
+* **stdio** (default) — for local clients: ``uv run --no-project --with "mcp>=1.10" python
+  mcp_server.py`` (see .mcp.json), or ``bin/hbot-mcp``.
+* **streamable HTTP** — ``--http`` (or ``HBOT_MCP_TRANSPORT=http``): serves
+  ``http://<host>:<port>/mcp`` for URL-based clients (Claude Desktop connectors, the
+  Docker image's MCP mode). ``HBOT_MCP_HOST`` defaults to **127.0.0.1** — the server has
+  no auth and can trade real money, so bind beyond loopback only on purpose.
+  ``HBOT_MCP_PORT`` defaults to 8211.
 """
 import json
 import os
@@ -374,5 +382,25 @@ def history(name: str = "", days: Optional[float] = None) -> dict:
     return _run_hbot(args)
 
 
+def _transport_config(argv: list, environ: dict) -> tuple:
+    """Resolve (transport, host, port) from argv/env.
+
+    HTTP must be opt-in and loopback-bound by default: this server has no auth layer and
+    its tools move real money.
+    """
+    if "--http" in argv or environ.get("HBOT_MCP_TRANSPORT") == "http":
+        return ("streamable-http",
+                environ.get("HBOT_MCP_HOST", "127.0.0.1"),
+                int(environ.get("HBOT_MCP_PORT", "8211")))
+    return ("stdio", None, None)
+
+
 if __name__ == "__main__":
-    mcp.run()
+    import sys
+    transport, host, port = _transport_config(sys.argv[1:], os.environ)
+    if transport == "streamable-http":
+        mcp.settings.host = host
+        mcp.settings.port = port
+        mcp.run(transport="streamable-http")
+    else:
+        mcp.run()

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -14,15 +14,16 @@ Configuration via environment variables (all optional):
 * ``HBOT_PASSWORD`` — the keystore password, passed through to the CLI's environment.
                       Set it in the MCP server config; it is NEVER a tool argument.
 
-Transports:
+Transport: **stdio only**, deliberately. The server's tools trade real money and MCP's HTTP
+transports ship no auth; stdio keeps trading access behind credentials the OS already
+manages (process spawn rights, the Docker socket). Every client reaches it by spawning a
+process:
 
-* **stdio** (default) — for local clients: ``uv run --no-project --with "mcp>=1.10" python
-  mcp_server.py`` (see .mcp.json), or ``bin/hbot-mcp``.
-* **streamable HTTP** — ``--http`` (or ``HBOT_MCP_TRANSPORT=http``): serves
-  ``http://<host>:<port>/mcp`` for URL-based clients (Claude Desktop connectors, the
-  Docker image's MCP mode). ``HBOT_MCP_HOST`` defaults to **127.0.0.1** — the server has
-  no auth and can trade real money, so bind beyond loopback only on purpose.
-  ``HBOT_MCP_PORT`` defaults to 8211.
+* source install — ``uv run --no-project --with "mcp>=1.10" python mcp_server.py``
+  (see .mcp.json), or ``bin/hbot-mcp``.
+* Docker — ``docker exec -i hummingbot hbot-mcp``: the harness on the host spawns the
+  server inside the container and speaks stdio through the exec channel. Nothing to
+  install on the host but the docker CLI; no port is ever opened.
 """
 import json
 import os
@@ -418,25 +419,5 @@ def update(check: bool = True) -> dict:
     return _run_hbot(args, json_output=True, op_timeout=900)
 
 
-def _transport_config(argv: list, environ: dict) -> tuple:
-    """Resolve (transport, host, port) from argv/env.
-
-    HTTP must be opt-in and loopback-bound by default: this server has no auth layer and
-    its tools move real money.
-    """
-    if "--http" in argv or environ.get("HBOT_MCP_TRANSPORT") == "http":
-        return ("streamable-http",
-                environ.get("HBOT_MCP_HOST", "127.0.0.1"),
-                int(environ.get("HBOT_MCP_PORT", "8211")))
-    return ("stdio", None, None)
-
-
 if __name__ == "__main__":
-    import sys
-    transport, host, port = _transport_config(sys.argv[1:], os.environ)
-    if transport == "streamable-http":
-        mcp.settings.host = host
-        mcp.settings.port = port
-        mcp.run(transport="streamable-http")
-    else:
-        mcp.run()
+    mcp.run()  # stdio only — see the module docstring for why there is no HTTP mode

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1,554 +1,312 @@
-"""MCP server for managing Hummingbot v2 bots as detached TMUX sessions.
+"""MCP server for Hummingbot — a thin, faithful wrapper over the ``hbot`` CLI.
 
-Each bot runs in its own ``tmux`` session named ``hb-<config-stem>``. The server
-exposes MCP tools to deploy controllers, start/stop bots, tail their logs and read
-the live status panel — so an assistant can operate a fleet of bots without a human
-attaching to each terminal.
+Each tool maps 1:1 onto an ``hbot`` command and runs it as a short subprocess. The CLI is
+the substrate (headless engine, structured status, signal-based stop, stable exit codes);
+this server only adds MCP transport so harnesses without a shell — or users who prefer
+native tools — can drive the same bot. There is no tmux, no interactive client, and no
+screen-scraping (see hbot-cli-vs-mcp-eval.md for why that substrate was replaced).
 
 Configuration via environment variables (all optional):
 
-* ``HB_PYTHON``     — absolute path to the Python interpreter of the ``hummingbot``
-                      conda env. If unset, common conda locations are probed.
-* ``HB_PROJECT_ROOT`` — Hummingbot checkout to operate on. Defaults to this file's dir.
+* ``HBOT_BIN``      — the hbot executable to invoke. Defaults to ``bin/hbot-host`` next to
+                      this file, which auto-detects a ``hummingbot`` conda env or a running
+                      ``hummingbot`` Docker container.
+* ``HBOT_PASSWORD`` — the keystore password, passed through to the CLI's environment.
+                      Set it in the MCP server config; it is NEVER a tool argument.
 
-Requirements: ``tmux`` on PATH, and (for ``open_terminal``) macOS with ``osascript``.
+Run: ``uv run --with mcp python mcp_server.py`` (see .mcp.json).
 """
-
+import json
 import os
-import platform
-import shlex
 import subprocess
-import time
-from datetime import datetime
 from pathlib import Path
+from typing import Optional
 
-import yaml
 from mcp.server.fastmcp import FastMCP
 
-PROJECT_ROOT = Path(os.environ.get("HB_PROJECT_ROOT", Path(__file__).resolve().parent))
-SESSION_PREFIX = "hb-"
+PROJECT_ROOT = Path(__file__).resolve().parent
 
-# Timeouts (seconds) for the short, synchronous helper subprocesses.
-TMUX_TIMEOUT = 10
-PGREP_TIMEOUT = 5
+# hbot's stable exit-code contract (hummingbot/cli/output.py). Branch on these, not on text.
+EXIT_NAMES = {
+    0: "SUCCESS",
+    1: "ERROR",
+    2: "NOT_FOUND",
+    3: "NOT_RUNNING",
+    4: "CONFIG_ERROR",
+    5: "TIMEOUT",
+}
 
-# Bounds for log tailing so a tool call never returns an unbounded blob.
-MAX_LOG_LINES = 2000
+# Ceiling for one subprocess call; per-command --timeout values stay well under it.
+SUBPROCESS_TIMEOUT = 300
 
-# Seconds to let the pane's interactive shell finish initializing before we type the
-# launch command. On heavy prompts (oh-my-zsh + git status) send-keys sent too early is
-# silently dropped, so the bot never starts. 0.5s is the empirical floor; 0.75s adds margin.
-SHELL_SETTLE = float(os.environ.get("HB_SHELL_SETTLE", "0.75"))
+INSTRUCTIONS = """\
+Operate a Hummingbot trading bot through the `hbot` CLI. Real money: prefer small sizes,
+verify state after every mutating call, and stop the bot when the user is done.
+
+Mental model:
+- ONE bot per install. `start`/`deploy` fail if a bot is running unless replace=true.
+- Three config types, one folder each: v1-strategy (conf/strategies/), v2-script
+  (conf/scripts/), controller (conf/controllers/). File names are unique across folders,
+  so a bare filename is unambiguous; the type is auto-detected.
+- A config is first LOADED (create/import), then RUN (start). `deploy` does both in one
+  call — it is the primitive to reach for when the user just wants a bot running.
+- Controllers apply live-updatable field changes (~10s) while running via `config`.
+
+The core loop:
+  connections() → balance() → deploy(target, values) → status() → logs() → stop()
+  Field discovery: create/deploy with missing required fields FAILS listing exactly the
+  fields needed — that error is the documentation; don't invent field names.
+
+Read results like this: every tool returns {ok, exit_code, exit_status, data|output, error}.
+`data` is the parsed --json payload where the CLI supports it; `output` is compact Markdown
+otherwise. Branch on ok/exit_status, never on prose.
+
+Health: status() reporting running=true does NOT mean healthy — it includes a recent-errors
+count; check it. history() also fetches balances, so it is the slowest call.
+
+Secrets policy (strict):
+- NEVER ask the user to paste API keys, private keys, or the keystore password into chat,
+  and never accept them as tool inputs. Key entry is deliberately NOT a tool: have the user
+  run `hbot connect <connector>` interactively in their own terminal (input is hidden and
+  goes straight into the encrypted keystore).
+- The keystore password comes from HBOT_PASSWORD in the MCP server's environment. If a tool
+  fails with exit_status CONFIG_ERROR mentioning the password, tell the user to set
+  HBOT_PASSWORD in their MCP config — do not ask for the password itself.
+- On a brand-new install the first password used BECOMES the keystore password.
+"""
+
+mcp = FastMCP("hummingbot", instructions=INSTRUCTIONS)
 
 
-def _resolve_hb_python() -> str:
-    """Locate the hummingbot env interpreter.
-
-    We invoke python by absolute path instead of ``conda run`` because on some setups
-    ``conda run`` does not put the env's python on PATH (it can resolve to an unrelated
-    active venv), and when the env is mounted as ``base`` then ``conda run -n hummingbot``
-    builds a doubled, invalid path. ``HB_PYTHON`` always wins if set.
-    """
-    override = os.environ.get("HB_PYTHON")
+def _hbot_bin() -> str:
+    override = os.environ.get("HBOT_BIN")
     if override:
         return override
-    candidates = [
-        Path.home() / "anaconda3" / "envs" / "hummingbot" / "bin" / "python",
-        Path.home() / "miniconda3" / "envs" / "hummingbot" / "bin" / "python",
-        Path.home() / "miniforge3" / "envs" / "hummingbot" / "bin" / "python",
-        Path("/opt/anaconda3/envs/hummingbot/bin/python"),
-        Path("/opt/homebrew/anaconda3/envs/hummingbot/bin/python"),
-        Path("/opt/miniconda3/envs/hummingbot/bin/python"),
-    ]
-    for cand in candidates:
-        if cand.exists():
-            return str(cand)
-    # Fall back to the first well-known location; start_bot surfaces a clear error
-    # if it does not exist, rather than failing opaquely inside tmux.
-    return str(candidates[3])
+    return str(PROJECT_ROOT / "bin" / "hbot-host")
 
 
-HB_PYTHON = _resolve_hb_python()
+def _run_hbot(args: list, stdin_data: Optional[str] = None, json_output: bool = False) -> dict:
+    """Run one hbot command and map it to the uniform tool result.
 
-mcp = FastMCP("hummingbot-manager")
-
-
-# ── Subprocess helpers ───────────────────────────────────────────────────────
-
-def _run(cmd: list[str], timeout: int) -> subprocess.CompletedProcess:
-    """Run a subprocess, converting environment failures into a CompletedProcess.
-
-    A missing binary or a timeout would otherwise raise and crash the tool call; we
-    surface them as returncode=-1 with a message on stderr so callers stay uniform.
+    ``json_output`` appends ``--json`` and parses stdout into ``data``; otherwise stdout
+    (compact Markdown) is returned verbatim as ``output``.
     """
+    cmd = [_hbot_bin(), *[str(a) for a in args]]
+    if json_output:
+        cmd.append("--json")
     try:
-        return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        proc = subprocess.run(
+            cmd,
+            input=stdin_data,
+            capture_output=True,
+            text=True,
+            timeout=SUBPROCESS_TIMEOUT,
+            cwd=PROJECT_ROOT,
+        )
     except FileNotFoundError:
-        return subprocess.CompletedProcess(cmd, -1, "", f"command not found: {cmd[0]}")
+        return {
+            "ok": False, "exit_code": -1, "exit_status": "NO_CLI",
+            "data": None, "output": None,
+            "error": f"hbot executable not found: {cmd[0]}. Set HBOT_BIN or install the CLI "
+                     f"(`make install`, or `make deploy && make link-cli` for Docker).",
+        }
     except subprocess.TimeoutExpired:
-        return subprocess.CompletedProcess(cmd, -1, "", f"timed out after {timeout}s: {cmd[0]}")
-
-
-def _run_tmux(*args: str) -> subprocess.CompletedProcess:
-    return _run(["tmux", *args], TMUX_TIMEOUT)
-
-
-def _session_exists(name: str) -> bool:
-    return _run_tmux("has-session", "-t", name).returncode == 0
-
-
-def _get_session_config(name: str) -> str | None:
-    result = _run_tmux("show-environment", "-t", name, "HB_CONFIG")
-    if result.returncode == 0 and "=" in result.stdout:
-        return result.stdout.strip().split("=", 1)[1]
-    return None
-
-
-def _config_to_log_path(config_name: str) -> Path:
-    stem = Path(config_name).stem
-    return PROJECT_ROOT / "logs" / f"logs_{stem}.log"
-
-
-def _capture_pane(name: str, lines: int = 40) -> str:
-    result = _run_tmux("capture-pane", "-t", name, "-p", "-S", f"-{lines}")
-    return result.stdout if result.returncode == 0 else ""
-
-
-def _process_alive(name: str) -> bool:
-    """True if the session's pane shell has a child process (i.e. the bot is running)."""
-    pid_result = _run_tmux("list-panes", "-t", name, "-F", "#{pane_pid}")
-    out = pid_result.stdout.strip().splitlines() if pid_result.returncode == 0 else []
-    pane_pid = out[0].strip() if out else ""
-    if not pane_pid:
-        return False
-    return _run(["pgrep", "-P", pane_pid], PGREP_TIMEOUT).returncode == 0
-
-
-def _safe_stem(name: str) -> str | None:
-    """Return the sanitized stem of a user-supplied name, or None if unsafe.
-
-    Guards the filesystem paths built from run/config names against traversal
-    (``..``) and separators, which would otherwise let a name escape conf/.
-    """
-    stem = Path(name).stem.strip()
-    if not stem or stem in (".", "..") or "/" in name or "\\" in name:
-        return None
-    return stem
-
-
-def _quickstart_cmd(config_file: str, password: str) -> str:
-    """Build the shell command that launches the bot inside the tmux pane.
-
-    The password is passed via the ``CONFIG_PASSWORD`` env var (which quickstart reads)
-    rather than the ``-p`` flag, so it does not appear in the process argv / ``ps`` output.
-    ``VIRTUAL_ENV``/``PYTHONPATH`` are cleared so the absolute-path interpreter is not
-    shadowed by an active venv. Every interpolated value is shell-quoted.
-    """
-    return (
-        f"VIRTUAL_ENV= PYTHONPATH= CONFIG_PASSWORD={shlex.quote(password)} "
-        f"{shlex.quote(HB_PYTHON)} ./bin/hummingbot_quickstart.py "
-        f"--v2 {shlex.quote(config_file)}"
-    )
-
-
-def _start_session(config_file: str, session_name: str, password: str) -> dict:
-    """Create a detached TMUX session and launch the bot in it."""
-    if _session_exists(session_name):
-        return {"status": "error", "error": f"Session '{session_name}' already exists. Stop it first."}
-
-    if not Path(HB_PYTHON).exists():
         return {
-            "status": "error",
-            "error": f"Hummingbot interpreter not found: {HB_PYTHON}. "
-                     f"Set HB_PYTHON to the conda env's python.",
+            "ok": False, "exit_code": -1, "exit_status": "CLIENT_TIMEOUT",
+            "data": None, "output": None,
+            "error": f"hbot did not return within {SUBPROCESS_TIMEOUT}s: {' '.join(cmd)}",
         }
 
-    result = _run_tmux("new-session", "-d", "-s", session_name, "-c", str(PROJECT_ROOT))
-    if result.returncode != 0:
-        return {"status": "error", "error": f"Failed to create tmux session: {result.stderr.strip()}"}
-
-    _run_tmux("set-environment", "-t", session_name, "HB_CONFIG", config_file)
-    # Let the interactive shell settle so the launch command is not typed before the
-    # prompt is ready (otherwise send-keys is dropped and the bot never starts).
-    time.sleep(SHELL_SETTLE)
-    _run_tmux("send-keys", "-t", session_name, _quickstart_cmd(config_file, password), "Enter")
-
-    return {
-        "status": "ok",
-        "session_name": session_name,
-        "config_file": config_file,
-        "log_path": str(_config_to_log_path(config_file)),
+    result = {
+        "ok": proc.returncode == 0,
+        "exit_code": proc.returncode,
+        "exit_status": EXIT_NAMES.get(proc.returncode, "UNKNOWN"),
+        "data": None,
+        "output": None,
+        "error": proc.stderr.strip() or None,
     }
-
-
-def _write_deploy_config(
-    controllers: list[str],
-    config_name: str,
-    script_file_name: str,
-    max_global_drawdown_quote: float | None,
-    max_controller_drawdown_quote: float | None,
-) -> dict:
-    if not controllers:
-        return {"status": "error", "error": "Must provide at least one controller config."}
-
-    controllers_dir = PROJECT_ROOT / "conf" / "controllers"
-    normalized = []
-    for c in controllers:
-        if not c.endswith(".yml"):
-            c += ".yml"
-        if _safe_stem(c) is None:
-            return {"status": "error", "error": f"Invalid controller name: {c}"}
-        if not (controllers_dir / c).exists():
-            return {"status": "error", "error": f"Controller config not found: conf/controllers/{c}"}
-        normalized.append(c)
-
-    if _safe_stem(script_file_name) is None or not (PROJECT_ROOT / "scripts" / script_file_name).exists():
-        return {"status": "error", "error": f"Script not found: scripts/{script_file_name}"}
-
-    if not config_name.endswith(".yml"):
-        config_name += ".yml"
-    if _safe_stem(config_name) is None:
-        return {"status": "error", "error": f"Invalid config name: {config_name}"}
-
-    config_data = {
-        "controllers_config": normalized,
-        "script_file_name": script_file_name,
-        "max_global_drawdown_quote": max_global_drawdown_quote,
-        "max_controller_drawdown_quote": max_controller_drawdown_quote,
-    }
-    output_path = PROJECT_ROOT / "conf" / "scripts" / config_name
-    with open(output_path, "w") as f:
-        yaml.dump(config_data, f, default_flow_style=False, sort_keys=False)
-
-    return {"status": "ok", "config_file": config_name, "path": str(output_path), "content": config_data}
-
-
-def _tail(path: Path, n: int) -> list[str]:
-    """Return the last ``n`` lines of a file without reading it fully into memory."""
-    n = max(1, n)
-    with open(path, "rb") as f:
-        f.seek(0, os.SEEK_END)
-        pos = f.tell()
-        data = b""
-        block = 8192
-        while pos > 0 and data.count(b"\n") <= n:
-            read = min(block, pos)
-            pos -= read
-            f.seek(pos)
-            data = f.read(read) + data
-        lines = data.splitlines()[-n:]
-    return [ln.decode("utf-8", "replace") for ln in lines]
-
-
-# ── Deploy / start ─────────────────────────────────────────────────────────
-
-@mcp.tool()
-def deploy(
-    controllers: list[str],
-    run_name: str = "",
-    password: str = "a",
-    max_global_drawdown_quote: float | None = None,
-    max_controller_drawdown_quote: float | None = None,
-    script_file_name: str = "v2_with_controllers.py",
-) -> dict:
-    """Deploy one or more controllers as a new bot run.
-
-    This is the high-level entry point: you say WHICH controllers to run and it
-    builds the v2 deploy config for you with a UNIQUE name, so each run gets its own
-    sqlite DB (data/{config}.sqlite) and log file (logs/logs_{config}.log) — easier to
-    review in isolation. Then it starts the bot in a detached TMUX session.
-
-    Args:
-        controllers: Controller config filenames from conf/controllers/ (e.g. ["pmm_king_wld.yml"]).
-        run_name: Optional label for this run. If omitted, a unique name is auto-generated
-            from the first controller + timestamp (e.g. pmm_king_wld_0604_2103).
-        password: Hummingbot password. Defaults to "a".
-        max_global_drawdown_quote: Max global drawdown in quote. None = no limit.
-        max_controller_drawdown_quote: Max per-controller drawdown in quote. None = no limit.
-        script_file_name: v2 runner script. Defaults to v2_with_controllers.py.
-    """
-    if not controllers:
-        return {"status": "error", "error": "Must provide at least one controller config."}
-
-    if run_name:
-        stem = _safe_stem(run_name)
-        if stem is None:
-            return {"status": "error", "error": f"Invalid run_name: {run_name}"}
+    stdout = proc.stdout.strip()
+    if json_output and proc.returncode == 0:
+        try:
+            result["data"] = json.loads(stdout)
+        except ValueError:
+            result["output"] = stdout or None
     else:
-        first_stem = _safe_stem(controllers[0]) or "run"
-        stem = f"{first_stem}_{datetime.now().strftime('%m%d_%H%M')}"
-    config_name = f"conf_{stem}.yml"
-    session_name = f"{SESSION_PREFIX}{Path(config_name).stem}"
+        result["output"] = stdout or None
+    return result
 
-    created = _write_deploy_config(
-        controllers, config_name, script_file_name,
-        max_global_drawdown_quote, max_controller_drawdown_quote,
-    )
-    if created["status"] != "ok":
-        return created
 
-    started = _start_session(config_name, session_name, password)
-    if started["status"] != "ok":
-        return started
+def _set_args(values: Optional[dict]) -> tuple:
+    """Encode a {field: value} dict as (extra_args, stdin) using --values-stdin (bulk fill)."""
+    if not values:
+        return [], None
+    return ["--values-stdin"], json.dumps(values)
 
-    db_stem = Path(config_name).stem
-    return {
-        "status": "ok",
-        "session_name": session_name,
-        "config_file": config_name,
-        "controllers": created["content"]["controllers_config"],
-        "log_path": str(_config_to_log_path(config_name)),
-        "db_path": str(PROJECT_ROOT / "data" / f"{db_stem}.sqlite"),
-        "note": "Unique DB + logs for this run. Attach with open_terminal, stop with stop_bot.",
-    }
 
+# ── set up (connectors & funds) ──────────────────────────────────────────────
 
 @mcp.tool()
-def start_bot(config_file: str, session_name: str = "", password: str = "a") -> dict:
-    """Start a bot from an EXISTING deploy config in conf/scripts/ (low-level).
+def connections(connector: str = "", show_fields: bool = False, show_all: bool = False) -> dict:
+    """Show connected connectors, list all connectable ones, or a connector's key fields.
 
-    Prefer `deploy` for new runs (it builds a uniquely-named config for you). Use this
-    when you want to re-run a specific existing conf/scripts/ file as-is.
+    Read-only. With no arguments: the user's current connections (requires the keystore
+    password, i.e. HBOT_PASSWORD). show_all=True: every connectable connector, no keys
+    needed. connector + show_fields=True: which API-key fields that connector requires.
 
-    Args:
-        config_file: Config filename in conf/scripts/ (e.g. conf_pmm_king_wld.yml).
-        session_name: TMUX session name. Defaults to hb-{config_stem}.
-        password: Hummingbot password. Defaults to "a".
+    Adding keys is deliberately NOT a tool — never accept keys in chat. Have the user run
+    `hbot connect <connector>` interactively in their own terminal instead.
     """
-    if not config_file.endswith(".yml"):
-        config_file += ".yml"
-    if _safe_stem(config_file) is None:
-        return {"status": "error", "error": f"Invalid config name: {config_file}"}
-    if not (PROJECT_ROOT / "conf" / "scripts" / config_file).exists():
-        return {"status": "error", "error": f"Config not found: conf/scripts/{config_file}"}
+    if connector and show_fields:
+        return _run_hbot(["connect", connector, "--fields"])
+    if show_all:
+        return _run_hbot(["connect", "--all"])
+    return _run_hbot(["connect"])
 
-    name = session_name or f"{SESSION_PREFIX}{Path(config_file).stem}"
-    return _start_session(config_file, name, password)
-
-
-# ── Stop / cleanup ─────────────────────────────────────────────────────────
 
 @mcp.tool()
-def stop_bot(session_name: str, force: bool = False, cancel_timeout: int = 25) -> dict:
-    """Stop a bot and ALWAYS clean up its TMUX session.
+def balance(units_only: bool = False) -> dict:
+    """Balances per connected connector with USD value; perps also show positions + net value.
 
-    Graceful by default: sends the hummingbot `stop` command (which cancels all open
-    orders on the exchange) and waits for confirmation, then `exit`s the app, then
-    kills the TMUX session so nothing is left behind. With force=True it skips the
-    graceful cancel and kills the session immediately (orders may stay open!).
-
-    Args:
-        session_name: TMUX session name (e.g. hb-conf_pmm_king_wld).
-        force: Skip graceful order-cancel and kill the session immediately.
-        cancel_timeout: Seconds to wait for graceful stop confirmation before exiting.
+    units_only=True skips the price fetch (token amounts only — faster).
     """
-    if not _session_exists(session_name):
-        return {"status": "error", "error": f"Session '{session_name}' not found."}
+    args = ["balance"]
+    if units_only:
+        args.append("--units-only")
+    return _run_hbot(args, json_output=True)
 
-    method = "force-killed"
-    if not force:
-        _run_tmux("send-keys", "-t", session_name, "stop", "Enter")
-        stopped = False
-        for _ in range(max(1, cancel_timeout)):
-            time.sleep(1.0)
-            pane = _capture_pane(session_name, 40).lower()
-            if "stopped successfully" in pane or "no active maker orders" in pane:
-                stopped = True
-                break
-        _run_tmux("send-keys", "-t", session_name, "exit", "Enter")
-        time.sleep(2.0)
-        method = "graceful" if stopped else "graceful-timeout"
 
-    # Guarantee cleanup: the session is always killed.
-    _run_tmux("kill-session", "-t", session_name)
-    return {"status": "ok", "method": method, "session_name": session_name, "cleaned_up": True}
-
+# ── create, load & configure ─────────────────────────────────────────────────
 
 @mcp.tool()
-def kill_session(session_name: str) -> dict:
-    """Force-kill a single TMUX session immediately (no graceful stop).
+def create(strategy: str, values: Optional[dict] = None, name: str = "",
+           with_defaults: bool = False) -> dict:
+    """Create a strategy/controller/script config file and load it (without starting).
 
-    Use to clean up a dead/zombie session, or one where the bot already crashed.
-    Does NOT cancel exchange orders — use stop_bot for a running bot.
+    `values` fills fields ({field: value}); a missing required field fails with the exact
+    list of fields needed — use that error for field discovery instead of guessing.
+    with_defaults=True scaffolds defaults + blank required fields to fill via config().
+    Prefer deploy() when the goal is a RUNNING bot.
     """
-    if not _session_exists(session_name):
-        return {"status": "error", "error": f"Session '{session_name}' not found."}
-    _run_tmux("kill-session", "-t", session_name)
-    return {"status": "ok", "session_name": session_name, "killed": True}
+    extra, stdin = _set_args(values)
+    args = ["create", strategy, *extra]
+    if name:
+        args += ["--name", name]
+    if with_defaults:
+        args.append("--with-defaults")
+    return _run_hbot(args, stdin_data=stdin)
 
 
 @mcp.tool()
-def kill_all_bots() -> dict:
-    """Force-kill ALL Hummingbot (hb-) TMUX sessions. Cleanup sweep.
+def import_config(config_file: str) -> dict:
+    """Load an existing config file (from conf/strategies|scripts|controllers) as the
+    current strategy, so config() can edit it and start() can run it."""
+    return _run_hbot(["import", config_file])
 
-    Does NOT gracefully cancel orders. Use stop_bot per-session if bots are live.
+
+@mcp.tool()
+def config(key: str = "", value: str = "") -> dict:
+    """View or set configuration — global client settings plus the loaded strategy's fields.
+
+    No args: show everything. key only: read one field. key + value: set it (global keys
+    win over strategy keys). On a RUNNING controller, live-updatable fields apply in ~10s;
+    the reply says when a change takes effect.
     """
-    result = _run_tmux("list-sessions", "-F", "#{session_name}")
-    killed = []
-    if result.returncode == 0:
-        for line in result.stdout.strip().splitlines():
-            name = line.strip()
-            if name.startswith(SESSION_PREFIX):
-                _run_tmux("kill-session", "-t", name)
-                killed.append(name)
-    return {"status": "ok", "killed": killed}
+    args = ["config"]
+    if key:
+        args.append(key)
+        if value:
+            args.append(value)
+    return _run_hbot(args, json_output=True)
 
 
-# ── Inspect ────────────────────────────────────────────────────────────────
+# ── run & control ────────────────────────────────────────────────────────────
 
 @mcp.tool()
-def list_bots() -> dict:
-    """List all Hummingbot TMUX sessions and whether each is actually running."""
-    result = _run_tmux("list-sessions", "-F", "#{session_name}")
-    if result.returncode != 0:
-        return {"status": "ok", "sessions": []}
+def deploy(target: str, values: Optional[dict] = None, name: str = "",
+           replace: bool = False, timeout: float = 120.0) -> dict:
+    """One shot: config → RUNNING bot. The primary way to launch.
 
-    sessions = []
-    for line in result.stdout.strip().splitlines():
-        name = line.strip()
-        if not name.startswith(SESSION_PREFIX):
-            continue
-        alive = _process_alive(name)
-        sessions.append({
-            "session_name": name,
-            "config": _get_session_config(name) or "unknown",
-            "process_alive": alive,
-            "state": "running" if alive else "idle/dead",
-        })
-    return {"status": "ok", "sessions": sessions}
-
-
-@mcp.tool()
-def open_terminal(session_name: str) -> dict:
-    """Open a new macOS Terminal window attached to the bot's TMUX session.
-
-    Lets you watch the live hummingbot UI directly. Detach with Ctrl-b then d
-    (this does NOT stop the bot). macOS only.
-
-    Args:
-        session_name: TMUX session name (e.g. hb-conf_pmm_king_wld).
+    `target` is either an existing config file name (deployed as-is, `values` edits it
+    first) or a strategy/controller/script name (a ready-to-run config is created; every
+    required field must then be in `values` — a miss fails listing the missing fields).
+    replace=True stops a currently running bot first. Verify with status() afterwards.
     """
-    if platform.system() != "Darwin":
-        return {
-            "status": "error",
-            "error": f"open_terminal is macOS-only. Attach manually: tmux attach -t {session_name}",
-        }
-    if not _session_exists(session_name):
-        return {"status": "error", "error": f"Session '{session_name}' not found."}
-    attach_cmd = f"tmux attach -t {shlex.quote(session_name)}"
-    r = _run(
-        [
-            "osascript",
-            "-e", 'tell application "Terminal" to activate',
-            "-e", f'tell application "Terminal" to do script "{attach_cmd}"',
-        ],
-        TMUX_TIMEOUT,
-    )
-    if r.returncode != 0:
-        return {"status": "error", "error": r.stderr.strip() or "osascript failed"}
-    return {"status": "ok", "session_name": session_name, "opened": True}
+    extra, stdin = _set_args(values)
+    args = ["deploy", target, *extra, "--timeout", timeout]
+    if name:
+        args += ["--name", name]
+    if replace:
+        args.append("--replace")
+    return _run_hbot(args, stdin_data=stdin, json_output=True)
 
 
 @mcp.tool()
-def read_logs(config_name: str = "", session_name: str = "", lines: int = 50) -> dict:
-    """Read recent log lines from a Hummingbot bot.
+def start(config_file: str = "", replace: bool = False, timeout: float = 120.0) -> dict:
+    """Start a bot from a config file (type auto-detected), detached.
 
-    Args:
-        config_name: Config filename to derive log path (e.g. conf_pmm_king_wld).
-        session_name: Alternatively, provide session name to look up config.
-        lines: Number of lines to read from end of log. Defaults to 50 (max 2000).
+    With no config_file, runs the currently loaded config (from create/import). Fails if a
+    bot is already running unless replace=True. Verify with status() afterwards.
     """
-    if not config_name and session_name:
-        config_name = _get_session_config(session_name) or ""
-    if not config_name:
-        return {"status": "error", "error": "Provide config_name or a valid session_name."}
-
-    log_path = _config_to_log_path(config_name)
-    if not log_path.exists():
-        return {"status": "error", "error": f"Log file not found: {log_path}"}
-
-    lines = min(max(1, lines), MAX_LOG_LINES)
-    try:
-        tail = _tail(log_path, lines)
-        return {
-            "status": "ok",
-            "log_path": str(log_path),
-            "lines_returned": len(tail),
-            "content": "\n".join(tail),
-        }
-    except Exception as e:
-        return {"status": "error", "error": str(e)}
+    args = ["start"]
+    if config_file:
+        args.append(config_file)
+    args += ["--timeout", timeout]
+    if replace:
+        args.append("--replace")
+    return _run_hbot(args, json_output=True)
 
 
 @mcp.tool()
-def bot_status(session_name: str) -> dict:
-    """Get status of a Hummingbot bot TMUX session.
+def stop(force: bool = False, timeout: float = 30.0) -> dict:
+    """Stop the running bot gracefully — cancels its open orders first.
 
-    Sends the hummingbot `status` command and returns the live strategy panel
-    (curve, target/actual/gap, budgets, held inventory, resting orders) plus whether
-    the process is alive. Requires a running strategy for the status panel to populate.
-
-    Args:
-        session_name: TMUX session name (e.g. hb-conf_pmm_king_wld).
+    force=True SIGKILLs if still alive after `timeout` seconds (open orders may survive on
+    the exchange — check afterwards). exit_status NOT_RUNNING means it was already stopped.
     """
-    if not _session_exists(session_name):
-        return {"status": "error", "error": f"Session '{session_name}' not found."}
+    args = ["stop", "--timeout", timeout]
+    if force:
+        args.append("--force")
+    return _run_hbot(args, json_output=True)
 
-    alive = _process_alive(session_name)
-    if alive:
-        # Trigger a fresh status render, then read it back.
-        _run_tmux("send-keys", "-t", session_name, "status", "Enter")
-        time.sleep(2.0)
 
-    return {
-        "status": "ok",
-        "session_name": session_name,
-        "config": _get_session_config(session_name) or "unknown",
-        "process_alive": alive,
-        "terminal_output": _capture_pane(session_name, 60).strip(),
-    }
-
+# ── observe ──────────────────────────────────────────────────────────────────
 
 @mcp.tool()
-def list_controllers() -> dict:
-    """List available controller config files in conf/controllers/."""
-    controllers_dir = PROJECT_ROOT / "conf" / "controllers"
-    if not controllers_dir.exists():
-        return {"status": "error", "error": "conf/controllers/ directory not found."}
-    configs = [f.name for f in sorted(controllers_dir.iterdir()) if f.suffix == ".yml"]
-    return {"status": "ok", "controllers": configs}
+def status() -> dict:
+    """Run state, live strategy status, and a recent-errors count.
 
-
-@mcp.tool()
-def create_config(
-    controllers: list[str],
-    config_name: str = "",
-    script_file_name: str = "v2_with_controllers.py",
-    max_global_drawdown_quote: float | None = None,
-    max_controller_drawdown_quote: float | None = None,
-) -> dict:
-    """Create a deploy config in conf/scripts/ without starting it (low-level).
-
-    Prefer `deploy` for new runs. Use this if you only want to write the config file.
-
-    Args:
-        controllers: Controller config filenames from conf/controllers/ (e.g. ["pmm_3.yml"]).
-        config_name: Output filename in conf/scripts/. Defaults to conf_v2_{first_controller_stem}.yml.
-        script_file_name: Script to use. Defaults to v2_with_controllers.py.
-        max_global_drawdown_quote: Max global drawdown in quote. None = no limit.
-        max_controller_drawdown_quote: Max per-controller drawdown in quote. None = no limit.
+    running=true does NOT mean healthy — a bot can be alive and erroring; check the error
+    count and read logs() when it is non-zero.
     """
-    if not config_name:
-        if not controllers:
-            return {"status": "error", "error": "Must provide at least one controller config."}
-        first_stem = _safe_stem(controllers[0])
-        if first_stem is None:
-            return {"status": "error", "error": f"Invalid controller name: {controllers[0]}"}
-        config_name = f"conf_v2_{first_stem}.yml"
-    return _write_deploy_config(
-        controllers, config_name, script_file_name,
-        max_global_drawdown_quote, max_controller_drawdown_quote,
-    )
+    return _run_hbot(["status"], json_output=True)
+
+
+@mcp.tool()
+def logs(name: str = "", lines: int = 100) -> dict:
+    """Trailing log lines (snapshot; there is no follow mode over MCP).
+
+    With no name: the current bot. Pass a name (a config stem from a previous start) to
+    read a past/stopped bot's log.
+    """
+    args = ["logs"]
+    if name:
+        args.append(name)
+    args += ["--lines", lines]
+    return _run_hbot(args, json_output=True)
+
+
+@mcp.tool()
+def history(name: str = "", days: Optional[float] = None) -> dict:
+    """PnL, fees, and volume per market (the slowest call — it also fetches balances).
+
+    With no name: the current bot. Pass a name to review a past/stopped bot indefinitely.
+    """
+    args = ["history"]
+    if name:
+        args.append(name)
+    if days is not None:
+        args += ["--days", days]
+    return _run_hbot(args)
 
 
 if __name__ == "__main__":

--- a/test/test_mcp_server.py
+++ b/test/test_mcp_server.py
@@ -87,12 +87,14 @@ class MCPServerStubTest(unittest.TestCase):
             self.assertEqual(result["exit_status"], name)
             self.assertIn("boom", result["error"])
 
-    def test_unparseable_json_falls_back_to_output(self):
+    def test_unparseable_json_is_a_loud_protocol_error(self):
         self.script(stdout="not json")
         result = mcp_server.status()
-        self.assertTrue(result["ok"])
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["exit_status"], "PROTOCOL_ERROR")
         self.assertIsNone(result["data"])
         self.assertEqual(result["output"], "not json")
+        self.assertIn("unparseable", result["error"])
 
     def test_hung_cli_reports_client_timeout(self):
         stub = self.stub_dir / "hbot"
@@ -109,6 +111,16 @@ class MCPServerStubTest(unittest.TestCase):
 
     def test_missing_binary_reports_no_cli(self):
         os.environ["HBOT_BIN"] = str(self.stub_dir / "does-not-exist")
+        result = mcp_server.status()
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["exit_status"], "NO_CLI")
+        self.assertIn("HBOT_BIN", result["error"])
+
+    def test_non_executable_binary_reports_no_cli(self):
+        # PermissionError and friends must also come back as the uniform result.
+        plain = self.stub_dir / "not-executable"
+        plain.write_text("data")
+        os.environ["HBOT_BIN"] = str(plain)
         result = mcp_server.status()
         self.assertFalse(result["ok"])
         self.assertEqual(result["exit_status"], "NO_CLI")
@@ -144,16 +156,31 @@ class MCPServerStubTest(unittest.TestCase):
         self.assertEqual(self.argv(), ["history", "conf_old", "--days", "7"])
         mcp_server.config("total_amount_quote", "250")
         self.assertEqual(self.argv(), ["config", "total_amount_quote", "250", "--json"])
+        mcp_server.config("some_field", "")  # empty string is a SET, not a read
+        self.assertEqual(self.argv(), ["config", "some_field", "", "--json"])
         mcp_server.balance(units_only=True)
         self.assertEqual(self.argv(), ["balance", "--units-only", "--json"])
+
+    def test_config_value_without_key_fails_client_side(self):
+        result = mcp_server.config(value="250")
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["exit_status"], "BAD_ARGUMENT")
+        self.assertFalse((self.stub_dir / "argv").exists(), "hbot must not be invoked")
+
+    def test_timeout_above_cap_fails_client_side(self):
+        for call in (lambda: mcp_server.deploy("x", timeout=601),
+                     lambda: mcp_server.start("x", timeout=99999),
+                     lambda: mcp_server.stop(timeout=601)):
+            result = call()
+            self.assertFalse(result["ok"])
+            self.assertEqual(result["exit_status"], "BAD_ARGUMENT")
+        self.assertFalse((self.stub_dir / "argv").exists(), "hbot must not be invoked")
 
     def test_connections_variants(self):
         self.script(stdout="x")
         mcp_server.connections(show_all=True)
         self.assertEqual(self.argv(), ["connect", "--all"])
-        mcp_server.connections(connector="binance", show_fields=True)
-        self.assertEqual(self.argv(), ["connect", "binance", "--fields"])
-        # A connector alone implies the fields listing — never the interactive key-entry path.
+        # A connector implies the fields listing — never the interactive key-entry path.
         mcp_server.connections(connector="binance")
         self.assertEqual(self.argv(), ["connect", "binance", "--fields"])
         mcp_server.import_config("conf_x.yml")
@@ -171,12 +198,19 @@ class MCPServerStubTest(unittest.TestCase):
         mcp_server.create("pmm_simple", config_type="controller")
         self.assertEqual(self.argv(), ["create", "pmm_simple", "--controller"])
 
-    def test_invalid_config_type_fails_client_side(self):
-        result = mcp_server.import_config("conf_x.yml", config_type="script")
-        self.assertFalse(result["ok"])
-        self.assertEqual(result["exit_status"], "BAD_ARGUMENT")
-        self.assertIn("v2-script", result["error"])
+    def test_invalid_config_type_raises_without_invoking_hbot(self):
+        # MCP clients are stopped by the Literal enum in the schema; direct callers get
+        # the ValueError from _type_args. Either way hbot is never invoked.
+        with self.assertRaises(ValueError):
+            mcp_server.import_config("conf_x.yml", config_type="script")
         self.assertFalse((self.stub_dir / "argv").exists(), "hbot must not be invoked")
+
+    def test_config_type_is_an_enum_in_the_tool_schema(self):
+        import asyncio
+        tools = asyncio.run(mcp_server.mcp.list_tools())
+        schema = next(t for t in tools if t.name == "import_config").inputSchema
+        self.assertEqual(schema["properties"]["config_type"]["enum"],
+                         ["", "v1-strategy", "v2-script", "controller"])
 
     # ── surface & secrets policy ────────────────────────────────────────
 

--- a/test/test_mcp_server.py
+++ b/test/test_mcp_server.py
@@ -228,6 +228,26 @@ class MCPServerStubTest(unittest.TestCase):
                 for banned in ("password", "secret", "api_key", "private_key"):
                     self.assertNotIn(banned, param.lower(), f"{tool.name}.{param}")
 
+    # ── transport selection ─────────────────────────────────────────────
+
+    def test_default_transport_is_stdio(self):
+        self.assertEqual(mcp_server._transport_config([], {}), ("stdio", None, None))
+        # Unrelated args/env do not accidentally open a port.
+        self.assertEqual(mcp_server._transport_config(["--verbose"], {"HBOT_MCP_TRANSPORT": "sse"}),
+                         ("stdio", None, None))
+
+    def test_http_transport_binds_loopback_by_default(self):
+        # No auth on this server — 0.0.0.0 must never be the default.
+        self.assertEqual(mcp_server._transport_config(["--http"], {}),
+                         ("streamable-http", "127.0.0.1", 8211))
+        self.assertEqual(mcp_server._transport_config([], {"HBOT_MCP_TRANSPORT": "http"}),
+                         ("streamable-http", "127.0.0.1", 8211))
+
+    def test_http_transport_honors_host_and_port_env(self):
+        transport, host, port = mcp_server._transport_config(
+            ["--http"], {"HBOT_MCP_HOST": "0.0.0.0", "HBOT_MCP_PORT": "9000"})
+        self.assertEqual((transport, host, port), ("streamable-http", "0.0.0.0", 9000))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_mcp_server.py
+++ b/test/test_mcp_server.py
@@ -176,6 +176,24 @@ class MCPServerStubTest(unittest.TestCase):
             self.assertEqual(result["exit_status"], "BAD_ARGUMENT")
         self.assertFalse((self.stub_dir / "argv").exists(), "hbot must not be invoked")
 
+    def test_doctor_and_update_argv(self):
+        self.script(stdout="{}")
+        mcp_server.doctor()
+        self.assertEqual(self.argv(), ["doctor", "--json"])
+        mcp_server.update()  # check-only is the DEFAULT — safe anytime
+        self.assertEqual(self.argv(), ["update", "--check", "--json"])
+        mcp_server.update(check=False)
+        self.assertEqual(self.argv(), ["update", "--json"])
+
+    def test_json_payload_on_nonzero_exit_is_parsed(self):
+        # doctor emits its checks payload AND exit 1 when unhealthy — data must come through.
+        self.script(stdout='{"healthy": false, "checks": []}',
+                    stderr="Error: doctor found problems (code 1)", exit_code=1)
+        result = mcp_server.doctor()
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["exit_status"], "ERROR")
+        self.assertEqual(result["data"], {"healthy": False, "checks": []})
+
     def test_connections_variants(self):
         self.script(stdout="x")
         mcp_server.connections(show_all=True)
@@ -222,6 +240,7 @@ class MCPServerStubTest(unittest.TestCase):
         self.assertEqual(names, {
             "connections", "balance", "create", "import_config", "config",
             "deploy", "start", "stop", "status", "logs", "history",
+            "doctor", "update",
         })
         for tool in tools:
             for param in tool.inputSchema.get("properties", {}):

--- a/test/test_mcp_server.py
+++ b/test/test_mcp_server.py
@@ -1,0 +1,164 @@
+"""Unit tests for the repo-root MCP server (mcp_server.py) — a thin wrapper over `hbot`.
+
+The `mcp` package is not part of the hummingbot conda env (the server runs under
+`uv run --with mcp`), so the whole module is skipped when it isn't importable.
+Every test drives the real subprocess boundary against a stub `hbot` executable
+that records its argv/stdin and plays back a scripted exit code and output.
+"""
+import json
+import os
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mcp")
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import mcp_server  # noqa: E402
+
+STUB = """#!/bin/sh
+# Stub hbot: record how we were called, then play back the scripted reply.
+printf '%s\\n' "$@" > "$STUB_DIR/argv"
+cat > "$STUB_DIR/stdin"
+cat "$STUB_DIR/reply_stdout" 2>/dev/null
+cat "$STUB_DIR/reply_stderr" 1>&2 2>/dev/null
+exit $(cat "$STUB_DIR/reply_exit" 2>/dev/null || echo 0)
+"""
+
+
+class MCPServerStubTest(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.TemporaryDirectory()
+        stub_dir = Path(self.dir.name)
+        stub = stub_dir / "hbot"
+        stub.write_text(STUB)
+        stub.chmod(stub.stat().st_mode | stat.S_IEXEC)
+        os.environ["HBOT_BIN"] = str(stub)
+        os.environ["STUB_DIR"] = str(stub_dir)
+        self.stub_dir = stub_dir
+
+    def tearDown(self):
+        os.environ.pop("HBOT_BIN", None)
+        os.environ.pop("STUB_DIR", None)
+        self.dir.cleanup()
+
+    def script(self, stdout="", stderr="", exit_code=0):
+        (self.stub_dir / "reply_stdout").write_text(stdout)
+        (self.stub_dir / "reply_stderr").write_text(stderr)
+        (self.stub_dir / "reply_exit").write_text(str(exit_code))
+
+    def argv(self):
+        return (self.stub_dir / "argv").read_text().splitlines()
+
+    def stdin(self):
+        return (self.stub_dir / "stdin").read_text()
+
+    # ── result mapping ──────────────────────────────────────────────────
+
+    def test_json_command_parses_data(self):
+        self.script(stdout='{"running": true, "pid": 42}')
+        result = mcp_server.status()
+        self.assertEqual(self.argv(), ["status", "--json"])
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["exit_status"], "SUCCESS")
+        self.assertEqual(result["data"], {"running": True, "pid": 42})
+        self.assertIsNone(result["output"])
+        self.assertIsNone(result["error"])
+
+    def test_markdown_command_returns_output_verbatim(self):
+        self.script(stdout="## connections\n\n| connector |\n")
+        result = mcp_server.connections()
+        self.assertEqual(self.argv(), ["connect"])
+        self.assertTrue(result["ok"])
+        self.assertIsNone(result["data"])
+        self.assertIn("## connections", result["output"])
+
+    def test_exit_codes_map_to_cli_contract(self):
+        for code, name in [(1, "ERROR"), (2, "NOT_FOUND"), (3, "NOT_RUNNING"),
+                           (4, "CONFIG_ERROR"), (5, "TIMEOUT"), (86, "UNKNOWN")]:
+            self.script(stderr=f"Error: boom (code {code})", exit_code=code)
+            result = mcp_server.status()
+            self.assertFalse(result["ok"])
+            self.assertEqual(result["exit_code"], code)
+            self.assertEqual(result["exit_status"], name)
+            self.assertIn("boom", result["error"])
+
+    def test_unparseable_json_falls_back_to_output(self):
+        self.script(stdout="not json")
+        result = mcp_server.status()
+        self.assertTrue(result["ok"])
+        self.assertIsNone(result["data"])
+        self.assertEqual(result["output"], "not json")
+
+    def test_missing_binary_reports_no_cli(self):
+        os.environ["HBOT_BIN"] = str(self.stub_dir / "does-not-exist")
+        result = mcp_server.status()
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["exit_status"], "NO_CLI")
+        self.assertIn("HBOT_BIN", result["error"])
+
+    # ── argv construction per tool ──────────────────────────────────────
+
+    def test_deploy_sends_values_via_stdin(self):
+        self.script(stdout="{}")
+        mcp_server.deploy("pmm_simple", values={"trading_pair": "ETH-USD"},
+                          name="conf_eth.yml", replace=True, timeout=60)
+        self.assertEqual(self.argv(), [
+            "deploy", "pmm_simple", "--values-stdin", "--timeout", "60",
+            "--name", "conf_eth.yml", "--replace", "--json",
+        ])
+        self.assertEqual(json.loads(self.stdin()), {"trading_pair": "ETH-USD"})
+
+    def test_create_with_defaults(self):
+        self.script(stdout="- created: x")
+        mcp_server.create("pmm_simple", name="conf_x.yml", with_defaults=True)
+        self.assertEqual(self.argv(), ["create", "pmm_simple", "--name", "conf_x.yml", "--with-defaults"])
+        self.assertEqual(self.stdin(), "")
+
+    def test_start_stop_logs_history_config(self):
+        self.script(stdout="{}")
+        mcp_server.start("conf_x.yml", replace=True)
+        self.assertEqual(self.argv(), ["start", "conf_x.yml", "--timeout", "120.0", "--replace", "--json"])
+        mcp_server.stop(force=True, timeout=10)
+        self.assertEqual(self.argv(), ["stop", "--timeout", "10", "--force", "--json"])
+        mcp_server.logs(name="conf_old", lines=25)
+        self.assertEqual(self.argv(), ["logs", "conf_old", "--lines", "25", "--json"])
+        mcp_server.history(name="conf_old", days=7)
+        self.assertEqual(self.argv(), ["history", "conf_old", "--days", "7"])
+        mcp_server.config("total_amount_quote", "250")
+        self.assertEqual(self.argv(), ["config", "total_amount_quote", "250", "--json"])
+        mcp_server.balance(units_only=True)
+        self.assertEqual(self.argv(), ["balance", "--units-only", "--json"])
+
+    def test_connections_variants(self):
+        self.script(stdout="x")
+        mcp_server.connections(show_all=True)
+        self.assertEqual(self.argv(), ["connect", "--all"])
+        mcp_server.connections(connector="binance", show_fields=True)
+        self.assertEqual(self.argv(), ["connect", "binance", "--fields"])
+        mcp_server.import_config("conf_x.yml")
+        self.assertEqual(self.argv(), ["import", "conf_x.yml"])
+
+    # ── surface & secrets policy ────────────────────────────────────────
+
+    def test_no_tool_accepts_secrets(self):
+        """No tool parameter may carry a password or API key — that is the contract."""
+        import asyncio
+        tools = asyncio.run(mcp_server.mcp.list_tools())
+        names = {t.name for t in tools}
+        self.assertEqual(names, {
+            "connections", "balance", "create", "import_config", "config",
+            "deploy", "start", "stop", "status", "logs", "history",
+        })
+        for tool in tools:
+            for param in tool.inputSchema.get("properties", {}):
+                for banned in ("password", "secret", "api_key", "private_key"):
+                    self.assertNotIn(banned, param.lower(), f"{tool.name}.{param}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_mcp_server.py
+++ b/test/test_mcp_server.py
@@ -247,25 +247,15 @@ class MCPServerStubTest(unittest.TestCase):
                 for banned in ("password", "secret", "api_key", "private_key"):
                     self.assertNotIn(banned, param.lower(), f"{tool.name}.{param}")
 
-    # ── transport selection ─────────────────────────────────────────────
+    # ── transport ────────────────────────────────────────────────────────
 
-    def test_default_transport_is_stdio(self):
-        self.assertEqual(mcp_server._transport_config([], {}), ("stdio", None, None))
-        # Unrelated args/env do not accidentally open a port.
-        self.assertEqual(mcp_server._transport_config(["--verbose"], {"HBOT_MCP_TRANSPORT": "sse"}),
-                         ("stdio", None, None))
-
-    def test_http_transport_binds_loopback_by_default(self):
-        # No auth on this server — 0.0.0.0 must never be the default.
-        self.assertEqual(mcp_server._transport_config(["--http"], {}),
-                         ("streamable-http", "127.0.0.1", 8211))
-        self.assertEqual(mcp_server._transport_config([], {"HBOT_MCP_TRANSPORT": "http"}),
-                         ("streamable-http", "127.0.0.1", 8211))
-
-    def test_http_transport_honors_host_and_port_env(self):
-        transport, host, port = mcp_server._transport_config(
-            ["--http"], {"HBOT_MCP_HOST": "0.0.0.0", "HBOT_MCP_PORT": "9000"})
-        self.assertEqual((transport, host, port), ("streamable-http", "0.0.0.0", 9000))
+    def test_server_is_stdio_only(self):
+        # The tools trade real money and MCP HTTP ships no auth: the server must have no
+        # way to open a port. If someone reintroduces an HTTP mode, this test is the
+        # tripwire — bring auth with it.
+        src = (Path(mcp_server.__file__)).read_text()
+        for marker in ("streamable-http", "sse_app", "HBOT_MCP_TRANSPORT", "HBOT_MCP_HOST"):
+            self.assertNotIn(marker, src)
 
 
 if __name__ == "__main__":

--- a/test/test_mcp_server.py
+++ b/test/test_mcp_server.py
@@ -94,6 +94,19 @@ class MCPServerStubTest(unittest.TestCase):
         self.assertIsNone(result["data"])
         self.assertEqual(result["output"], "not json")
 
+    def test_hung_cli_reports_client_timeout(self):
+        stub = self.stub_dir / "hbot"
+        stub.write_text("#!/bin/sh\nsleep 30\n")
+        old = (mcp_server.SUBPROCESS_TIMEOUT, mcp_server.TIMEOUT_SLACK)
+        mcp_server.SUBPROCESS_TIMEOUT, mcp_server.TIMEOUT_SLACK = 1, 0
+        try:
+            result = mcp_server.status()
+        finally:
+            mcp_server.SUBPROCESS_TIMEOUT, mcp_server.TIMEOUT_SLACK = old
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["exit_status"], "CLIENT_TIMEOUT")
+        self.assertIn("did not return within 1s", result["error"])
+
     def test_missing_binary_reports_no_cli(self):
         os.environ["HBOT_BIN"] = str(self.stub_dir / "does-not-exist")
         result = mcp_server.status()
@@ -140,8 +153,30 @@ class MCPServerStubTest(unittest.TestCase):
         self.assertEqual(self.argv(), ["connect", "--all"])
         mcp_server.connections(connector="binance", show_fields=True)
         self.assertEqual(self.argv(), ["connect", "binance", "--fields"])
+        # A connector alone implies the fields listing — never the interactive key-entry path.
+        mcp_server.connections(connector="binance")
+        self.assertEqual(self.argv(), ["connect", "binance", "--fields"])
         mcp_server.import_config("conf_x.yml")
         self.assertEqual(self.argv(), ["import", "conf_x.yml"])
+
+    def test_config_type_maps_to_the_cli_disambiguation_flag(self):
+        self.script(stdout="x")
+        mcp_server.import_config("conf_x.yml", config_type="controller")
+        self.assertEqual(self.argv(), ["import", "conf_x.yml", "--controller"])
+        mcp_server.start("conf_x.yml", config_type="v2-script")
+        self.assertEqual(self.argv(), ["start", "conf_x.yml", "--v2-script", "--timeout", "120.0", "--json"])
+        mcp_server.deploy("conf_x.yml", config_type="v1-strategy")
+        self.assertEqual(self.argv(),
+                         ["deploy", "conf_x.yml", "--v1-strategy", "--timeout", "120.0", "--json"])
+        mcp_server.create("pmm_simple", config_type="controller")
+        self.assertEqual(self.argv(), ["create", "pmm_simple", "--controller"])
+
+    def test_invalid_config_type_fails_client_side(self):
+        result = mcp_server.import_config("conf_x.yml", config_type="script")
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["exit_status"], "BAD_ARGUMENT")
+        self.assertIn("v2-script", result["error"])
+        self.assertFalse((self.stub_dir / "argv").exists(), "hbot must not be invoked")
 
     # ── surface & secrets policy ────────────────────────────────────────
 


### PR DESCRIPTION
## MCP server over the `hbot` CLI — stdio-only (stacked on #8337)

This re-engineers the MCP server experiment from #8336 (thanks @cardosofede) onto the `hbot` CLI
from #8337, and packages it into the Docker image. **Stacked PR: base is `feat/hbot-cli`** — the
diff here is only the MCP layer. Goal: open Claude Desktop / Claude Code / any MCP-capable harness
and use Hummingbot as a pro, with zero shell access required.

### Design: the server is a thin transport, the CLI is the contract

Each MCP tool is exactly one `hbot` subprocess call — no tmux, no interactive shell, no screen
scraping (the #8336 substrate drove the curses TUI via tmux `send-keys`/`capture-pane`, which
benchmarked with false "graceful-timeout" stops and garbled status output). Every tool returns one
JSON object:

```json
{"ok": true, "exit_code": 0, "exit_status": "SUCCESS", "data": {...} | "output": "...", "error": null}
```

`exit_status` maps the CLI's stable exit codes (SUCCESS / ERROR / NOT_FOUND / NOT_RUNNING /
CONFIG_ERROR / TIMEOUT, plus server-side NO_CLI / BAD_ARGUMENT / PROTOCOL_ERROR). Commands with
`--json` support are parsed into `data`; the rest return Markdown in `output`.

### Transport: stdio only, deliberately

These tools trade real money and MCP's HTTP transports ship no auth. So the server never opens a
port: every client reaches it by **spawning a process**, which keeps trading access behind
credentials the OS already manages (process spawn rights, the Docker socket). This matches the
stdio-only stance of the org's other MCP surface ([hummingbot/condor](https://github.com/hummingbot/condor)),
where the network boundary also lives at an authenticated layer.

- **Source install** — `.mcp.json` (picked up automatically by Claude Code in the repo root), or
  `bin/hbot-mcp` for any stdio client.
- **Docker + shell-less clients (Claude Desktop):** the client spawns the server *inside* the
  container and speaks stdio through the exec channel — nothing on the host but the docker CLI:

  ```json
  { "mcpServers": { "hummingbot": {
      "command": "docker", "args": ["exec", "-i", "hummingbot", "hbot-mcp"] } } }
  ```

A tripwire test asserts no HTTP mode reappears in the server source — if remote access ever
becomes a target, it must arrive together with real auth (OAuth per the MCP spec), not before.

### Tool surface (13 tools, mirrors the CLI)

`connections` · `balance` · `create` · `import_config` · `config` · `deploy` · `start` · `stop` ·
`status` · `logs` · `history` · `doctor` · `update`

- `doctor` — the server's instructions tell agents to run it FIRST when any tool fails
  unexpectedly; returns the full health-check table as JSON.
- `update(check=True)` — defaults to a safe report-only check; `check=False` fast-forwards and
  rebuilds (900s ceiling).

### Security model (test-enforced)

- **No tool accepts a password or API key** — a test asserts no tool parameter matches
  `password`/`secret`/`api_key`/`private_key`. The keystore password reaches the server via
  `HBOT_PASSWORD` in its environment, never on argv and never through the model's context.
- Connector key entry stays **interactive-only**: `hbot connect` in the user's own terminal.
- **No listening socket, ever** (tripwire-tested) — see the transport section.
- Subprocesses run with stdin detached (`DEVNULL`) so no hidden prompt can ever hang a tool call.

### Docker packaging

- Builder stage creates `/opt/mcp-venv` (isolated `mcp>=1.10` venv — the server's deps can never
  conflict with the trading env); release stage copies it, symlinks `hbot-mcp`, presets
  `HBOT_BIN`, and activates the hummingbot conda env for interactive shells
  (`docker exec -it hummingbot bash` → `hbot` just works).
- `bin/hbot-mcp` resolves symlinks to find the repo root and prefers the packaged venv, falling
  back to `uv` for source installs.

### Testing

- `test/test_mcp_server.py` — 20 tests against a stub `hbot` binary (argv/stdin recording):
  argv construction per tool, the secrets policy, exit-code mapping, `--json` parsing on both
  zero and nonzero exits, PROTOCOL_ERROR on broken payloads, timeout ceilings, the stdio-only
  tripwire, config-type enum schema. Skips cleanly when `mcp` isn't installed
  (`pytest.importorskip`), so CI without the dependency stays green.
- Live-verified end to end: image built, `docker exec -i hummingbot hbot-mcp` spoken to by a real
  MCP client over stdio (Claude Desktop's exact spawn path) — `tools/list` → 13 tools, `doctor`
  round-trip healthy from inside the container, keystore decrypt in-container. Plus a three-way
  live-trading benchmark (CLI direct vs this MCP vs the #8336 tmux design) showing this server
  adds no measurable overhead over the CLI.

## How to test (QA)

```bash
git fetch origin feat/hbot-mcp && git checkout feat/hbot-mcp

# stdio (Claude Code): the repo's .mcp.json is picked up automatically —
# open Claude Code in the repo, approve the server, then: "check my bot's health" → doctor tool.

# Claude Desktop against Docker:
docker build -t hummingbot/hummingbot:latest .
docker compose up -d           # set HBOT_PASSWORD under environment: in docker-compose.yml
# then add the mcpServers snippet above to claude_desktop_config.json and restart Desktop

# sanity: the server answers over the exec channel and no port is open
docker exec -i hummingbot hbot-mcp <<< '{"jsonrpc":"2.0","id":1,"method":"ping"}' >/dev/null; echo $?
docker exec hummingbot sh -c 'command -v ss >/dev/null && ss -tln || netstat -tln' 2>/dev/null

# unit tests
uv run --no-project --with "mcp>=1.10" --with pytest python -m pytest test/test_mcp_server.py -q
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011NkMBwTS3T9zSarCg77mVm
