### PR TITLE
(fix) replace eval() with json.loads() in Foxbit WebSocket parsing

### DIFF
--- a/hummingbot/connector/exchange/foxbit/foxbit_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/foxbit/foxbit_api_order_book_data_source.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
@@ -144,7 +145,7 @@ class FoxbitAPIOrderBookDataSource(OrderBookTrackerDataSource):
 
     async def _parse_trade_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
         if CONSTANTS.WS_SUBSCRIBE_TRADES or CONSTANTS.WS_TRADE_RESPONSE in raw_message['n']:
-            full_msg = eval(raw_message['o'].replace(",false,", ",False,"))
+            full_msg = json.loads(raw_message['o'])
             for msg in full_msg:
                 instrument_id = int(msg[FoxbitTradeFields.INSTRUMENTID.value])
                 trading_pair = ""
@@ -162,7 +163,7 @@ class FoxbitAPIOrderBookDataSource(OrderBookTrackerDataSource):
 
     async def _parse_order_book_diff_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
         if CONSTANTS.WS_ORDER_BOOK_RESPONSE or CONSTANTS.WS_ORDER_STATE in raw_message['n']:
-            full_msg = eval(raw_message['o'])
+            full_msg = json.loads(raw_message['o'])
             for msg in full_msg:
                 instrument_id = int(msg[FoxbitOrderBookFields.PRODUCTPAIRCODE.value])
 

--- a/hummingbot/connector/exchange/foxbit/foxbit_utils.py
+++ b/hummingbot/connector/exchange/foxbit/foxbit_utils.py
@@ -67,7 +67,7 @@ def is_exchange_information_valid(exchange_info: Dict[str, Any]) -> bool:
 
 
 def ws_data_to_dict(data: str) -> Dict[str, Any]:
-    return eval(data.replace(":null", ":None").replace(":false", ":False").replace(":true", ":True"))
+    return json.loads(data)
 
 
 def datetime_val_or_now(string_value: str,

--- a/test/hummingbot/connector/exchange/foxbit/test_foxbit_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/foxbit/test_foxbit_api_order_book_data_source.py
@@ -472,7 +472,7 @@ class FoxbitAPIOrderBookDataSourceUnitTests(IsolatedAsyncioWrapperTestCase):
 
         msg: OrderBookMessage = await msg_queue.get()
 
-        expected_id = eval(diff_event["o"])[0][0]
+        expected_id = json.loads(diff_event["o"])[0][0]
         self.assertEqual(expected_id, msg.update_id)
 
     # Dynamic subscription tests

--- a/test/hummingbot/connector/exchange/foxbit/test_foxbit_user_stream_data_source.py
+++ b/test/hummingbot/connector/exchange/foxbit/test_foxbit_user_stream_data_source.py
@@ -135,7 +135,7 @@ class FoxbitUserStreamDataSourceUnitTests(unittest.TestCase):
         mock_ws.connect = AsyncMock()
         mock_ws.send = AsyncMock()
         # Simulate authenticated response
-        mock_ws.receive = AsyncMock(return_value=MagicMock(data={"o": '{"Authenticated": True}'}))
+        mock_ws.receive = AsyncMock(return_value=MagicMock(data={"o": '{"Authenticated": true}'}))
         mock_ws_assistant_cls.return_value = mock_ws
 
         mock_api_factory = MagicMock()

--- a/test/hummingbot/connector/exchange/foxbit/test_foxbit_utils.py
+++ b/test/hummingbot/connector/exchange/foxbit/test_foxbit_utils.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 from datetime import datetime
 from decimal import Decimal
@@ -47,6 +48,12 @@ class FoxbitUtilTestCases(unittest.TestCase):
         _msg = '[{"Key":"field0","Value":"Google"},{"Key":"field2","Value":null},{"Key":"field3","Value":"São Paulo"},{"Key":"field4","Value":false},{"Key":"field5","Value":"SAO PAULO"},{"Key":"field6","Value":"00000001"},{"Key":"field7","Value":true}]'
         _retValue = utils.ws_data_to_dict(_msg)
         self.assertEqual(_expectedValue, _retValue)
+
+    def test_ws_data_to_dict_does_not_execute_code(self):
+        # ws_data_to_dict previously used eval(), which executes arbitrary code embedded
+        # in a network-controlled message. json.loads must reject it instead of running it.
+        with self.assertRaises(json.JSONDecodeError):
+            utils.ws_data_to_dict('__import__("os").system("touch /tmp/foxbit_pwned")')
 
     def test_datetime_val_or_now(self):
         self.assertIsNone(utils.datetime_val_or_now('NotValidDate', '', False))


### PR DESCRIPTION
## Summary

Removes three arbitrary-code-execution sinks in the Foxbit connector that ran `eval()` on network-controlled WebSocket / message data. Because `eval()` executes arbitrary Python, anything an attacker (or a compromised/spoofed exchange endpoint) can place in these payloads becomes a code-execution path. Closes #8083 and #8084.

All three payloads are already JSON, so `json.loads()` is a drop-in replacement — it parses the same data and rejects (raises `JSONDecodeError`) instead of executing anything else.

**Fixed sinks:**
- `foxbit_utils.ws_data_to_dict()` — was `eval(data.replace(":null", ":None")…)`; now `json.loads(data)` (the `null`/`false`/`true` replacements existed only to satisfy `eval`; JSON has them natively).
- `foxbit_api_order_book_data_source._parse_trade_message()` — was `eval(raw_message['o'].replace(",false,", ",False,"))`; now `json.loads(raw_message['o'])`.
- `foxbit_api_order_book_data_source._parse_order_book_diff_message()` — was `eval(raw_message['o'])`; now `json.loads(raw_message['o'])`.

Also replaced an `eval(diff_event["o"])` in the existing order-book test with `json.loads` so no `eval` on message data remains.

## Notes

- `#8085` (pickle.loads in `RemoteAPIOrderBookDataSource`) is the same disclosure batch but lives in core code and touches a different data path; kept out of this PR to keep the diff focused on the Foxbit connector. Happy to follow up.
- Behavior is unchanged for well-formed messages: verified `json.loads` produces byte-for-byte the same result as the old `eval` path on every `'o'` payload used in the existing Foxbit tests (trade update, L2 update, order-book diff, and the `ws_data_to_dict` fixture).

## Testing

- [x] Added `test_ws_data_to_dict_does_not_execute_code` asserting a code-execution payload now raises `JSONDecodeError` instead of running.
- [x] Existing `test_ws_data_to_dict` and the order-book data-source tests still pass with the parser swap (verified the parsed output matches the previous `eval` output on all fixtures).
- [x] `json` already imported in `foxbit_utils.py`; added the import to the order-book data source and the utils test.
