### PR TITLE
fix(foxbit): parse websocket payloads with json.loads instead of eval()

### DIFF
--- a/hummingbot/connector/exchange/foxbit/foxbit_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/foxbit/foxbit_api_order_book_data_source.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
@@ -144,7 +145,7 @@ class FoxbitAPIOrderBookDataSource(OrderBookTrackerDataSource):
 
     async def _parse_trade_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
         if CONSTANTS.WS_SUBSCRIBE_TRADES or CONSTANTS.WS_TRADE_RESPONSE in raw_message['n']:
-            full_msg = eval(raw_message['o'].replace(",false,", ",False,"))
+            full_msg = json.loads(raw_message['o'])
             for msg in full_msg:
                 instrument_id = int(msg[FoxbitTradeFields.INSTRUMENTID.value])
                 trading_pair = ""
@@ -162,7 +163,7 @@ class FoxbitAPIOrderBookDataSource(OrderBookTrackerDataSource):
 
     async def _parse_order_book_diff_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
         if CONSTANTS.WS_ORDER_BOOK_RESPONSE or CONSTANTS.WS_ORDER_STATE in raw_message['n']:
-            full_msg = eval(raw_message['o'])
+            full_msg = json.loads(raw_message['o'])
             for msg in full_msg:
                 instrument_id = int(msg[FoxbitOrderBookFields.PRODUCTPAIRCODE.value])
 

--- a/hummingbot/connector/exchange/foxbit/foxbit_utils.py
+++ b/hummingbot/connector/exchange/foxbit/foxbit_utils.py
@@ -67,7 +67,10 @@ def is_exchange_information_valid(exchange_info: Dict[str, Any]) -> bool:
 
 
 def ws_data_to_dict(data: str) -> Dict[str, Any]:
-    return eval(data.replace(":null", ":None").replace(":false", ":False").replace(":true", ":True"))
+    # The `o` payload of a Foxbit websocket frame is a JSON string. Parse it with json.loads rather than eval() —
+    # eval() on data received from the network is a remote-code-execution risk (a compromised/MITM'd feed could
+    # execute arbitrary Python on the trader's host). json.loads handles the lowercase true/false/null natively.
+    return json.loads(data)
 
 
 def datetime_val_or_now(string_value: str,


### PR DESCRIPTION
## Problem

The Foxbit connector parses the `o` field of websocket frames with `eval()` in three places:

- `foxbit_utils.ws_data_to_dict` (used by the user-stream data source and the exchange message handler)
- `FoxbitAPIOrderBookDataSource._parse_trade_message`
- `FoxbitAPIOrderBookDataSource._parse_order_book_diff_message`

`eval()` on data received from the network is a remote-code-execution risk: a compromised or MITM'd exchange feed could execute arbitrary Python on the trader's host, which holds API keys and signing material. These paths are on the live order-book and user-stream flows.

## Fix

The payload is JSON, so `json.loads` is a correct drop-in. It handles lowercase `true`/`false`/`null` natively and is more robust than the ad-hoc `:true`/`:false`/`:null` and `,false,` string replacements the `eval` path relied on (those only matched compact, unspaced JSON).

## Testing

- `json.loads` verified behaviorally equivalent to the previous `eval`-based parsing on representative compact Foxbit payloads (lists of dicts with `true`/`false`/`null`).
- Both modified files compile.
- No functional change beyond the parser; no `eval()` remains in the connector.