### PR TITLE
fix: unpack tuple in SQLConnectionManager for PostgreSQL compatibility

### DIFF
--- a/hummingbot/model/sql_connection_manager.py
+++ b/hummingbot/model/sql_connection_manager.py
@@ -86,7 +86,7 @@ class SQLConnectionManager(TransactionBase):
                     if fkcs:
                         if not self._engine.dialect.supports_alter:
                             continue
-                        for fkc in fkcs:
+                        for _fk_tname, fkc in fkcs:
                             fk_constraint = ForeignKeyConstraint((), (), name=fkc)
                             Table(tname, MetaData(), fk_constraint)
                             conn.execute(DropConstraint(fk_constraint))


### PR DESCRIPTION
## Description

Fixes #8360

`Inspector.get_sorted_table_and_fkc_names()` returns foreign key constraints as `(table_name, fk_constraint_name)` tuples, not plain strings. The code was passing the raw tuple as `name=fkc` to `ForeignKeyConstraint`, which crashes on PostgreSQL (and any dialect with `supports_alter = True`) because SQLAlchemy tries to call `.lower()` on the tuple.

## Fix

Unpack the tuple to extract the constraint name:

```python
# Before
for fkc in fkcs:

# After
for _fk_tname, fkc in fkcs:
```

## Testing

- Verified `get_sorted_table_and_fkc_names()` returns `(table_name, constraint_name)` tuples
- SQLite path unaffected (`supports_alter = False` skips the loop)
- `SQLConnectionManager` import works correctly after fix