### PR TITLE
fix: default gate_io_perpetual quanto_multiplier to 1 instead of None

### DIFF
--- a/hummingbot/data_feed/candles_feed/gate_io_perpetual_candles/gate_io_perpetual_candles.py
+++ b/hummingbot/data_feed/candles_feed/gate_io_perpetual_candles/gate_io_perpetual_candles.py
@@ -18,7 +18,7 @@ class GateioPerpetualCandles(CandlesBase):
 
     def __init__(self, trading_pair: str, interval: str = "1m", max_records: int = 150):
         super().__init__(trading_pair, interval, max_records)
-        self.quanto_multiplier = None
+        self.quanto_multiplier = 1
 
     @property
     def name(self):


### PR DESCRIPTION
## Description

Fixes #8351

The `gate_io_perpetual` candles feed crashes with `TypeError: unsupported operand type(s) for *: 'int' and 'NoneType'` when `fetch_candles()` or WebSocket candle streaming is called before `initialize_exchange_data()` has completed.

The root cause is that `self.quanto_multiplier` is initialized as `None` in `__init__` and only gets set when `initialize_exchange_data()` fetches data from the Gate.io API. Both `_parse_rest_candles` and `_parse_websocket_message` multiply volume by `self.quanto_multiplier`, which crashes when it's `None`.

## Fix

Default `quanto_multiplier` to `1` instead of `None` in `__init__`:

```python
# Before
self.quanto_multiplier = None

# After
self.quanto_multiplier = 1
```

A default of `1` is safe because:
- If `initialize_exchange_data()` hasn't completed yet, volume will be reported without the quanto adjustment (acceptable fallback)
- Once the exchange data is fetched, `quanto_multiplier` is updated to the correct value
- This matches the suggestion in the issue (Option A)

## Testing

- Verified `quanto_multiplier` defaults to `None` causing `TypeError` on multiplication
- After fix, default is `1` so multiplication works without error
- Once `initialize_exchange_data()` completes, the real value overwrites the default