### PR TITLE
fix: replace eval() with json.loads() in Foxbit connector to prevent RCE

### DIFF
--- a/hummingbot/connector/exchange/foxbit/foxbit_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/foxbit/foxbit_api_order_book_data_source.py
@@ -143,8 +143,8 @@ class FoxbitAPIOrderBookDataSource(OrderBookTrackerDataSource):
         return snapshot_msg
 
     async def _parse_trade_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
-        if CONSTANTS.WS_SUBSCRIBE_TRADES or CONSTANTS.WS_TRADE_RESPONSE in raw_message['n']:
-            full_msg = eval(raw_message['o'].replace(",false,", ",False,"))
+        if CONSTANTS.WS_SUBSCRIBE_TRADES in raw_message['n'] or CONSTANTS.WS_TRADE_RESPONSE in raw_message['n']:
+            full_msg = json.loads(raw_message['o'])
             for msg in full_msg:
                 instrument_id = int(msg[FoxbitTradeFields.INSTRUMENTID.value])
                 trading_pair = ""
@@ -161,8 +161,8 @@ class FoxbitAPIOrderBookDataSource(OrderBookTrackerDataSource):
                 message_queue.put_nowait(trade_message)
 
     async def _parse_order_book_diff_message(self, raw_message: Dict[str, Any], message_queue: asyncio.Queue):
-        if CONSTANTS.WS_ORDER_BOOK_RESPONSE or CONSTANTS.WS_ORDER_STATE in raw_message['n']:
-            full_msg = eval(raw_message['o'])
+        if CONSTANTS.WS_ORDER_BOOK_RESPONSE in raw_message['n'] or CONSTANTS.WS_ORDER_STATE in raw_message['n']:
+            full_msg = json.loads(raw_message['o'])
             for msg in full_msg:
                 instrument_id = int(msg[FoxbitOrderBookFields.PRODUCTPAIRCODE.value])
 

--- a/hummingbot/connector/exchange/foxbit/foxbit_utils.py
+++ b/hummingbot/connector/exchange/foxbit/foxbit_utils.py
@@ -67,7 +67,7 @@ def is_exchange_information_valid(exchange_info: Dict[str, Any]) -> bool:
 
 
 def ws_data_to_dict(data: str) -> Dict[str, Any]:
-    return eval(data.replace(":null", ":None").replace(":false", ":False").replace(":true", ":True"))
+    return json.loads(data)
 
 
 def datetime_val_or_now(string_value: str,


### PR DESCRIPTION
## Description

Fixes #8353 (part 1 of 2)

Three `eval()` calls in the Foxbit connector allow Remote Code Execution if an attacker can inject crafted WebSocket messages. This is a **critical security vulnerability** (CWE-94).

### Affected paths:
- `foxbit_api_order_book_data_source.py:147` — `eval(raw_message['o']...)` in trade parsing
- `foxbit_api_order_book_data_source.py:165` — `eval(raw_message['o'])` in order book diff parsing
- `foxbit_utils.py:70` — `eval(data.replace(...))` in `ws_data_to_dict()`

## Fix

Replace all three `eval()` calls with `json.loads()`:

```python
# Before (all 3 locations)
eval(raw_message['o'])
eval(raw_message['o'].replace(",false,", ",False,"))
eval(data.replace(":null", ":None").replace(":false", ":False").replace(":true", ":True"))

# After
json.loads(raw_message['o'])
json.loads(raw_message['o'])
json.loads(data)
```

`json.loads()` natively handles JSON's `null`, `false`, `true` — no manual string replacement needed.

### Also fixed: dead-code conditions (lines 146, 164)

The original conditions used `or` with a non-empty string constant, making them always `True`:
```python
# Before (always True due to short-circuit)
if CONSTANTS.WS_SUBSCRIBE_TRADES or CONSTANTS.WS_TRADE_RESPONSE in raw_message['n']:
# After (correct intent)
if CONSTANTS.WS_SUBSCRIBE_TRADES in raw_message['n'] or CONSTANTS.WS_TRADE_RESPONSE in raw_message['n']:
```

## Security Impact

Without this fix, an attacker who can intercept or spoof the Foxbit WebSocket endpoint can execute arbitrary Python code within the Hummingbot process, potentially stealing API keys and wallet credentials.

## Not in scope (separate PR)

`remote_api_order_book_data_source.py:65` uses `pickle.loads()` on untrusted data (CWE-502). This requires a more complex fix (switching serialization format) and will be addressed separately.

## Testing

- `json.loads()` produces identical output to `eval()` for valid JSON strings
- No behavioral change for legitimate WebSocket messages
- Attacker-controlled payloads no longer execute as Python code