### PR TITLE
fix: trigger balance refresh after ORDER_TRADE_UPDATE in binance_perpetual

### DIFF
--- a/hummingbot/connector/derivative/binance_perpetual/binance_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/binance_perpetual/binance_perpetual_derivative.py
@@ -28,7 +28,7 @@ from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderUpdate
 from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
 from hummingbot.core.data_type.trade_fee import TokenAmount, TradeFeeBase
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
-from hummingbot.core.utils.async_utils import safe_gather
+from hummingbot.core.utils.async_utils import safe_gather, safe_ensure_future
 from hummingbot.core.utils.estimate_fee import build_trade_fee
 from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
 
@@ -433,6 +433,10 @@ class BinancePerpetualDerivative(PerpetualDerivativePyBase):
                 )
 
                 self._order_tracker.process_order_update(order_update)
+
+            # Trigger balance update because ACCOUNT_UPDATE only fires on position changes,
+            # not on order cancellations/fills that release reserved balance
+            safe_ensure_future(self._update_balances())
 
         elif event_type == "ACCOUNT_UPDATE":
             update_data = event_message.get("a", {})


### PR DESCRIPTION
## Problem

When running perpetual market making strategies (e.g., PMM Simple Controller) with the `binance_perpetual` connector, there is a critical delay of up to **120 seconds** between actual balance changes and their recognition by Hummingbot.

This occurs because Binance's `ACCOUNT_UPDATE` WebSocket event only fires on actual position changes, not when orders are placed, cancelled, or filled without position changes. During this window, `validate_sufficient_balance()` fails repeatedly, generating hundreds of "Not enough budget to open position" error logs.

## Root Cause

In `binance_perpetual_derivative.py`, the `_process_user_stream_event` method handles `ORDER_TRADE_UPDATE` events (order fills, cancels, etc.) but does not trigger a balance refresh. The balance update only happens via:
1. `ACCOUNT_UPDATE` WebSocket event (only on position changes)
2. `_status_polling_loop_fetch_updates()` (every 120 seconds)

## Fix

Added `safe_ensure_future(self._update_balances())` after processing `ORDER_TRADE_UPDATE` events, matching the approach used by the `bybit_perpetual` connector which explicitly notes:

> "Trigger balance update because Bybit doesn't have balance updates through the websocket"

The async call ensures the balance refresh doesn't block the event processing loop while providing near-instant balance recognition.

## References

- [Binance User Data Stream Events](https://developers.binance.com/docs/derivatives/usds-margined-futures/user-data-streams/Event-Balance-and-Position-Update)
- Fixes #7827

## Testing

This change was verified by reviewing the Binance WebSocket documentation and comparing with the Bybit perpetual connector implementation which already uses the same pattern (line 626 of `bybit_perpetual_derivative.py`).