### PR TITLE
fix: add testnet connector mappings to v2_funding_rate_arb strategy

### DIFF
--- a/scripts/v2_funding_rate_arb.py
+++ b/scripts/v2_funding_rate_arb.py
@@ -80,11 +80,15 @@ class FundingRateArbitrageConfig(StrategyV2ConfigBase):
 class FundingRateArbitrage(StrategyV2Base):
     quote_markets_map = {
         "hyperliquid_perpetual": "USD",
-        "binance_perpetual": "USDT"
+        "hyperliquid_perpetual_testnet": "USD",
+        "binance_perpetual": "USDT",
+        "binance_perpetual_testnet": "USDT",
     }
     funding_payment_interval_map = {
         "binance_perpetual": 60 * 60 * 8,
-        "hyperliquid_perpetual": 60 * 60 * 1
+        "binance_perpetual_testnet": 60 * 60 * 8,
+        "hyperliquid_perpetual": 60 * 60 * 1,
+        "hyperliquid_perpetual_testnet": 60 * 60 * 1,
     }
     funding_profitability_interval = 60 * 60 * 24
 


### PR DESCRIPTION
## Problem

The `v2_funding_rate_arb` strategy only maps mainnet connectors in `quote_markets_map` and `funding_payment_interval_map`. When using testnet connectors (e.g., `hyperliquid_perpetual_testnet`, `binance_perpetual_testnet`), the strategy falls back to the default `'USDT'` quote currency, generating invalid trading pairs like `BTC-USDT` instead of `BTC-USD`.

This causes a `KeyError: 'BTC-USDT'` in `exchange_symbol_associated_to_pair()` because the Hyperliquid perpetual connector's symbol map only contains `BTC-USD` entries (Hyperliquid uses USD, not USDT).

## Root Cause

```python
# Only mainnet connectors are mapped
quote_markets_map = {
    "hyperliquid_perpetual": "USD",
    "binance_perpetual": "USDT"
}
```

When `connector = "hyperliquid_perpetual_testnet"`, `quote_markets_map.get(connector, "USDT")` returns `"USDT"` (the default), producing `BTC-USDT` which doesn't exist in Hyperliquid's symbol map.

## Fix

Added testnet connector variants to both `quote_markets_map` and `funding_payment_interval_map`:

```python
quote_markets_map = {
    "hyperliquid_perpetual": "USD",
    "hyperliquid_perpetual_testnet": "USD",
    "binance_perpetual": "USDT",
    "binance_perpetual_testnet": "USDT",
}
funding_payment_interval_map = {
    "binance_perpetual": 60 * 60 * 8,
    "binance_perpetual_testnet": 60 * 60 * 8,
    "hyperliquid_perpetual": 60 * 60 * 1,
    "hyperliquid_perpetual_testnet": 60 * 60 * 1,
}
```

## Testing

Verified that the strategy now correctly generates `BTC-USD` for `hyperliquid_perpetual_testnet` and `BTC-USDT` for `bybit_perpetual_testnet` (which defaults to USDT).

Fixes #7814