### PR TITLE
fix: add missing import json to foxbit_api_order_book_data_source

### DIFF
--- a/hummingbot/connector/exchange/foxbit/foxbit_api_order_book_data_source.py
+++ b/hummingbot/connector/exchange/foxbit/foxbit_api_order_book_data_source.py
@@ -1,5 +1,6 @@
 import asyncio
 import time
+import json
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from hummingbot.connector.exchange.foxbit import (


### PR DESCRIPTION
## Summary

The `eval()` calls in the Foxbit connector are a security risk and should be replaced with `json.loads()` (Foxbit's `o` payloads are plain JSON, so the `false`/`null` string-replace hacks were never necessary).

The previous PR (#8367) made this replacement correctly but forgot to add `import json`, causing `NameError: name 'json' is not defined` at runtime.

This PR adds the missing import to complete the fix.

## Changes

- Added `import json` to the imports section of `foxbit_api_order_book_data_source.py`

## Related Issue

Fixes #8353

## Testing

- Verified that `json.loads()` handles Foxbit's `o` payloads correctly (plain JSON with `false`/`null` values)
- The condition fixes in the original PR are correct and behavior-preserving given how `_channel_originating_message` routes messages