### PR TITLE
fix: unpack FK tuple in SQLConnectionManager for correct constraint handling

### DIFF
--- a/hummingbot/model/sql_connection_manager.py
+++ b/hummingbot/model/sql_connection_manager.py
@@ -86,8 +86,8 @@ class SQLConnectionManager(TransactionBase):
                     if fkcs:
                         if not self._engine.dialect.supports_alter:
                             continue
-                        for fkc in fkcs:
-                            fk_constraint = ForeignKeyConstraint((), (), name=fkc)
+                        for _, fkname in fkcs:
+                            fk_constraint = ForeignKeyConstraint((), (), name=fkname)
                             Table(tname, MetaData(), fk_constraint)
                             conn.execute(DropConstraint(fk_constraint))
 


### PR DESCRIPTION
## Summary

`Inspector.get_sorted_table_and_fkc_names()` returns each entry in `fkcs` as a list of `(tname, fkname)` tuples per [SQLAlchemy 2.0.x documentation](https://docs.sqlalchemy.org/en/20/core/internals.html#sqlalchemy.Inspector.get_sorted_table_and_fkc_names).

The current code passes the raw tuple to `ForeignKeyConstraint(name=fkc)`, which crashes in the DDL compiler's identifier quoting when the dialect's `supports_alter` is True.

While SQLite's default stock schema avoids this code path, the fix is still valuable:
- Custom models or schema migrations that trigger foreign key introspection will hit this crash
- The code should be correct regardless of the database backend
- It matches SQLAlchemy's documented drop-constraints recipe

## Changes

- Changed `for fkc in fkcs:` to `for _, fkname in fkcs:` and `name=fkc` to `name=fkname`

## Related Issue

Fixes #8360