### PR TITLE
fix: restore has_in_flight_cancel filter in PerpetualMarketMakingOrderTracker

### DIFF
--- a/hummingbot/strategy/perpetual_market_making/perpetual_market_making_order_tracker.py
+++ b/hummingbot/strategy/perpetual_market_making/perpetual_market_making_order_tracker.py
@@ -18,7 +18,13 @@ class PerpetualMarketMakingOrderTracker(OrderTracker):
 
     @property
     def active_limit_orders(self) -> List[Tuple[ConnectorBase, LimitOrder]]:
-        return self.tracked_limit_orders
+        limit_orders = []
+        for market_pair, orders_map in self.tracked_limit_orders_map.items():
+            for limit_order in orders_map.values():
+                if self.has_in_flight_cancel(limit_order.client_order_id):
+                    continue
+                limit_orders.append((market_pair.market, limit_order))
+        return limit_orders
 
     @property
     def shadow_limit_orders(self) -> List[Tuple[ConnectorBase, LimitOrder]]:
@@ -32,5 +38,10 @@ class PerpetualMarketMakingOrderTracker(OrderTracker):
     def market_pair_to_active_orders(self) -> Dict[MarketTradingPairTuple, List[LimitOrder]]:
         market_pair_to_orders = {}
         for market_pair, orders_map in self.tracked_limit_orders_map.items():
-            market_pair_to_orders[market_pair] = list(self.tracked_limit_orders_map[market_pair].values())
+            limit_orders = []
+            for limit_order in orders_map.values():
+                if self.has_in_flight_cancel(limit_order.client_order_id):
+                    continue
+                limit_orders.append(limit_order)
+            market_pair_to_orders[market_pair] = limit_orders
         return market_pair_to_orders


### PR DESCRIPTION
## Summary

The `PerpetualMarketMakingOrderTracker` overrides `active_limit_orders` and `market_pair_to_active_orders` from the base `OrderTracker` class, but drops the `has_in_flight_cancel` filtering that the base class applies.

In the base `OrderTracker` (order_tracker.pyx:45-46, 67-68):
```python
if self.c_has_in_flight_cancel(limit_order.client_order_id):
    continue
```

This filter excludes orders with in-flight cancellations from `active_orders`. Without it, the PMM strategy sees already-canceling orders as active, and attempts to cancel them again every tick — generating duplicate cancel requests and log spam.

The fix uses the existing `has_in_flight_cancel()` method from the base `OrderTracker`, which auto-expires after `CANCEL_EXPIRY_DURATION` (60s), preserving the base class's retry behavior without introducing any new state.

## Changes

- `active_limit_orders`: Now filters out orders where `has_in_flight_cancel()` is True
- `market_pair_to_active_orders`: Same filtering applied

## Related Issue

Fixes #7853