### PR TITLE
fix: keep maker_order reference during cancel window in XEMM executor

### DIFF
--- a/hummingbot/strategy_v2/executors/xemm_executor/xemm_executor.py
+++ b/hummingbot/strategy_v2/executors/xemm_executor/xemm_executor.py
@@ -232,11 +232,9 @@ class XEMMExecutor(ExecutorBase):
         if self._current_trade_profitability - self._tx_cost_pct < self.config.min_profitability:
             self.logger().info(f"Order {self.maker_order.order_id} profitability {self._current_trade_profitability - self._tx_cost_pct} is below minimum profitability {self.config.min_profitability}. Cancelling order.")
             self._strategy.cancel(self.maker_connector, self.maker_trading_pair, self.maker_order.order_id)
-            self.maker_order = None
         elif self._current_trade_profitability - self._tx_cost_pct > self.config.max_profitability:
             self.logger().info(f"Order {self.maker_order.order_id} profitability {self._current_trade_profitability - self._tx_cost_pct} is above maximum profitability {self.config.max_profitability}. Cancelling order.")
             self._strategy.cancel(self.maker_connector, self.maker_trading_pair, self.maker_order.order_id)
-            self.maker_order = None
 
     async def update_current_trade_profitability(self):
         trade_profitability = Decimal("0")
@@ -269,6 +267,14 @@ class XEMMExecutor(ExecutorBase):
         elif self.taker_order and event.order_id == self.taker_order.order_id:
             self.logger().info(f"Taker order {event.order_id} created.")
             self.taker_order.order = self.get_in_flight_order(self.taker_connector, event.order_id)
+
+    def process_order_canceled_event(self,
+                                     event_tag: int,
+                                     market: ConnectorBase,
+                                     event: OrderCancelledEvent):
+        if self.maker_order and event.order_id == self.maker_order.order_id:
+            self.logger().info(f"Maker order {event.order_id} cancelled successfully.")
+            self.maker_order = None
 
     def process_order_completed_event(self,
                                       event_tag: int,


### PR DESCRIPTION
## Summary

Fixes #8094 — a race condition where the XEMM executor's `control_update_maker_order()` sets `self.maker_order = None` immediately when calling `strategy.cancel()`. If the maker order fills during the cancel window (before the exchange confirms the cancel), the fill event has no `maker_order` to match against, so it's silently dropped. The executor then deadlocks because `control_maker_order()` never calls `create_maker_order()` again.

The previous PR (#8375) tried to fix this by removing `maker_order = None` entirely, but that introduced a worse regression: without clearing `maker_order`, `control_update_maker_order()` would keep canceling the dead order every tick.

## Changes

- **Removed immediate `self.maker_order = None`** from both profitability cancel paths in `control_update_maker_order()`
- **Added `process_order_canceled_event()`** override that clears `self.maker_order` only when the exchange confirms the cancel
- This keeps the reference alive during the cancel window (so fills can still match), while ensuring cleanup happens exactly once on confirmed cancel

## Related Issue

Fixes #8094