### PR TITLE
fix: add configurable execution timeout to arbitrage executor

### DIFF
--- a/hummingbot/strategy_v2/executors/arbitrage_executor/arbitrage_executor.py
+++ b/hummingbot/strategy_v2/executors/arbitrage_executor/arbitrage_executor.py
@@ -86,6 +86,7 @@ class ArbitrageExecutor(ExecutorBase):
         self.quote_conversion_pair = f"{sell_quote_asset}-{buy_quote_asset}"
         self.rate_oracle = RateOracle.get_instance()
         self._cumulative_failures = 0
+        self._exec_start_timestamp = None
 
     async def validate_sufficient_balance(self):
         base_asset_for_selling_exchange = self.connectors[self.selling_market.connector_name].get_available_balance(
@@ -186,9 +187,18 @@ class ArbitrageExecutor(ExecutorBase):
                 self.sell_order.order and self.sell_order.order.is_filled:
             self.close_type = CloseType.COMPLETED
             self.stop()
+        elif self._exec_start_timestamp is not None:
+            elapsed = self._strategy.current_timestamp - self._exec_start_timestamp
+            if elapsed > self.config.max_exec_duration:
+                self.logger().warning(
+                    f"Arbitrage timed out after {elapsed:.1f}s "
+                    f"(limit: {self.config.max_exec_duration}s)")
+                self.close_type = CloseType.TIME_LIMIT
+                self.stop()
 
     async def execute_arbitrage(self):
         self._status = RunnableStatus.SHUTTING_DOWN
+        self._exec_start_timestamp = self._strategy.current_timestamp
         self.place_buy_arbitrage_order()
         self.place_sell_arbitrage_order()
 

--- a/hummingbot/strategy_v2/executors/arbitrage_executor/arbitrage_executor.py
+++ b/hummingbot/strategy_v2/executors/arbitrage_executor/arbitrage_executor.py
@@ -193,8 +193,21 @@ class ArbitrageExecutor(ExecutorBase):
                 self.logger().warning(
                     f"Arbitrage timed out after {elapsed:.1f}s "
                     f"(limit: {self.config.max_exec_duration}s)")
+                self._cancel_outstanding_orders()
                 self.close_type = CloseType.TIME_LIMIT
                 self.stop()
+
+    def _cancel_outstanding_orders(self):
+        if self.buy_order.order and self.buy_order.order.is_open:
+            self._strategy.cancel(
+                connector_name=self.buying_market.connector_name,
+                trading_pair=self.buying_market.trading_pair,
+                order_id=self.buy_order.order_id)
+        if self.sell_order.order and self.sell_order.order.is_open:
+            self._strategy.cancel(
+                connector_name=self.selling_market.connector_name,
+                trading_pair=self.selling_market.trading_pair,
+                order_id=self.sell_order.order_id)
 
     async def execute_arbitrage(self):
         self._status = RunnableStatus.SHUTTING_DOWN

--- a/hummingbot/strategy_v2/executors/arbitrage_executor/data_types.py
+++ b/hummingbot/strategy_v2/executors/arbitrage_executor/data_types.py
@@ -11,3 +11,4 @@ class ArbitrageExecutorConfig(ExecutorConfigBase):
     order_amount: Decimal
     min_profitability: Decimal
     gas_conversion_price: Optional[Decimal] = None
+    max_exec_duration: float = 120.0

--- a/test/hummingbot/strategy_v2/executors/arbitrage_executor/test_arbitrage_executor.py
+++ b/test/hummingbot/strategy_v2/executors/arbitrage_executor/test_arbitrage_executor.py
@@ -104,6 +104,59 @@ class TestArbitrageExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         await self.executor.control_task()
         self.assertEqual(self.executor.close_type, CloseType.COMPLETED)
         self.assertEqual(self.executor._status, RunnableStatus.TERMINATED)
+        self.strategy.cancel.assert_not_called()
+
+    async def test_control_task_within_execution_duration_keeps_running(self):
+        self.executor._status = RunnableStatus.SHUTTING_DOWN
+        self.executor._cumulative_failures = 0
+        self.arbitrage_config.max_exec_duration = 120
+        self.strategy.current_timestamp = 100.0
+        self.executor._exec_start_timestamp = 50.0
+        self.executor._buy_order = Mock(spec=TrackedOrder)
+        self.executor._sell_order = Mock(spec=TrackedOrder)
+        self.executor._buy_order.order.is_filled = False
+        self.executor._sell_order.order.is_filled = False
+        await self.executor.control_task()
+        self.assertEqual(self.executor._status, RunnableStatus.SHUTTING_DOWN)
+        self.assertIsNone(self.executor.close_type)
+        self.strategy.cancel.assert_not_called()
+
+    async def test_control_task_time_limit_cancels_outstanding_orders(self):
+        self.executor._status = RunnableStatus.SHUTTING_DOWN
+        self.executor._cumulative_failures = 0
+        self.arbitrage_config.max_exec_duration = 120
+        self.strategy.current_timestamp = 1000.0
+        self.executor._exec_start_timestamp = 500.0
+        self.executor._buy_order = Mock(spec=TrackedOrder)
+        self.executor._sell_order = Mock(spec=TrackedOrder)
+        self.executor._buy_order.order.is_filled = False
+        self.executor._sell_order.order.is_filled = False
+        self.executor._buy_order.order.is_open = True
+        self.executor._sell_order.order.is_open = True
+        await self.executor.control_task()
+        self.assertEqual(self.executor.close_type, CloseType.TIME_LIMIT)
+        self.assertEqual(self.executor._status, RunnableStatus.TERMINATED)
+        self.assertEqual(self.strategy.cancel.call_count, 2)
+
+    async def test_control_task_time_limit_cancels_only_open_order(self):
+        self.executor._status = RunnableStatus.SHUTTING_DOWN
+        self.executor._cumulative_failures = 0
+        self.arbitrage_config.max_exec_duration = 120
+        self.strategy.current_timestamp = 1000.0
+        self.executor._exec_start_timestamp = 500.0
+        self.executor._buy_order = Mock(spec=TrackedOrder)
+        self.executor._sell_order = Mock(spec=TrackedOrder)
+        self.executor._buy_order.order.is_filled = True
+        self.executor._sell_order.order.is_filled = False
+        self.executor._buy_order.order.is_open = False
+        self.executor._sell_order.order.is_open = True
+        await self.executor.control_task()
+        self.assertEqual(self.executor.close_type, CloseType.TIME_LIMIT)
+        self.assertEqual(self.executor._status, RunnableStatus.TERMINATED)
+        self.strategy.cancel.assert_called_once_with(
+            connector_name=self.executor.selling_market.connector_name,
+            trading_pair=self.executor.selling_market.trading_pair,
+            order_id=self.executor.sell_order.order_id)
 
     def test_to_format_status(self):
         self.executor._status = RunnableStatus.RUNNING


### PR DESCRIPTION
## Summary

Fixes #7972 — the arbitrage executor can get stuck in `SHUTTING_DOWN` indefinitely if one order fills but the other fails and exhausts retries, or if a gateway order never reaches a terminal state.

## Changes (following maintainer review)

1. **Configurable timeout via `ArbitrageExecutorConfig.max_exec_duration`** (default 120s) — exposed in the config instead of being hardcoded
2. **Uses `self._strategy.current_timestamp`** instead of `time.time()` for consistency with clock-controlled backtesting
3. **No conflict with retry mechanism**: the timeout only triggers after the full duration elapses, giving `process_order_failed_event`'s retry logic time to work. When a timeout fires, the executor stops cleanly with `CloseType.TIME_LIMIT`
4. **Tracks `_exec_start_timestamp`** — set when entering `SHUTTING_DOWN`, used for timeout calculation
5. **Cancels outstanding orders on timeout**: before closing with `CloseType.TIME_LIMIT`, any buy/sell leg that is still open is cancelled via `strategy.cancel()`, so a live order cannot fill after the executor has abandoned ownership

## Testing

Added unit tests in `test_arbitrage_executor.py`:
- `test_control_task_time_limit_cancels_outstanding_orders` — both legs open at timeout → executor closes with `TIME_LIMIT` and cancels both orders
- `test_control_task_time_limit_cancels_only_open_order` — one leg filled at timeout → only the still-open leg is cancelled
- `test_control_task_within_execution_duration_keeps_running` — elapsed time below the limit → executor keeps polling, no cancellation
- `test_control_task_complete` (updated) — asserts no cancellation when both orders fill

## Related Issue

Fixes #7972