### PR TITLE
fix: sanitize non-finite Decimals in executor custom_info (#7330)

### DIFF
--- a/hummingbot/strategy_v2/executors/executor_base.py
+++ b/hummingbot/strategy_v2/executors/executor_base.py
@@ -27,6 +27,25 @@ from hummingbot.strategy_v2.models.executors_info import ExecutorInfo
 from hummingbot.strategy_v2.runnable_base import RunnableBase
 
 
+def sanitize_non_finite_decimals(value):
+    """
+    Recursively replace non-finite Decimals (NaN / Infinity) with Decimal("0").
+
+    ``custom_info`` dicts can carry a non-finite Decimal (e.g. an unfilled price),
+    which used to crash executor persistence via pydantic v1's ``decimal_encoder``
+    and, after the v2 migration, still serializes to the string ``"NaN"`` in the DB.
+    Applying the same coercion already used for the typed ``ExecutorInfo`` fields
+    keeps ``custom_info`` consistent and safe to serialize. See issue #7330.
+    """
+    if isinstance(value, Decimal):
+        return value if value.is_finite() else Decimal("0")
+    if isinstance(value, dict):
+        return {k: sanitize_non_finite_decimals(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return type(value)(sanitize_non_finite_decimals(v) for v in value)
+    return value
+
+
 class ExecutorBase(RunnableBase):
     """
     Base class for all executors. Executors are responsible for executing orders based on the strategy.
@@ -131,7 +150,7 @@ class ExecutorBase(RunnableBase):
             filled_amount_quote=_safe_decimal(self.filled_amount_quote),
             is_active=self.is_active,
             is_trading=self.is_trading,
-            custom_info=self.get_custom_info(),
+            custom_info=sanitize_non_finite_decimals(self.get_custom_info()),
             controller_id=self.config.controller_id,
         )
         return ei

--- a/test/hummingbot/strategy_v2/executors/test_executor_base.py
+++ b/test/hummingbot/strategy_v2/executors/test_executor_base.py
@@ -17,7 +17,7 @@ from hummingbot.core.event.events import (
 )
 from hummingbot.strategy.strategy_v2_base import StrategyV2Base
 from hummingbot.strategy_v2.executors.data_types import ExecutorConfigBase
-from hummingbot.strategy_v2.executors.executor_base import ExecutorBase
+from hummingbot.strategy_v2.executors.executor_base import ExecutorBase, sanitize_non_finite_decimals
 from hummingbot.strategy_v2.models.base import RunnableStatus
 from hummingbot.strategy_v2.models.executors import CloseType
 
@@ -249,3 +249,31 @@ class TestExecutorBase(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         self.assertEqual(self.component.close_type, CloseType.POSITION_HOLD)
         self.assertEqual(self.component.status, RunnableStatus.TERMINATED)
         self.assertTrue(self.is_partially_logged("ERROR", "Failed to cancel outstanding orders during forced stop."))
+
+
+class TestSanitizeNonFiniteDecimals(IsolatedAsyncioWrapperTestCase):
+    """Guards issue #7330: non-finite Decimals in custom_info must not reach persistence."""
+
+    def test_replaces_nan_and_inf_with_zero(self):
+        self.assertEqual(sanitize_non_finite_decimals(Decimal("NaN")), Decimal("0"))
+        self.assertEqual(sanitize_non_finite_decimals(Decimal("Infinity")), Decimal("0"))
+        self.assertEqual(sanitize_non_finite_decimals(Decimal("-Infinity")), Decimal("0"))
+
+    def test_preserves_finite_decimals_and_other_types(self):
+        self.assertEqual(sanitize_non_finite_decimals(Decimal("1.5")), Decimal("1.5"))
+        self.assertEqual(sanitize_non_finite_decimals("NaN"), "NaN")  # a plain string is untouched
+        self.assertEqual(sanitize_non_finite_decimals(3), 3)
+        self.assertIsNone(sanitize_non_finite_decimals(None))
+
+    def test_recurses_into_dicts_lists_and_tuples(self):
+        raw = {
+            "price": Decimal("NaN"),
+            "orders": [Decimal("Infinity"), Decimal("2.0")],
+            "meta": {"pct": Decimal("-Infinity")},
+            "pair": (Decimal("NaN"), "AVAX-USDC"),
+        }
+        cleaned = sanitize_non_finite_decimals(raw)
+        self.assertEqual(cleaned["price"], Decimal("0"))
+        self.assertEqual(cleaned["orders"], [Decimal("0"), Decimal("2.0")])
+        self.assertEqual(cleaned["meta"]["pct"], Decimal("0"))
+        self.assertEqual(cleaned["pair"], (Decimal("0"), "AVAX-USDC"))


### PR DESCRIPTION
## Summary
Extends the existing non-finite `Decimal` coercion in `ExecutorBase.executor_info` to `custom_info`, closing the last path by which a `NaN`/`Infinity` `Decimal` can reach executor persistence. Addresses the residual behind #7330.

## Background (#7330)
The issue reported a crash while persisting an executor:

```
File "pydantic/json.py", line 38, in pydantic.json.decimal_encoder
TypeError: '>=' not supported between instances of 'str' and 'int'
```

Root cause: pydantic v1's `decimal_encoder` does `dec_value.as_tuple().exponent >= 0`; for a non-finite `Decimal`, `as_tuple().exponent` is a string (`'n'` / `'F'`), so `'n' >= 0` raises exactly this `TypeError`. The non-finite value reaches serialization through `custom_info` — the typed `ExecutorInfo` Decimal fields are already sanitized via the local `_safe_decimal`, but `custom_info` was passed through unmodified.

The specific crash no longer reproduces on `development`, because persistence now uses pydantic v2 (`model_dump_json`), which has no `decimal_encoder`. **However**, a non-finite `Decimal` in `custom_info` now serializes to the string `"NaN"` / `"Infinity"` in the DB rather than being coerced like the typed fields — an inconsistency, and a latent hazard for any consumer that later reads those values back as numbers.

## Change
Add a small recursive helper `sanitize_non_finite_decimals` and apply it to `custom_info`, using exactly the coercion already applied to the typed fields (non-finite → `Decimal("0")`). Dicts, lists and tuples are walked; non-`Decimal` values are left untouched.

## Tests
`TestSanitizeNonFiniteDecimals` covers `NaN` / ±`Inf` → `0`, preservation of finite `Decimal`s and non-`Decimal` types, and recursion through nested dict / list / tuple.

Note: I couldn't re-run the exact long-running dYdX v2 scenario from the report, so this change is scoped to the serialization path shown in the traceback; the pydantic-v2 migration already removed the crash itself, and this keeps `custom_info` consistent with the typed fields.
