### PR TITLE
fix(strategy_v2): full LP unwind, realized swap fills, and shutdown that preserves position holds

### DIFF
--- a/hummingbot/connector/gateway/gateway.py
+++ b/hummingbot/connector/gateway/gateway.py
@@ -353,15 +353,36 @@ class Gateway(GatewayBase):
         order_result: Dict[str, Any],
         transaction_hash: str
     ):
-        """Store swap result data by creating a TradeUpdate for proper fill tracking."""
+        """Store swap result data by creating a TradeUpdate for proper fill tracking.
+
+        ``amountIn``/``amountOut`` are Gateway's REALIZED amounts, derived from the
+        wallet's on-chain pre/post token balance deltas for the settled transaction.
+        They are what actually moved, which is not the amount that was requested:
+        slippage and fees mean a swap for 62 base tokens may land 61.962753. Callers
+        that spend the proceeds downstream (e.g. an LP open's ``base_amount``) must
+        see the realized figure, or they will ask the chain for tokens that aren't
+        there.
+        """
         data = order_result.get("data", {})
         amount_in = Decimal(str(data.get("amountIn", "0")))
         amount_out = Decimal(str(data.get("amountOut", "0")))
 
+        # Gateway only populates `data` once the swap is CONFIRMED. Without this
+        # guard a pending or failed swap yields zeroed amounts and would still be
+        # forced to FILLED below, reporting a phantom 0-amount fill. Leave the order
+        # OPEN so update_order_status() resolves it from the chain instead.
+        if amount_in <= 0 or amount_out <= 0:
+            self.logger().warning(
+                f"Swap {order_id} ({transaction_hash}) returned no realized amounts "
+                f"(status={order_result.get('status')!r}, amountIn={amount_in}, amountOut={amount_out}); "
+                f"not marking as filled. Order stays open for status polling."
+            )
+            return
+
         if trade_type == TradeType.SELL:
-            executed_price = amount_out / amount_in if amount_in > 0 and amount_out > 0 else Decimal("0")
+            executed_price = amount_out / amount_in
         else:
-            executed_price = amount_in / amount_out if amount_in > 0 and amount_out > 0 else Decimal("0")
+            executed_price = amount_in / amount_out
 
         tracked_order = self._order_tracker.fetch_order(order_id)
         if not tracked_order:
@@ -371,7 +392,11 @@ class Gateway(GatewayBase):
         fee_asset = self._native_currency
         trade_fee = AddedToCostTradeFee(flat_fees=[TokenAmount(fee_asset, fee)])
 
-        fill_base_amount = tracked_order.amount
+        # A SELL sends base and receives quote; a BUY is the mirror image.
+        if trade_type == TradeType.SELL:
+            fill_base_amount, fill_quote_amount = amount_in, amount_out
+        else:
+            fill_base_amount, fill_quote_amount = amount_out, amount_in
 
         trade_update = TradeUpdate(
             trade_id=transaction_hash,
@@ -381,13 +406,14 @@ class Gateway(GatewayBase):
             fill_timestamp=self.current_timestamp,
             fill_price=executed_price,
             fill_base_amount=fill_base_amount,
-            fill_quote_amount=fill_base_amount * executed_price,
+            fill_quote_amount=fill_quote_amount,
             fee=trade_fee
         )
 
         self.logger().info(
-            f"Processing trade update for {order_id}: fill_amount={fill_base_amount}, "
-            f"fill_price={executed_price}, trade_id={transaction_hash}"
+            f"Processing trade update for {order_id}: requested={amount}, "
+            f"realized fill_amount={fill_base_amount}, fill_price={executed_price}, "
+            f"trade_id={transaction_hash}"
         )
 
         # Process order update to mark order as FILLED (triggers OrderCompleted event)

--- a/hummingbot/connector/gateway/gateway.py
+++ b/hummingbot/connector/gateway/gateway.py
@@ -362,6 +362,16 @@ class Gateway(GatewayBase):
         that spend the proceeds downstream (e.g. an LP open's ``base_amount``) must
         see the realized figure, or they will ask the chain for tokens that aren't
         there.
+
+        Base and quote are assigned from the trade side rather than from the token
+        identities, so this is independent of the quote asset (SOL, USDC, ...).
+
+        One caveat: for an SPL token Gateway diffs the token balance exactly, but a
+        NATIVE SOL leg is measured as a lamport delta that also absorbs the tx fee
+        and any rent. So on a SOL-quoted pair the quote leg carries a few thousand
+        lamports of noise, and on a SOL-BASE pair the base leg does. The error is
+        gas-sized (~1e-5 SOL) and, for a buy, understates what arrived - which is
+        the safe direction for anything that spends the proceeds.
         """
         data = order_result.get("data", {})
         amount_in = Decimal(str(data.get("amountIn", "0")))

--- a/hummingbot/strategy_v2/executors/dca_executor/dca_executor.py
+++ b/hummingbot/strategy_v2/executors/dca_executor/dca_executor.py
@@ -376,6 +376,21 @@ class DCAExecutor(ExecutorBase):
             self.close_type = CloseType.EARLY_STOP
             self.place_close_order_and_cancel_open_orders()
 
+    def _collect_held_position_orders(self) -> List[Dict]:
+        """Snapshot residual exposure for a forced stop at the shutdown deadline.
+
+        Every open- and close-side fill is reported; the position store nets them by
+        side, so a partially-closed DCA resolves to its remaining exposure.
+        """
+        held = list(self._held_position_orders)
+        seen = {order.get("client_order_id") for order in held}
+        for tracked in self._open_orders + self._close_orders:
+            if (tracked.order and tracked.executed_amount_base > Decimal("0")
+                    and tracked.order.client_order_id not in seen):
+                seen.add(tracked.order.client_order_id)
+                held.append(tracked.order.to_json())
+        return held
+
     def place_close_order_and_cancel_open_orders(self, price: Decimal = Decimal("NaN")):
         """
         This method is responsible for placing the close order
@@ -543,4 +558,5 @@ class DCAExecutor(ExecutorBase):
             "max_retries": self._max_retries,
             "level_id": self.config.level_id,
             "order_ids": [order.order_id for order in self._open_orders + self._close_orders],
+            "held_position_orders": self._held_position_orders,
         }

--- a/hummingbot/strategy_v2/executors/executor_base.py
+++ b/hummingbot/strategy_v2/executors/executor_base.py
@@ -208,6 +208,49 @@ class ExecutorBase(RunnableBase):
         """
         raise NotImplementedError
 
+    def _collect_held_position_orders(self) -> List[Dict]:
+        """
+        Synchronous snapshot of every fill that still represents exchange exposure.
+
+        Subclasses override this to report their fills from state they already hold —
+        no awaiting, no extra control-loop ticks — so that a forced stop at the
+        shutdown deadline can convert whatever executed into a position hold. The
+        default returns the orders a normal shutdown already accumulated.
+        """
+        return list(self._held_position_orders)
+
+    def _cancel_outstanding_orders(self):
+        """
+        Best-effort cancellation of live orders before a forced stop. Subclasses whose
+        cancellation entry point is not ``cancel_open_orders`` override this.
+        """
+        cancel_open_orders = getattr(self, "cancel_open_orders", None)
+        if callable(cancel_open_orders):
+            cancel_open_orders()
+
+    def force_stop_with_position_hold(self):
+        """
+        Terminate immediately, converting whatever has already executed into a
+        position hold.
+
+        This is the shutdown-deadline fallback. A normal shutdown lets the control
+        loop finish its close/unwind asynchronously; when the orchestrator's budget
+        expires the loop is about to lose its market registrations, so the only safe
+        move is to stop synchronously and hand any residual exposure to the position
+        store for recovery on the next start. Executors with nothing executed are
+        closed as FAILED so the abnormal end stays visible.
+        """
+        try:
+            self._cancel_outstanding_orders()
+        except Exception:
+            # The exposure still has to be persisted and the control loop stopped even
+            # if shutdown has already made strategy-level cancellation unavailable.
+            self.logger().exception("Failed to cancel outstanding orders during forced stop.")
+        held_orders = self._collect_held_position_orders()
+        self._held_position_orders = held_orders
+        self.close_type = CloseType.POSITION_HOLD if held_orders else CloseType.FAILED
+        self.stop()
+
     def evaluate_max_retries(self):
         """
         Evaluates the maximum number of retries to place an order and stops the executor

--- a/hummingbot/strategy_v2/executors/executor_orchestrator.py
+++ b/hummingbot/strategy_v2/executors/executor_orchestrator.py
@@ -22,6 +22,7 @@ from hummingbot.strategy_v2.executors.order_executor.order_executor import Order
 from hummingbot.strategy_v2.executors.position_executor.position_executor import PositionExecutor
 from hummingbot.strategy_v2.executors.twap_executor.twap_executor import TWAPExecutor
 from hummingbot.strategy_v2.executors.xemm_executor.xemm_executor import XEMMExecutor
+from hummingbot.strategy_v2.models.base import RunnableStatus
 from hummingbot.strategy_v2.models.executor_actions import (
     CreateExecutorAction,
     ExecutorAction,
@@ -364,20 +365,97 @@ class ExecutorOrchestrator:
                 self.logger().info(f"Created initial position for controller {controller_id}: {position_config.amount} "
                                    f"{position_config.side.name} {position_config.trading_pair} on {position_config.connector_name}")
 
+    def _all_executors_done(self) -> bool:
+        return all(executor.executor_info.is_done
+                   for executors_list in self.active_executors.values()
+                   for executor in executors_list)
+
+    def _executors_shutdown_signature(self) -> tuple:
+        """
+        Observable shutdown progress across all executors. Any change — a status or
+        close_type transition, an executor finishing, or an internal state advance the
+        executor reports through custom_info["state"] (e.g. an LP unwind moving from
+        CLOSING to SWAPPING) — counts as progress and earns the shutdown wait more time.
+        """
+        signature = []
+        for executors_list in self.active_executors.values():
+            for executor in executors_list:
+                info = executor.executor_info
+                signature.append((
+                    executor.config.id,
+                    executor.status,
+                    info.is_done,
+                    executor.close_type,
+                    str(info.custom_info.get("state")),
+                ))
+        return tuple(signature)
+
     async def stop(self, max_executors_close_attempts: int = 3):
         """
         Stop the orchestrator task and all active executors.
+
+        Executors that are already SHUTTING_DOWN keep the close_type their controller
+        chose; the wait extends while executors make observable progress (an on-chain
+        unwind takes several ticks); and any executor still unfinished at the deadline
+        is force-stopped synchronously, converting whatever it executed into a
+        position hold so no exposure goes untracked.
         """
-        # first we stop all active executors
         for controller_id, executors_list in self.active_executors.items():
             for executor in executors_list:
-                if not executor.is_closed:
-                    executor.early_stop()
-        for i in range(max_executors_close_attempts):
-            if all([executor.executor_info.is_done for executors_list in self.active_executors.values()
-                    for executor in executors_list]):
-                break  # All executors are done, exit early
-            await asyncio.sleep(2.0)
+                if executor.is_closed or executor.status == RunnableStatus.SHUTTING_DOWN:
+                    # A SHUTTING_DOWN executor already had its close_type chosen (by a
+                    # StopExecutorAction or its own logic). Calling early_stop again
+                    # would overwrite it with this type's default keep_position — e.g.
+                    # flipping an LP mid-unwind from EARLY_STOP to POSITION_HOLD, which
+                    # silently skips its close-out swap.
+                    continue
+                executor.early_stop()
+
+        # Wait for executors to finish, extending the deadline while any of them makes
+        # observable progress. max_executors_close_attempts keeps its historical
+        # meaning as a budget of ~2s units, but the budget now bounds *stall* time
+        # rather than total time: a draining grid or a mid-swap LP keeps earning time,
+        # while a hung executor still hits the deadline.
+        poll_interval = 1.0
+        stall_budget = max_executors_close_attempts * 2.0
+        hard_cap = max(30.0, stall_budget)
+        elapsed = stalled = 0.0
+        last_signature = None
+        while not self._all_executors_done():
+            if stalled >= stall_budget or elapsed >= hard_cap:
+                break
+            if last_signature is None:
+                last_signature = self._executors_shutdown_signature()
+            await asyncio.sleep(poll_interval)
+            elapsed += poll_interval
+            signature = self._executors_shutdown_signature()
+            if signature != last_signature:
+                stalled = 0.0
+                last_signature = signature
+            else:
+                stalled += poll_interval
+
+        unfinished_executors = [
+            (controller_id, executor)
+            for controller_id, executors_list in self.active_executors.items()
+            for executor in executors_list
+            if not executor.executor_info.is_done
+        ]
+        if unfinished_executors:
+            executor_ids = [executor.config.id for _, executor in unfinished_executors]
+            self.logger().error(
+                f"Executors {executor_ids} did not finish closing before shutdown. "
+                f"Force-stopping them and converting executed exposure into position holds.")
+            for controller_id, executor in unfinished_executors:
+                try:
+                    executor.force_stop_with_position_hold()
+                except Exception:
+                    self.logger().exception(
+                        f"Error forcing executor {executor.config.id} for controller {controller_id} to stop.")
+
+        # Convert executors that ended holding exposure into persisted position records
+        # while connector prices and strategy market registrations are still available.
+        self._update_positions_from_done_executors()
         # Store all positions and executors
         self.store_all_positions()
         self.store_all_executors()

--- a/hummingbot/strategy_v2/executors/grid_executor/grid_executor.py
+++ b/hummingbot/strategy_v2/executors/grid_executor/grid_executor.py
@@ -278,6 +278,26 @@ class GridExecutor(ExecutorBase):
         self._status = RunnableStatus.SHUTTING_DOWN
         self.close_type = CloseType.POSITION_HOLD if keep_position else CloseType.EARLY_STOP
 
+    def _collect_held_position_orders(self) -> List[Dict]:
+        """Snapshot residual exposure for a forced stop at the shutdown deadline.
+
+        Mirrors the POSITION_HOLD branch of control_shutdown_process without waiting
+        for open/close liquidity to drain: levels whose open order filled but whose
+        close order has not completed are the net exposure still on the exchange.
+        """
+        held = list(self._held_position_orders)
+        seen = {order.get("client_order_id") for order in held}
+        for state in (GridLevelStates.OPEN_ORDER_FILLED, GridLevelStates.CLOSE_ORDER_PLACED):
+            for level in self.levels_by_state.get(state, []):
+                tracked = (level.active_open_order if state == GridLevelStates.OPEN_ORDER_FILLED
+                           else level.active_close_order)
+                if tracked and tracked.order:
+                    order_json = tracked.order.to_json()
+                    if order_json.get("client_order_id") not in seen:
+                        seen.add(order_json.get("client_order_id"))
+                        held.append(order_json)
+        return held
+
     def update_grid_levels(self):
         self.levels_by_state = {state: [] for state in GridLevelStates}
         for level in self.grid_levels:

--- a/hummingbot/strategy_v2/executors/lp_executor/lp_executor.py
+++ b/hummingbot/strategy_v2/executors/lp_executor/lp_executor.py
@@ -711,7 +711,25 @@ class LPExecutor(ExecutorBase):
         self._add_tx_fee_quote = float(tx_fee * native_to_quote)
 
     def _store_lp_event_from_remove(self, event: RangePositionLiquidityRemovedEvent):
-        """Calculate net trade from ADD/REMOVE and store single order.
+        """Calculate net trade from ADD/REMOVE and store single order."""
+        # TX fee for REMOVE
+        native_to_quote = self._get_native_to_quote_rate()
+        tx_fee = sum(fee.amount for fee in event.trade_fee.flat_fees) if event.trade_fee.flat_fees else Decimal("0")
+        remove_tx_fee_quote = float(tx_fee * native_to_quote)
+        self._store_net_trade_from_withdrawal(
+            total_base_returned=event.base_amount + event.base_fee,
+            total_quote_returned=event.quote_amount + event.quote_fee,
+            mid_price=event.mid_price,
+            remove_tx_fee_quote=remove_tx_fee_quote,
+            order_id=event.order_id,
+            exchange_order_id=event.exchange_order_id,
+            trading_pair=event.trading_pair,
+        )
+
+    def _store_net_trade_from_withdrawal(self, total_base_returned: Decimal, total_quote_returned: Decimal,
+                                         mid_price: Decimal, remove_tx_fee_quote: float,
+                                         order_id: str, exchange_order_id: str, trading_pair: str):
+        """Store the net trade of a liquidity withdrawal against the recorded ADD.
 
         The LP position net change determines if this was effectively a BUY or SELL:
         - net_base > 0, net_quote < 0: BUY (gained base, spent quote)
@@ -725,15 +743,8 @@ class LPExecutor(ExecutorBase):
 
         # Calculate net change (REMOVE - ADD)
         # Include LP fees earned in the returned amounts
-        total_base_returned = event.base_amount + event.base_fee
-        total_quote_returned = event.quote_amount + event.quote_fee
         net_base = total_base_returned - add_base
         net_quote = total_quote_returned - add_quote
-
-        # TX fee for REMOVE
-        native_to_quote = self._get_native_to_quote_rate()
-        tx_fee = sum(fee.amount for fee in event.trade_fee.flat_fees) if event.trade_fee.flat_fees else Decimal("0")
-        remove_tx_fee_quote = float(tx_fee * native_to_quote)
 
         # Total TX fees for this LP position
         total_tx_fee_quote = add_tx_fee + remove_tx_fee_quote
@@ -746,9 +757,9 @@ class LPExecutor(ExecutorBase):
             # But still track fees if any
             if total_tx_fee_quote > 0:
                 self._held_position_orders.append({
-                    "client_order_id": event.exchange_order_id,
+                    "client_order_id": exchange_order_id,
                     "trade_type": "BUY",  # Dummy, won't affect P&L with 0 amounts
-                    "price": float(event.mid_price),
+                    "price": float(mid_price),
                     "executed_amount_base": 0.0,
                     "executed_amount_quote": 0.0,
                     "cumulative_fee_paid_quote": total_tx_fee_quote,
@@ -762,13 +773,13 @@ class LPExecutor(ExecutorBase):
             trade_type = "BUY"
             amount_base = float(net_base)
             amount_quote = float(abs(net_quote))
-            price = amount_quote / amount_base if amount_base > 0 else float(event.mid_price)
+            price = amount_quote / amount_base if amount_base > 0 else float(mid_price)
         elif net_base < -threshold and net_quote > threshold:
             # Lost base, gained quote = SELL
             trade_type = "SELL"
             amount_base = float(abs(net_base))
             amount_quote = float(net_quote)
-            price = amount_quote / amount_base if amount_base > 0 else float(event.mid_price)
+            price = amount_quote / amount_base if amount_base > 0 else float(mid_price)
         elif abs(net_base) > threshold:
             # Base changed but quote didn't significantly - use mid_price
             # This happens when LP fees are collected in the same asset
@@ -778,14 +789,14 @@ class LPExecutor(ExecutorBase):
             else:
                 trade_type = "SELL"
                 amount_base = float(abs(net_base))
-            amount_quote = amount_base * float(event.mid_price)
-            price = float(event.mid_price)
+            amount_quote = amount_base * float(mid_price)
+            price = float(mid_price)
         else:
             # Only quote changed - record as 0-base trade (fees only)
             self._held_position_orders.append({
-                "client_order_id": event.exchange_order_id,
+                "client_order_id": exchange_order_id,
                 "trade_type": "BUY",
-                "price": float(event.mid_price),
+                "price": float(mid_price),
                 "executed_amount_base": 0.0,
                 "executed_amount_quote": float(abs(net_quote)),
                 "cumulative_fee_paid_quote": total_tx_fee_quote,
@@ -796,10 +807,10 @@ class LPExecutor(ExecutorBase):
 
         # Create single order representing the net trade
         self._held_position_orders.append({
-            "client_order_id": event.exchange_order_id,
-            "order_id": event.order_id,
-            "exchange_order_id": event.exchange_order_id,
-            "trading_pair": event.trading_pair,
+            "client_order_id": exchange_order_id,
+            "order_id": order_id,
+            "exchange_order_id": exchange_order_id,
+            "trading_pair": trading_pair,
             "trade_type": trade_type,
             "price": price,
             "amount": amount_base,
@@ -809,6 +820,38 @@ class LPExecutor(ExecutorBase):
             "lp_source": True,
             "lp_net_trade": True,
         })
+
+    def _collect_held_position_orders(self) -> List[Dict]:
+        """Snapshot residual exposure for a forced stop at the shutdown deadline.
+
+        Mid-SWAPPING the liquidity is already out of the pool but the close-out swap
+        has not confirmed, so the withdrawn tokens sit in the wallet as spot. Record
+        the same net trade the keep_position path would have stored at REMOVE, so the
+        exposure becomes a tracked hold instead of invisible dust. (A swap submitted
+        in the same tick can still land after the stop; next-start reconciliation
+        absorbs that one fill.)
+
+        A position still on-chain (address set, REMOVE not confirmed) cannot be
+        represented as spot orders — log it loudly so it can be recovered.
+        """
+        if not self._held_position_orders and self.lp_position_state.state == LPExecutorStates.SWAPPING:
+            mid_price = self._current_price if self._current_price else Decimal("0")
+            self._store_net_trade_from_withdrawal(
+                total_base_returned=self.lp_position_state.base_amount + self.lp_position_state.base_fee,
+                total_quote_returned=self.lp_position_state.quote_amount + self.lp_position_state.quote_fee,
+                mid_price=mid_price,
+                remove_tx_fee_quote=0.0,
+                order_id=f"{self.config.id}-forced-hold",
+                exchange_order_id=f"{self.config.id}-forced-hold",
+                trading_pair=self.config.trading_pair,
+            )
+        if not self._held_position_orders and self.lp_position_state.position_address:
+            self.logger().error(
+                f"Forced stop with LP position still on-chain at {self.lp_position_state.position_address} "
+                f"({self.config.trading_pair}). An on-chain position cannot be held as spot orders; "
+                f"recover it on the next start or manually."
+            )
+        return list(self._held_position_orders)
 
     def early_stop(self, keep_position: bool = True):
         """Stop executor - transitions to CLOSING state.

--- a/hummingbot/strategy_v2/executors/lp_executor/lp_executor.py
+++ b/hummingbot/strategy_v2/executors/lp_executor/lp_executor.py
@@ -526,17 +526,19 @@ class LPExecutor(ExecutorBase):
             # If keep_position=False, execute close-out swap to return to original position
             # Similar to how grid executor sells/buys back to rebalance
             if not self.config.keep_position and self.close_type != CloseType.POSITION_HOLD:
-                # Calculate net base change using helper (same calculation as position_hold)
-                base_diff = self._calculate_net_base_difference()
-                if abs(base_diff) > Decimal("0.000001"):  # Non-trivial difference
+                # keep_position=False means "leave me holding no base token" — swap the
+                # ENTIRE withdrawn base balance back to quote, not just the drift versus
+                # what was deposited.
+                closeout_base = self._calculate_closeout_base_amount()
+                if closeout_base > Decimal("0.000001"):
                     self.logger().info(
-                        f"Close-out swap needed: base_diff={base_diff:.6f} "
-                        f"(received={self.lp_position_state.base_amount + self.lp_position_state.base_fee:.6f}, "
-                        f"initial={self.lp_position_state.initial_base_amount:.6f})"
+                        f"Close-out swap needed: selling {closeout_base:.6f} base "
+                        f"(withdrawn={self.lp_position_state.base_amount:.6f}, "
+                        f"fees={self.lp_position_state.base_fee:.6f})"
                     )
                     self.lp_position_state.state = LPExecutorStates.SWAPPING
                 else:
-                    self.logger().info("No close-out swap needed (base amounts match)")
+                    self.logger().info("No close-out swap needed (no base token withdrawn)")
                     self.lp_position_state.state = LPExecutorStates.COMPLETE
             else:
                 self.lp_position_state.state = LPExecutorStates.COMPLETE
@@ -603,23 +605,21 @@ class LPExecutor(ExecutorBase):
             # Otherwise still pending - wait for next tick
             return
 
-        # Calculate swap amount and direction using helper (consistent with _close_position)
-        base_diff = self._calculate_net_base_difference()
+        # Calculate swap amount using helper (consistent with _close_position)
+        amount = self._calculate_closeout_base_amount()
 
-        if abs(base_diff) < Decimal("0.000001"):
+        if amount < Decimal("0.000001"):
             # No swap needed
             self.lp_position_state.state = LPExecutorStates.COMPLETE
             return
 
-        # Determine trade direction
-        # If base_diff > 0: We received more base than deposited → SELL excess base
-        # If base_diff < 0: We received less base than deposited → BUY base to restore
-        is_buy = base_diff < 0
-        amount = abs(base_diff)
-        side = TradeType.BUY if is_buy else TradeType.SELL
+        # Full unwind is always a SELL: we hold base withdrawn from the pool and
+        # want to end denominated in quote.
+        is_buy = False
+        side = TradeType.SELL
 
         self.logger().info(
-            f"Executing close-out swap: {side.name} {amount:.6f} base (diff={base_diff:.6f})"
+            f"Executing close-out swap: {side.name} {amount:.6f} base (full unwind)"
         )
 
         try:
@@ -836,28 +836,29 @@ class LPExecutor(ExecutorBase):
             # No position was created, just complete
             self.lp_position_state.state = LPExecutorStates.COMPLETE
 
-    def _calculate_net_base_difference(self) -> Decimal:
+    def _calculate_closeout_base_amount(self) -> Decimal:
         """
-        Calculate net base token difference from LP position lifecycle.
+        Base token to sell back to quote when unwinding with keep_position=False.
 
-        This is the difference between what we received when closing the position
-        (including fees) and what we initially deposited.
+        This is the ENTIRE base balance withdrawn from the pool — the position's
+        base amount plus accrued base fees — because keep_position=False means the
+        executor must end holding no base token.
+
+        It is deliberately NOT the difference against initial_base_amount. A
+        two-sided position that is closed near its opening price withdraws roughly
+        what it deposited, so a difference-based amount rounds to zero and the
+        executor completes with a clean EARLY_STOP while the full base position
+        silently remains in the wallet as spot.
 
         Returns:
-            Positive: We have more base than we started with (need to SELL)
-            Negative: We have less base than we started with (need to BUY)
-            Zero: Position is balanced
+            The base amount to SELL. Zero if the position withdrew no base token
+            (e.g. a single-sided quote position that never crossed into range).
 
         Used by:
-            - _close_position: To determine if close-out swap is needed
-            - _execute_closeout_swap: To determine swap amount and direction
-            - position_hold: Uses same calculation (ADD as SELL, REMOVE+fees as BUY)
+            - _close_position: To determine if a close-out swap is needed
+            - _execute_closeout_swap: To determine the swap amount
         """
-        # What we received when closing: base_amount + base_fee
-        received_base = self.lp_position_state.base_amount + self.lp_position_state.base_fee
-        # What we deposited when opening: initial_base_amount
-        initial_base = self.lp_position_state.initial_base_amount
-        return received_base - initial_base
+        return self.lp_position_state.base_amount + self.lp_position_state.base_fee
 
     def _get_quote_to_global_rate(self) -> Decimal:
         """

--- a/hummingbot/strategy_v2/executors/order_executor/order_executor.py
+++ b/hummingbot/strategy_v2/executors/order_executor/order_executor.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 from decimal import Decimal
-from typing import Dict, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from hummingbot.connector.connector_base import ConnectorBase
 from hummingbot.connector.gateway.gateway_base import GatewayBase
@@ -149,6 +149,26 @@ class OrderExecutor(ExecutorBase):
         :return: None
         """
         self._status = RunnableStatus.SHUTTING_DOWN
+
+    def _cancel_outstanding_orders(self):
+        self.cancel_order()
+
+    def _collect_held_position_orders(self) -> List[Dict]:
+        """Snapshot residual exposure for a forced stop at the shutdown deadline.
+
+        Same fills control_shutdown_process would retain: the tracked order if
+        filled, plus any partial fills from renewals.
+        """
+        held = list(self._held_position_orders)
+        seen = {order.get("client_order_id") for order in held}
+        candidates = list(self._partial_filled_orders)
+        if self._order and self._order.is_filled:
+            candidates.append(self._order)
+        for tracked in candidates:
+            if tracked.order and tracked.order.client_order_id not in seen:
+                seen.add(tracked.order.client_order_id)
+                held.append(tracked.order.to_json())
+        return held
 
     async def control_shutdown_process(self):
         """

--- a/hummingbot/strategy_v2/executors/position_executor/position_executor.py
+++ b/hummingbot/strategy_v2/executors/position_executor/position_executor.py
@@ -628,6 +628,20 @@ class PositionExecutor(ExecutorBase):
         self.close_type = CloseType.POSITION_HOLD if keep_position else CloseType.EARLY_STOP
         self._status = RunnableStatus.SHUTTING_DOWN
 
+    def _collect_held_position_orders(self) -> List[Dict]:
+        """Snapshot residual exposure for a forced stop at the shutdown deadline.
+
+        Same fills the POSITION_HOLD branch of control_shutdown_process would retain:
+        the entry and any close-side fills, deduped by client order id.
+        """
+        held = list(self._held_position_orders)
+        seen = {order.get("client_order_id") for order in held}
+        for tracked in (self._open_order, self._close_order, self._take_profit_limit_order):
+            if tracked and tracked.is_filled and tracked.order and tracked.order.client_order_id not in seen:
+                seen.add(tracked.order.client_order_id)
+                held.append(tracked.order.to_json())
+        return held
+
     def update_tracked_orders_with_order_id(self, order_id: str):
         """
         This method is responsible for updating the tracked orders with the information from the InFlightOrder, using

--- a/hummingbot/strategy_v2/executors/twap_executor/twap_executor.py
+++ b/hummingbot/strategy_v2/executors/twap_executor/twap_executor.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 from decimal import Decimal
-from typing import Dict, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from hummingbot.connector.connector_base import ConnectorBase
 from hummingbot.core.data_type.common import PositionAction, PriceType, TradeType
@@ -218,6 +218,22 @@ class TWAPExecutor(ExecutorBase):
         self._status = RunnableStatus.SHUTTING_DOWN
         self.logger().info("Executor stopped early.")
 
+    def _collect_held_position_orders(self) -> List[Dict]:
+        """Snapshot residual exposure for a forced stop at the shutdown deadline.
+
+        Every tracked order with an executed amount — planned, refreshed, or failed —
+        still represents exposure on the exchange.
+        """
+        held = list(self._held_position_orders)
+        seen = {order.get("client_order_id") for order in held}
+        candidates = list(self._order_plan.values()) + self._refreshed_orders + self._failed_orders
+        for tracked in candidates:
+            if (tracked and tracked.order and tracked.executed_amount_base > Decimal("0")
+                    and tracked.order.client_order_id not in seen):
+                seen.add(tracked.order.client_order_id)
+                held.append(tracked.order.to_json())
+        return held
+
     @property
     def filled_amount_quote(self) -> Decimal:
         return self.get_total_executed_amount_quote()
@@ -295,4 +311,5 @@ class TWAPExecutor(ExecutorBase):
             "current_retries": self._current_retries,
             "max_retries": self._max_retries,
             "order_ids": [order.order_id for order in self._order_plan.values() if order],
+            "held_position_orders": self._held_position_orders,
         }

--- a/test/hummingbot/connector/gateway/test_gateway_swap_result.py
+++ b/test/hummingbot/connector/gateway/test_gateway_swap_result.py
@@ -76,6 +76,54 @@ class GatewayStoreSwapResultTests(unittest.TestCase):
         # Re-deriving as base * price would give 7 * (0.3/7) with Decimal rounding.
         self.assertEqual(trade_update.fill_price, Decimal("0.3") / Decimal("7"))
 
+    def test_usdc_quote_buy_maps_by_side_not_by_token(self):
+        """Base/quote are assigned from the trade side, so any quote asset works.
+
+        Here both legs are SPL tokens (memecoin/USDC) rather than the memecoin/SOL
+        shape above - the mapping must be identical.
+        """
+        self.connector._store_swap_result(
+            order_id=self.ORDER_ID,
+            trade_type=TradeType.BUY,
+            trading_pair="ANSEM-USDC",
+            amount=Decimal("62"),
+            order_result={"status": 1, "data": {"amountIn": "40.25", "amountOut": "61.962753", "fee": "0.000005"}},
+            transaction_hash=self.TX_HASH,
+        )
+
+        trade_update = self._trade_update()
+        self.assertEqual(trade_update.fill_base_amount, Decimal("61.962753"))
+        self.assertEqual(trade_update.fill_quote_amount, Decimal("40.25"))
+
+    def test_usdc_quote_sell_maps_by_side_not_by_token(self):
+        self.connector._store_swap_result(
+            order_id=self.ORDER_ID,
+            trade_type=TradeType.SELL,
+            trading_pair="ANSEM-USDC",
+            amount=Decimal("62"),
+            order_result={"status": 1, "data": {"amountIn": "61.9", "amountOut": "40.1", "fee": "0.000005"}},
+            transaction_hash=self.TX_HASH,
+        )
+
+        trade_update = self._trade_update()
+        self.assertEqual(trade_update.fill_base_amount, Decimal("61.9"))
+        self.assertEqual(trade_update.fill_quote_amount, Decimal("40.1"))
+
+    def test_fee_asset_is_native_currency_not_the_quote(self):
+        """Gas is always paid in SOL even when the pair is quoted in USDC."""
+        self.connector._store_swap_result(
+            order_id=self.ORDER_ID,
+            trade_type=TradeType.BUY,
+            trading_pair="ANSEM-USDC",
+            amount=Decimal("62"),
+            order_result={"status": 1, "data": {"amountIn": "40.25", "amountOut": "61.9", "fee": "0.000005"}},
+            transaction_hash=self.TX_HASH,
+        )
+
+        trade_update = self._trade_update()
+        self.assertEqual(trade_update.fee.flat_fees[0].token, "SOL")
+        self.assertEqual(trade_update.fee.flat_fees[0].amount, Decimal("0.000005"))
+
     def test_unconfirmed_swap_is_not_marked_filled(self):
         """No realized amounts means the swap has not settled - leave the order open.
 

--- a/test/hummingbot/connector/gateway/test_gateway_swap_result.py
+++ b/test/hummingbot/connector/gateway/test_gateway_swap_result.py
@@ -1,0 +1,99 @@
+import unittest
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+from hummingbot.connector.gateway.gateway import Gateway
+from hummingbot.core.data_type.common import TradeType
+from hummingbot.core.data_type.in_flight_order import OrderState
+
+
+class GatewayStoreSwapResultTests(unittest.TestCase):
+    """_store_swap_result must report the amounts that actually moved on-chain.
+
+    Gateway's `amountIn`/`amountOut` come from the wallet's pre/post token balance
+    deltas for the settled transaction. Reporting the requested amount instead
+    overstates the fill, and callers that spend the proceeds downstream (an LP
+    open's base_amount) then ask the chain for tokens that were never received.
+    """
+
+    ORDER_ID = "order-1"
+    TX_HASH = "sig-1"
+    PAIR = "ANSEM-SOL"
+
+    def setUp(self):
+        self.connector = Gateway.__new__(Gateway)
+        self.connector._native_currency = "SOL"
+        self.connector._order_tracker = MagicMock()
+
+        # The order was placed for 62 base tokens.
+        self.tracked_order = MagicMock()
+        self.tracked_order.amount = Decimal("62")
+        self.connector._order_tracker.fetch_order.return_value = self.tracked_order
+
+        patcher = unittest.mock.patch.object(
+            Gateway, "current_timestamp", new_callable=unittest.mock.PropertyMock, return_value=1234.0
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _store(self, trade_type, data, status=1):
+        self.connector._store_swap_result(
+            order_id=self.ORDER_ID,
+            trade_type=trade_type,
+            trading_pair=self.PAIR,
+            amount=Decimal("62"),
+            order_result={"status": status, "data": data},
+            transaction_hash=self.TX_HASH,
+        )
+
+    def _trade_update(self):
+        self.connector._order_tracker.process_trade_update.assert_called_once()
+        return self.connector._order_tracker.process_trade_update.call_args[0][0]
+
+    def test_buy_fill_uses_realized_amount_not_requested(self):
+        """A BUY receives base as amountOut - slippage means it is under the request."""
+        self._store(TradeType.BUY, {"amountIn": "0.5", "amountOut": "61.962753", "fee": "0.000005"})
+
+        trade_update = self._trade_update()
+        self.assertEqual(trade_update.fill_base_amount, Decimal("61.962753"))
+        self.assertNotEqual(trade_update.fill_base_amount, self.tracked_order.amount)
+        self.assertEqual(trade_update.fill_quote_amount, Decimal("0.5"))
+
+    def test_sell_fill_uses_realized_amount(self):
+        """A SELL sends base as amountIn and receives quote as amountOut."""
+        self._store(TradeType.SELL, {"amountIn": "61.9", "amountOut": "0.497", "fee": "0.000005"})
+
+        trade_update = self._trade_update()
+        self.assertEqual(trade_update.fill_base_amount, Decimal("61.9"))
+        self.assertEqual(trade_update.fill_quote_amount, Decimal("0.497"))
+
+    def test_fill_quote_amount_is_not_rederived_from_price(self):
+        """Both legs come straight from Gateway, so no rounding drift is introduced."""
+        self._store(TradeType.BUY, {"amountIn": "0.3", "amountOut": "7", "fee": "0"})
+
+        trade_update = self._trade_update()
+        self.assertEqual(trade_update.fill_quote_amount, Decimal("0.3"))
+        # Re-deriving as base * price would give 7 * (0.3/7) with Decimal rounding.
+        self.assertEqual(trade_update.fill_price, Decimal("0.3") / Decimal("7"))
+
+    def test_unconfirmed_swap_is_not_marked_filled(self):
+        """No realized amounts means the swap has not settled - leave the order open.
+
+        Previously this produced a phantom 0-amount fill at price 0 and still
+        forced the order to FILLED.
+        """
+        self._store(TradeType.BUY, {}, status=0)
+
+        self.connector._order_tracker.process_trade_update.assert_not_called()
+        self.connector._order_tracker.process_order_update.assert_not_called()
+
+    def test_confirmed_swap_is_marked_filled(self):
+        self._store(TradeType.BUY, {"amountIn": "0.5", "amountOut": "61.9", "fee": "0"})
+
+        self.connector._order_tracker.process_order_update.assert_called_once()
+        order_update = self.connector._order_tracker.process_order_update.call_args[0][0]
+        self.assertEqual(order_update.new_state, OrderState.FILLED)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/hummingbot/strategy_v2/executors/dca_executor/test_dca_executor.py
+++ b/test/hummingbot/strategy_v2/executors/dca_executor/test_dca_executor.py
@@ -652,3 +652,48 @@ class TestDCAExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         self.assertTrue(executor._is_within_activation_bounds(order_price, Decimal("100.5")))
         # Case 2: close_price is outside the activation bounds
         self.assertFalse(executor._is_within_activation_bounds(order_price, Decimal("106")))
+
+    def test_force_stop_with_position_hold_holds_partial_fills(self):
+        """A forced stop nets every open- and close-side fill into the position hold."""
+        config = DCAExecutorConfig(id="test-forced", timestamp=123, side=TradeType.BUY, connector_name="binance",
+                                   trading_pair="ETH-USDT",
+                                   amounts_quote=[Decimal(10), Decimal(20)],
+                                   prices=[Decimal(100), Decimal(80)])
+        executor = self.get_dca_executor_from_config(config)
+        executor._status = RunnableStatus.SHUTTING_DOWN
+
+        filled = InFlightOrder(
+            client_order_id="OID-DCA-1",
+            trading_pair=config.trading_pair,
+            order_type=OrderType.LIMIT,
+            trade_type=config.side,
+            price=Decimal("100"),
+            amount=Decimal("0.1"),
+            creation_timestamp=1640001112.223,
+            initial_state=OrderState.PARTIALLY_FILLED
+        )
+        filled.executed_amount_base = Decimal("0.05")
+        tracked_filled = TrackedOrder("OID-DCA-1")
+        tracked_filled.order = filled
+
+        untouched = InFlightOrder(
+            client_order_id="OID-DCA-2",
+            trading_pair=config.trading_pair,
+            order_type=OrderType.LIMIT,
+            trade_type=config.side,
+            price=Decimal("80"),
+            amount=Decimal("0.25"),
+            creation_timestamp=1640001112.223,
+            initial_state=OrderState.OPEN
+        )
+        tracked_untouched = TrackedOrder("OID-DCA-2")
+        tracked_untouched.order = untouched
+
+        executor._open_orders = [tracked_filled, tracked_untouched]
+
+        executor.force_stop_with_position_hold()
+
+        self.assertEqual(executor.close_type, CloseType.POSITION_HOLD)
+        self.assertEqual(executor.status, RunnableStatus.TERMINATED)
+        held_ids = {order["client_order_id"] for order in executor._held_position_orders}
+        self.assertEqual(held_ids, {"OID-DCA-1"})

--- a/test/hummingbot/strategy_v2/executors/grid_executor/test_grid_executor.py
+++ b/test/hummingbot/strategy_v2/executors/grid_executor/test_grid_executor.py
@@ -125,6 +125,61 @@ class TestGridExecutorBugFixes(IsolatedAsyncioWrapperTestCase, LoggerMixinForTes
         self.assertEqual(executor.close_type, CloseType.POSITION_HOLD)
         self.assertEqual(executor.status, RunnableStatus.SHUTTING_DOWN)
 
+    @patch.object(GridExecutor, "get_price", MagicMock(return_value=Decimal("100")))
+    @patch.object(GridExecutor, "get_trading_rules")
+    def test_force_stop_mid_drain_holds_filled_levels(self, trading_rules_mock):
+        """A forced stop while the shutdown drain is still running keeps the hold.
+
+        control_shutdown_process only moves fills into _held_position_orders after
+        open and close liquidity have drained; the shutdown-deadline fallback must
+        collect the same fills synchronously instead of losing them.
+        """
+        trading_rules = TradingRule(trading_pair="ETH-USDT", min_order_size=Decimal("0.001"),
+                                    min_base_amount_increment=Decimal("0.001"),
+                                    min_price_increment=Decimal("0.01"), min_notional_size=Decimal("10"))
+        trading_rules_mock.return_value = trading_rules
+        from hummingbot.strategy_v2.executors.grid_executor.data_types import GridExecutorConfig
+        from hummingbot.strategy_v2.executors.position_executor.data_types import TripleBarrierConfig
+        config = GridExecutorConfig(
+            id="test", timestamp=1234567890, trading_pair="ETH-USDT",
+            connector_name="binance", side=TradeType.BUY,
+            start_price=Decimal("90"), end_price=Decimal("110"),
+            limit_price=Decimal("90"),
+            total_amount_quote=Decimal("100"),
+            min_order_amount_quote=Decimal("10"),
+            min_spread_between_orders=Decimal("0.01"),
+            keep_position=True,
+            triple_barrier_config=TripleBarrierConfig(
+                take_profit=Decimal("0.02"),
+                stop_loss=Decimal("0.05"),
+                take_profit_order_type=OrderType.LIMIT,
+                stop_loss_order_type=OrderType.MARKET,
+            ),
+        )
+        executor = GridExecutor(self.strategy, config)
+        executor.early_stop(keep_position=True)  # POSITION_HOLD chosen, drain in progress
+
+        filled_open = MagicMock()
+        filled_open.order.to_json.return_value = {"client_order_id": "open-1", "trade_type": "BUY"}
+        level_open_filled = MagicMock()
+        level_open_filled.active_open_order = filled_open
+        pending_close = MagicMock()
+        pending_close.order.to_json.return_value = {"client_order_id": "close-1", "trade_type": "SELL"}
+        level_close_placed = MagicMock()
+        level_close_placed.active_close_order = pending_close
+        executor.levels_by_state = {
+            GridLevelStates.OPEN_ORDER_PLACED: [],
+            GridLevelStates.OPEN_ORDER_FILLED: [level_open_filled],
+            GridLevelStates.CLOSE_ORDER_PLACED: [level_close_placed],
+        }
+
+        executor.force_stop_with_position_hold()
+
+        self.assertEqual(CloseType.POSITION_HOLD, executor.close_type)
+        self.assertEqual(RunnableStatus.TERMINATED, executor.status)
+        held_ids = {order["client_order_id"] for order in executor._held_position_orders}
+        self.assertEqual({"open-1", "close-1"}, held_ids)
+
 
 class TestGridExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
     def setUp(self) -> None:

--- a/test/hummingbot/strategy_v2/executors/lp_executor/test_lp_executor.py
+++ b/test/hummingbot/strategy_v2/executors/lp_executor/test_lp_executor.py
@@ -1397,6 +1397,42 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
 
         self.assertEqual(executor.lp_position_state.state, LPExecutorStates.SWAPPING)
 
+    async def test_close_position_with_keep_position_false_quote_only_completes(self):
+        """A quote-only withdrawal has no base to sell back, so no close-out swap is needed."""
+        config = self.get_default_config()
+        config_dict = config.model_dump()
+        config_dict["keep_position"] = False
+        config_dict["swap_provider"] = "jupiter/router"
+        new_config = LPExecutorConfig(**config_dict)
+
+        executor = self.get_executor(new_config)
+        executor.lp_position_state.position_address = "pos123"
+        executor.lp_position_state.initial_base_amount = Decimal("0")
+        executor.lp_position_state.initial_quote_amount = Decimal("100.0")
+
+        mock_position = MagicMock()
+        mock_position.price = 100.0
+        connector = self.strategy.connectors["solana-mainnet-beta"]
+        connector.get_position_info = AsyncMock(return_value=mock_position)
+        connector._clmm_close_position = AsyncMock(return_value="sig789")
+        connector._lp_orders_metadata = {
+            "order-123": {
+                "base_amount": Decimal("0"),  # Price moved below range: all base converted to quote
+                "quote_amount": Decimal("99.0"),
+                "base_fee": Decimal("0"),
+                "quote_fee": Decimal("0.5"),
+                "position_rent_refunded": Decimal("0.002"),
+                "tx_fee": Decimal("0.0001")
+            }
+        }
+        connector._trigger_remove_liquidity_event = MagicMock(return_value=create_mock_remove_event(
+            base_amount=Decimal("0"), quote_amount=Decimal("99.0"), base_fee=Decimal("0")
+        ))
+
+        await executor._close_position()
+
+        self.assertEqual(executor.lp_position_state.state, LPExecutorStates.COMPLETE)
+
     async def test_execute_closeout_swap_no_connector(self):
         """Test _execute_closeout_swap handles missing connector"""
         executor = self.get_executor()

--- a/test/hummingbot/strategy_v2/executors/lp_executor/test_lp_executor.py
+++ b/test/hummingbot/strategy_v2/executors/lp_executor/test_lp_executor.py
@@ -1549,6 +1549,32 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         self.assertEqual(call_kwargs["amount"], Decimal("0.51"))  # base + base_fee
         self.assertIsNotNone(executor.lp_position_state.active_swap_order)
 
+    async def test_execute_closeout_swap_is_quote_asset_agnostic(self):
+        """The close-out sells the base balance whatever the quote asset is.
+
+        The rest of this suite runs on SOL-USDC (USDC quote); this covers the
+        other common shape, a token quoted in SOL. The amount is pure base-side
+        arithmetic, so it must not vary with the quote token.
+        """
+        config_dict = self.get_default_config().model_dump()
+        config_dict["trading_pair"] = "BONK-SOL"
+        executor = self.get_executor(LPExecutorConfig(**config_dict))
+        executor.config.swap_provider = "jupiter/router"
+        executor.lp_position_state.initial_base_amount = Decimal("1000")
+        executor.lp_position_state.base_amount = Decimal("1400")
+        executor.lp_position_state.base_fee = Decimal("25")
+
+        connector = self.strategy.connectors["solana-mainnet-beta"]
+        connector.place_order = MagicMock(return_value="swap-order-123")
+
+        await executor._execute_closeout_swap()
+
+        connector.place_order.assert_called_once()
+        call_kwargs = connector.place_order.call_args[1]
+        self.assertFalse(call_kwargs["is_buy"])  # SELL base for quote
+        self.assertEqual(call_kwargs["trading_pair"], "BONK-SOL")
+        self.assertEqual(call_kwargs["amount"], Decimal("1425"))  # base + base_fee
+
     async def test_execute_closeout_swap_exception(self):
         """Test _execute_closeout_swap handles exception when placing swap"""
         executor = self.get_executor()

--- a/test/hummingbot/strategy_v2/executors/lp_executor/test_lp_executor.py
+++ b/test/hummingbot/strategy_v2/executors/lp_executor/test_lp_executor.py
@@ -1356,8 +1356,13 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         # Should transition to SWAPPING since base_diff > 0.000001
         self.assertEqual(executor.lp_position_state.state, LPExecutorStates.SWAPPING)
 
-    async def test_close_position_with_keep_position_false_no_swap_needed(self):
-        """Test _close_position goes to COMPLETE when no swap needed"""
+    async def test_close_position_with_keep_position_false_unwinds_unchanged_position(self):
+        """Regression: keep_position=False must swap back even when base is unchanged.
+
+        Withdrawing exactly what was deposited used to compute a zero difference
+        and skip the swap, completing cleanly while the base tokens stayed in the
+        wallet. The full balance must be sold instead.
+        """
         config = self.get_default_config()
         config_dict = config.model_dump()
         config_dict["keep_position"] = False
@@ -1390,7 +1395,7 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
 
         await executor._close_position()
 
-        self.assertEqual(executor.lp_position_state.state, LPExecutorStates.COMPLETE)
+        self.assertEqual(executor.lp_position_state.state, LPExecutorStates.SWAPPING)
 
     async def test_execute_closeout_swap_no_connector(self):
         """Test _execute_closeout_swap handles missing connector"""
@@ -1491,11 +1496,11 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         self.assertIsNone(executor.lp_position_state.active_swap_order)
 
     async def test_execute_closeout_swap_no_swap_needed(self):
-        """Test _execute_closeout_swap completes when no swap needed"""
+        """Test _execute_closeout_swap completes when no base token was withdrawn"""
         executor = self.get_executor()
         executor.config.swap_provider = "jupiter/router"
         executor.lp_position_state.initial_base_amount = Decimal("1.0")
-        executor.lp_position_state.base_amount = Decimal("1.0")  # Same
+        executor.lp_position_state.base_amount = Decimal("0")  # Nothing came back
         executor.lp_position_state.base_fee = Decimal("0.0")
 
         await executor._execute_closeout_swap()
@@ -1521,8 +1526,12 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         self.assertFalse(call_kwargs["is_buy"])  # SELL
         self.assertIsNotNone(executor.lp_position_state.active_swap_order)
 
-    async def test_execute_closeout_swap_buy_back_base(self):
-        """Test _execute_closeout_swap buys back base tokens"""
+    async def test_execute_closeout_swap_sells_full_balance_when_base_shrank(self):
+        """Withdrawing less base than deposited still sells the whole balance.
+
+        A full unwind is always a SELL - there is no buy-back leg, since the goal
+        is to end holding no base token rather than to restore the deposit.
+        """
         executor = self.get_executor()
         executor.config.swap_provider = "jupiter/router"
         executor.lp_position_state.initial_base_amount = Decimal("1.0")
@@ -1534,10 +1543,10 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
 
         await executor._execute_closeout_swap()
 
-        # Should place a BUY order
         connector.place_order.assert_called_once()
         call_kwargs = connector.place_order.call_args[1]
-        self.assertTrue(call_kwargs["is_buy"])  # BUY
+        self.assertFalse(call_kwargs["is_buy"])  # SELL
+        self.assertEqual(call_kwargs["amount"], Decimal("0.51"))  # base + base_fee
         self.assertIsNotNone(executor.lp_position_state.active_swap_order)
 
     async def test_execute_closeout_swap_exception(self):
@@ -1689,40 +1698,39 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         self.assertEqual(executor.lp_position_state.state, LPExecutorStates.FAILED)
         self.assertEqual(executor.close_type, CloseType.EARLY_STOP)
 
-    # Tests for _calculate_net_base_difference
+    # Tests for _calculate_closeout_base_amount
 
-    def test_calculate_net_base_difference_positive(self):
-        """Test _calculate_net_base_difference returns positive when gained base"""
+    def test_calculate_closeout_base_amount_includes_fees(self):
+        """Close-out sells the withdrawn base plus accrued base fees"""
         executor = self.get_executor()
         executor.lp_position_state.initial_base_amount = Decimal("1.0")
         executor.lp_position_state.base_amount = Decimal("1.4")
         executor.lp_position_state.base_fee = Decimal("0.1")
 
-        # received = 1.4 + 0.1 = 1.5, initial = 1.0, diff = 0.5
-        diff = executor._calculate_net_base_difference()
-        self.assertEqual(diff, Decimal("0.5"))
+        self.assertEqual(executor._calculate_closeout_base_amount(), Decimal("1.5"))
 
-    def test_calculate_net_base_difference_negative(self):
-        """Test _calculate_net_base_difference returns negative when lost base"""
-        executor = self.get_executor()
-        executor.lp_position_state.initial_base_amount = Decimal("1.0")
-        executor.lp_position_state.base_amount = Decimal("0.4")
-        executor.lp_position_state.base_fee = Decimal("0.1")
+    def test_calculate_closeout_base_amount_ignores_initial_deposit(self):
+        """Regression: a position closing near its opening price must still fully unwind.
 
-        # received = 0.4 + 0.1 = 0.5, initial = 1.0, diff = -0.5
-        diff = executor._calculate_net_base_difference()
-        self.assertEqual(diff, Decimal("-0.5"))
-
-    def test_calculate_net_base_difference_zero(self):
-        """Test _calculate_net_base_difference returns zero when balanced"""
+        The old difference-based calculation returned 0 here, so no close-out swap
+        ran and the whole base position was silently left in the wallet as spot
+        while the executor reported a clean EARLY_STOP.
+        """
         executor = self.get_executor()
         executor.lp_position_state.initial_base_amount = Decimal("1.0")
         executor.lp_position_state.base_amount = Decimal("0.9")
         executor.lp_position_state.base_fee = Decimal("0.1")
 
-        # received = 0.9 + 0.1 = 1.0, initial = 1.0, diff = 0
-        diff = executor._calculate_net_base_difference()
-        self.assertEqual(diff, Decimal("0"))
+        self.assertEqual(executor._calculate_closeout_base_amount(), Decimal("1.0"))
+
+    def test_calculate_closeout_base_amount_zero_when_no_base_withdrawn(self):
+        """No swap when the position withdrew no base token at all"""
+        executor = self.get_executor()
+        executor.lp_position_state.initial_base_amount = Decimal("1.0")
+        executor.lp_position_state.base_amount = Decimal("0")
+        executor.lp_position_state.base_fee = Decimal("0")
+
+        self.assertEqual(executor._calculate_closeout_base_amount(), Decimal("0"))
 
     # Test for filled_amount_base property
 

--- a/test/hummingbot/strategy_v2/executors/lp_executor/test_lp_executor.py
+++ b/test/hummingbot/strategy_v2/executors/lp_executor/test_lp_executor.py
@@ -1590,6 +1590,58 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
 
         self.assertEqual(executor.lp_position_state.state, LPExecutorStates.FAILED)
 
+    def test_force_stop_mid_swap_holds_withdrawn_balance(self):
+        """A forced stop mid-SWAPPING converts the withdrawn tokens into a position hold.
+
+        Liquidity is out of the pool but the close-out swap has not confirmed, so the
+        base sits in the wallet as spot. The shutdown-deadline fallback must record the
+        net trade versus the ADD — the same record the keep_position path would have
+        stored at REMOVE — instead of terminating with nothing tracked.
+        """
+        executor = self.get_executor()
+        executor.close_type = CloseType.EARLY_STOP
+        executor._status = RunnableStatus.SHUTTING_DOWN
+        executor._current_price = Decimal("100")
+        executor._add_base_amount = Decimal("1.0")
+        executor._add_quote_amount = Decimal("100.0")
+        executor.lp_position_state.state = LPExecutorStates.SWAPPING
+        executor.lp_position_state.position_address = None
+        executor.lp_position_state.base_amount = Decimal("1.5")
+        executor.lp_position_state.base_fee = Decimal("0.01")
+        executor.lp_position_state.quote_amount = Decimal("40.0")
+        executor.lp_position_state.quote_fee = Decimal("0.5")
+
+        executor.force_stop_with_position_hold()
+
+        self.assertEqual(CloseType.POSITION_HOLD, executor.close_type)
+        self.assertEqual(RunnableStatus.TERMINATED, executor.status)
+        self.assertEqual(1, len(executor._held_position_orders))
+        held = executor._held_position_orders[0]
+        # net_base = (1.5 + 0.01) - 1.0 = +0.51; net_quote = 40.5 - 100 = -59.5 -> BUY
+        self.assertEqual("BUY", held["trade_type"])
+        self.assertAlmostEqual(0.51, held["executed_amount_base"])
+        self.assertAlmostEqual(59.5, held["executed_amount_quote"])
+        self.assertIn("held_position_orders", executor.get_custom_info())
+
+    def test_force_stop_with_position_still_onchain_fails_loudly(self):
+        """A position that never got its REMOVE cannot be held as spot orders.
+
+        The forced stop must not fabricate a hold; it closes as FAILED and names the
+        on-chain address so the position can be recovered.
+        """
+        executor = self.get_executor()
+        executor.close_type = CloseType.EARLY_STOP
+        executor._status = RunnableStatus.SHUTTING_DOWN
+        executor.lp_position_state.state = LPExecutorStates.CLOSING
+        executor.lp_position_state.position_address = "position-abc"
+
+        executor.force_stop_with_position_hold()
+
+        self.assertEqual(CloseType.FAILED, executor.close_type)
+        self.assertEqual(RunnableStatus.TERMINATED, executor.status)
+        self.assertEqual(0, len(executor._held_position_orders))
+        self.assertTrue(self.is_partially_logged("ERROR", "still on-chain at position-abc"))
+
     # Tests for _store_lp_event_from_remove variations
 
     def test_store_lp_event_from_remove_tx_fee_only(self):

--- a/test/hummingbot/strategy_v2/executors/order_executor/test_order_executor.py
+++ b/test/hummingbot/strategy_v2/executors/order_executor/test_order_executor.py
@@ -903,3 +903,53 @@ class TestOrderExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
 
         # filled_amount_quote = 0.5 * 100 = 50
         self.assertEqual(executor.filled_amount_quote, Decimal("50"))
+
+    def test_force_stop_with_position_hold_holds_fills(self):
+        """A forced stop cancels the live order and hands over the filled exposure."""
+        config = OrderExecutorConfig(
+            id="test-forced",
+            timestamp=123,
+            side=TradeType.BUY,
+            connector_name="binance",
+            trading_pair="ETH-USDT",
+            amount=Decimal("1"),
+            price=Decimal("100"),
+            execution_strategy=ExecutionStrategy.MARKET
+        )
+        executor = self.get_order_executor_from_config(config)
+        executor._status = RunnableStatus.SHUTTING_DOWN
+
+        filled = InFlightOrder(
+            client_order_id="OID-FILLED",
+            trading_pair=config.trading_pair,
+            order_type=OrderType.MARKET,
+            trade_type=config.side,
+            price=Decimal("100"),
+            amount=Decimal("1"),
+            creation_timestamp=1640001112.223,
+            initial_state=OrderState.FILLED
+        )
+        tracked = TrackedOrder("OID-FILLED")
+        tracked.order = filled
+        executor._order = tracked
+
+        partial = InFlightOrder(
+            client_order_id="OID-PARTIAL",
+            trading_pair=config.trading_pair,
+            order_type=OrderType.LIMIT,
+            trade_type=config.side,
+            price=Decimal("99"),
+            amount=Decimal("1"),
+            creation_timestamp=1640001112.223,
+            initial_state=OrderState.PARTIALLY_FILLED
+        )
+        tracked_partial = TrackedOrder("OID-PARTIAL")
+        tracked_partial.order = partial
+        executor._partial_filled_orders = [tracked_partial]
+
+        executor.force_stop_with_position_hold()
+
+        self.assertEqual(executor.close_type, CloseType.POSITION_HOLD)
+        self.assertEqual(executor.status, RunnableStatus.TERMINATED)
+        held_ids = {order["client_order_id"] for order in executor._held_position_orders}
+        self.assertEqual(held_ids, {"OID-FILLED", "OID-PARTIAL"})

--- a/test/hummingbot/strategy_v2/executors/position_executor/test_position_executor.py
+++ b/test/hummingbot/strategy_v2/executors/position_executor/test_position_executor.py
@@ -929,3 +929,30 @@ class TestPositionExecutor(IsolatedAsyncioWrapperTestCase):
             executor.place_take_profit_limit_order()
         self.strategy.sell.assert_called_once()
         self.assertEqual(PositionAction.CLOSE, self.strategy.sell.call_args.args[5])
+
+    def test_force_stop_with_position_hold_holds_entry_fill(self):
+        """A forced stop at the shutdown deadline hands over the filled entry."""
+        position_config = self.get_position_config_market_long()
+        executor = PositionExecutor(self.strategy, position_config)
+        executor._status = RunnableStatus.SHUTTING_DOWN
+
+        entry = InFlightOrder(
+            client_order_id="OID-ENTRY",
+            trading_pair=position_config.trading_pair,
+            order_type=OrderType.MARKET,
+            trade_type=position_config.side,
+            price=Decimal("100"),
+            amount=Decimal("1"),
+            creation_timestamp=1640001112.223,
+            initial_state=OrderState.FILLED
+        )
+        tracked = TrackedOrder("OID-ENTRY")
+        tracked.order = entry
+        executor._open_order = tracked
+
+        executor.force_stop_with_position_hold()
+
+        self.assertEqual(executor.close_type, CloseType.POSITION_HOLD)
+        self.assertEqual(executor.status, RunnableStatus.TERMINATED)
+        held_ids = {order["client_order_id"] for order in executor._held_position_orders}
+        self.assertEqual(held_ids, {"OID-ENTRY"})

--- a/test/hummingbot/strategy_v2/executors/test_executor_base.py
+++ b/test/hummingbot/strategy_v2/executors/test_executor_base.py
@@ -218,3 +218,34 @@ class TestExecutorBase(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         self.component.evaluate_max_retries()
         self.assertEqual(self.component.close_type, CloseType.FAILED)
         self.assertEqual(self.component.status, RunnableStatus.TERMINATED)
+
+    def test_force_stop_with_position_hold_uses_accumulated_orders(self):
+        """The default collector hands over whatever a normal shutdown already accumulated."""
+        self.set_loggers(loggers=[self.component.logger()])
+        held = [{"client_order_id": "OID-HELD"}]
+        self.component._held_position_orders = list(held)
+
+        self.component.force_stop_with_position_hold()
+
+        self.assertEqual(self.component.close_type, CloseType.POSITION_HOLD)
+        self.assertEqual(self.component.status, RunnableStatus.TERMINATED)
+        self.assertEqual(self.component._held_position_orders, held)
+
+    def test_force_stop_with_position_hold_without_exposure_fails_visibly(self):
+        """Nothing executed means nothing to hold — the abnormal end must stay visible."""
+        self.set_loggers(loggers=[self.component.logger()])
+        self.component.force_stop_with_position_hold()
+
+        self.assertEqual(self.component.close_type, CloseType.FAILED)
+        self.assertEqual(self.component.status, RunnableStatus.TERMINATED)
+
+    def test_force_stop_with_position_hold_survives_cancel_failure(self):
+        """Exposure must still be persisted when order cancellation is already unavailable."""
+        self.set_loggers(loggers=[self.component.logger()])
+        self.component._held_position_orders = [{"client_order_id": "OID-HELD"}]
+        with patch.object(self.component, "_cancel_outstanding_orders", side_effect=RuntimeError("strategy stopped")):
+            self.component.force_stop_with_position_hold()
+
+        self.assertEqual(self.component.close_type, CloseType.POSITION_HOLD)
+        self.assertEqual(self.component.status, RunnableStatus.TERMINATED)
+        self.assertTrue(self.is_partially_logged("ERROR", "Failed to cancel outstanding orders during forced stop."))

--- a/test/hummingbot/strategy_v2/executors/test_executor_orchestrator.py
+++ b/test/hummingbot/strategy_v2/executors/test_executor_orchestrator.py
@@ -494,6 +494,24 @@ class TestExecutorOrchestrator(unittest.TestCase):
 
         asyncio.run(test_async())
 
+    @patch.object(ExecutorOrchestrator, "store_all_positions")
+    @patch.object(ExecutorOrchestrator, "store_all_executors")
+    def test_stop_logs_and_continues_when_force_stop_raises(self, store_all_executors, store_all_positions):
+        """One executor failing to force-stop must not prevent the others from being forced."""
+        async def test_async():
+            broken = self._make_unfinished_executor("broken", RunnableStatus.SHUTTING_DOWN)
+            broken.force_stop_with_position_hold.side_effect = RuntimeError("connector already gone")
+            healthy = self._make_unfinished_executor("healthy", RunnableStatus.SHUTTING_DOWN)
+            self.orchestrator.active_executors["test"] = [broken, healthy]
+
+            await self.orchestrator.stop(max_executors_close_attempts=0)
+
+            broken.force_stop_with_position_hold.assert_called_once()
+            healthy.force_stop_with_position_hold.assert_called_once()
+            store_all_executors.assert_called_once()
+
+        asyncio.run(test_async())
+
     def test_stop_executor(self):
         position_executor = MagicMock(spec=PositionExecutor)
         position_executor.is_closed = False

--- a/test/hummingbot/strategy_v2/executors/test_executor_orchestrator.py
+++ b/test/hummingbot/strategy_v2/executors/test_executor_orchestrator.py
@@ -399,6 +399,101 @@ class TestExecutorOrchestrator(unittest.TestCase):
 
         asyncio.run(test_async())
 
+    @staticmethod
+    def _make_unfinished_executor(executor_id: str = "unfinished", status: RunnableStatus = RunnableStatus.RUNNING):
+        executor = MagicMock()
+        executor.is_closed = False
+        executor.status = status
+        executor.close_type = None
+        executor.early_stop = MagicMock(return_value=None)
+        executor.force_stop_with_position_hold = MagicMock(return_value=None)
+        executor.executor_info = MagicMock()
+        executor.executor_info.is_done = False
+        executor.executor_info.custom_info = {}
+        executor.config = MagicMock()
+        executor.config.id = executor_id
+        return executor
+
+    @patch.object(ExecutorOrchestrator, "store_all_positions")
+    @patch.object(ExecutorOrchestrator, "store_all_executors")
+    def test_stop_does_not_re_early_stop_shutting_down_executors(self, store_all_executors, store_all_positions):
+        """An executor already SHUTTING_DOWN keeps the close_type its controller chose.
+
+        Re-calling early_stop would overwrite it with the type's default keep_position —
+        e.g. flipping an LP mid-unwind from EARLY_STOP to POSITION_HOLD, which silently
+        skips its close-out swap.
+        """
+        async def test_async():
+            executor = self._make_unfinished_executor("mid-unwind", RunnableStatus.SHUTTING_DOWN)
+            self.orchestrator.active_executors["test"] = [executor]
+
+            await self.orchestrator.stop(max_executors_close_attempts=0)
+
+            executor.early_stop.assert_not_called()
+            executor.force_stop_with_position_hold.assert_called_once()
+
+        asyncio.run(test_async())
+
+    @patch.object(ExecutorOrchestrator, "store_all_positions")
+    @patch.object(ExecutorOrchestrator, "store_all_executors")
+    def test_stop_force_stops_unfinished_executors_with_position_hold(self, store_all_executors, store_all_positions):
+        async def test_async():
+            executor = self._make_unfinished_executor()
+            self.orchestrator.active_executors["test"] = [executor]
+
+            await self.orchestrator.stop(max_executors_close_attempts=0)
+
+            executor.early_stop.assert_called_once()
+            executor.force_stop_with_position_hold.assert_called_once()
+            store_all_positions.assert_called_once()
+            store_all_executors.assert_called_once()
+            self.assertEqual({}, self.orchestrator.active_executors)
+
+        asyncio.run(test_async())
+
+    @patch.object(ExecutorOrchestrator, "store_all_positions")
+    @patch.object(ExecutorOrchestrator, "store_all_executors")
+    def test_stop_extends_wait_while_executor_makes_progress(self, store_all_executors, store_all_positions):
+        """The stall budget resets on observable progress, so a multi-tick unwind that
+        outlives the base budget still finishes without being force-stopped."""
+        async def test_async():
+            executor = self._make_unfinished_executor("slow-unwind", RunnableStatus.SHUTTING_DOWN)
+            # Advance through one custom_info state per poll — more polls than the
+            # stall budget (one attempt = 2 polls) would allow without progress.
+            states = iter(["CLOSING", "CLOSING_CONFIRMING", "SWAPPING", "SWAPPING_CONFIRMING", "COMPLETE"])
+
+            async def advance(_delay):
+                state = next(states, "COMPLETE")
+                executor.executor_info.custom_info = {"state": state}
+                if state == "COMPLETE":
+                    executor.executor_info.is_done = True
+
+            self.orchestrator.active_executors["test"] = [executor]
+            with patch("hummingbot.strategy_v2.executors.executor_orchestrator.asyncio.sleep", side_effect=advance):
+                await self.orchestrator.stop(max_executors_close_attempts=1)
+
+            executor.force_stop_with_position_hold.assert_not_called()
+
+        asyncio.run(test_async())
+
+    @patch.object(ExecutorOrchestrator, "store_all_positions")
+    @patch.object(ExecutorOrchestrator, "store_all_executors")
+    def test_stop_gives_up_on_stalled_executor(self, store_all_executors, store_all_positions):
+        """No observable progress exhausts the stall budget and triggers the forced stop."""
+        async def test_async():
+            executor = self._make_unfinished_executor("hung", RunnableStatus.SHUTTING_DOWN)
+
+            async def no_progress(_delay):
+                pass
+
+            self.orchestrator.active_executors["test"] = [executor]
+            with patch("hummingbot.strategy_v2.executors.executor_orchestrator.asyncio.sleep", side_effect=no_progress):
+                await self.orchestrator.stop(max_executors_close_attempts=1)
+
+            executor.force_stop_with_position_hold.assert_called_once()
+
+        asyncio.run(test_async())
+
     def test_stop_executor(self):
         position_executor = MagicMock(spec=PositionExecutor)
         position_executor.is_closed = False

--- a/test/hummingbot/strategy_v2/executors/twap_executor/test_twap_executor.py
+++ b/test/hummingbot/strategy_v2/executors/twap_executor/test_twap_executor.py
@@ -228,3 +228,35 @@ class TestTWAPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
             )
         )
         self.assertEqual(executor.trade_pnl_pct, Decimal("0.2"))
+
+    def test_force_stop_with_position_hold_holds_executed_orders(self):
+        """A forced stop hands over every tracked order that has executed anything."""
+        executor = self.get_twap_executor_from_config(self.twap_config_long_taker)
+        executor._status = RunnableStatus.SHUTTING_DOWN
+
+        filled = self.in_flight_order_taker
+        filled.executed_amount_base = Decimal("0.4")
+        tracked_filled = TrackedOrder("OID-BUY-1")
+        tracked_filled.order = filled
+        executor._order_plan = {1: tracked_filled, 2: None}
+
+        refreshed = InFlightOrder(
+            client_order_id="OID-REFRESHED",
+            trading_pair=self.twap_config_long_taker.trading_pair,
+            order_type=OrderType.LIMIT,
+            trade_type=TradeType.BUY,
+            amount=Decimal("1"),
+            price=Decimal("119"),
+            creation_timestamp=1,
+            initial_state=OrderState.OPEN
+        )
+        tracked_refreshed = TrackedOrder("OID-REFRESHED")
+        tracked_refreshed.order = refreshed
+        executor._refreshed_orders = [tracked_refreshed]
+
+        executor.force_stop_with_position_hold()
+
+        self.assertEqual(executor.close_type, CloseType.POSITION_HOLD)
+        self.assertEqual(executor.status, RunnableStatus.TERMINATED)
+        held_ids = {order["client_order_id"] for order in executor._held_position_orders}
+        self.assertEqual(held_ids, {"OID-BUY-1"})


### PR DESCRIPTION
## Summary

Three related fixes, all found running LP executors live on Solana CLMM pools (hummingbot/condor#162):

1. **`keep_position=False` must fully unwind** — the LP executor's close-out swap sold the *difference* against the initial deposit instead of the withdrawn balance, so a two-sided position closed near its opening price rounded to zero, no swap ran, and the full base position silently remained in the wallet while the executor reported a clean `EARLY_STOP`.
2. **Gateway swaps must report realized amounts** — `_store_swap_result` reported the *requested* amount as the fill. Slippage and fees mean the wallet receives less (−0.06% to −0.44% observed); feeding the phantom amount into a follow-on LP open asked the pool for tokens that weren't there and failed every simulation.
3. **Shutdown must preserve position holds for every executor type** — three defects in `ExecutorOrchestrator.stop` could strand or mislabel exposure at shutdown, and only `PositionExecutor`-style flows had any chance of surviving the timeout.

## Fix 1 — LP close-out swap sells the withdrawn balance

`_calculate_closeout_base_amount` now returns `base_amount + base_fee` — the entire base balance withdrawn from the pool — because `keep_position=False` means "leave me holding no base token." The buy-back branch is removed (a full unwind is always a SELL). Verified live: three unwinds, three `Close-out swap needed … Close-out swap completed` pairs, wallet returned to quote with no residue.

## Fix 2 — Gateway reports realized swap fills

`_store_swap_result` reads `amountIn`/`amountOut` from the confirmed transaction (SPL balance diffs from `pre/postTokenBalances`) and maps them by side: SELL sends base/receives quote, BUY is the mirror. Zero or missing realized amounts leave the order open for status polling instead of fabricating a fill. Verified on-chain: requested 3605, wallet delta +3602.707335, reported 3602.707335. Native-SOL caveat documented: a native leg is a lamport delta that absorbs the tx fee, gas-sized error in the safe direction.

## Fix 3 — shutdown preserves position holds across all executor types

**3a. Don't re-call `early_stop` on executors already `SHUTTING_DOWN`.** `is_closed` is only true at `TERMINATED`, so `stop()` hit every shutting-down executor a second time with the type's default `keep_position`, overwriting the close_type its controller chose. Concretely: stop an LP with `keep_position=False`, then stop the bot while the unwind is in flight — the re-call flipped it to `POSITION_HOLD`, which silently skips the close-out swap. The mirror case actively closed positions a controller asked to hold.

**3b. The wait extends while executors make observable progress.** The fixed 3 × 2s budget was shorter than a routine on-chain LP unwind (~7s measured live), making the timeout path the *common* case. The budget now bounds **stall** time: any change in status, close_type, doneness, or reported state resets it; a hung executor still times out on the same 6s default; a 30s hard cap bounds the whole wait. Polling drops to 1s, so quick shutdowns finish *faster* (measured: 0.4ms when everything is done; 1s vs 2s detection when an executor finishes mid-wait).

**3c. Whatever remains is force-stopped into a position hold.** `ExecutorBase.force_stop_with_position_hold()` — cancel outstanding orders, snapshot fills synchronously via per-type `_collect_held_position_orders()`, terminate as `POSITION_HOLD` (or `FAILED` when nothing executed), then convert holds into persisted position records while markets are still registered. Per type:

| executor | collection |
|---|---|
| grid | mirrors `control_shutdown_process`'s hold branch without waiting for liquidity to drain |
| position | entry + close + take-profit fills, deduped by client order id |
| order | tracked order + renewal partial fills |
| dca, twap | every fill; **also now expose `held_position_orders` in `custom_info` — without this their `POSITION_HOLD` closes persisted nothing at all** |
| lp | mid-`SWAPPING`: stores the same net-trade-vs-ADD record the keep_position path writes at REMOVE (the withdrawn tokens are spot at that point). Position still on-chain: cannot be represented as spot orders — closes `FAILED` with the position address logged for recovery |
| xemm, arbitrage | stop synchronously inside `early_stop`; can never reach the deadline |

## Tests

- `test_lp_executor.py`: full-unwind regression (delta-vs-balance), quote-asset-agnostic close-out (BONK-SOL), forced stop mid-`SWAPPING` holds the withdrawn balance, forced stop with position still on-chain fails loudly
- `test_gateway_swap_result.py` (new): realized BUY/SELL amounts, no re-derivation from price, unconfirmed guard, USDC-quote both sides, native-SOL fee asset
- `test_executor_orchestrator.py`: no re-`early_stop` of `SHUTTING_DOWN` executors, forced stop of unfinished executors, stall budget extends on progress, stall budget expires on a hung executor
- `test_grid_executor.py`: forced stop mid-drain collects filled levels

**Regression check:** 3307 tests pass outside the CEX connector suites; the two failures reproduce identically on the base branch (pre-existing). flake8 clean.

## Relationship to #8389

#8389's `StrategyV2Base.on_stop` market re-registration is complementary and still needed — orders placed during shutdown need registered markets. Its orchestrator timeout block and `PositionExecutor.force_stop_with_position_hold` are superseded by the generic mechanism here (this one also covers grid/dca/twap/order/lp, and 3a/3b fix the paths that made the timeout common). Suggest #8389 be reduced to the `on_stop` fix after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)