### PR TITLE
fix(lp): close the position when an open fails after add_liquidity landed

### DIFF
--- a/hummingbot/strategy_v2/executors/lp_executor/lp_executor.py
+++ b/hummingbot/strategy_v2/executors/lp_executor/lp_executor.py
@@ -414,9 +414,31 @@ class LPExecutor(ExecutorBase):
             self._handle_create_failure(e)
 
     def _handle_create_failure(self, error: Exception):
-        """Handle position creation failure - transition to FAILED state."""
-        self.logger().error(f"Position creation failed: {error}")
+        """Handle position creation failure.
+
+        A position_address means add_liquidity already landed on-chain and only
+        the bookkeeping after it threw, so the funds are real. FAILED would stop
+        the executor without ever calling _close_position, stranding them: the
+        add-liquidity event that records the position for lphistory is emitted
+        after the code most likely to throw, so the position would survive only
+        in this log line. Close it instead, and name the address either way.
+
+        Retrying the open is not an option here -- the add succeeded, so a retry
+        would deposit a second position on top of the first.
+        """
         self.lp_position_state.active_open_order = None
+
+        if self.lp_position_state.position_address:
+            self.logger().error(
+                f"Position creation failed after the position was opened at "
+                f"{self.lp_position_state.position_address} ({self.config.trading_pair}): "
+                f"{error}. Closing it to recover the funds."
+            )
+            self.close_type = CloseType.FAILED
+            self.lp_position_state.state = LPExecutorStates.CLOSING
+            return
+
+        self.logger().error(f"Position creation failed: {error}")
         self.lp_position_state.state = LPExecutorStates.FAILED
 
     async def _close_position(self):

--- a/test/hummingbot/strategy_v2/executors/lp_executor/test_lp_executor.py
+++ b/test/hummingbot/strategy_v2/executors/lp_executor/test_lp_executor.py
@@ -463,6 +463,60 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         self.assertEqual(executor.lp_position_state.state, LPExecutorStates.FAILED)
         self.assertIsNone(executor.lp_position_state.active_open_order)
 
+    def test_handle_create_failure_closes_an_already_opened_position(self):
+        """A throw after add_liquidity landed must close the position, not abandon it.
+
+        FAILED stops the executor without ever calling _close_position, and the
+        add-liquidity event that records the position is emitted after the code
+        most likely to throw -- so the funds would survive only in a log line.
+        """
+        executor = self.get_executor()
+        executor.lp_position_state.state = LPExecutorStates.OPENING
+        executor.lp_position_state.active_open_order = MagicMock()
+        executor.lp_position_state.position_address = "position-abc"
+
+        executor._handle_create_failure(Exception("bad position_info field"))
+
+        self.assertEqual(executor.lp_position_state.state, LPExecutorStates.CLOSING)
+        self.assertEqual(executor.close_type, CloseType.FAILED)
+        self.assertIsNone(executor.lp_position_state.active_open_order)
+        self.assertTrue(self.is_partially_logged("ERROR", "position-abc"))
+
+    async def test_recovery_close_records_no_hold_and_no_swap(self):
+        """The recovery close is pure cleanup: CloseType.FAILED holds nothing."""
+        executor = self.get_executor()
+        executor._get_native_to_quote_rate = MagicMock(return_value=Decimal("1"))
+        executor._current_price = Decimal("100")
+        executor.lp_position_state.position_address = "position-abc"
+        executor._handle_create_failure(Exception("bad position_info field"))
+
+        mock_position = MagicMock()
+        mock_position.price = 100.0
+        connector = self.strategy.connectors["solana-mainnet-beta"]
+        connector.get_position_info = AsyncMock(return_value=mock_position)
+        connector._clmm_close_position = AsyncMock(return_value="sig-remove")
+        connector._lp_orders_metadata = {
+            "order-123": {
+                "base_amount": Decimal("1.0"),
+                "quote_amount": Decimal("100.0"),
+                "base_fee": Decimal("0"),
+                "quote_fee": Decimal("0"),
+                "position_rent_refunded": Decimal("0.002"),
+                "tx_fee": Decimal("0"),
+            }
+        }
+        connector._trigger_remove_liquidity_event = MagicMock(
+            return_value=create_mock_remove_event(
+                base_amount=Decimal("1.0"), quote_amount=Decimal("100.0")
+            )
+        )
+
+        await executor._close_position()
+
+        self.assertEqual(executor.lp_position_state.state, LPExecutorStates.COMPLETE)
+        self.assertEqual(executor.close_type, CloseType.FAILED)
+        self.assertEqual(executor._held_position_orders, [])
+
     def test_handle_close_failure_transitions_to_failed(self):
         """Test _handle_close_failure transitions to FAILED state (retry at connector level)"""
         executor = self.get_executor()


### PR DESCRIPTION
> **Stacked on #8394** — targets `fix/lp-keep-position-hold-consistency`, so the diff here is just this fix. GitHub will retarget to `development` automatically once #8394 merges. See "Why it stacks" below.

## Problem

`_create_position` stores `position_address` the moment the add is confirmed on-chain, then keeps working — it parses six fields off `position_info` through `Decimal(str(...))`, builds a trade fee, and triggers the add-liquidity event:

```python
322:  self.lp_position_state.position_address = position_address   # liquidity is now ON-CHAIN
...
343:  self.lp_position_state.base_amount = Decimal(str(position_info.base_token_amount))   # ×6 fields
...
408:  event = connector._trigger_add_liquidity_event(...)
413:  except Exception as e:
414:      self._handle_create_failure(e)     # -> FAILED -> stop(), no close
```

Anything that throws in that window lands in `_handle_create_failure`, which sets `FAILED`; `control_task` then stops the executor **without ever calling `_close_position`**. The likeliest trigger is a `position_info` that is truthy but has a `None` or non-numeric field — the `if position_info:` guard checks the object, not its fields, so `Decimal(str(None))` raises `InvalidOperation`.

Note this is *not* `get_position_info` failing: that swallows exceptions and returns `None` (`gateway.py:1228-1236`), and the `None` return is handled by the config-value fallback. `asyncio.CancelledError` doesn't reach here either — it's a `BaseException`, so `except Exception` doesn't catch it.

The liquidity is real and nobody unwinds it. It's also **invisible**:

- the add-liquidity event that writes the `lphistory` row is emitted at line 408, *after* the code that threw — so no DB record
- the `"Position created: {position_address}"` info log is also after it
- the failure message was `f"Position creation failed: {error}"` — no address, despite the executor holding it in memory
- the loud *"Forced stop with LP position still on-chain at {address}"* error in `_collect_held_position_orders` only fires on the **forced-stop** path (`executor_base.py:249`), not this one

Narrow trigger, but when it hits, funds sit in a position that appears nowhere in logs or DB.

## Fix

When `position_address` is set, the add demonstrably succeeded, so close the position instead of abandoning it — and name the address in the error either way. `FAILED` stays correct only when the add never landed.

Retrying the open is deliberately not an option: the add succeeded, so a retry would deposit a *second* position on top of the first. That's why the original code went to `FAILED` rather than back to `OPENING`.

## Why it stacks on #8394

The recovery close runs with `CloseType.FAILED`, which matches neither the `POSITION_HOLD` nor the `EARLY_STOP` gate, so it records no hold and fires no close-out swap — pure cleanup, which is what a failed open wants.

That only holds because #8394 makes those gates key off `close_type`. On `development` the hold gate still reads `config.keep_position` (default `True`), so routing to `CLOSING` there would record a **phantom hold for a failed open** — and `_store_lp_event_from_add` is also gated on the config *and* sits after the risky block, so the net would be computed against a zero deposit and book the entire withdrawn balance. Landing this on `development` alone would introduce the exact bug #8394 removes.

## Tests

Two cases: a failure with `position_address` set routes to `CLOSING` with `CloseType.FAILED` and logs the address; the recovery close then completes recording no hold and no swap. The existing "transitions to FAILED" test still covers the no-address path.

`511 passed` across `test/hummingbot/strategy_v2` + `test/hummingbot/connector/gateway`; flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
