### PR TITLE
fix: validate Hyperliquid funding updates

### DIFF
--- a/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_api_order_book_data_source.py
+++ b/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_api_order_book_data_source.py
@@ -1,7 +1,7 @@
 import asyncio
 import time
 from collections import defaultdict
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional
 
 import hummingbot.connector.derivative.hyperliquid_perpetual.hyperliquid_perpetual_constants as CONSTANTS
@@ -283,12 +283,35 @@ class HyperliquidPerpetualAPIOrderBookDataSource(PerpetualAPIOrderBookDataSource
 
             # Handle both regular and HIP-3 market formats
             ctx = data.get("ctx", data)  # Fallback to data itself if ctx doesn't exist
+            raw_funding = ctx.get("funding")
+            if raw_funding is None:
+                self.logger().warning(
+                    "Skipping Hyperliquid funding update: funding field is missing"
+                )
+                return
+            if isinstance(raw_funding, bool):
+                self.logger().warning(
+                    "Skipping Hyperliquid funding update: funding field is not a decimal"
+                )
+                return
+            try:
+                funding_rate = Decimal(str(raw_funding))
+            except (InvalidOperation, TypeError, ValueError):
+                self.logger().warning(
+                    "Skipping Hyperliquid funding update: funding field is not a decimal"
+                )
+                return
+            if not funding_rate.is_finite():
+                self.logger().warning(
+                    "Skipping Hyperliquid funding update: funding field is not finite"
+                )
+                return
             funding_info = FundingInfoUpdate(
                 trading_pair=trading_pair,
                 index_price=Decimal(str(ctx.get("oraclePx", "0"))),
                 mark_price=Decimal(str(ctx.get("markPx", "0"))),
                 next_funding_utc_timestamp=self._next_funding_time(),
-                rate=Decimal(str(ctx.get("openInterest", ctx.get("funding", "0")))),
+                rate=funding_rate,
             )
 
             message_queue.put_nowait(funding_info)

--- a/test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_api_order_book_data_source.py
@@ -553,8 +553,8 @@ class HyperliquidPerpetualAPIOrderBookDataSourceTests(IsolatedAsyncioWrapperTest
                 "ctx": {
                     "oraclePx": "36717.0",
                     "markPx": "36733.0",
-                    "openInterest": "0.00001793",  # This is used as the rate
-                    "funding": "0.00001793"
+                    "openInterest": "22368164",
+                    "funding": "0.000012"
                 }
             }
         }
@@ -576,8 +576,54 @@ class HyperliquidPerpetualAPIOrderBookDataSourceTests(IsolatedAsyncioWrapperTest
         self.assertEqual(expected_mark_price, msg.mark_price)
         expected_funding_time = next_funding_time_mock.return_value
         self.assertEqual(expected_funding_time, msg.next_funding_utc_timestamp)
-        expected_rate = Decimal('0.00001793')
+        expected_rate = Decimal('0.000012')
         self.assertEqual(expected_rate, msg.rate)
+
+    async def test_parse_funding_info_never_uses_open_interest_as_rate(self):
+        message_queue: asyncio.Queue = asyncio.Queue()
+        funding_message = {
+            "data": {
+                "coin": self.base_asset,
+                "ctx": {
+                    "oraclePx": "36717.0",
+                    "markPx": "36733.0",
+                    "openInterest": "22368164",
+                },
+            }
+        }
+
+        await self.data_source._parse_funding_info_message(funding_message, message_queue)
+
+        self.assertTrue(message_queue.empty())
+        self.assertTrue(
+            self._is_logged(
+                "WARNING",
+                "Skipping Hyperliquid funding update: funding field is missing",
+            )
+        )
+
+    async def test_parse_funding_info_rejects_malformed_non_finite_and_boolean_rates(self):
+        for raw_funding in ("not-a-rate", "NaN", "Infinity", True):
+            with self.subTest(raw_funding=raw_funding):
+                message_queue: asyncio.Queue = asyncio.Queue()
+                funding_message = {
+                    "data": {
+                        "coin": self.base_asset,
+                        "ctx": {
+                            "oraclePx": "36717.0",
+                            "markPx": "36733.0",
+                            "openInterest": "22368164",
+                            "funding": raw_funding,
+                        },
+                    }
+                }
+
+                await self.data_source._parse_funding_info_message(
+                    funding_message,
+                    message_queue,
+                )
+
+                self.assertTrue(message_queue.empty())
 
     @aioresponses()
     @patch("hummingbot.connector.derivative.hyperliquid_perpetual.hyperliquid_perpetual_api_order_book_data_source.HyperliquidPerpetualAPIOrderBookDataSource._next_funding_time")


### PR DESCRIPTION
## Summary

- map Hyperliquid websocket funding updates only from the explicit `funding` field
- reject missing, boolean, malformed, and non-finite funding values without emitting an update
- add regressions proving large `openInterest` values cannot become funding rates

## Validation

- `micromamba run -p /Users/maverick/micromamba/envs/hummingbot python setup.py build_ext --inplace`
- `micromamba run -p /Users/maverick/micromamba/envs/hummingbot pytest -q test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_api_order_book_data_source.py`
- result: 32 passed, 4 subtests passed
- exact SHA: `7674ad88f9320709dbbd3727538928e79d5472ba`

Coordinated deployment issue: https://github.com/erickuhn19/git-ops-prediction/issues/67

No runtime or exchange actions are part of this PR.
