### PR TITLE
fix: Pacifica connector crash on spot instruments and lost order fills

### DIFF
--- a/hummingbot/connector/derivative/pacifica_perpetual/pacifica_perpetual_api_order_book_data_source.py
+++ b/hummingbot/connector/derivative/pacifica_perpetual/pacifica_perpetual_api_order_book_data_source.py
@@ -380,7 +380,11 @@ class PacificaPerpetualAPIOrderBookDataSource(PerpetualAPIOrderBookDataSource):
         Next funding timestamp = :00 of next hour
         """
         for price_entry in raw_message["data"]:
-            trading_pair = await self._connector.trading_pair_associated_to_exchange_symbol(price_entry["symbol"])
+            try:
+                trading_pair = await self._connector.trading_pair_associated_to_exchange_symbol(price_entry["symbol"])
+            except KeyError:
+                # spot instruments are not in the perp symbol map
+                continue
             if trading_pair not in self._trading_pairs:
                 continue
 

--- a/hummingbot/connector/derivative/pacifica_perpetual/pacifica_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/pacifica_perpetual/pacifica_perpetual_derivative.py
@@ -21,7 +21,7 @@ from hummingbot.connector.trading_rule import TradingRule
 from hummingbot.connector.utils import combine_to_hb_trading_pair
 from hummingbot.core.api_throttler.data_types import RateLimit
 from hummingbot.core.data_type.common import OrderType, PositionAction, PositionMode, PositionSide, TradeType
-from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderUpdate, TradeUpdate
+from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState, OrderUpdate, TradeUpdate
 from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
 from hummingbot.core.data_type.trade_fee import TokenAmount, TradeFeeBase, TradeFeeSchema
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
@@ -345,16 +345,27 @@ class PacificaPerpetualDerivative(PerpetualDerivativePyBase):
         rules = []
 
         for pair_info in exchange_info_dict.get("data", []):
-            rules.append(
-                TradingRule(
-                    trading_pair=await self.trading_pair_associated_to_exchange_symbol(symbol=pair_info["symbol"]),
-                    min_order_size=Decimal(pair_info["lot_size"]),
-                    min_price_increment=Decimal(pair_info["tick_size"]),
-                    min_base_amount_increment=Decimal(pair_info["lot_size"]),
-                    min_notional_size=Decimal(pair_info["min_order_size"]),
-                    min_order_value=Decimal(pair_info["min_order_size"]),
+            # Pacifica lists spot instruments (e.g. "SOL-USDC") in the same market-info response;
+            # this connector only handles perpetuals.
+            if pair_info.get("instrument_type", "perpetual") != "perpetual":
+                continue
+            # A single malformed or not-yet-mapped entry must not discard the whole batch. The symbol
+            # map is only refreshed *after* this method returns (see `_update_trading_rules`), so a perp
+            # listed by the venue since the last poll is still unknown here; raising would also skip
+            # that refresh and leave the map permanently stale.
+            try:
+                rules.append(
+                    TradingRule(
+                        trading_pair=await self.trading_pair_associated_to_exchange_symbol(symbol=pair_info["symbol"]),
+                        min_order_size=Decimal(pair_info["lot_size"]),
+                        min_price_increment=Decimal(pair_info["tick_size"]),
+                        min_base_amount_increment=Decimal(pair_info["lot_size"]),
+                        min_notional_size=Decimal(pair_info["min_order_size"]),
+                        min_order_value=Decimal(pair_info["min_order_size"]),
+                    )
                 )
-            )
+            except Exception:
+                self.logger().exception(f"Error parsing the trading pair rule {pair_info}. Skipping.")
 
         return rules
 
@@ -436,27 +447,34 @@ class PacificaPerpetualDerivative(PerpetualDerivativePyBase):
     async def _update_balances(self):
         """
         https://docs.pacifica.fi/api-documentation/api/rest-api/account/get-account-info
+
+        Since the unified-margin rollout, account_equity and available_to_spend are computed
+        venue-side to include LTV-adjusted spot collateral and exclude spot order locks, so they
+        remain the correct totals for a perp connector.
         ```
         {
           "success": true,
-          "data": [{
+          "data": {
             "balance": "2000.000000",
             "fee_level": 0,
             "maker_fee": "0.00015",
             "taker_fee": "0.0004",
             "account_equity": "2150.250000",
+            "cross_account_equity": "2150.250000",
+            "spot_market_value": "0",
+            "spot_collateral": "0",
             "available_to_spend": "1800.750000",
             "available_to_withdraw": "1500.850000",
             "pending_balance": "0.000000",
+            "pending_interest": "0",
             "total_margin_used": "349.500000",
             "cross_mmr": "420.690000",
             "positions_count": 2,
             "orders_count": 3,
             "stop_orders_count": 1,
-            "updated_at": 1716200000000,
-            "use_ltp_for_stop_orders": false
-          }
-        ],
+            "spot_balances": [],
+            "updated_at": 1716200000000
+          },
           "error": null,
           "code": null
         }
@@ -488,7 +506,6 @@ class PacificaPerpetualDerivative(PerpetualDerivativePyBase):
         self._account_balances.clear()
         self._account_available_balances.clear()
 
-        self._account_balances[asset] = Decimal(str(data["account_equity"]))
         self._account_balances[asset] = Decimal(str(data["account_equity"]))
         self._account_available_balances[asset] = Decimal(str(data["available_to_spend"]))
         self._fee_tier = data.get("fee_level", 0)
@@ -651,8 +668,12 @@ class PacificaPerpetualDerivative(PerpetualDerivativePyBase):
         else:
             start_time = int(order.creation_timestamp * 1000)
 
-        current_time = self.current_timestamp
-        end_time = int(current_time * 1000)
+        # current_timestamp is the clock tick, floored to the whole second — a fill that happened
+        # later within the same second would fall outside the window. Use the wall clock plus a
+        # small buffer for venue clock skew instead; overlapping windows are safe because the
+        # order tracker dedups fills by trade_id.
+        current_time = time.time()
+        end_time = int((current_time + 2) * 1000)
 
         params = {
             "account": self.user_wallet_public_key,
@@ -838,31 +859,9 @@ class PacificaPerpetualDerivative(PerpetualDerivativePyBase):
     async def _update_trading_fees(self):
         """
         https://docs.pacifica.fi/api-documentation/api/rest-api/account/get-account-info
-        ```
-        {
-          "success": true,
-          "data": [{
-            "balance": "2000.000000",
-            "fee_level": 0,
-            "maker_fee": "0.00015",
-            "taker_fee": "0.0004",
-            "account_equity": "2150.250000",
-            "available_to_spend": "1800.750000",
-            "available_to_withdraw": "1500.850000",
-            "pending_balance": "0.000000",
-            "total_margin_used": "349.500000",
-            "cross_mmr": "420.690000",
-            "positions_count": 2,
-            "orders_count": 3,
-            "stop_orders_count": 1,
-            "updated_at": 1716200000000,
-            "use_ltp_for_stop_orders": false
-          }
-        ],
-          "error": null,
-          "code": null
-        }
-        ```
+
+        See the _update_balances docstring for a full sample of the account-info response
+        (``data`` is a single object); only maker_fee / taker_fee are used here.
         """
         response = await self._api_get(
             path_url=CONSTANTS.GET_ACCOUNT_INFO_PATH_URL,
@@ -1023,6 +1022,8 @@ class PacificaPerpetualDerivative(PerpetualDerivativePyBase):
     def _initialize_trading_pair_symbols_from_exchange_info(self, exchange_info: Dict[str, Any]):
         mapping = bidict()
         for symbol_data in exchange_info.get("data", []):
+            if symbol_data.get("instrument_type", "perpetual") != "perpetual":
+                continue
             exchange_symbol = symbol_data["symbol"]
             base = exchange_symbol
             quote = "USDC"
@@ -1112,6 +1113,25 @@ class PacificaPerpetualDerivative(PerpetualDerivativePyBase):
             tracked_order = tracked_orders.get(exchange_order_id)
             if tracked_order:
                 order_status = CONSTANTS.ORDER_STATE[order_update_message["os"]]
+                if order_status in (OrderState.FILLED, OrderState.PARTIALLY_FILLED):
+                    # The account_trades WS channel has been observed (2026-07-17, live) not to
+                    # deliver the fill within the tracker's grace period, which completes the order
+                    # with zero amounts. If the fills known to the tracker don't cover the filled
+                    # amount this update reports ("f"), recover them via REST; when account_trades
+                    # already delivered, no request is made. Overlaps are deduped by trade_id.
+                    ws_filled_amount = order_update_message.get("f")
+                    needs_fills_fetch = True
+                    if ws_filled_amount is not None:
+                        needs_fills_fetch = tracked_order.executed_amount_base < Decimal(str(ws_filled_amount))
+                    if needs_fills_fetch:
+                        try:
+                            for trade_update in await self._all_trade_updates_for_order(tracked_order):
+                                self._order_tracker.process_trade_update(trade_update)
+                        except Exception:
+                            self.logger().exception(
+                                f"Could not fetch fills for order {tracked_order.client_order_id} after a "
+                                f"{order_status} update; relying on the account_trades stream."
+                            )
                 order_update = OrderUpdate(
                     trading_pair=tracked_order.trading_pair,
                     update_timestamp=order_update_message["ut"] / 1000,
@@ -1431,8 +1451,13 @@ class PacificaPerpetualDerivative(PerpetualDerivativePyBase):
 
         results = []
         for price_data in response.get("data", []):
+            try:
+                trading_pair = await self.trading_pair_associated_to_exchange_symbol(symbol=price_data["symbol"])
+            except KeyError:
+                # spot instruments are not in the perp symbol map
+                continue
             results.append({
-                "trading_pair": await self.trading_pair_associated_to_exchange_symbol(symbol=price_data["symbol"]),
+                "trading_pair": trading_pair,
                 "price": price_data["mark"]
             })
 

--- a/hummingbot/connector/derivative/pacifica_perpetual/pacifica_perpetual_user_stream_data_source.py
+++ b/hummingbot/connector/derivative/pacifica_perpetual/pacifica_perpetual_user_stream_data_source.py
@@ -107,7 +107,8 @@ class PacificaPerpetualUserStreamDataSource(UserStreamTrackerDataSource):
         while True:
             try:
                 await asyncio.sleep(CONSTANTS.WS_PING_INTERVAL)
-                await ws.send(WSJSONRequest(payload={"op": "ping"}))
+                # the venue only understands {"method": "ping"} — {"op": "ping"} is rejected with a 400 frame
+                await ws.send(WSJSONRequest(payload={"method": "ping"}))
             except asyncio.CancelledError:
                 raise
             except RuntimeError as e:

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ def main():
         "base58>=2.1.1",
         "bidict>=0.22.1",
         "bip-utils",
+        "Brotli>=1.2.0",
         "cachetools>=5.3.1",
         "cryptography>=41.0.2",
         "decibel-python-sdk==0.2.1",

--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -26,6 +26,7 @@ dependencies:
   - async-timeout>=4.0.2,<5
   - bidict>=0.22.1
   - bip-utils
+  - brotli-python>=1.2.0  # aiohttp>=3.13.3 calls Decompressor.process(data, max_length); Brotli<1.2.0 takes only one arg
   - cachetools>=5.3.1
   - cryptography>=41.0.2
   - eth-account>=0.13.0

--- a/test/hummingbot/connector/derivative/pacifica_perpetual/test_pacifica_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/pacifica_perpetual/test_pacifica_perpetual_derivative.py
@@ -20,8 +20,8 @@ from hummingbot.connector.derivative.pacifica_perpetual.pacifica_perpetual_deriv
 )
 from hummingbot.connector.test_support.network_mocking_assistant import NetworkMockingAssistant
 from hummingbot.core.data_type.common import OrderType, PositionAction, PositionMode, TradeType
-from hummingbot.core.data_type.in_flight_order import InFlightOrder
-from hummingbot.core.data_type.trade_fee import TradeFeeSchema
+from hummingbot.core.data_type.in_flight_order import InFlightOrder, TradeUpdate
+from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee, TokenAmount, TradeFeeSchema
 from hummingbot.core.event.event_logger import EventLogger
 from hummingbot.core.event.events import MarketEvent
 from hummingbot.core.network_iterator import NetworkStatus
@@ -701,3 +701,231 @@ class PacificaPerpetualDerivativeUnitTest(IsolatedAsyncioWrapperTestCase):
                 taker_percent_fee_decimal=Decimal("0.0004"),
             )
         )
+
+    # === WS filled order updates trigger a REST fills fetch (account_trades can be late) ===
+
+    @aioresponses()
+    async def test_ws_filled_order_update_fetches_fills_via_rest(self, req_mock):
+        await self._simulate_trading_rules_initialized()
+
+        url = web_utils.public_rest_url(CONSTANTS.GET_TRADE_HISTORY_PATH_URL, domain=self.domain)
+        regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
+        req_mock.get(regex_url, payload={
+            "success": True,
+            "data": [
+                {
+                    "history_id": 19329801,
+                    "order_id": 123456789,
+                    "client_order_id": None,
+                    "symbol": self.symbol,
+                    "amount": "0.6",
+                    "price": "1900.0",
+                    "entry_price": "1899.0",
+                    "fee": "0.1",
+                    "pnl": "-0.001",
+                    "event_type": "fulfill_taker",
+                    "side": "open_long",
+                    "created_at": 1640780000500,
+                    "cause": "normal"
+                }
+            ],
+            "has_more": False,
+        })
+
+        self.exchange._order_tracker.start_tracking_order(
+            InFlightOrder(
+                client_order_id="test_client_order_id",
+                exchange_order_id="123456789",
+                trading_pair=self.trading_pair,
+                order_type=OrderType.MARKET,
+                trade_type=TradeType.BUY,
+                amount=Decimal("0.6"),
+                price=Decimal("1900.0"),
+                creation_timestamp=1640780000,
+            )
+        )
+
+        await self.exchange._process_account_order_updates_ws_event_message({
+            "channel": "account_order_updates",
+            "data": [
+                {"i": 123456789, "os": "filled", "f": "0.6", "ut": 1640780001000},
+            ],
+        })
+        # let the tracker's order-update future run to completion
+        await asyncio.sleep(0.1)
+
+        self.assertEqual(1, len(self.order_filled_logger.event_log))
+        fill_event = self.order_filled_logger.event_log[0]
+        self.assertEqual("test_client_order_id", fill_event.order_id)
+        self.assertEqual(Decimal("0.6"), fill_event.amount)
+        self.assertEqual(Decimal("1900.0"), fill_event.price)
+
+        self.assertEqual(1, len(self.buy_order_completed_logger.event_log))
+        completed_event = self.buy_order_completed_logger.event_log[0]
+        # the incident signature was base_asset_amount == 0 here
+        self.assertEqual(Decimal("0.6"), completed_event.base_asset_amount)
+
+    @aioresponses()
+    async def test_ws_filled_order_update_skips_rest_when_fills_already_known(self, req_mock):
+        """No trade-history request is made when account_trades already delivered the fills
+        (the GET is deliberately not mocked — an attempt to call it would fail the test)."""
+        await self._simulate_trading_rules_initialized()
+
+        order = InFlightOrder(
+            client_order_id="test_client_order_id",
+            exchange_order_id="123456789",
+            trading_pair=self.trading_pair,
+            order_type=OrderType.MARKET,
+            trade_type=TradeType.BUY,
+            amount=Decimal("0.6"),
+            price=Decimal("1900.0"),
+            creation_timestamp=1640780000,
+        )
+        self.exchange._order_tracker.start_tracking_order(order)
+        self.exchange._order_tracker.process_trade_update(TradeUpdate(
+            trade_id="ws_trade_1",
+            client_order_id="test_client_order_id",
+            exchange_order_id="123456789",
+            trading_pair=self.trading_pair,
+            fill_timestamp=1640780000.5,
+            fill_price=Decimal("1900.0"),
+            fill_base_amount=Decimal("0.6"),
+            fill_quote_amount=Decimal("1140.0"),
+            fee=AddedToCostTradeFee(flat_fees=[TokenAmount(token="USDC", amount=Decimal("0.1"))]),
+        ))
+
+        await self.exchange._process_account_order_updates_ws_event_message({
+            "channel": "account_order_updates",
+            "data": [
+                {"i": 123456789, "os": "filled", "f": "0.6", "ut": 1640780001000},
+            ],
+        })
+        await asyncio.sleep(0.1)
+
+        # completed correctly from the WS-delivered fill alone
+        self.assertEqual(1, len(self.buy_order_completed_logger.event_log))
+        self.assertEqual(Decimal("0.6"), self.buy_order_completed_logger.event_log[0].base_asset_amount)
+
+    # === Spot instruments are skipped (the venue lists them alongside perpetuals) ===
+
+    async def test_format_trading_rules_skips_spot_instruments(self):
+        exchange_info = {
+            "success": True,
+            "data": [
+                {
+                    "symbol": self.symbol,
+                    "tick_size": "0.1",
+                    "lot_size": "0.0001",
+                    "min_order_size": "10",
+                    "instrument_type": "perpetual",
+                },
+                {
+                    "symbol": "SOL-USDC",
+                    "tick_size": "0.01",
+                    "lot_size": "0.001",
+                    "min_order_size": "10",
+                    "instrument_type": "spot",
+                },
+            ],
+        }
+
+        rules = await self.exchange._format_trading_rules(exchange_info)
+
+        self.assertEqual(1, len(rules))
+        self.assertEqual(self.trading_pair, rules[0].trading_pair)
+
+    async def test_symbol_map_skips_spot_instruments(self):
+        exchange_info = {
+            "success": True,
+            "data": [
+                {"symbol": "SOL-USDC", "instrument_type": "spot"},
+                {"symbol": "DOGE", "instrument_type": "perpetual"},
+            ],
+        }
+
+        self.exchange._initialize_trading_pair_symbols_from_exchange_info(exchange_info)
+
+        mapping = await self.exchange.trading_pair_symbol_map()
+        self.assertIn("DOGE", mapping)
+        self.assertEqual("DOGE-USDC", mapping["DOGE"])
+        self.assertNotIn("SOL-USDC", mapping)
+
+    # === Perpetuals listed by the venue since the last poll are tolerated ===
+
+    async def test_format_trading_rules_skips_symbols_missing_from_the_symbol_map(self):
+        exchange_info = {
+            "success": True,
+            "data": [
+                {
+                    "symbol": self.symbol,
+                    "tick_size": "0.1",
+                    "lot_size": "0.0001",
+                    "min_order_size": "10",
+                    "instrument_type": "perpetual",
+                },
+                {
+                    # listed by the venue after the symbol map was built, so not in it yet
+                    "symbol": "VVV",
+                    "tick_size": "0.001",
+                    "lot_size": "0.1",
+                    "min_order_size": "10",
+                    "instrument_type": "perpetual",
+                },
+            ],
+        }
+
+        rules = await self.exchange._format_trading_rules(exchange_info)
+
+        self.assertEqual(1, len(rules))
+        self.assertEqual(self.trading_pair, rules[0].trading_pair)
+
+    @aioresponses()
+    async def test_update_trading_rules_recovers_from_newly_listed_symbols(self, req_mock):
+        url = web_utils.public_rest_url(CONSTANTS.EXCHANGE_INFO_PATH_URL, domain=self.domain)
+        regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
+        exchange_info = {
+            "success": True,
+            "data": [
+                {
+                    "symbol": self.symbol,
+                    "tick_size": "0.1",
+                    "lot_size": "0.0001",
+                    "min_order_size": "10",
+                    "instrument_type": "perpetual",
+                },
+                {
+                    "symbol": "VVV",
+                    "tick_size": "0.001",
+                    "lot_size": "0.1",
+                    "min_order_size": "10",
+                    "instrument_type": "perpetual",
+                },
+            ],
+        }
+        req_mock.get(regex_url, payload=exchange_info)
+
+        await self.exchange._update_trading_rules()
+
+        # the known pair keeps its rules...
+        self.assertIn(self.trading_pair, self.exchange.trading_rules)
+        # ...and the symbol map refresh still runs, so the next poll can price the new listing
+        mapping = await self.exchange.trading_pair_symbol_map()
+        self.assertEqual("VVV-USDC", mapping["VVV"])
+
+    @aioresponses()
+    async def test_get_all_pairs_prices_skips_unmapped_symbols(self, req_mock):
+        url = web_utils.public_rest_url(CONSTANTS.GET_PRICES_PATH_URL, domain=self.domain)
+        regex_url = re.compile(f"^{url}".replace(".", r"\.").replace("?", r"\?"))
+        req_mock.get(regex_url, payload={
+            "success": True,
+            "data": [
+                {"symbol": self.symbol, "mark": "1900.5"},
+                {"symbol": "SOL-USDC", "mark": "85.9"},
+            ],
+        })
+
+        results = await self.exchange.get_all_pairs_prices()
+
+        self.assertEqual(1, len(results))
+        self.assertEqual(self.trading_pair, results[0]["trading_pair"])
+        self.assertEqual("1900.5", results[0]["price"])

--- a/test/hummingbot/connector/derivative/pacifica_perpetual/test_pacifica_perpetual_user_stream_data_source.py
+++ b/test/hummingbot/connector/derivative/pacifica_perpetual/test_pacifica_perpetual_user_stream_data_source.py
@@ -242,3 +242,21 @@ class PacificaPerpetualUserStreamDataSourceTests(IsolatedAsyncioWrapperTestCase)
         # ping_found = any(msg.get("op") == "ping" for msg in sent_messages)
         # Note: ping might not be sent depending on timing, this test is optional
         # The important thing is that it doesn't error
+
+    async def test_ping_uses_method_field(self):
+        """The venue only understands {"method": "ping"}; {"op": "ping"} is rejected with a 400 frame."""
+        sent_payloads = []
+        ws = MagicMock()
+        ws.send = AsyncMock(side_effect=lambda request: sent_payloads.append(request.payload))
+
+        with patch.object(CONSTANTS, "WS_PING_INTERVAL", 0):
+            ping_task = asyncio.create_task(self.data_source._ping_loop(ws))
+            await asyncio.sleep(0.05)
+            ping_task.cancel()
+            try:
+                await ping_task
+            except asyncio.CancelledError:
+                pass
+
+        self.assertGreater(len(sent_payloads), 0)
+        self.assertEqual({"method": "ping"}, sent_payloads[0])


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] Tests all pass
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Split out of #8355 (Pacifica builder-code support) so bugfixes land separately from the feature. The first two bugs below were found during that PR's live mainnet verification, the third during QA of this branch; #8355 currently still contains the earlier fixes and its branch will be slimmed to builder-only separately.

Three live-found `pacifica_perpetual` bugs, plus two smaller hardening fixes and one venue-independent dependency pin:

1. **Spot-instrument crash — breaks every Pacifica user on `development` since ~April 19.** Pacifica listed its first spot market (`SOL-USDC`, `instrument_type: "spot"`) in the same `/api/v1/info` list and price feeds the connector consumes; perp-only pair parsing built `SOL-USDC-USDC` and crashed trading-rule updates, leaving the connector permanently not-ready. Fix: keep only `instrument_type == "perpetual"` entries in trading rules and the symbol map (the Pacifica team confirmed this is the officially supported discriminator; future instrument types are skipped automatically), and skip unmapped symbols in the REST and WS price feeds.
2. **A perp listed while the bot is running permanently broke trading-rule updates — found by QA on this branch after ~14h of uptime.** Pacifica listed three new perpetuals (`VVV`, `KAITO`, `kSHIB`) at 2026-07-29 07:03 UTC — confirmed by their `created_at` in `/api/v1/info` — and the next 30-minute trading-rules poll died with `KeyError: 'VVV'`. `_update_trading_rules()` formats the rules *before* it refreshes the symbol map, so a perp listed since the last poll is present in the fresh `/info` response but not yet in the map; the unguarded lookup raised, and because the exception escaped before the refresh line, the map never learned the new symbol and the failure could not self-heal. The polling loop's error path then sleeps 0.5s rather than 30 minutes, so the bot hot-spun on `/info` for the rest of the session (3928 tracebacks in 56 minutes) with trading rules frozen at their startup values. Existing pairs kept trading throughout — `self._trading_rules.clear()` only runs after formatting succeeds — so the user-visible damage was log spam, permanently stale rules, and ~2 req/s of avoidable load on the venue. Fix: skip the offending entry instead of discarding the whole batch (matching the Binance connector's `_format_trading_rules`), so the map refresh still runs and the new listing is picked up on the following poll — recovery within one interval instead of never. Same class of defect as (1): unguarded parsing of an instrument list the venue changes underneath us, so guarding the loop also covers future malformed or partial entries, not just unmapped symbols.
3. **Market-order fills could be lost, completing orders with zero amounts.** Observed live: the order-updates WS delivered `filled` instantly, but the `account_trades` WS event never arrived within the order tracker's 5s grace — the order completed with `base_asset_amount=0` and `OrderFilled` never fired. Fix: on a filled/partially-filled WS order update, if the tracker's fills don't cover the reported `f` amount, recover them via REST (zero extra requests when the WS delivered; trade-id dedup makes overlap safe).
4. **Private WS keepalive was broken since the connector shipped**: `{"op": "ping"}` is rejected by the venue with a 400 frame; correct is `{"method": "ping"}` (the public data source already used it).
5. **Trade-history query window** used the tick timestamp (floored to the whole second) as `end_time`, which can exclude just-executed fills; now wall-clock + a 2s skew buffer, deduped by trade id.
6. **Pinned a working Brotli — latent, venue-independent, and worth fixing on its own merits.** `aiohttp` advertises `br` in `Accept-Encoding` whenever the `brotli` module is importable, and **`aiohttp>=3.13.3` (2026-01-03) calls `Decompressor.process(data, max_length)`** — a second argument Brotli only accepted from **1.2.0 (2025-11-05)**. On 1.0.9 and 1.1.0 that raises `TypeError`, which aiohttp's blanket `except Exception` in `DeflateBuffer.feed_data` converts into `ContentEncodingError`, surfacing as `Error: 400, message: Can not decode content-encoding: br`. The trap is that `urllib3` pulls `brotli-python` in *transitively* with a floor of `>=1.0.9`, so the constraint is already satisfied and neither `pip install` nor `conda env update` ever upgrades it — **any environment solved before Nov 2025 decodes every `br` response into an error**, for every venue that serves brotli, not just Pacifica. Pacifica happens to make this very easy to hit because its CDN br-encodes *everything*, down to 60-byte 404 bodies. Fix: `Brotli>=1.2.0` in `setup.py` and `brotli-python>=1.2.0` in `setup/environment.yml` — note the conda package named `brotli` is the C library and CLI (~20 KB, no Python ABI tag) and does **not** provide `import brotli`; the bindings package is `brotli-python`.

   To be explicit about provenance, since this one is easy to misattribute: it was found while diagnosing a QA report of that exact error string, but **it was not the cause of that report** — QA's error disappeared when they switched to a different region, and a broken Brotli would have failed identically from every region. That error was the *other* branch of the same exception: Brotli present but the body not decodable, i.e. a mangled or mislabelled `br` response on the blocked-region path. Worth knowing when triaging, because the two causes are indistinguishable from the message alone — a **missing** Brotli gives the longer `Can not decode content-encoding: brotli (br). Please install \`Brotli\`` from `DeflateBuffer.__init__`, whereas the short `... content-encoding: br` always means Brotli was importable and the *stream* failed. This item is cleanly separable from the connector fixes if a reviewer would rather it went in its own PR.

Also refreshes stale account-info docstrings (unified-margin fields; `data` is an object) and removes a duplicated balance assignment. Balance *logic* needs no change under unified margin — `account_equity` / `available_to_spend` are venue-aggregated. Related to #8201 (suggest closing with this PR after QA).

**Tests performed by the developer**:

- `pytest test/hummingbot/connector/derivative/pacifica_perpetual/` — **110 passed** (8 new: 3 spot filtering, 2 fills recovery incl. a no-extra-HTTP guard test, 1 ping format, 2 mid-session listings). flake8 + pre-commit clean.
- Bugs 1 and 3 reproduced and their fixes exercised live on mainnet (2026-07-17) during #8355's verification.
- Bug 2 was hit live by QA on 2026-07-29 and is covered by two unit tests — one on `_format_trading_rules` in isolation, one driving `_update_trading_rules()` end-to-end to assert the symbol map still gets refreshed with the new listing. Both fail with `KeyError: 'VVV'` against the previous revision. The fix has not been re-exercised against a real listing, since that needs the venue to list a perp mid-session.
- Bug 6 verified end-to-end against live `api.pacifica.fi/api/v1/info` on aiohttp 3.13.5, holding everything else constant: Brotli **1.0.9 → fails**, **1.1.0 → fails** (both with the reported message), **1.2.0 → succeeds** (22932 bytes decoded), and **Brotli absent → succeeds** via gzip, since aiohttp then does not advertise `br`. The aiohttp boundary was bisected to 3.13.3 by inspecting `BrotliDecompressor.decompress_sync` across 3.13.0–3.13.5. Brotli 1.2.0's `process()` accepts both the 1-arg and 2-arg forms, so the pin is safe across the whole `aiohttp>=3.8.5,<3.14` range.

**Tips for QA testing**:

- Connect `pacifica_perpetual` with any funded account and start any strategy. Before this fix the connector loops "Could not fetch new trading rules… `ValueError: too many values to unpack`" and never becomes ready; after it, it starts cleanly against current mainnet.
- Place a small market order (min $10 notional): `OrderFilled` fires and the completed event carries real amounts (the bug signature was `base_asset_amount=0` after a "fill updates did not arrive on time" warning).
- Bug 2 can't be triggered on demand. On a long-running bot the signature is a repeating "Could not fetch new trading rules from Pacifica_perpetual" warning with `KeyError: '<SYMBOL>'` — that should no longer appear, and a perp listed mid-session should become available within one 30-minute poll.
- If `Can not decode content-encoding: br` ever shows up again, check the environment before suspecting the connector: `python -c "import aiohttp,brotli;print(aiohttp.__version__,brotli.__version__)"`. Brotli ≥1.2.0 with aiohttp ≥3.13.3 rules out bug 6, which points at the response itself (region block, proxy, or truncated body) rather than the codec.
- Note: #8355 (builder codes) requires this fix to pass live QA — suggest merging this one first.