### PR TITLE
fix(backtesting): allow hyperliquid and hyperliquid_perpetual to be backtested

### DIFF
--- a/hummingbot/strategy_v2/backtesting/backtesting_data_provider.py
+++ b/hummingbot/strategy_v2/backtesting/backtesting_data_provider.py
@@ -21,9 +21,14 @@ logger = logging.getLogger(__name__)
 class BacktestingDataProvider(MarketDataProvider):
     CONNECTOR_TYPES = [ConnectorType.CLOB_SPOT, ConnectorType.CLOB_PERP, ConnectorType.Exchange,
                        ConnectorType.Derivative]
-    EXCLUDED_CONNECTORS = ["hyperliquid_perpetual", "dydx_perpetual",
+    # hyperliquid / hyperliquid_perpetual re-enabled for backtesting: their public
+    # `info` endpoints (meta, candleSnapshot) need no credentials, so
+    # `_update_trading_rules` and the candle feed both work without a connector config.
+    # Leaving them excluded made `initialize_trading_rules` dereference None
+    # ("'NoneType' object has no attribute '_update_trading_rules'").
+    EXCLUDED_CONNECTORS = ["dydx_perpetual",
                            "coinbase_advanced_trade", "kraken", "dydx_v4_perpetual", "hitbtc",
-                           "hyperliquid", "injective_v2_perpetual", "injective_v2"]
+                           "injective_v2_perpetual", "injective_v2"]
 
     def __init__(self, connectors: Dict[str, ConnectorBase]):
         super().__init__(connectors)


### PR DESCRIPTION
## Problem

`BacktestingDataProvider.EXCLUDED_CONNECTORS` lists both `hyperliquid` and
`hyperliquid_perpetual`, so `self.connectors[name]` resolves to `None` and
`initialize_trading_rules` raises:

```
'NoneType' object has no attribute '_update_trading_rules'
```

`BacktestingEngineBase.run_backtesting()` calls
`initialize_trading_rules(controller_config.connector_name)` before anything else, so
this is a hard failure rather than a degraded path — **hyperliquid cannot be backtested
at all today**, via the engine directly or through hummingbot-api's
`POST /backtesting/run`.

## Why the exclusion looks unnecessary

Hyperliquid's `info` endpoints (`meta`, `candleSnapshot`) are public. Both the
trading-rules fetch and the candle feed work with **no API keys and no connector
config**, which is exactly the situation a backtest runs in.

## Verification

Against the live API with no credentials configured:

```
hyperliquid_perpetual -> 470 trading rules loaded (ETH-USD present)
hyperliquid           -> 301 trading rules loaded (PURR-USDC present)
```

An end-to-end directional-controller backtest on `hyperliquid_perpetual` ETH-USD 1m now
completes and returns executors and metrics, both from `BacktestingEngineBase` directly
and through hummingbot-api:

```
total_executors 40 | accuracy 0.575 | net_pnl_quote +1.42
close types: TAKE_PROFIT 18, STOP_LOSS 16, TIME_LIMIT 6
```

## Scope

One-line change to the exclusion list plus an explanatory comment. The other excluded
connectors (`dydx_perpetual`, `coinbase_advanced_trade`, `kraken`, `dydx_v4_perpetual`,
`hitbtc`, `injective_v2*`) are untouched — I only verified hyperliquid, so I have left
the rest alone rather than assume the same reasoning applies.

Note: Hyperliquid retains only ~5000 candles per interval (1m ≈ 3.5 days, 15m ≈ 52 days,
1h ≈ 7 months), so backtest windows on it are inherently short. That is a data-availability
limit, not a reason to block the connector.
