### PR TITLE
fix: skip NaN-priced market orders in XRPL locked balance calculation

### DIFF
--- a/hummingbot/connector/exchange/xrpl/xrpl_exchange.py
+++ b/hummingbot/connector/exchange/xrpl/xrpl_exchange.py
@@ -2479,8 +2479,14 @@ class XrplExchange(ExchangePyBase):
         locked_amount = Decimal("0")
 
         for order in self._order_tracker.all_fillable_orders.values():
-            # Skip orders that don't have a price (e.g., market orders)
-            if order.price is None:
+            # Skip orders that don't have a usable price (e.g., market orders).
+            #
+            # A market order's price is Decimal("NaN"), not None, so checking for None alone lets
+            # it through. It then reaches `remaining_amount * order.price` in the BUY branch below,
+            # which makes locked_amount NaN, and the caller's
+            # `max(Decimal("0"), absolute_value - locked)` raises InvalidOperation on the ordered
+            # comparison -- aborting the balance update for every token, not just this one.
+            if order.price is None or not order.price.is_finite():
                 continue
 
             remaining_amount = order.amount - order.executed_amount_base

--- a/test/hummingbot/connector/exchange/xrpl/test_xrpl_exchange_balances.py
+++ b/test/hummingbot/connector/exchange/xrpl/test_xrpl_exchange_balances.py
@@ -236,6 +236,62 @@ class TestXRPLExchangeBalances(XRPLExchangeTestBase, IsolatedAsyncioTestCase):
         locked = self.connector._calculate_locked_balance_for_token("XRP")
         self.assertEqual(locked, Decimal("0"))
 
+    def test_calculate_locked_balance_market_order_nan_price_skipped(self):
+        """A market order's price is NaN, not None or zero -- it must still be skipped.
+
+        The test above uses Decimal("0") to stand in for a market order, which is not the value
+        the framework actually produces: OrderCandidate/market orders carry Decimal("NaN"). With
+        NaN the BUY branch computes remaining_amount * NaN, so locked_amount becomes NaN and the
+        caller's max(Decimal("0"), balance - locked) raises InvalidOperation, aborting the whole
+        balance update rather than this one order.
+        """
+        order = InFlightOrder(
+            client_order_id="test_market_nan",
+            exchange_order_id="12345-67890",
+            trading_pair=self.trading_pair,
+            order_type=OrderType.MARKET,
+            trade_type=TradeType.BUY,
+            amount=Decimal("100"),
+            price=Decimal("NaN"),
+            creation_timestamp=1000000,
+            initial_state=OrderState.OPEN,
+        )
+        self.connector._order_tracker._in_flight_orders["test_market_nan"] = order
+
+        locked = self.connector._calculate_locked_balance_for_token("XRP")
+        self.assertTrue(locked.is_finite(), "locked balance must not be NaN")
+        self.assertEqual(locked, Decimal("0"))
+
+    def test_calculate_locked_balance_nan_order_does_not_hide_other_orders(self):
+        """One NaN-priced order must not take the other orders' locked amounts with it."""
+        limit_order = InFlightOrder(
+            client_order_id="limit_buy",
+            exchange_order_id="111-222",
+            trading_pair=self.trading_pair,
+            order_type=OrderType.LIMIT,
+            trade_type=TradeType.BUY,
+            amount=Decimal("100"),
+            price=Decimal("0.2"),
+            creation_timestamp=1000000,
+            initial_state=OrderState.OPEN,
+        )
+        market_order = InFlightOrder(
+            client_order_id="market_buy",
+            exchange_order_id="333-444",
+            trading_pair=self.trading_pair,
+            order_type=OrderType.MARKET,
+            trade_type=TradeType.BUY,
+            amount=Decimal("50"),
+            price=Decimal("NaN"),
+            creation_timestamp=1000000,
+            initial_state=OrderState.OPEN,
+        )
+        self.connector._order_tracker._in_flight_orders["limit_buy"] = limit_order
+        self.connector._order_tracker._in_flight_orders["market_buy"] = market_order
+
+        locked = self.connector._calculate_locked_balance_for_token("XRP")
+        self.assertEqual(locked, Decimal("20"))  # 100 * 0.2, the market order contributing nothing
+
     def test_calculate_locked_balance_multiple_orders(self):
         """New: multiple orders accumulate locked balances."""
         order1 = InFlightOrder(


### PR DESCRIPTION
### Problem

`XrplExchange._calculate_locked_balance_for_token` intends to skip market orders — the comment says so — but the check is `order.price is None`, and a market order's price is `Decimal("NaN")`, not `None`.

So the NaN survives the guard and reaches the BUY branch:

```python
locked_amount += remaining_amount * order.price   # -> NaN
```

`locked_amount` becomes NaN, and the caller does:

```python
new_available = max(Decimal("0"), absolute_value - locked)
```

An ordered comparison against a `Decimal` NaN raises `InvalidOperation`, so this does not merely mis-count one order — **it aborts the balance update for every token.**

### Why it is hard to notice

The failure is invisible from inside the process. The connector keeps running and keeps quoting, against balances it can no longer update. Nothing logs an error at the point where the state actually stops being real.

On a live XRPL account it surfaced only indirectly, as executors closing with `INSUFFICIENT_BALANCE` — 84 of them over about three hours. The same configuration with this change produced zero.

### Fix

```python
if order.price is None or not order.price.is_finite():
    continue
```

This preserves the existing intent (skip market orders) rather than changing behaviour: a market order was always meant to be skipped here, and now it actually is. Limit orders are untouched.

### Tests

There is an existing `test_calculate_locked_balance_market_order_skipped`, but it stands in `Decimal("0")` for the market-order price, which is not the value the framework produces — which is precisely why this slipped through.

Two tests are added that use the real value, `Decimal("NaN")`:

- `test_calculate_locked_balance_market_order_nan_price_skipped` — asserts the result `is_finite()`, not just that it equals zero
- `test_calculate_locked_balance_nan_order_does_not_hide_other_orders` — a NaN order alongside a live limit order must not take the limit order's locked amount with it

Both fail on `development` without this change and pass with it.

### Relation to #8232

Sibling, not a duplicate. #8232 guards the **outbound** path — `ExecutorBase.place_order` refuses a non-finite price for a non-MARKET order. This one is the **accounting** path: a legitimately NaN-priced MARKET order, which #8232 deliberately allows, breaking a balance calculation downstream.

Same underlying point in two places: NaN is a valid price sentinel in this codebase, so every site that reads `order.price` has to treat "no price" as `None or not finite`, not `None` alone. It may be worth grepping other connectors for the same `price is None` shape.