### PR TITLE
fix: ignore stop actions for executors already terminated or shutting down

### DIFF
--- a/hummingbot/strategy_v2/executors/executor_orchestrator.py
+++ b/hummingbot/strategy_v2/executors/executor_orchestrator.py
@@ -580,6 +580,14 @@ class ExecutorOrchestrator:
         if not executor:
             self.logger().error(f"Executor ID {executor_id} not found for controller {controller_id}.")
             return
+        if executor.is_closed or executor.status == RunnableStatus.SHUTTING_DOWN:
+            # Same guard as stop(): a SHUTTING_DOWN executor already chose its close_type,
+            # and a terminated one may have torn down internal state (e.g. GridExecutor
+            # clears levels_by_state before stopping), so re-entering early_stop can
+            # crash or overwrite the close_type.
+            self.logger().warning(
+                f"Executor ID {executor_id} is already {executor.status.name}; ignoring stop action.")
+            return
         executor.early_stop(action.keep_position)
 
     def _update_positions_from_done_executors(self):

--- a/test/hummingbot/strategy_v2/executors/test_executor_orchestrator.py
+++ b/test/hummingbot/strategy_v2/executors/test_executor_orchestrator.py
@@ -520,6 +520,26 @@ class TestExecutorOrchestrator(unittest.TestCase):
         position_executor.config.id = "123"
         self.orchestrator.active_executors["test"] = [position_executor]
         self.orchestrator.stop_executor(StopExecutorAction(executor_id="123", controller_id="test"))
+        position_executor.early_stop.assert_called_once()
+
+    def test_stop_executor_ignores_terminated_executor(self):
+        """A stop action can arrive after the executor already terminated (e.g. a
+        GridExecutor that finished control_shutdown_process cleared levels_by_state
+        before stopping), so re-entering early_stop would crash — see #7720."""
+        executor = self._make_unfinished_executor("123")
+        executor.is_closed = True
+        executor.status = RunnableStatus.TERMINATED
+        self.orchestrator.active_executors["test"] = [executor]
+        self.orchestrator.stop_executor(StopExecutorAction(executor_id="123", controller_id="test"))
+        executor.early_stop.assert_not_called()
+
+    def test_stop_executor_ignores_shutting_down_executor(self):
+        """An executor already SHUTTING_DOWN keeps the close_type it chose; a second
+        early_stop would overwrite it with the action's keep_position."""
+        executor = self._make_unfinished_executor("123", RunnableStatus.SHUTTING_DOWN)
+        self.orchestrator.active_executors["test"] = [executor]
+        self.orchestrator.stop_executor(StopExecutorAction(executor_id="123", controller_id="test"))
+        executor.early_stop.assert_not_called()
 
     @patch("hummingbot.strategy_v2.executors.executor_orchestrator.MarketsRecorder.get_instance")
     def test_generate_performance_report_with_loaded_positions(self, mock_get_instance: MagicMock):


### PR DESCRIPTION
Fixes #7720

**A description of the changes proposed in the pull request**:

`ExecutorOrchestrator.stop_executor()` dispatched `early_stop()` unconditionally. A `StopExecutorAction` can arrive for an executor that has already terminated: `GridExecutor.control_shutdown_process()` clears `levels_by_state = {}` and calls `stop()`, then still sleeps for 5 seconds, and the executor remains in `active_executors` the whole time. Re-entering `early_stop()` in that window makes `cancel_open_orders()` do a direct `levels_by_state[GridLevelStates.OPEN_ORDER_PLACED]` lookup on the emptied dict, raising the `KeyError` reported in #7720.

This applies the same guard `ExecutorOrchestrator.stop()` already uses: a stop action targeting an executor that is `is_closed` or `SHUTTING_DOWN` is logged and ignored. Besides fixing the crash, this also keeps a second stop action from overwriting the `close_type` a SHUTTING_DOWN executor already chose (the same hazard the guard in `stop()` documents), and it covers every executor type rather than only `GridExecutor`.

**Tests performed by the developer**:

- Added `test_stop_executor_ignores_terminated_executor` and `test_stop_executor_ignores_shutting_down_executor`; also made the existing `test_stop_executor` assert that `early_stop` is dispatched for a running executor.
- `python -m unittest discover -s test/hummingbot/strategy_v2` — 342 tests, all passing (run inside the `hummingbot/hummingbot:development` Docker image).
- flake8 clean on the two changed files.

**Tips for QA testing**:

Run a grid controller and send a stop command for an executor that is finishing its shutdown (or repeatedly stop the same executor). Before this change the strategy logs the `KeyError: <GridLevelStates.OPEN_ORDER_PLACED>` traceback from #7720; after it, the duplicate stop is ignored with a warning log and the executor completes its shutdown normally.