### PR TITLE
fix(strategy_v2): correct net pnl units and sign in XEMM and arbitrage executors

### DIFF
--- a/hummingbot/strategy_v2/executors/arbitrage_executor/arbitrage_executor.py
+++ b/hummingbot/strategy_v2/executors/arbitrage_executor/arbitrage_executor.py
@@ -102,20 +102,20 @@ class ArbitrageExecutor(ExecutorBase):
 
     def get_net_pnl_quote(self) -> Decimal:
         if self.close_type == CloseType.COMPLETED:
-            sell_quote_amount = self.sell_order.order.executed_amount_base * self.sell_order.average_executed_price
-            buy_quote_amount = self.buy_order.order.executed_amount_base * self.buy_order.average_executed_price
-            return sell_quote_amount - buy_quote_amount - self.cum_fees_quote
+            return (self.sell_order.executed_amount_quote
+                    - self.buy_order.executed_amount_quote
+                    - self.cum_fees_quote)
         else:
             return Decimal("0")
 
     def get_net_pnl_pct(self) -> Decimal:
         if self.is_closed:
-            if self.buy_order.order and self.buy_order.order.executed_amount_base > 0:
-                return self.net_pnl_quote / self.buy_order.order.executed_amount_base
-            else:
-                return Decimal("0")
-        else:
-            return Decimal("0")
+            # The pnl is in quote, so the denominator has to be quote as well.
+            # Dividing by the base amount scales the result by the entry price.
+            quote_spent = self.buy_order.executed_amount_quote
+            if quote_spent > 0:
+                return self.net_pnl_quote / quote_spent
+        return Decimal("0")
 
     def get_cum_fees_quote(self) -> Decimal:
         return self.buy_order.cum_fees_quote + self.sell_order.cum_fees_quote

--- a/hummingbot/strategy_v2/executors/arbitrage_executor/arbitrage_executor.py
+++ b/hummingbot/strategy_v2/executors/arbitrage_executor/arbitrage_executor.py
@@ -122,20 +122,20 @@ class ArbitrageExecutor(ExecutorBase):
 
     def get_net_pnl_quote(self) -> Decimal:
         if self.close_type == CloseType.COMPLETED:
-            sell_quote_amount = self.sell_order.order.executed_amount_base * self.sell_order.average_executed_price
-            buy_quote_amount = self.buy_order.order.executed_amount_base * self.buy_order.average_executed_price
-            return sell_quote_amount - buy_quote_amount - self.cum_fees_quote
+            return (self.sell_order.executed_amount_quote
+                    - self.buy_order.executed_amount_quote
+                    - self.cum_fees_quote)
         else:
             return Decimal("0")
 
     def get_net_pnl_pct(self) -> Decimal:
         if self.is_closed:
-            if self.buy_order.order and self.buy_order.order.executed_amount_base > 0:
-                return self.net_pnl_quote / self.buy_order.order.executed_amount_base
-            else:
-                return Decimal("0")
-        else:
-            return Decimal("0")
+            # The pnl is in quote, so the denominator has to be quote as well.
+            # Dividing by the base amount scales the result by the entry price.
+            quote_spent = self.buy_order.executed_amount_quote
+            if quote_spent > 0:
+                return self.net_pnl_quote / quote_spent
+        return Decimal("0")
 
     def get_cum_fees_quote(self) -> Decimal:
         return self.buy_order.cum_fees_quote + self.sell_order.cum_fees_quote

--- a/hummingbot/strategy_v2/executors/xemm_executor/xemm_executor.py
+++ b/hummingbot/strategy_v2/executors/xemm_executor/xemm_executor.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 from decimal import Decimal
-from typing import Dict
+from typing import Dict, Optional
 
 from hummingbot.connector.connector_base import ConnectorBase, Union
 from hummingbot.connector.utils import split_hb_trading_pair
@@ -75,6 +75,10 @@ class XEMMExecutor(ExecutorBase):
         self._maker_target_price = Decimal("1")
         self._tx_cost = Decimal("1")
         self._tx_cost_pct = Decimal("1")
+        # Both fees are converted into the base asset, so the status line has
+        # to name that token rather than the quote.
+        buying_base, _ = split_hb_trading_pair(config.buying_market.trading_pair)
+        self._tx_cost_token = buying_base[1:] if buying_base.startswith("W") else buying_base
         self._current_trade_profitability = Decimal("0")
         self.maker_order = None
         self.taker_order = None
@@ -137,15 +141,13 @@ class XEMMExecutor(ExecutorBase):
             self._maker_target_price = self._taker_result_price / (Decimal("1") + self.config.target_profitability + self._tx_cost_pct)
 
     async def update_tx_costs(self):
-        base, quote = split_hb_trading_pair(trading_pair=self.config.buying_market.trading_pair)
-        base_without_wrapped = base[1:] if base.startswith("W") else base
         taker_fee_task = asyncio.create_task(self.get_tx_cost_in_asset(
             exchange=self.taker_connector,
             trading_pair=self.taker_trading_pair,
             order_type=OrderType.MARKET,
             is_buy=self.taker_order_side == TradeType.BUY,
             order_amount=self.config.order_amount,
-            asset=base_without_wrapped
+            asset=self._tx_cost_token
         ))
         maker_fee_task = asyncio.create_task(self.get_tx_cost_in_asset(
             exchange=self.maker_connector,
@@ -153,7 +155,7 @@ class XEMMExecutor(ExecutorBase):
             order_type=OrderType.LIMIT,
             is_buy=self.maker_order_side == TradeType.BUY,
             order_amount=self.config.order_amount,
-            asset=base_without_wrapped
+            asset=self._tx_cost_token
         ))
 
         taker_fee, maker_fee = await asyncio.gather(taker_fee_task, maker_fee_task)
@@ -312,17 +314,34 @@ class XEMMExecutor(ExecutorBase):
         else:
             return Decimal("0")
 
+    @property
+    def buy_order(self) -> Optional[TrackedOrder]:
+        """The leg that spends quote, whichever venue it sits on."""
+        return self.maker_order if self.maker_order_side == TradeType.BUY else self.taker_order
+
+    @property
+    def sell_order(self) -> Optional[TrackedOrder]:
+        """The leg that receives quote, whichever venue it sits on."""
+        return self.taker_order if self.maker_order_side == TradeType.BUY else self.maker_order
+
     def get_net_pnl_quote(self) -> Decimal:
         if self.is_closed and self.maker_order and self.taker_order and self.maker_order.is_done and self.taker_order.is_done:
-            maker_pnl = self.maker_order.executed_amount_base * self.maker_order.average_executed_price
-            taker_pnl = self.taker_order.executed_amount_base * self.taker_order.average_executed_price
-            return taker_pnl - maker_pnl - self.get_cum_fees_quote()
+            # Which leg spends the quote depends on the maker side, so the
+            # subtraction has to follow it rather than assume the taker sells.
+            return (self.sell_order.executed_amount_quote
+                    - self.buy_order.executed_amount_quote
+                    - self.get_cum_fees_quote())
         else:
             return Decimal("0")
 
     def get_net_pnl_pct(self) -> Decimal:
-        pnl_quote = self.get_net_pnl_quote()
-        return pnl_quote / self.config.order_amount
+        # config.order_amount is a requested size in base, so dividing a quote
+        # pnl by it both scales the result by the entry price and ignores
+        # partial fills. The capital at risk is what the buy leg spent.
+        quote_spent = self.buy_order.executed_amount_quote if self.buy_order else Decimal("0")
+        if quote_spent > 0:
+            return self.get_net_pnl_quote() / quote_spent
+        return Decimal("0")
 
     async def get_quote_asset_conversion_rate(self) -> Decimal:
         """
@@ -346,6 +365,6 @@ Maker Side: {self.maker_order_side}
     - Maker: {self.maker_connector} {self.maker_trading_pair} | Taker: {self.taker_connector} {self.taker_trading_pair}
     - Min profitability: {self.config.min_profitability * 100:.2f}% | Target profitability: {self.config.target_profitability * 100:.2f}% | Max profitability: {self.config.max_profitability * 100:.2f}% | Current profitability: {(self._current_trade_profitability - self._tx_cost_pct) * 100:.2f}%
     - Trade profitability: {self._current_trade_profitability * 100:.2f}% | Tx cost: {self._tx_cost_pct * 100:.2f}%
-    - Taker result price: {self._taker_result_price:.3f} | Tx cost: {self._tx_cost:.3f} {self.maker_trading_pair.split('-')[-1]} | Order amount (Base): {self.config.order_amount:.2f}
+    - Taker result price: {self._taker_result_price:.3f} | Tx cost: {self._tx_cost:.3f} {self._tx_cost_token} | Order amount (Base): {self.config.order_amount:.2f}
 -----------------------------------------------------------------------------------------------------------------------
 """

--- a/hummingbot/strategy_v2/executors/xemm_executor/xemm_executor.py
+++ b/hummingbot/strategy_v2/executors/xemm_executor/xemm_executor.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 from decimal import Decimal
-from typing import Dict
+from typing import Dict, Optional
 
 from hummingbot.connector.connector_base import ConnectorBase, Union
 from hummingbot.connector.utils import split_hb_trading_pair
@@ -95,6 +95,10 @@ class XEMMExecutor(ExecutorBase):
         self._maker_target_price = Decimal("1")
         self._tx_cost = Decimal("1")
         self._tx_cost_pct = Decimal("1")
+        # Both fees are converted into the base asset, so the status line has
+        # to name that token rather than the quote.
+        buying_base, _ = split_hb_trading_pair(config.buying_market.trading_pair)
+        self._tx_cost_token = buying_base[1:] if buying_base.startswith("W") else buying_base
         self._current_trade_profitability = Decimal("0")
         self.maker_order = None
         self.taker_order = None
@@ -157,15 +161,13 @@ class XEMMExecutor(ExecutorBase):
             self._maker_target_price = self._taker_result_price / (Decimal("1") + self.config.target_profitability + self._tx_cost_pct)
 
     async def update_tx_costs(self):
-        base, quote = split_hb_trading_pair(trading_pair=self.config.buying_market.trading_pair)
-        base_without_wrapped = base[1:] if base.startswith("W") else base
         taker_fee_task = asyncio.create_task(self.get_tx_cost_in_asset(
             exchange=self.taker_connector,
             trading_pair=self.taker_trading_pair,
             order_type=OrderType.MARKET,
             is_buy=self.taker_order_side == TradeType.BUY,
             order_amount=self.config.order_amount,
-            asset=base_without_wrapped
+            asset=self._tx_cost_token
         ))
         maker_fee_task = asyncio.create_task(self.get_tx_cost_in_asset(
             exchange=self.maker_connector,
@@ -173,7 +175,7 @@ class XEMMExecutor(ExecutorBase):
             order_type=OrderType.LIMIT,
             is_buy=self.maker_order_side == TradeType.BUY,
             order_amount=self.config.order_amount,
-            asset=base_without_wrapped
+            asset=self._tx_cost_token
         ))
 
         taker_fee, maker_fee = await asyncio.gather(taker_fee_task, maker_fee_task)
@@ -332,17 +334,34 @@ class XEMMExecutor(ExecutorBase):
         else:
             return Decimal("0")
 
+    @property
+    def buy_order(self) -> Optional[TrackedOrder]:
+        """The leg that spends quote, whichever venue it sits on."""
+        return self.maker_order if self.maker_order_side == TradeType.BUY else self.taker_order
+
+    @property
+    def sell_order(self) -> Optional[TrackedOrder]:
+        """The leg that receives quote, whichever venue it sits on."""
+        return self.taker_order if self.maker_order_side == TradeType.BUY else self.maker_order
+
     def get_net_pnl_quote(self) -> Decimal:
         if self.is_closed and self.maker_order and self.taker_order and self.maker_order.is_done and self.taker_order.is_done:
-            maker_pnl = self.maker_order.executed_amount_base * self.maker_order.average_executed_price
-            taker_pnl = self.taker_order.executed_amount_base * self.taker_order.average_executed_price
-            return taker_pnl - maker_pnl - self.get_cum_fees_quote()
+            # Which leg spends the quote depends on the maker side, so the
+            # subtraction has to follow it rather than assume the taker sells.
+            return (self.sell_order.executed_amount_quote
+                    - self.buy_order.executed_amount_quote
+                    - self.get_cum_fees_quote())
         else:
             return Decimal("0")
 
     def get_net_pnl_pct(self) -> Decimal:
-        pnl_quote = self.get_net_pnl_quote()
-        return pnl_quote / self.config.order_amount
+        # config.order_amount is a requested size in base, so dividing a quote
+        # pnl by it both scales the result by the entry price and ignores
+        # partial fills. The capital at risk is what the buy leg spent.
+        quote_spent = self.buy_order.executed_amount_quote if self.buy_order else Decimal("0")
+        if quote_spent > 0:
+            return self.get_net_pnl_quote() / quote_spent
+        return Decimal("0")
 
     async def get_quote_asset_conversion_rate(self) -> Decimal:
         """
@@ -366,6 +385,6 @@ Maker Side: {self.maker_order_side}
     - Maker: {self.maker_connector} {self.maker_trading_pair} | Taker: {self.taker_connector} {self.taker_trading_pair}
     - Min profitability: {self.config.min_profitability * 100:.2f}% | Target profitability: {self.config.target_profitability * 100:.2f}% | Max profitability: {self.config.max_profitability * 100:.2f}% | Current profitability: {(self._current_trade_profitability - self._tx_cost_pct) * 100:.2f}%
     - Trade profitability: {self._current_trade_profitability * 100:.2f}% | Tx cost: {self._tx_cost_pct * 100:.2f}%
-    - Taker result price: {self._taker_result_price:.3f} | Tx cost: {self._tx_cost:.3f} {self.maker_trading_pair.split('-')[-1]} | Order amount (Base): {self.config.order_amount:.2f}
+    - Taker result price: {self._taker_result_price:.3f} | Tx cost: {self._tx_cost:.3f} {self._tx_cost_token} | Order amount (Base): {self.config.order_amount:.2f}
 -----------------------------------------------------------------------------------------------------------------------
 """

--- a/test/hummingbot/strategy_v2/executors/arbitrage_executor/test_arbitrage_executor.py
+++ b/test/hummingbot/strategy_v2/executors/arbitrage_executor/test_arbitrage_executor.py
@@ -4,7 +4,8 @@ from test.logger_mixin_for_test import LoggerMixinForTest
 from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
 from hummingbot.connector.connector_base import ConnectorBase
-from hummingbot.core.data_type.common import OrderType
+from hummingbot.core.data_type.common import OrderType, TradeType
+from hummingbot.core.data_type.in_flight_order import InFlightOrder
 from hummingbot.core.event.events import MarketOrderFailureEvent
 from hummingbot.strategy.strategy_v2_base import StrategyV2Base
 from hummingbot.strategy_v2.executors.arbitrage_executor.arbitrage_executor import ArbitrageExecutor
@@ -55,15 +56,47 @@ class TestArbitrageExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         self.executor.close_type = CloseType.COMPLETED
         self.executor._buy_order = Mock(spec=TrackedOrder)
         self.executor._sell_order = Mock(spec=TrackedOrder)
-        self.executor._buy_order.order.executed_amount_base = Decimal('1')
-        self.executor._sell_order.order.executed_amount_base = Decimal('1')
-        self.executor._buy_order.average_executed_price = Decimal('100')
-        self.executor._sell_order.average_executed_price = Decimal('200')
+        self.executor._buy_order.executed_amount_quote = Decimal('100')
+        self.executor._sell_order.executed_amount_quote = Decimal('200')
         self.executor._buy_order.cum_fees_quote = Decimal('1')
         self.executor._sell_order.cum_fees_quote = Decimal('1')
         self.executor._status = RunnableStatus.TERMINATED
         self.assertEqual(self.executor.get_net_pnl_quote(), Decimal('98'))
-        self.assertEqual(self.executor.get_net_pnl_pct(), Decimal('98'))
+        # 98 USDT earned on the 100 USDT the buy leg spent.
+        self.assertEqual(self.executor.get_net_pnl_pct(), Decimal('0.98'))
+
+    def test_net_pnl_pct_is_a_return_on_quote_spent(self):
+        # The two legs move different amounts of quote, so a denominator taken
+        # from the wrong leg or the wrong unit cannot coincide with the answer.
+        self.executor.close_type = CloseType.COMPLETED
+        self.executor._buy_order = Mock(spec=TrackedOrder)
+        self.executor._sell_order = Mock(spec=TrackedOrder)
+        self.executor._buy_order.executed_amount_quote = Decimal('6000')
+        self.executor._sell_order.executed_amount_quote = Decimal('6020')
+        self.executor._buy_order.cum_fees_quote = Decimal('2')
+        self.executor._sell_order.cum_fees_quote = Decimal('2')
+        self.executor._status = RunnableStatus.TERMINATED
+        # 6020 received, 6000 spent, 4 in fees.
+        self.assertEqual(self.executor.get_net_pnl_quote(), Decimal('16'))
+        self.assertEqual(self.executor.get_net_pnl_pct(), Decimal('16') / Decimal('6000'))
+
+    def test_net_pnl_pct_with_an_unfilled_market_order(self):
+        # ExecutorBase.place_order defaults the price to NaN, so reconstructing
+        # the quote from the base amount and the average price would give NaN
+        # here, and NaN raises on comparison rather than coming out false.
+        unfilled = InFlightOrder(
+            client_order_id="OID-BUY-1",
+            trading_pair="ETH-USDT",
+            order_type=OrderType.MARKET,
+            trade_type=TradeType.BUY,
+            creation_timestamp=1234,
+            amount=Decimal('1'),
+            price=Decimal('NaN'),
+        )
+        self.executor._buy_order = TrackedOrder(order_id="OID-BUY-1")
+        self.executor._buy_order.order = unfilled
+        self.executor._status = RunnableStatus.TERMINATED
+        self.assertEqual(self.executor.get_net_pnl_pct(), Decimal('0'))
 
     @patch.object(ArbitrageExecutor, "get_resulting_price_for_amount")
     @patch.object(ArbitrageExecutor, "get_tx_cost_in_asset")

--- a/test/hummingbot/strategy_v2/executors/xemm_executor/test_xemm_executor.py
+++ b/test/hummingbot/strategy_v2/executors/xemm_executor/test_xemm_executor.py
@@ -85,12 +85,11 @@ class TestXEMMExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         self.executor._status = RunnableStatus.TERMINATED
         self.executor.maker_order = Mock(spec=TrackedOrder)
         self.executor.taker_order = Mock(spec=TrackedOrder)
-        self.executor.maker_order.executed_amount_base = Decimal('1')
-        self.executor.taker_order.executed_amount_base = Decimal('1')
-        self.executor.maker_order.average_executed_price = Decimal('100')
-        self.executor.taker_order.average_executed_price = Decimal('200')
+        self.executor.maker_order.executed_amount_quote = Decimal('100')
+        self.executor.taker_order.executed_amount_quote = Decimal('200')
         self.executor.maker_order.cum_fees_quote = Decimal('1')
         self.executor.taker_order.cum_fees_quote = Decimal('1')
+        # The maker buys for 100 and the taker sells for 200, less 2 in fees.
         self.assertEqual(self.executor.net_pnl_quote, Decimal('98'))
         self.assertEqual(self.executor.net_pnl_pct, Decimal('0.98'))
 
@@ -99,14 +98,94 @@ class TestXEMMExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         executor._status = RunnableStatus.TERMINATED
         executor.maker_order = Mock(spec=TrackedOrder)
         executor.taker_order = Mock(spec=TrackedOrder)
-        executor.maker_order.executed_amount_base = Decimal('1')
-        executor.taker_order.executed_amount_base = Decimal('1')
-        executor.maker_order.average_executed_price = Decimal('100')
-        executor.taker_order.average_executed_price = Decimal('200')
+        executor.maker_order.executed_amount_quote = Decimal('100')
+        executor.taker_order.executed_amount_quote = Decimal('200')
         executor.maker_order.cum_fees_quote = Decimal('1')
         executor.taker_order.cum_fees_quote = Decimal('1')
-        self.assertEqual(executor.net_pnl_quote, Decimal('98'))
-        self.assertEqual(executor.net_pnl_pct, Decimal('0.98'))
+        # Here the maker is the one selling, for 100, while the taker buys for
+        # 200, so the round trip loses 100 on the spread and 2 more in fees.
+        self.assertEqual(executor.net_pnl_quote, Decimal('-102'))
+        # Measured against the 200 the taker leg spent.
+        self.assertEqual(executor.net_pnl_pct, Decimal('-0.51'))
+
+    def test_net_pnl_pct_is_a_return_on_quote_spent(self):
+        # The two legs move different amounts of quote, so a denominator taken
+        # from the wrong leg or the wrong unit cannot coincide with the answer.
+        self.executor._status = RunnableStatus.TERMINATED
+        self.executor.maker_order = Mock(spec=TrackedOrder)
+        self.executor.taker_order = Mock(spec=TrackedOrder)
+        self.executor.maker_order.executed_amount_quote = Decimal('6000')
+        self.executor.taker_order.executed_amount_quote = Decimal('6020')
+        self.executor.maker_order.cum_fees_quote = Decimal('2')
+        self.executor.taker_order.cum_fees_quote = Decimal('2')
+        # 6020 received, 6000 spent, 4 in fees.
+        self.assertEqual(self.executor.net_pnl_quote, Decimal('16'))
+        self.assertEqual(self.executor.net_pnl_pct, Decimal('16') / Decimal('6000'))
+
+    def test_net_pnl_pct_with_an_unfilled_market_order(self):
+        # The taker leg is a market order and ExecutorBase.place_order defaults
+        # its price to NaN, so reconstructing the quote from the base amount
+        # and the average price would give NaN here, and NaN raises on
+        # comparison rather than coming out false.
+        executor = XEMMExecutor(self.strategy, self.base_config_short, self.update_interval)
+        unfilled = InFlightOrder(
+            client_order_id="OID-BUY-1",
+            trading_pair="ETH-USDT",
+            order_type=OrderType.MARKET,
+            trade_type=TradeType.BUY,
+            creation_timestamp=1234,
+            amount=Decimal('1'),
+            price=Decimal('NaN'),
+        )
+        executor.taker_order = TrackedOrder(order_id="OID-BUY-1")
+        executor.taker_order.order = unfilled
+        executor.maker_order = Mock(spec=TrackedOrder)
+        executor.maker_order.executed_amount_quote = Decimal('100')
+        executor.maker_order.cum_fees_quote = Decimal('1')
+        executor._status = RunnableStatus.TERMINATED
+        self.assertEqual(executor.net_pnl_pct, Decimal('0'))
+
+    def test_net_pnl_quote_with_a_cancelled_leg_is_not_nan(self):
+        # A cancelled order is done with no fills, so its price is still the
+        # NaN that place_order defaulted to. Reconstructing the quote from it
+        # left the pnl NaN, which ExecutorInfo reports as zero, hiding a loss.
+        self.executor.maker_order = Mock(spec=TrackedOrder)
+        self.executor.maker_order.executed_amount_quote = Decimal('6000')
+        self.executor.maker_order.cum_fees_quote = Decimal('2')
+        cancelled = InFlightOrder(
+            client_order_id="OID-SELL-1",
+            trading_pair="ETH-USDT",
+            order_type=OrderType.MARKET,
+            trade_type=TradeType.SELL,
+            creation_timestamp=1234,
+            amount=Decimal('2'),
+            price=Decimal('NaN'),
+            initial_state=OrderState.CANCELED,
+        )
+        self.executor.taker_order = TrackedOrder(order_id="OID-SELL-1")
+        self.executor.taker_order.order = cancelled
+        self.executor._status = RunnableStatus.TERMINATED
+        # 6000 spent on the maker leg, nothing sold, 2 in fees.
+        self.assertFalse(self.executor.net_pnl_quote.is_nan())
+        self.assertEqual(self.executor.net_pnl_quote, Decimal('-6002'))
+
+    def test_status_names_the_token_the_tx_cost_is_denominated_in(self):
+        # get_tx_cost_in_asset converts both fees into the base asset of the
+        # buying market, unwrapped, so the status line has to name that.
+        self.assertEqual(self.executor._tx_cost_token, "ETH")
+        self.assertIn(f"{self.executor._tx_cost:.3f} ETH", self.executor.to_format_status())
+
+        wrapped = XEMMExecutorConfig(
+            timestamp=1234,
+            buying_market=ConnectorPair(connector_name='binance', trading_pair='WETH-USDT'),
+            selling_market=ConnectorPair(connector_name='kucoin', trading_pair='ETH-USDT'),
+            maker_side=TradeType.BUY,
+            order_amount=Decimal('100'),
+            min_profitability=Decimal('0.01'),
+            target_profitability=Decimal('0.015'),
+            max_profitability=Decimal('0.02'),
+        )
+        self.assertEqual(XEMMExecutor(self.strategy, wrapped, self.update_interval)._tx_cost_token, "ETH")
 
     @patch.object(XEMMExecutor, 'get_trading_rules')
     @patch.object(XEMMExecutor, 'adjust_order_candidates')


### PR DESCRIPTION

`get_net_pnl_pct` divides a quote-denominated pnl by a base amount in
`XEMMExecutor` and `ArbitrageExecutor`, so the percentage comes out scaled by
the entry price. Buying 2 ETH at 3000 and selling at 3010 with 4 USDT of fees
earns 16 USDT on 6000 deployed, a return of 0.27%. Both executors report 800%.
`dca`, `twap`, `position`, `grid`, `lp` and `backtesting_engine_base.py:600`
all divide by a quote amount.

XEMM has a second problem. `get_net_pnl_quote` computes `taker - maker`
whatever side the maker is on, but when `maker_side` is SELL the maker receives
the quote and the taker spends it. The same round trip that earns 16 USDT is
reported as -24. That value is finite, so it passes `ExecutorInfo._safe_decimal`
untouched and lands in `ExecutorOrchestrator.realized_pnl_quote` with the wrong
sign. `update_current_trade_profitability` already branches on the maker side,
so the two functions disagreed about the same trade. I added `buy_order` and
`sell_order`, named after the pair `ArbitrageExecutor` already exposes, so both
calculations resolve the legs one way.

While fixing the denominator I dropped the `executed_amount_base *
average_executed_price` reconstruction in favour of
`TrackedOrder.executed_amount_quote`, which already holds that figure,
accumulated from the `fill_quote_amount` the connectors report and used by
`ExecutorOrchestrator` for its own volume accounting. That is also why
`get_net_pnl_quote` changed in the arbitrage executor even though its sign was
right: the numerator and the denominator should be the same quantity read the
same way. The reconstruction has a second problem anyway. `place_order`
defaults the price to `Decimal("NaN")` and `average_executed_price` falls back
to it, so a cancelled taker leg left `net_pnl_quote` as NaN, which
`ExecutorInfo` then reports as zero and hides a real loss.

Two existing tests pinned the old numbers and had to change.
`test_net_pnl_quote` asserted `get_net_pnl_pct() == 98` for what is a 0.98
return. `test_net_pnl_short` asserted a profit of 98 on a round trip that loses
102. The XEMM long case passed only because the fixture used an order amount of
100 base at a price of 100, so base and quote cancelled; that coincidence is
what hid this.

Last and smallest, the status line named the tx cost in the quote asset while
`get_tx_cost_in_asset` converts both fees into the unwrapped base. The token is
now worked out once in `__init__`, since `update_tx_costs` had the same
expression.

The tests covering the unit, the sign and the token label fail on
`development`. The two unfilled-order tests pass there as well and are here to
stop the reconstruction coming back. `pytest test/hummingbot/strategy_v2/`
gives 481 passed; the one failure, `test_backtest_directional`, is `pandas_ta`
having no wheel for 3.10 and fails the same way on a clean checkout. flake8 and
isort are clean.
