### PR TITLE
fix: prevent XEMM executor maker order race between control loop and fill events

### DIFF
--- a/hummingbot/strategy_v2/executors/xemm_executor/xemm_executor.py
+++ b/hummingbot/strategy_v2/executors/xemm_executor/xemm_executor.py
@@ -11,6 +11,7 @@ from hummingbot.core.event.events import (
     BuyOrderCompletedEvent,
     BuyOrderCreatedEvent,
     MarketOrderFailureEvent,
+    OrderCancelledEvent,
     SellOrderCompletedEvent,
     SellOrderCreatedEvent,
 )
@@ -223,20 +224,25 @@ class XEMMExecutor(ExecutorBase):
         self.logger().info(f"Created maker order {order_id} at price {self._maker_target_price}.")
 
     async def control_shutdown_process(self):
-        if self.maker_order.is_done and self.taker_order.is_done:
+        maker_order_done = self.maker_order is None or self.maker_order.is_done
+        taker_order_done = self.taker_order is None or self.taker_order.is_done
+        if maker_order_done and taker_order_done:
             self.logger().info("Both orders are done, executor terminated.")
             self.stop()
 
     async def control_update_maker_order(self):
         await self.update_current_trade_profitability()
+        # The maker order may have been filled while profitability was being updated
+        if self.status != RunnableStatus.RUNNING or self.maker_order is None:
+            return
+        if self.maker_order.order is None or not self.maker_order.order.is_open or self.maker_order.order.is_pending_cancel_confirmation:
+            return
         if self._current_trade_profitability - self._tx_cost_pct < self.config.min_profitability:
             self.logger().info(f"Order {self.maker_order.order_id} profitability {self._current_trade_profitability - self._tx_cost_pct} is below minimum profitability {self.config.min_profitability}. Cancelling order.")
             self._strategy.cancel(self.maker_connector, self.maker_trading_pair, self.maker_order.order_id)
-            self.maker_order = None
         elif self._current_trade_profitability - self._tx_cost_pct > self.config.max_profitability:
             self.logger().info(f"Order {self.maker_order.order_id} profitability {self._current_trade_profitability - self._tx_cost_pct} is above maximum profitability {self.config.max_profitability}. Cancelling order.")
             self._strategy.cancel(self.maker_connector, self.maker_trading_pair, self.maker_order.order_id)
-            self.maker_order = None
 
     async def update_current_trade_profitability(self):
         trade_profitability = Decimal("0")
@@ -287,6 +293,14 @@ class XEMMExecutor(ExecutorBase):
             side=self.taker_order_side,
             amount=self.config.order_amount)
         self.taker_order = TrackedOrder(order_id=taker_order_id)
+
+    def process_order_canceled_event(self,
+                                     event_tag: int,
+                                     market: ConnectorBase,
+                                     event: OrderCancelledEvent):
+        if self.maker_order and event.order_id == self.maker_order.order_id:
+            self.failed_orders.append(self.maker_order)
+            self.maker_order = None
 
     def process_order_failed_event(self, _, market, event: MarketOrderFailureEvent):
         if self.maker_order and self.maker_order.order_id == event.order_id:

--- a/test/hummingbot/strategy_v2/executors/xemm_executor/test_xemm_executor.py
+++ b/test/hummingbot/strategy_v2/executors/xemm_executor/test_xemm_executor.py
@@ -8,7 +8,12 @@ from hummingbot.connector.trading_rule import TradingRule
 from hummingbot.core.data_type.common import OrderType, TradeType
 from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState
 from hummingbot.core.data_type.order_candidate import OrderCandidate
-from hummingbot.core.event.events import BuyOrderCompletedEvent, BuyOrderCreatedEvent, MarketOrderFailureEvent
+from hummingbot.core.event.events import (
+    BuyOrderCompletedEvent,
+    BuyOrderCreatedEvent,
+    MarketOrderFailureEvent,
+    OrderCancelledEvent,
+)
 from hummingbot.strategy.strategy_v2_base import StrategyV2Base
 from hummingbot.strategy_v2.executors.data_types import ConnectorPair
 from hummingbot.strategy_v2.executors.xemm_executor.data_types import XEMMExecutorConfig
@@ -190,6 +195,11 @@ class TestXEMMExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         )
         await self.executor.control_task()
         self.assertEqual(self.executor._status, RunnableStatus.RUNNING)
+        self.strategy.cancel.assert_called_once_with("binance", "ETH-USDT", "OID-BUY-1")
+        # The order is kept until the cancellation is confirmed by the exchange
+        self.assertIsNotNone(self.executor.maker_order)
+        cancel_event = OrderCancelledEvent(timestamp=1234, order_id="OID-BUY-1")
+        self.executor.process_order_canceled_event(1, MagicMock(), cancel_event)
         self.assertEqual(self.executor.maker_order, None)
 
     @patch.object(XEMMExecutor, "get_resulting_price_for_amount")
@@ -213,6 +223,10 @@ class TestXEMMExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         )
         await self.executor.control_task()
         self.assertEqual(self.executor._status, RunnableStatus.RUNNING)
+        self.strategy.cancel.assert_called_once_with("binance", "ETH-USDT", "OID-BUY-1")
+        self.assertIsNotNone(self.executor.maker_order)
+        cancel_event = OrderCancelledEvent(timestamp=1234, order_id="OID-BUY-1")
+        self.executor.process_order_canceled_event(1, MagicMock(), cancel_event)
         self.assertEqual(self.executor.maker_order, None)
 
     async def test_control_task_shut_down_process(self):
@@ -223,6 +237,46 @@ class TestXEMMExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         self.executor._status = RunnableStatus.SHUTTING_DOWN
         await self.executor.control_task()
         self.assertEqual(self.executor._status, RunnableStatus.TERMINATED)
+
+    async def test_control_task_shut_down_process_with_maker_order_none(self):
+        self.executor.maker_order = None
+        self.executor.taker_order = Mock(spec=TrackedOrder)
+        self.executor.taker_order.is_done = True
+        self.executor._status = RunnableStatus.SHUTTING_DOWN
+        await self.executor.control_task()
+        self.assertEqual(self.executor._status, RunnableStatus.TERMINATED)
+
+    @patch.object(XEMMExecutor, "update_current_trade_profitability")
+    async def test_control_update_maker_order_skips_cancel_when_shutting_down(self, update_profitability_mock):
+        async def flip_status_to_shutting_down():
+            self.executor._status = RunnableStatus.SHUTTING_DOWN
+            return Decimal("0")
+
+        update_profitability_mock.side_effect = flip_status_to_shutting_down
+        self.executor._status = RunnableStatus.RUNNING
+        self.executor.maker_order = Mock(spec=TrackedOrder)
+        self.executor.maker_order.order_id = "OID-BUY-1"
+        self.executor.maker_order.order = InFlightOrder(
+            creation_timestamp=1234,
+            trading_pair="ETH-USDT",
+            client_order_id="OID-BUY-1",
+            order_type=OrderType.LIMIT,
+            trade_type=TradeType.BUY,
+            amount=Decimal("100"),
+            price=Decimal("99.5"),
+            initial_state=OrderState.OPEN,
+        )
+        await self.executor.control_update_maker_order()
+        self.strategy.cancel.assert_not_called()
+        self.assertIsNotNone(self.executor.maker_order)
+
+    def test_process_order_canceled_event(self):
+        self.executor.maker_order = TrackedOrder(order_id="OID-BUY-1")
+        cancel_event = OrderCancelledEvent(timestamp=1234, order_id="OID-BUY-1")
+        self.executor.process_order_canceled_event(1, MagicMock(), cancel_event)
+        self.assertEqual(self.executor.maker_order, None)
+        self.assertEqual(len(self.executor.failed_orders), 1)
+        self.assertEqual(self.executor.failed_orders[0].order_id, "OID-BUY-1")
 
     @patch.object(XEMMExecutor, "get_in_flight_order")
     def test_process_order_created_event(self, in_flight_order_mock):


### PR DESCRIPTION
Fixes #7729

## Root cause

`control_update_maker_order` awaits `update_current_trade_profitability()` inside the control loop while order events are processed independently. Two interleavings of the same race break the executor:

1. While the coroutine is suspended, the maker order completes: `process_order_completed_event` places the taker order and flips the status to `SHUTTING_DOWN`. The coroutine then resumes with stale profitability data, cancels the already-filled maker order and sets `self.maker_order = None`. From the next tick on, `control_shutdown_process` evaluates `self.maker_order.is_done` on `None`, raising `'NoneType' object has no attribute 'is_done'` on every tick, and the executor never terminates.
2. In the opposite ordering, the profitability check cancels the maker order and immediately sets `self.maker_order = None`. If the order was already filled on the exchange before the cancel landed, the completed event finds `maker_order` set to `None`, so no taker order is placed and the fill stays unhedged. This matches the "maker filled but no taker order created" part of the report.

## Fix

Follows the pattern `position_executor` already uses for cancellations:

- `control_update_maker_order` no longer clears `self.maker_order` when requesting a cancel; the `TrackedOrder` is kept until the exchange confirms. A new `process_order_canceled_event` override moves it to `failed_orders` and clears it on confirmation, after which the control loop places a fresh maker order as before. If the order gets filled instead, the completed event still finds it and places the taker order.
- After the profitability await, the method returns early if the executor is no longer `RUNNING` or the order is gone / not open / pending cancel confirmation, so stale data can never cancel a filled order.
- `control_shutdown_process` tolerates a missing maker/taker order so shutdown can always complete instead of crashing every tick.

## Tests

- Updated the min/max profitability refresh tests to the new flow: cancel requested, order kept until `OrderCancelledEvent`, then cleared.
- New tests: shutdown completes with `maker_order = None`; no cancel is issued when the status flips to `SHUTTING_DOWN` during the profitability update; `process_order_canceled_event` clears the maker order and archives it in `failed_orders`.

All 21 tests in `test_xemm_executor.py` pass, flake8 clean on both files.
