### PR TITLE
fix: prevent empty balance snapshot during Bybit Perpetual balance refresh

### DIFF
--- a/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/bybit_perpetual/bybit_perpetual_derivative.py
@@ -412,17 +412,18 @@ class BybitPerpetualDerivative(PerpetualDerivativePyBase):
         unified_wallet_balance = [d for d in unified_wallet_response["result"]["list"][0]["coin"] if
                                   Decimal(d["equity"]) > 0]
 
-        self._account_available_balances.clear()
+        total_balances = {asset["coin"]: Decimal(asset["equity"]) for asset in unified_wallet_balance}
+
+        available_balances = {}
+        for coin in total_balances:
+            available_balances[coin] = await self._fetch_available_balance(coin)
+
+        # Swap in the new balances only once all requests have completed, so that concurrent
+        # readers (e.g. budget checks) never see a partially populated balance map
         self._account_balances.clear()
-
-        for asset in unified_wallet_balance:
-            self._account_balances[asset["coin"]] = Decimal(asset["equity"])
-
-        available_coins = self._account_balances.keys()
-
-        for coin in available_coins:
-            available_balance = await self._fetch_available_balance(coin)
-            self._account_available_balances[coin] = available_balance
+        self._account_balances.update(total_balances)
+        self._account_available_balances.clear()
+        self._account_available_balances.update(available_balances)
 
     async def _fetch_available_balance(self, coin: str):
         available_balance_resp = await self._api_get(path_url=CONSTANTS.GET_TRANSFERABLE_AMOUNT_PATH_URL,

--- a/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/bybit_perpetual/test_bybit_perpetual_derivative.py
@@ -1295,6 +1295,33 @@ class BybitPerpetualDerivativeTests(AbstractPerpetualDerivativeTests.PerpetualDe
         self.assertEqual(Decimal("15"), total_balances[self.base_asset])
 
     @aioresponses()
+    def test_update_balances_keeps_previous_snapshot_while_fetching(self, mock_api):
+        # Concurrent readers (e.g. budget checks) must never see a partially populated
+        # balance map while the per-coin available balance requests are in flight
+        self.exchange._account_balances[self.quote_asset] = Decimal("2000")
+        self.exchange._account_available_balances[self.quote_asset] = Decimal("2000")
+
+        response = self.balance_request_mock_response_for_base_and_quote
+        self._configure_balance_response(response=response, mock_api=mock_api)
+
+        snapshots = []
+
+        async def capture_snapshot(coin: str):
+            snapshots.append((dict(self.exchange.get_all_balances()), dict(self.exchange.available_balances)))
+            return Decimal("10")
+
+        with patch.object(self.exchange, "_fetch_available_balance", side_effect=capture_snapshot):
+            self.async_run_with_timeout(self.exchange._update_balances())
+
+        self.assertEqual(2, len(snapshots))
+        for total_snapshot, available_snapshot in snapshots:
+            self.assertEqual(Decimal("2000"), total_snapshot[self.quote_asset])
+            self.assertEqual(Decimal("2000"), available_snapshot[self.quote_asset])
+
+        self.assertEqual(Decimal("10"), self.exchange.available_balances[self.base_asset])
+        self.assertEqual(Decimal("10"), self.exchange.available_balances[self.quote_asset])
+
+    @aioresponses()
     def test_fetch_available_balance_failure(self, mock_api):
         mock_url = web_utils.get_rest_url_for_endpoint(
             endpoint=CONSTANTS.GET_TRANSFERABLE_AMOUNT_PATH_URL


### PR DESCRIPTION
Fixes #7775

## Root cause

`BybitPerpetualDerivative._update_balances` cleared both `_account_balances` and `_account_available_balances` up front, then repopulated the available balances one coin at a time, awaiting a separate REST request (`_fetch_available_balance`) per coin. Between the `clear()` and the completion of that loop, any concurrent reader sees an empty or partially populated balance map. `check_budget_available` in `spot_perpetual_arbitrage` ticks every second, so it regularly lands inside that window and reports the balance as insufficient even though the account holds enough. The more coins with balance the account has, the longer the window, which matches the reporter's observation that the bug is most reliable when the traded coin appears last in the API response.

## Fix

Collect the total and available balances into local dictionaries first, and only swap them into `_account_balances` / `_account_available_balances` after all requests have completed, with no awaits between the clear and the update. Readers now always see a complete, consistent snapshot: either the previous one or the fully refreshed one. Stale assets are still removed because the swap replaces the full contents.

## Tests

- Existing `_update_balances` tests pass unchanged, including the stale-asset removal case.
- New regression test `test_update_balances_keeps_previous_snapshot_while_fetching` seeds a previous balance snapshot, then captures the state of `get_all_balances()` / `available_balances` at the moment each per-coin fetch runs and asserts the previous snapshot is still fully visible mid-refresh.

All 62 tests in `test_bybit_perpetual_derivative.py` pass, flake8 clean on both files. Not tested against the live Bybit API.
