### PR TITLE
fix(xrpl): sweep orphaned offers that no tracked order can cancel

### DIFF
--- a/hummingbot/connector/exchange/xrpl/xrpl_constants.py
+++ b/hummingbot/connector/exchange/xrpl/xrpl_constants.py
@@ -127,6 +127,20 @@ CANCEL_MAX_RETRY = 5
 CANCEL_RETRY_INTERVAL = 5  # Seconds between retries
 
 # =============================================================================
+# Orphan Offer Cleanup
+# =============================================================================
+# An offer resting on the ledger that no tracked order owns has no cancel path at all:
+# _place_cancel needs tracked_order.exchange_order_id, so once the tracker loses an order
+# (e.g. across a websocket reconnect) its offer rests indefinitely, holding balance.
+#
+# Seconds an unowned offer must persist, across separate ledger reads, before it is cancelled.
+# The grace matters: a just-placed offer is legitimately unowned for the moment between landing
+# on the ledger and being linked to its tracked order. Set to 0 to disable the sweep entirely.
+ORPHAN_CANCEL_SECONDS = 180
+# Cancel at most this many offers per sweep, so one bad ledger read cannot become a cancel storm.
+ORPHAN_CANCEL_MAX_PER_SWEEP = 3
+
+# =============================================================================
 # Transaction Verification Retry Configuration
 # =============================================================================
 VERIFY_TRANSACTION_MAX_RETRY = 5

--- a/hummingbot/connector/exchange/xrpl/xrpl_exchange.py
+++ b/hummingbot/connector/exchange/xrpl/xrpl_exchange.py
@@ -143,6 +143,11 @@ class XrplExchange(ExchangePyBase):
         self._order_status_locks: Dict[str, asyncio.Lock] = {}
         self._order_status_lock_manager_lock = asyncio.Lock()
 
+        # Offer sequences seen on the ledger in the latest balance snapshot, and the first time
+        # each unowned one was noticed — see _cancel_orphan_offers.
+        self._ledger_offer_sequences: Optional[set] = None
+        self._orphan_first_seen: Dict[int, float] = {}
+
         # Worker pools (lazy initialization after start_network)
         self._tx_pool: Optional[XRPLTransactionWorkerPool] = None
         self._query_pool: Optional[XRPLQueryWorkerPool] = None
@@ -409,6 +414,74 @@ class XrplExchange(ExchangePyBase):
         if self._query_pool is None:
             self._query_pool = self._worker_manager.get_query_pool()
         return self._query_pool
+
+    def _tracked_offer_sequences(self) -> set:
+        """Ledger offer sequences that some tracked order claims. Anything else on the book is unowned."""
+        known = set()
+        for order in list(self._order_tracker.all_fillable_orders.values()):
+            eid = order.exchange_order_id
+            if not eid:
+                continue
+            try:
+                known.add(int(str(eid).split("-")[0]))
+            except (TypeError, ValueError):
+                continue
+        return known
+
+    async def _cancel_orphan_offers(self):
+        """Cancel offers resting on the ledger that no tracked order owns.
+
+        _place_cancel needs tracked_order.exchange_order_id, so an order the tracker lost (for
+        example across a websocket reconnect) has no cancel path — not a slow one, none. Its offer
+        rests on the ledger until someone takes it, holding balance the whole time; each such
+        offer shrinks the available balance the strategy can quote with, so the leak compounds.
+
+        Two things keep this from being reckless. An offer must be unowned for
+        ORPHAN_CANCEL_SECONDS across separate ledger reads before it is touched, because an offer
+        is legitimately unowned for the moment between landing and being linked to its tracked
+        order. And the per-sweep cap means one bad ledger read cannot become a cancel storm.
+
+        Note what is NOT claimed: this does not identify orphans as this bot's own. On an account
+        shared by several processes it would cancel the other process's offers — which is why the
+        grace is generous and ORPHAN_CANCEL_SECONDS = 0 switches the sweep off entirely.
+        """
+        grace = CONSTANTS.ORPHAN_CANCEL_SECONDS
+        if grace <= 0:
+            return
+        ledger = getattr(self, "_ledger_offer_sequences", None)
+        if not ledger:
+            return
+
+        unowned = set(ledger) - self._tracked_offer_sequences()
+        seen = self._orphan_first_seen
+        now = time.time()
+        for seq in unowned:
+            seen.setdefault(seq, now)
+        # An offer that became owned, or left the book, starts over if it ever comes back.
+        for seq in [s for s in seen if s not in unowned]:
+            del seen[seq]
+
+        ripe = sorted(s for s, first in seen.items() if now - first >= grace)
+        for seq in ripe[:CONSTANTS.ORPHAN_CANCEL_MAX_PER_SWEEP]:
+            try:
+                await self.tx_pool.submit_transaction(
+                    transaction=OfferCancel(account=self._xrpl_auth.get_account(),
+                                            offer_sequence=int(seq)),
+                    wallet=self._xrpl_auth.get_wallet(),
+                )
+                self.logger().info(
+                    f"Cancelled unowned offer {seq}; it had been on the ledger with no "
+                    f"tracked order for {now - seen[seq]:.0f}s and was holding balance")
+                seen.pop(seq, None)
+            except Exception as e:
+                # Leave it in `seen` so the next sweep retries; do not lose the record of it.
+                self.logger().warning(f"Could not cancel unowned offer {seq}: {e}")
+
+    async def _status_polling_loop_fetch_updates(self):
+        await super()._status_polling_loop_fetch_updates()
+        # Straight after the balance refresh, because _update_balances is what makes
+        # _ledger_offer_sequences current — the comparison is worthless against a stale set.
+        await self._cancel_orphan_offers()
 
     @property
     def verification_pool(self) -> XRPLVerificationWorkerPool:
@@ -2520,6 +2593,10 @@ class XrplExchange(ExchangePyBase):
         )
 
         open_offers = [x for x in objects.result.get("account_objects", []) if x.get("LedgerEntryType") == "Offer"]
+        # Record which offer sequences are actually live on the ledger. _cancel_orphan_offers
+        # compares this set against the order tracker to find offers no tracked order owns.
+        self._ledger_offer_sequences = {o.get("Sequence") for o in open_offers
+                                        if o.get("Sequence") is not None}
 
         if account_lines is not None:
             balances = account_lines.result.get("lines", [])

--- a/test/hummingbot/connector/exchange/xrpl/test_xrpl_exchange_balances.py
+++ b/test/hummingbot/connector/exchange/xrpl/test_xrpl_exchange_balances.py
@@ -9,10 +9,11 @@ Covers:
 from decimal import Decimal
 from test.hummingbot.connector.exchange.xrpl.test_xrpl_exchange_base import XRPLExchangeTestBase
 from unittest.async_case import IsolatedAsyncioTestCase
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 from xrpl.models.requests.request import RequestMethod
 
+from hummingbot.connector.exchange.xrpl import xrpl_constants as CONSTANTS
 from hummingbot.core.data_type.common import OrderType, TradeType
 from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState
 
@@ -60,6 +61,10 @@ class TestXRPLExchangeBalances(XRPLExchangeTestBase, IsolatedAsyncioTestCase):
             self.connector._account_available_balances["SOLO"],
             Decimal("32.337975848655761"),
         )
+
+        # The refresh also publishes which offer sequences are live on the ledger,
+        # for _cancel_orphan_offers to compare against the order tracker.
+        self.assertIsNotNone(self.connector._ledger_offer_sequences)
 
     @patch("hummingbot.connector.exchange.xrpl.xrpl_auth.XRPLAuth.get_account")
     async def test_update_balances_empty_lines(self, get_account_mock):
@@ -284,3 +289,153 @@ class TestXRPLExchangeBalances(XRPLExchangeTestBase, IsolatedAsyncioTestCase):
 
         locked = self.connector._calculate_locked_balance_for_token("SOLO")
         self.assertEqual(locked, Decimal("0"))
+
+
+class TestXRPLOrphanOfferSweep(XRPLExchangeTestBase, IsolatedAsyncioTestCase):
+    """An offer no tracked order owns has no cancel path at all, and rests until someone takes it.
+
+    _place_cancel needs tracked_order.exchange_order_id. An order the tracker lost therefore cannot
+    be cancelled by any route the connector has — it is not slow, it is impossible. The offer keeps
+    holding balance for as long as it sits, and every quote refused for lack of budget leaves the
+    leak in place, so it feeds itself.
+
+    The tests below are mostly about restraint: what the sweep must REFUSE to cancel.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.connector._orphan_first_seen = {}
+        self.cancelled = []
+
+        async def submit(transaction=None, **kw):
+            self.cancelled.append(int(transaction.offer_sequence))
+            return MagicMock()
+
+        pool = MagicMock()
+        pool.submit_transaction = submit
+        self.connector._tx_pool = pool          # tx_pool is a lazy property with no setter
+        self.connector._xrpl_auth.get_wallet = MagicMock(return_value=MagicMock())
+
+    def _tracked(self, *seqs):
+        orders = {}
+        for i, s in enumerate(seqs):
+            o = MagicMock()
+            o.exchange_order_id = f"{s}-abc-DEF"
+            orders[f"c{i}"] = o
+        # all_fillable_orders is a read-only property; patch it on the instance's type instead
+        patcher = patch.object(type(self.connector._order_tracker), "all_fillable_orders",
+                               new_callable=PropertyMock, return_value=orders)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    async def test_an_unowned_offer_is_cancelled_once_it_has_aged(self):
+        self.connector._ledger_offer_sequences = {111}
+        self._tracked()
+        with patch("time.time", return_value=1000.0):
+            await self.connector._cancel_orphan_offers()
+        self.assertEqual([], self.cancelled, "first sighting is not yet evidence of abandonment")
+        with patch("time.time", return_value=1000.0 + CONSTANTS.ORPHAN_CANCEL_SECONDS + 1):
+            await self.connector._cancel_orphan_offers()
+        self.assertEqual([111], self.cancelled)
+
+    async def test_a_tracked_offer_is_never_touched(self):
+        """The whole point is offers with no owner; cancelling a live quote would be a disaster."""
+        self.connector._ledger_offer_sequences = {222}
+        self._tracked(222)
+        with patch("time.time", return_value=1000.0):
+            await self.connector._cancel_orphan_offers()
+        with patch("time.time", return_value=99999.0):
+            await self.connector._cancel_orphan_offers()
+        self.assertEqual([], self.cancelled)
+
+    async def test_an_offer_that_gets_claimed_during_the_grace_is_spared(self):
+        """The exact race the grace exists for: it lands, then the tracker links it."""
+        self.connector._ledger_offer_sequences = {333}
+        self._tracked()
+        with patch("time.time", return_value=1000.0):
+            await self.connector._cancel_orphan_offers()
+        self._tracked(333)                       # tracker catches up
+        with patch("time.time", return_value=1000.0 + CONSTANTS.ORPHAN_CANCEL_SECONDS + 1):
+            await self.connector._cancel_orphan_offers()
+        self.assertEqual([], self.cancelled)
+        self.assertNotIn(333, self.connector._orphan_first_seen,
+                         "a claimed offer must lose its accumulated age")
+
+    async def test_the_clock_restarts_if_it_leaves_the_book_and_returns(self):
+        self.connector._ledger_offer_sequences = {444}
+        self._tracked()
+        with patch("time.time", return_value=1000.0):
+            await self.connector._cancel_orphan_offers()
+        self.connector._ledger_offer_sequences = set()
+        with patch("time.time", return_value=1050.0):
+            await self.connector._cancel_orphan_offers()
+        self.connector._ledger_offer_sequences = {444}
+        with patch("time.time", return_value=1100.0):
+            await self.connector._cancel_orphan_offers()
+        self.assertEqual([], self.cancelled, "age must not carry across an absence")
+
+    async def test_a_sweep_is_capped(self):
+        """One bad ledger read must not become a cancel storm."""
+        self.connector._ledger_offer_sequences = set(range(500, 520))
+        self._tracked()
+        with patch("time.time", return_value=1000.0):
+            await self.connector._cancel_orphan_offers()
+        with patch("time.time", return_value=1000.0 + CONSTANTS.ORPHAN_CANCEL_SECONDS + 1):
+            await self.connector._cancel_orphan_offers()
+        self.assertEqual(CONSTANTS.ORPHAN_CANCEL_MAX_PER_SWEEP, len(self.cancelled))
+
+    async def test_a_failed_cancel_is_retried_not_forgotten(self):
+        async def boom(transaction=None, **kw):
+            raise RuntimeError("node said no")
+
+        self.connector._tx_pool.submit_transaction = boom
+        self.connector._ledger_offer_sequences = {666}
+        self._tracked()
+        with patch("time.time", return_value=1000.0):
+            await self.connector._cancel_orphan_offers()
+        with patch("time.time", return_value=1000.0 + CONSTANTS.ORPHAN_CANCEL_SECONDS + 1):
+            await self.connector._cancel_orphan_offers()
+        self.assertIn(666, self.connector._orphan_first_seen)
+
+    async def test_an_empty_or_missing_ledger_set_cancels_nothing(self):
+        """No knowledge of the book is not the same as a book full of orphans."""
+        self._tracked()
+        self.connector._ledger_offer_sequences = set()
+        with patch("time.time", return_value=99999.0):
+            await self.connector._cancel_orphan_offers()
+        self.connector._ledger_offer_sequences = None
+        with patch("time.time", return_value=99999.0):
+            await self.connector._cancel_orphan_offers()
+        self.assertEqual([], self.cancelled)
+
+    async def test_the_sweep_can_be_switched_off(self):
+        self.connector._ledger_offer_sequences = {777}
+        self._tracked()
+        with patch.object(CONSTANTS, "ORPHAN_CANCEL_SECONDS", 0):
+            with patch("time.time", return_value=99999.0):
+                await self.connector._cancel_orphan_offers()
+        self.assertEqual([], self.cancelled)
+
+    async def test_an_order_without_an_exchange_id_does_not_shield_an_orphan(self):
+        """A tracked order with no id claims no sequence, so it cannot vouch for one."""
+        o = MagicMock()
+        o.exchange_order_id = None
+        patcher = patch.object(type(self.connector._order_tracker), "all_fillable_orders",
+                               new_callable=PropertyMock, return_value={"c": o})
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.connector._ledger_offer_sequences = {888}
+        with patch("time.time", return_value=1000.0):
+            await self.connector._cancel_orphan_offers()
+        with patch("time.time", return_value=1000.0 + CONSTANTS.ORPHAN_CANCEL_SECONDS + 1):
+            await self.connector._cancel_orphan_offers()
+        self.assertEqual([888], self.cancelled)
+
+    async def test_the_sweep_runs_after_each_status_poll(self):
+        """The hook: the sweep rides the status polling loop, right after balances refresh."""
+        with patch("hummingbot.connector.exchange_py_base.ExchangePyBase._status_polling_loop_fetch_updates",
+                   new_callable=AsyncMock) as base_poll, \
+             patch.object(self.connector, "_cancel_orphan_offers", new_callable=AsyncMock) as sweep:
+            await self.connector._status_polling_loop_fetch_updates()
+        base_poll.assert_awaited_once()
+        sweep.assert_awaited_once()


### PR DESCRIPTION
## The leak

`_place_cancel` requires `tracked_order.exchange_order_id`. An order the tracker has lost — most easily across the XRPL connector's websocket reconnects, where an acknowledgement can vanish — therefore has **no cancel path at all**. Its offer keeps resting on the ledger until someone takes it, holding balance the whole time.

Observed live on an XRP-RLUSD market-making account: four abandoned BUY offers sitting 24–31 bps from the touch locked ~11 RLUSD of a 24.9 RLUSD balance. Available RLUSD fell to 0.14, and the strategy logged 169 "Not enough budget" refusals in half an hour — *accelerating*, because every refused quote left the leak in place, so it fed itself. The only remedy today is manual: notice the stuck balance, find the offer, cancel it outside the bot.

## The fix

- `_update_balances` records which offer sequences are actually live on the ledger (it already fetches `account_objects`; this adds a set comprehension, no new requests).
- After each status poll, `_cancel_orphan_offers()` compares that set against the order tracker and cancels offers that no tracked order owns.

Restraint is most of the design, because cancelling a live quote would be worse than the leak:

- An offer must stay unowned for `ORPHAN_CANCEL_SECONDS` (180 s) **across separate ledger reads** before it is touched — a just-placed offer is legitimately unowned for the moment between landing on the ledger and being linked to its tracked order, and an offer that becomes owned (or leaves the book) loses its accumulated age.
- At most `ORPHAN_CANCEL_MAX_PER_SWEEP` (3) cancels per sweep, so one bad ledger read cannot become a cancel storm.
- The sweep cannot prove an orphan is *this* bot's, so on an account shared by several processes it should be disabled: `ORPHAN_CANCEL_SECONDS = 0` switches it off.
- A failed cancel stays in the ledger of first sightings and is retried next sweep rather than forgotten.

## Tests

10 new tests in `test_xrpl_exchange_balances.py` (`TestXRPLOrphanOfferSweep`), mostly about what the sweep must **refuse** to cancel: tracked offers, offers claimed during the grace, offers that leave the book and return, unknown books, and the switched-off case. Plus the polling hook and the recording of live sequences in `_update_balances`. All 21 tests in the file pass; the rest of the XRPL suite is unaffected (the 3 failures on my Windows box — transaction-pipeline exception propagation and node-pool ping timing — fail identically on a pristine `development` checkout).