### PR TITLE
fix(xrpl): read the balance snapshot from one ledger, not three

### DIFF
--- a/hummingbot/connector/exchange/xrpl/xrpl_constants.py
+++ b/hummingbot/connector/exchange/xrpl/xrpl_constants.py
@@ -151,6 +151,12 @@ WEBSOCKET_CONNECTION_TIMEOUT = 30  # Connection timeout (seconds)
 # =============================================================================
 CONNECTION_POOL_HEALTH_CHECK_INTERVAL = 30.0  # Seconds between health checks
 CONNECTION_POOL_MAX_AGE = 300.0  # Max connection age before refresh (seconds)
+# A balance snapshot may answer from a slightly older ledger than the one already held (the pool
+# spreads requests across nodes at differing validation heights). Within this tolerance the skew
+# is ordinary; a snapshot further behind than this is a laggard backend and is skipped, because
+# balances only move forward in time — an old read can only undo a correct value. ~4s per ledger,
+# so 20 is roughly a minute and a half.
+SNAPSHOT_MAX_LAG_LEDGERS = 20
 CONNECTION_POOL_TIMEOUT = 30.0  # Connection timeout (seconds)
 CONNECTION_MAX_CONSECUTIVE_ERRORS = 3  # Errors before marking unhealthy
 PROACTIVE_PING_INTERVAL = 20.0  # Seconds between proactive pings

--- a/hummingbot/connector/exchange/xrpl/xrpl_exchange.py
+++ b/hummingbot/connector/exchange/xrpl/xrpl_exchange.py
@@ -143,6 +143,9 @@ class XrplExchange(ExchangePyBase):
         self._order_status_locks: Dict[str, asyncio.Lock] = {}
         self._order_status_lock_manager_lock = asyncio.Lock()
 
+        # The ledger version the currently-held balances describe — see _update_balances.
+        self._balances_ledger_index: Optional[int] = None
+
         # Worker pools (lazy initialization after start_network)
         self._tx_pool: Optional[XRPLTransactionWorkerPool] = None
         self._query_pool: Optional[XRPLQueryWorkerPool] = None
@@ -1516,8 +1519,9 @@ class XrplExchange(ExchangePyBase):
                         if len(currency) > 3:
                             try:
                                 currency = hex_to_str(currency).strip("\x00").upper()
-                            except UnicodeDecodeError:
-                                # Do nothing since this is a non-hex string
+                            except ValueError:
+                                # Keep the raw code. ValueError, not just UnicodeDecodeError:
+                                # bytes.fromhex raises the plain kind on a non-hex character.
                                 pass
 
                         self.logger().debug(
@@ -2499,25 +2503,119 @@ class XrplExchange(ExchangePyBase):
 
         return locked_amount
 
-    async def _update_balances(self):
-        account_address = self._xrpl_auth.get_account()
+    async def _account_snapshot(self, account_address: str, ledger_index="validated"):
+        """The three account queries, all pinned to ONE ledger version.
 
-        # Run all three queries in parallel for faster balance updates
-        # These queries are independent and can be executed concurrently
-        account_info, objects, account_lines = await asyncio.gather(
+        They are independent requests, so they run in parallel — but independence is exactly the
+        problem when the results are combined into a single portfolio number. XRPL closes a ledger
+        roughly every four seconds, and three requests issued together can land on either side of
+        a close — more easily here than elsewhere, because this connector spreads them across a
+        pool of nodes that are not all at the same validation height. Two of the three then
+        describe the account one ledger apart, and the difference lands in the portfolio as a
+        gain or loss that never happened.
+        """
+        return await asyncio.gather(
             self._query_xrpl(
-                AccountInfo(account=account_address, ledger_index="validated"),
+                AccountInfo(account=account_address, ledger_index=ledger_index),
                 priority=RequestPriority.LOW,
             ),
             self._query_xrpl(
-                AccountObjects(account=account_address),
+                AccountObjects(account=account_address, ledger_index=ledger_index),
                 priority=RequestPriority.LOW,
             ),
             self._query_xrpl(
-                AccountLines(account=account_address),
+                AccountLines(account=account_address, ledger_index=ledger_index),
                 priority=RequestPriority.LOW,
             ),
         )
+
+    @staticmethod
+    def _snapshot_ledger_indexes(responses) -> List[int]:
+        """The ledger version each response actually answered from. Asking is not assuming."""
+        out = []
+        for r in responses:
+            if r is None:
+                continue
+            idx = r.result.get("ledger_index")
+            if idx is not None:
+                try:
+                    out.append(int(idx))
+                except (TypeError, ValueError):
+                    pass
+        return out
+
+    @staticmethod
+    def _snapshot_is_complete(responses) -> bool:
+        """Does this snapshot actually carry an account, its objects and its trust lines?
+
+        Not-None is not the same as usable: a node that cannot serve the requested ledger answers
+        with an error RESPONSE, not with None, so a None-check waves it through — and the balance
+        built from it is zero. A zero balance and a failed read must not look alike, because the
+        strategies reading these balances cannot tell them apart.
+        """
+        if not responses or len(responses) != 3 or any(r is None for r in responses):
+            return False
+        account_info, objects, account_lines = responses
+        try:
+            if not account_info.result.get("account_data", {}).get("Balance"):
+                return False
+            if objects.result.get("account_objects") is None:
+                return False
+            if account_lines.result.get("lines") is None:
+                return False
+        except AttributeError:
+            return False
+        return True
+
+    async def _update_balances(self):
+        account_address = self._xrpl_auth.get_account()
+
+        # ONE MOMENT, NOT THREE. XRPL settles atomically, so no real trade can move one currency
+        # without moving another — a snapshot in which they change independently is two ledgers
+        # read as one. Asking all three queries for "validated" narrows the window but cannot
+        # close it: a validation can land between the requests. So do not assume — ask which
+        # version each one answered from, and if they disagree, re-read at an explicit integer,
+        # which every node must answer identically or refuse. The re-read pins the NEWEST ledger
+        # seen: behind one load-balancer hostname sit many backends, and pinning to the oldest
+        # would follow the laggard rather than the chain.
+        responses = await self._account_snapshot(account_address, "validated")
+        seen = self._snapshot_ledger_indexes(responses)
+        if len(set(seen)) > 1:
+            pinned = max(seen)
+            retry = await self._account_snapshot(account_address, pinned)
+            if self._snapshot_is_complete(retry):
+                responses = retry
+                self.logger().debug(
+                    f"Balance snapshot spanned ledgers {sorted(set(seen))}; re-read pinned to {pinned}")
+            else:
+                # Keep the skewed read rather than none at all, but say so: a silent skew is the
+                # thing this whole branch exists to stop.
+                self.logger().warning(
+                    f"Balance snapshot spanned ledgers {sorted(set(seen))} and the pinned re-read "
+                    f"at {pinned} came back incomplete; using the skewed snapshot for this tick")
+        if not self._snapshot_is_complete(responses):
+            self.logger().warning(
+                "Incomplete account snapshot; keeping the balances already held "
+                "rather than writing zeros")
+            return
+        account_info, objects, account_lines = responses
+
+        # A SNAPSHOT THAT GOES BACKWARDS IS NOT WRITTEN AT ALL. Pinning stops this method from
+        # choosing a laggard, but it cannot stop a whole tick from landing on one: the balancer
+        # decides which backend answers. Balances only move forward in time, so a read from a
+        # much older ledger than the one already held carries no information — it can only undo
+        # a correct value. The tolerance absorbs ordinary skew; beyond it, skip the tick and let
+        # the next one land on a healthy backend.
+        seen_now = self._snapshot_ledger_indexes(responses)
+        idx_now = max(seen_now) if seen_now else None
+        have = self._balances_ledger_index
+        if idx_now is not None and have is not None and idx_now < have - CONSTANTS.SNAPSHOT_MAX_LAG_LEDGERS:
+            self.logger().warning(
+                f"Skipping balance snapshot from ledger {idx_now}; already hold {have} "
+                f"({have - idx_now} ledgers behind, tolerance {CONSTANTS.SNAPSHOT_MAX_LAG_LEDGERS})")
+            return
+        if idx_now is not None:
+            self._balances_ledger_index = max(idx_now, have or 0)
 
         open_offers = [x for x in objects.result.get("account_objects", []) if x.get("LedgerEntryType") == "Offer"]
 
@@ -2547,8 +2645,12 @@ class XrplExchange(ExchangePyBase):
                 if len(currency) > 3:
                     try:
                         currency = hex_to_str(currency)
-                    except UnicodeDecodeError:
-                        # Do nothing since this is a non-hex string
+                    except ValueError:
+                        # Keep the raw code. ValueError, not just UnicodeDecodeError: bytes.fromhex
+                        # raises the plain kind on a non-hex character, and that one used to escape
+                        # and abort the whole balance update. One odd trustline would then freeze
+                        # every balance — silently, because the last good numbers stay in place and
+                        # look no different from fresh ones.
                         pass
 
                 token = currency.strip("\x00").upper()

--- a/test/hummingbot/connector/exchange/xrpl/test_xrpl_exchange_balances.py
+++ b/test/hummingbot/connector/exchange/xrpl/test_xrpl_exchange_balances.py
@@ -9,10 +9,11 @@ Covers:
 from decimal import Decimal
 from test.hummingbot.connector.exchange.xrpl.test_xrpl_exchange_base import XRPLExchangeTestBase
 from unittest.async_case import IsolatedAsyncioTestCase
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from xrpl.models.requests.request import RequestMethod
 
+from hummingbot.connector.exchange.xrpl import xrpl_constants as CONSTANTS
 from hummingbot.core.data_type.common import OrderType, TradeType
 from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState
 
@@ -284,3 +285,172 @@ class TestXRPLExchangeBalances(XRPLExchangeTestBase, IsolatedAsyncioTestCase):
 
         locked = self.connector._calculate_locked_balance_for_token("SOLO")
         self.assertEqual(locked, Decimal("0"))
+
+
+class TestXRPLBalanceSnapshotIsOneMoment(XRPLExchangeTestBase, IsolatedAsyncioTestCase):
+    """XRP and the token balances must describe the SAME ledger, or the portfolio is fiction.
+
+    XRPL settles atomically, so no real trade can move one currency without moving another — yet
+    a balance refresh built from three independent queries can straddle a ledger close and read
+    the account at two moments, printing a gain or loss that never happened and undoing it on the
+    next tick. Ledgers close every ~4s and the connector spreads these requests across a pool of
+    nodes at differing validation heights, so straddling a close is routine, not exotic.
+
+    The failure is silent by construction: every individual response is correct and validated.
+    Only their combination is wrong, so nothing errors and the number merely lies.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.connector._balances_ledger_index = None
+
+    def _resp(self, ledger_index, xrp_drops="30000000", token="20"):
+        r = MagicMock()
+        r.result = {"ledger_index": ledger_index, "validated": True,
+                    "account_data": {"Balance": xrp_drops},
+                    "account_objects": [],
+                    "lines": [{"currency": "USD", "account": "r_issuer", "balance": token}]}
+        return r
+
+    async def test_agreeing_ledgers_are_read_once(self):
+        """The common case must not pay for the rare one."""
+        calls = []
+
+        async def q(req, **kw):
+            calls.append(getattr(req, "ledger_index", None))
+            return self._resp(900)
+
+        self.connector._query_xrpl = q
+        await self.connector._update_balances()
+        self.assertEqual(3, len(calls), "one agreeing snapshot needs no re-read")
+
+    async def test_a_straddled_close_is_detected_and_re_read(self):
+        """Two responses at ledger N and one at N+1 — the exact shape of a phantom loss."""
+        seq = []
+
+        async def q(req, **kw):
+            idx = getattr(req, "ledger_index", None)
+            seq.append(idx)
+            if idx == "validated":
+                # first round straddles a close
+                return self._resp(900 if len(seq) < 3 else 901)
+            return self._resp(idx)
+
+        self.connector._query_xrpl = q
+        await self.connector._update_balances()
+        self.assertEqual(6, len(seq), "a straddle must trigger exactly one pinned re-read")
+        self.assertEqual([901, 901, 901], seq[3:], "the re-read must pin an explicit integer")
+
+    async def test_the_re_read_pins_the_newest_ledger(self):
+        """Behind one balancer hostname sit many backends; the oldest seen may be a laggard's
+        hour-old view, so following it would follow the laggard rather than the chain."""
+        seq = []
+
+        async def q(req, **kw):
+            idx = getattr(req, "ledger_index", None)
+            seq.append(idx)
+            if idx == "validated":
+                return self._resp(905 if len(seq) == 1 else 904)
+            return self._resp(idx)
+
+        self.connector._query_xrpl = q
+        await self.connector._update_balances()
+        self.assertEqual(905, seq[3], "pin the newest seen, not the oldest")
+
+    async def test_an_incomplete_re_read_keeps_the_data_and_warns(self):
+        """Losing the snapshot entirely would be worse than a skewed one — but not silently."""
+        seq = []
+
+        async def q(req, **kw):
+            idx = getattr(req, "ledger_index", None)
+            seq.append(idx)
+            if idx != "validated":
+                return None            # pinned re-read fails
+            return self._resp(900 if len(seq) < 3 else 901)
+
+        self.connector._query_xrpl = q
+        with self.assertLogs(level="WARNING") as cm:
+            await self.connector._update_balances()
+        self.assertTrue(any("skewed snapshot" in m for m in cm.output),
+                        "a fallback to skewed data has to announce itself")
+        self.assertIn("XRP", self.connector._account_balances)
+
+    async def test_a_response_without_a_ledger_index_does_not_trigger_a_re_read(self):
+        """Missing metadata is ignorance, not disagreement; re-reading on it would loop forever."""
+        seq = []
+
+        async def q(req, **kw):
+            seq.append(getattr(req, "ledger_index", None))
+            r = self._resp(900)
+            if len(seq) == 2:
+                r.result.pop("ledger_index")
+            return r
+
+        self.connector._query_xrpl = q
+        await self.connector._update_balances()
+        self.assertEqual(3, len(seq))
+
+    def test_index_parsing_survives_junk(self):
+        r = MagicMock()
+        r.result = {"ledger_index": "not-a-number"}
+        ok = MagicMock()
+        ok.result = {"ledger_index": 12}
+        self.assertEqual([12], self.connector._snapshot_ledger_indexes([r, ok, None]))
+
+    async def test_an_incomplete_snapshot_writes_nothing(self):
+        """A node that cannot serve the ledger answers with an error RESPONSE, not None.
+
+        A None-check waves it through, and the balance built from it is zero — indistinguishable,
+        to every strategy reading it, from an account that is actually empty.
+        """
+        async def q(req, **kw):
+            r = MagicMock()
+            r.result = {"error": "lgrNotFound", "ledger_index": 900}
+            return r
+
+        self.connector._query_xrpl = q
+        with self.assertLogs(level="WARNING") as cm:
+            await self.connector._update_balances()
+        self.assertTrue(any("Incomplete account snapshot" in m for m in cm.output))
+        self.assertNotIn("XRP", self.connector._account_balances,
+                         "a failed read must not masquerade as a zero balance")
+
+    async def test_a_snapshot_from_a_laggard_ledger_is_skipped(self):
+        """Balances only move forward in time; an hour-old read can only undo a correct value."""
+        async def q(req, **kw):
+            return self._resp(900)
+
+        self.connector._query_xrpl = q
+        self.connector._balances_ledger_index = 900 + CONSTANTS.SNAPSHOT_MAX_LAG_LEDGERS + 1
+        with self.assertLogs(level="WARNING") as cm:
+            await self.connector._update_balances()
+        self.assertTrue(any("Skipping balance snapshot" in m for m in cm.output))
+        self.assertNotIn("XRP", self.connector._account_balances)
+
+    async def test_ordinary_skew_within_the_tolerance_is_accepted(self):
+        """The pool's nodes legitimately sit a few ledgers apart; only the outlier is refused."""
+        async def q(req, **kw):
+            return self._resp(900)
+
+        self.connector._query_xrpl = q
+        self.connector._balances_ledger_index = 900 + CONSTANTS.SNAPSHOT_MAX_LAG_LEDGERS
+        await self.connector._update_balances()
+        self.assertIn("XRP", self.connector._account_balances)
+        self.assertEqual(900 + CONSTANTS.SNAPSHOT_MAX_LAG_LEDGERS,
+                         self.connector._balances_ledger_index,
+                         "the held index must never move backwards")
+
+    async def test_a_malformed_trustline_currency_does_not_freeze_every_balance(self):
+        """bytes.fromhex raises plain ValueError; only UnicodeDecodeError was caught.
+
+        The uncaught kind escaped and aborted the whole update — silently, because the previous
+        numbers stay in place and nothing distinguishes them from fresh ones.
+        """
+        async def q(req, **kw):
+            r = self._resp(900)
+            r.result["lines"] = [{"currency": "NOTHEXAT", "account": "r_issuer", "balance": "5"}]
+            return r
+
+        self.connector._query_xrpl = q
+        await self.connector._update_balances()   # must not raise
+        self.assertIn("XRP", self.connector._account_balances)


### PR DESCRIPTION
## The phantom loss

XRPL settles atomically — no real trade can move one currency without moving another. Yet `_update_balances` builds the account view from three independent parallel queries (`AccountInfo`, `AccountObjects`, `AccountLines`), and only the first is pinned to `validated`; the other two read the default (current) ledger. Ledgers close every ~4 s and the connector spreads these requests across a pool of nodes at differing validation heights, so the three responses routinely describe the account at **different moments**.

Observed live on a small XRP-RLUSD market-making account: the portfolio meter printed a $3.28 loss in which RLUSD fell with no matching XRP change — impossible on an atomically-settling ledger — and the next 30-second tick undid it. The failure is silent by construction: every individual response is correct and `validated: true`. Only their combination is wrong, so nothing errors and the number merely lies. Anything downstream that reads these balances (inventory logic, risk limits, user-facing P&L) acts on the fiction.

## The fix

1. **All three queries pin the same `ledger_index`** (`validated`).
2. **Ask, don't assume:** the refresh reads which ledger each response actually answered from. If they disagree (a validation landed between the requests), it re-reads pinned to the **newest** explicit integer index — which every node must answer identically or refuse. Newest, not oldest: behind one load-balancer hostname sit many backends, and pinning to the oldest seen would follow a laggard rather than the chain. The common case (all agree) costs nothing extra.
3. **An incomplete snapshot is not written at all.** A node that cannot serve the requested ledger answers with an error *response*, not `None`, so a None-check waves it through — and the balance built from it is zero. A zero balance and a failed read must not look alike; the previous balances are kept and a warning says so.
4. **A snapshot that goes backwards is skipped** (`SNAPSHOT_MAX_LAG_LEDGERS = 20`). Pinning stops the method from choosing a laggard, but the balancer decides which backend answers a given tick. Balances only move forward in time, so a read from a much older ledger than the one already held can only undo a correct value. Ordinary pool skew within the tolerance is accepted.
5. **A malformed trustline currency no longer freezes every balance.** `hex_to_str` → `bytes.fromhex` raises plain `ValueError` on a non-hex character, but only `UnicodeDecodeError` was caught — the plain kind escaped and aborted the whole update, silently, because the last good numbers stay in place and look no different from fresh ones.

## Tests

10 new tests in `test_xrpl_exchange_balances.py` (`TestXRPLBalanceSnapshotIsOneMoment`): the agreeing case pays no re-read, a straddled close triggers exactly one pinned re-read at the newest index, an incomplete re-read falls back to the skewed data with a warning rather than silently, missing `ledger_index` metadata is treated as ignorance rather than disagreement (no re-read loop), an incomplete snapshot writes nothing, a laggard snapshot is skipped while ordinary skew is accepted, and the malformed-trustline case completes instead of raising. All 21 tests in the file pass; the rest of the XRPL suite is unaffected (the 4 failures on my Windows box — transaction-pipeline exception propagation and node-pool ping timing — fail identically on a pristine `development` checkout).

Note: this touches the same `_update_balances` region as #8415 (orphan-offer sweep); whichever merges second has a trivial context conflict. Happy to rebase either.