### PR TITLE
Fix Hyperliquid builder fee not resolving when connector is embedded

### DIFF
--- a/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_derivative.py
@@ -69,9 +69,12 @@ class HyperliquidPerpetualDerivative(PerpetualDerivativePyBase):
         self._dex_markets: List[Dict] = []  # Store HIP-3 DEX market info separately
         self._is_hip3_market: Dict[str, bool] = {}  # Track which coins are HIP-3
         self._user_abstraction_mode: Optional[str] = None
-        # Builder code (HGP-87). Fee starts at 0 and is resolved at startup (_initialize_builder_fee).
+        # Builder code (HGP-87). Fee starts at 0 and is resolved once per session
+        # (_ensure_builder_fee_resolved), at start_network or on the first order.
         self._builder_address: str = CONSTANTS.FOUNDATION_BUILDER_ADDRESS.lower()
         self._builder_fee_tenths_bps: int = 0
+        self._builder_fee_resolved: bool = False
+        self._builder_fee_lock: asyncio.Lock = asyncio.Lock()
         super().__init__(balance_asset_limit, rate_limits_share_pct)
 
     @property
@@ -139,7 +142,7 @@ class HyperliquidPerpetualDerivative(PerpetualDerivativePyBase):
     async def start_network(self):
         await super().start_network()
         if self._trading_required:
-            await self._initialize_builder_fee()
+            await self._ensure_builder_fee_resolved()
 
     def supported_order_types(self) -> List[OrderType]:
         """
@@ -646,7 +649,9 @@ class HyperliquidPerpetualDerivative(PerpetualDerivativePyBase):
                 "cloid": order_id,
             }
         }
-        # Builder code (HGP-87): part of the signed action dict.
+        # Builder code (HGP-87): part of the signed action dict. Resolve the fee here too —
+        # embedders like hummingbot-api start connector tasks without calling start_network().
+        await self._ensure_builder_fee_resolved()
         builder_field = self._build_builder_field()
         if builder_field is not None:
             api_params["builder"] = builder_field
@@ -686,8 +691,20 @@ class HyperliquidPerpetualDerivative(PerpetualDerivativePyBase):
             return None
         return {"b": self._builder_address.lower(), "f": self._builder_fee_tenths_bps}
 
+    async def _ensure_builder_fee_resolved(self) -> None:
+        """Resolve the builder fee exactly once per session, whichever path gets there first:
+        start_network on normal client startup, or the first _place_order for embedders that
+        start connector tasks without calling start_network."""
+        if self._builder_fee_resolved:
+            return
+        async with self._builder_fee_lock:
+            if self._builder_fee_resolved:
+                return
+            await self._initialize_builder_fee()
+            self._builder_fee_resolved = True
+
     async def _initialize_builder_fee(self) -> None:
-        """Resolve the per-order builder fee once at startup as min(on-chain approved, hardcoded fee):
+        """Resolve the per-order builder fee as min(on-chain approved, hardcoded fee):
         the hardcoded fee if the user has approved this builder in Condor, 0 if not (or if the lookup
         fails)."""
         if not self._should_inject_builder():

--- a/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_derivative.py
@@ -144,6 +144,11 @@ class HyperliquidPerpetualDerivative(PerpetualDerivativePyBase):
         if self._trading_required:
             await self._ensure_builder_fee_resolved()
 
+    async def stop_network(self):
+        await super().stop_network()
+        # Re-resolve the builder fee on the next session so mid-session approval changes are picked up.
+        self._builder_fee_resolved = False
+
     def supported_order_types(self) -> List[OrderType]:
         """
         :return a list of OrderType supported by this connector
@@ -692,23 +697,23 @@ class HyperliquidPerpetualDerivative(PerpetualDerivativePyBase):
         return {"b": self._builder_address.lower(), "f": self._builder_fee_tenths_bps}
 
     async def _ensure_builder_fee_resolved(self) -> None:
-        """Resolve the builder fee exactly once per session, whichever path gets there first:
+        """Resolve the builder fee once per network session, whichever path gets there first:
         start_network on normal client startup, or the first _place_order for embedders that
-        start connector tasks without calling start_network."""
+        start connector tasks without calling start_network. A failed lookup does not latch the
+        flag, so the next order retries; stop_network clears it, so a reconnect re-resolves."""
         if self._builder_fee_resolved:
             return
         async with self._builder_fee_lock:
             if self._builder_fee_resolved:
                 return
-            await self._initialize_builder_fee()
-            self._builder_fee_resolved = True
+            self._builder_fee_resolved = await self._initialize_builder_fee()
 
-    async def _initialize_builder_fee(self) -> None:
+    async def _initialize_builder_fee(self) -> bool:
         """Resolve the per-order builder fee as min(on-chain approved, hardcoded fee):
-        the hardcoded fee if the user has approved this builder in Condor, 0 if not (or if the lookup
-        fails)."""
+        the hardcoded fee if the user has approved this builder in Condor, 0 if not.
+        Returns False when the lookup failed (fee left at 0 until the next attempt)."""
         if not self._should_inject_builder():
-            return
+            return True
         try:
             approved_max_tenths_bps = int(await self._api_post(
                 path_url=CONSTANTS.EXCHANGE_INFO_URL,
@@ -720,11 +725,12 @@ class HyperliquidPerpetualDerivative(PerpetualDerivativePyBase):
             ))
         except Exception:
             self.logger().exception(
-                "Could not query the approved Hyperliquid builder fee; charging 0 bps this session."
+                "Could not query the approved Hyperliquid builder fee; charging 0 bps until it can be resolved."
             )
             self._builder_fee_tenths_bps = 0
-            return
+            return False
         self._builder_fee_tenths_bps = min(approved_max_tenths_bps, CONSTANTS.FOUNDATION_BUILDER_FEE_TENTHS_BPS)
+        return True
 
     async def _update_trade_history(self):
         orders = list(self._order_tracker.all_fillable_orders.values())

--- a/hummingbot/connector/exchange/hyperliquid/hyperliquid_exchange.py
+++ b/hummingbot/connector/exchange/hyperliquid/hyperliquid_exchange.py
@@ -67,9 +67,12 @@ class HyperliquidExchange(ExchangePyBase):
         self._last_trades_poll_timestamp = 1.0
         self.coin_to_asset: Dict[str, int] = {}
         self.name_to_coin: Dict[str, str] = {}
-        # Builder code (HGP-87). Fee starts at 0 and is resolved at startup (_initialize_builder_fee).
+        # Builder code (HGP-87). Fee starts at 0 and is resolved once per session
+        # (_ensure_builder_fee_resolved), at start_network or on the first order.
         self._builder_address: str = CONSTANTS.FOUNDATION_BUILDER_ADDRESS.lower()
         self._builder_fee_tenths_bps: int = 0
+        self._builder_fee_resolved: bool = False
+        self._builder_fee_lock: asyncio.Lock = asyncio.Lock()
         super().__init__(balance_asset_limit, rate_limits_share_pct)
 
     @property
@@ -133,7 +136,7 @@ class HyperliquidExchange(ExchangePyBase):
     async def start_network(self):
         await super().start_network()
         if self._trading_required:
-            await self._initialize_builder_fee()
+            await self._ensure_builder_fee_resolved()
 
     def supported_order_types(self) -> List[OrderType]:
         """
@@ -383,7 +386,9 @@ class HyperliquidExchange(ExchangePyBase):
                 "cloid": order_id,
             }
         }
-        # Builder code (HGP-87): part of the signed action dict.
+        # Builder code (HGP-87): part of the signed action dict. Resolve the fee here too —
+        # embedders like hummingbot-api start connector tasks without calling start_network().
+        await self._ensure_builder_fee_resolved()
         builder_field = self._build_builder_field()
         if builder_field is not None:
             api_params["builder"] = builder_field
@@ -423,8 +428,20 @@ class HyperliquidExchange(ExchangePyBase):
             return None
         return {"b": self._builder_address.lower(), "f": self._builder_fee_tenths_bps}
 
+    async def _ensure_builder_fee_resolved(self) -> None:
+        """Resolve the builder fee exactly once per session, whichever path gets there first:
+        start_network on normal client startup, or the first _place_order for embedders that
+        start connector tasks without calling start_network."""
+        if self._builder_fee_resolved:
+            return
+        async with self._builder_fee_lock:
+            if self._builder_fee_resolved:
+                return
+            await self._initialize_builder_fee()
+            self._builder_fee_resolved = True
+
     async def _initialize_builder_fee(self) -> None:
-        """Resolve the per-order builder fee once at startup as min(on-chain approved, hardcoded fee):
+        """Resolve the per-order builder fee as min(on-chain approved, hardcoded fee):
         the hardcoded fee if the user has approved this builder in Condor, 0 if not (or if the lookup
         fails)."""
         if not self._should_inject_builder():

--- a/hummingbot/connector/exchange/hyperliquid/hyperliquid_exchange.py
+++ b/hummingbot/connector/exchange/hyperliquid/hyperliquid_exchange.py
@@ -138,6 +138,11 @@ class HyperliquidExchange(ExchangePyBase):
         if self._trading_required:
             await self._ensure_builder_fee_resolved()
 
+    async def stop_network(self):
+        await super().stop_network()
+        # Re-resolve the builder fee on the next session so mid-session approval changes are picked up.
+        self._builder_fee_resolved = False
+
     def supported_order_types(self) -> List[OrderType]:
         """
         :return a list of OrderType supported by this connector
@@ -429,23 +434,23 @@ class HyperliquidExchange(ExchangePyBase):
         return {"b": self._builder_address.lower(), "f": self._builder_fee_tenths_bps}
 
     async def _ensure_builder_fee_resolved(self) -> None:
-        """Resolve the builder fee exactly once per session, whichever path gets there first:
+        """Resolve the builder fee once per network session, whichever path gets there first:
         start_network on normal client startup, or the first _place_order for embedders that
-        start connector tasks without calling start_network."""
+        start connector tasks without calling start_network. A failed lookup does not latch the
+        flag, so the next order retries; stop_network clears it, so a reconnect re-resolves."""
         if self._builder_fee_resolved:
             return
         async with self._builder_fee_lock:
             if self._builder_fee_resolved:
                 return
-            await self._initialize_builder_fee()
-            self._builder_fee_resolved = True
+            self._builder_fee_resolved = await self._initialize_builder_fee()
 
-    async def _initialize_builder_fee(self) -> None:
+    async def _initialize_builder_fee(self) -> bool:
         """Resolve the per-order builder fee as min(on-chain approved, hardcoded fee):
-        the hardcoded fee if the user has approved this builder in Condor, 0 if not (or if the lookup
-        fails)."""
+        the hardcoded fee if the user has approved this builder in Condor, 0 if not.
+        Returns False when the lookup failed (fee left at 0 until the next attempt)."""
         if not self._should_inject_builder():
-            return
+            return True
         try:
             approved_max_tenths_bps = int(await self._api_post(
                 path_url=CONSTANTS.EXCHANGE_INFO_URL,
@@ -457,11 +462,12 @@ class HyperliquidExchange(ExchangePyBase):
             ))
         except Exception:
             self.logger().exception(
-                "Could not query the approved Hyperliquid builder fee; charging 0 bps this session."
+                "Could not query the approved Hyperliquid builder fee; charging 0 bps until it can be resolved."
             )
             self._builder_fee_tenths_bps = 0
-            return
+            return False
         self._builder_fee_tenths_bps = min(approved_max_tenths_bps, CONSTANTS.FOUNDATION_BUILDER_FEE_TENTHS_BPS)
+        return True
 
     async def _update_trade_history(self):
         orders = list(self._order_tracker.all_fillable_orders.values())

--- a/test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_derivative.py
@@ -3905,6 +3905,7 @@ class HyperliquidPerpetualBuilderCodeTests(TestCase):
                                           (self._build_connector(use_vault=True), False),
                                           (self._build_connector(domain=CONSTANTS.TESTNET_DOMAIN), False)):
             connector._builder_fee_tenths_bps = 10  # as if the user approved 1 bps
+            connector._builder_fee_resolved = True  # skip the lazy fee lookup in _place_order
             connector.coin_to_asset = {"BTC": 0}
             with patch.object(connector, "exchange_symbol_associated_to_pair",
                               new_callable=AsyncMock, return_value="BTC"):
@@ -3917,6 +3918,30 @@ class HyperliquidPerpetualBuilderCodeTests(TestCase):
             self.assertEqual(expect_builder, "builder" in sent)
             if expect_builder:
                 self.assertEqual({"b": connector._builder_address, "f": 10}, sent["builder"])
+
+    @patch.object(HyperliquidPerpetualDerivative, "_api_post", new_callable=AsyncMock)
+    def test_place_order_resolves_builder_fee_without_start_network(self, api_post_mock):
+        # Embedders like hummingbot-api start connector tasks without calling start_network,
+        # so the first order must resolve the approved fee itself instead of charging 0 bps —
+        # and only the first: the maxBuilderFee lookup runs once, not per order.
+        order_result = {"status": "ok", "response": {"data": {"statuses": [{"resting": {"oid": 7}}]}}}
+        api_post_mock.side_effect = [10, order_result, order_result]
+        connector = self._build_connector()
+        connector.coin_to_asset = {"BTC": 0}
+        with patch.object(connector, "exchange_symbol_associated_to_pair",
+                          new_callable=AsyncMock, return_value="BTC"):
+            for _ in range(2):
+                self.async_run_with_timeout(connector._place_order(
+                    order_id="0xabc", trading_pair="BTC-USD", amount=Decimal("1"),
+                    trade_type=TradeType.BUY, order_type=OrderType.LIMIT, price=Decimal("100"),
+                    position_action=PositionAction.OPEN,
+                ))
+        self.assertEqual(10, connector._builder_fee_tenths_bps)
+        self.assertEqual(
+            {"b": connector._builder_address, "f": 10},
+            api_post_mock.call_args.kwargs["data"]["builder"],
+        )
+        self.assertEqual(3, api_post_mock.call_count)
 
     @patch.object(HyperliquidPerpetualDerivative, "_api_post", new_callable=AsyncMock)
     def test_initialize_builder_fee_applies_approved(self, api_post_mock):

--- a/test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_derivative.py
@@ -3944,6 +3944,42 @@ class HyperliquidPerpetualBuilderCodeTests(TestCase):
         self.assertEqual(3, api_post_mock.call_count)
 
     @patch.object(HyperliquidPerpetualDerivative, "_api_post", new_callable=AsyncMock)
+    def test_failed_fee_lookup_does_not_latch_and_next_order_retries(self, api_post_mock):
+        # A transient maxBuilderFee lookup failure must not freeze the fee at 0 for the whole
+        # session: the failing order goes out at 0 bps, and the next order retries the lookup.
+        order_result = {"status": "ok", "response": {"data": {"statuses": [{"resting": {"oid": 7}}]}}}
+        api_post_mock.side_effect = [Exception("info endpoint down"), order_result, 10, order_result]
+        connector = self._build_connector()
+        connector.coin_to_asset = {"BTC": 0}
+        with patch.object(connector, "exchange_symbol_associated_to_pair",
+                          new_callable=AsyncMock, return_value="BTC"):
+            self.async_run_with_timeout(connector._place_order(
+                order_id="0xabc", trading_pair="BTC-USD", amount=Decimal("1"),
+                trade_type=TradeType.BUY, order_type=OrderType.LIMIT, price=Decimal("100"),
+                position_action=PositionAction.OPEN,
+            ))
+            self.assertFalse(connector._builder_fee_resolved)
+            self.assertEqual(0, connector._builder_fee_tenths_bps)
+            self.async_run_with_timeout(connector._place_order(
+                order_id="0xdef", trading_pair="BTC-USD", amount=Decimal("1"),
+                trade_type=TradeType.BUY, order_type=OrderType.LIMIT, price=Decimal("100"),
+                position_action=PositionAction.OPEN,
+            ))
+        self.assertTrue(connector._builder_fee_resolved)
+        self.assertEqual(10, connector._builder_fee_tenths_bps)
+        self.assertEqual(
+            {"b": connector._builder_address, "f": 10},
+            api_post_mock.call_args.kwargs["data"]["builder"],
+        )
+
+    def test_stop_network_resets_builder_fee_resolution(self):
+        # A reconnect must re-query the approval so mid-session approvals/revocations are picked up.
+        connector = self._build_connector()
+        connector._builder_fee_resolved = True
+        self.async_run_with_timeout(connector.stop_network())
+        self.assertFalse(connector._builder_fee_resolved)
+
+    @patch.object(HyperliquidPerpetualDerivative, "_api_post", new_callable=AsyncMock)
     def test_initialize_builder_fee_applies_approved(self, api_post_mock):
         api_post_mock.return_value = 10  # user approved 0.01% = 1 bps
         connector = self._build_connector()

--- a/test/hummingbot/connector/exchange/hyperliquid/test_hyperliquid_exchange.py
+++ b/test/hummingbot/connector/exchange/hyperliquid/test_hyperliquid_exchange.py
@@ -2019,6 +2019,7 @@ class HyperliquidBuilderCodeTests(TestCase):
                                           (self._build_connector(use_vault=True), False),
                                           (self._build_connector(domain=CONSTANTS.TESTNET_DOMAIN), False)):
             connector._builder_fee_tenths_bps = 10  # as if the user approved 1 bps
+            connector._builder_fee_resolved = True  # skip the lazy fee lookup in _place_order
             connector.coin_to_asset = {"HFUN": 0}
             with patch.object(connector, "exchange_symbol_associated_to_pair",
                               new_callable=AsyncMock, return_value="HFUN"):
@@ -2030,6 +2031,29 @@ class HyperliquidBuilderCodeTests(TestCase):
             self.assertEqual(expect_builder, "builder" in sent)
             if expect_builder:
                 self.assertEqual({"b": connector._builder_address, "f": 10}, sent["builder"])
+
+    @patch.object(HyperliquidExchange, "_api_post", new_callable=AsyncMock)
+    def test_place_order_resolves_builder_fee_without_start_network(self, api_post_mock):
+        # Embedders like hummingbot-api start connector tasks without calling start_network,
+        # so the first order must resolve the approved fee itself instead of charging 0 bps —
+        # and only the first: the maxBuilderFee lookup runs once, not per order.
+        order_result = {"status": "ok", "response": {"data": {"statuses": [{"resting": {"oid": 7}}]}}}
+        api_post_mock.side_effect = [10, order_result, order_result]
+        connector = self._build_connector()
+        connector.coin_to_asset = {"HFUN": 0}
+        with patch.object(connector, "exchange_symbol_associated_to_pair",
+                          new_callable=AsyncMock, return_value="HFUN"):
+            for _ in range(2):
+                self.async_run_with_timeout(connector._place_order(
+                    order_id="0xabc", trading_pair="HFUN-USDC", amount=Decimal("1"),
+                    trade_type=TradeType.BUY, order_type=OrderType.LIMIT, price=Decimal("100"),
+                ))
+        self.assertEqual(10, connector._builder_fee_tenths_bps)
+        self.assertEqual(
+            {"b": connector._builder_address, "f": 10},
+            api_post_mock.call_args.kwargs["data"]["builder"],
+        )
+        self.assertEqual(3, api_post_mock.call_count)
 
     @patch.object(HyperliquidExchange, "_api_post", new_callable=AsyncMock)
     def test_initialize_builder_fee_applies_approved(self, api_post_mock):

--- a/test/hummingbot/connector/exchange/hyperliquid/test_hyperliquid_exchange.py
+++ b/test/hummingbot/connector/exchange/hyperliquid/test_hyperliquid_exchange.py
@@ -2056,6 +2056,40 @@ class HyperliquidBuilderCodeTests(TestCase):
         self.assertEqual(3, api_post_mock.call_count)
 
     @patch.object(HyperliquidExchange, "_api_post", new_callable=AsyncMock)
+    def test_failed_fee_lookup_does_not_latch_and_next_order_retries(self, api_post_mock):
+        # A transient maxBuilderFee lookup failure must not freeze the fee at 0 for the whole
+        # session: the failing order goes out at 0 bps, and the next order retries the lookup.
+        order_result = {"status": "ok", "response": {"data": {"statuses": [{"resting": {"oid": 7}}]}}}
+        api_post_mock.side_effect = [Exception("info endpoint down"), order_result, 10, order_result]
+        connector = self._build_connector()
+        connector.coin_to_asset = {"HFUN": 0}
+        with patch.object(connector, "exchange_symbol_associated_to_pair",
+                          new_callable=AsyncMock, return_value="HFUN"):
+            self.async_run_with_timeout(connector._place_order(
+                order_id="0xabc", trading_pair="HFUN-USDC", amount=Decimal("1"),
+                trade_type=TradeType.BUY, order_type=OrderType.LIMIT, price=Decimal("100"),
+            ))
+            self.assertFalse(connector._builder_fee_resolved)
+            self.assertEqual(0, connector._builder_fee_tenths_bps)
+            self.async_run_with_timeout(connector._place_order(
+                order_id="0xdef", trading_pair="HFUN-USDC", amount=Decimal("1"),
+                trade_type=TradeType.BUY, order_type=OrderType.LIMIT, price=Decimal("100"),
+            ))
+        self.assertTrue(connector._builder_fee_resolved)
+        self.assertEqual(10, connector._builder_fee_tenths_bps)
+        self.assertEqual(
+            {"b": connector._builder_address, "f": 10},
+            api_post_mock.call_args.kwargs["data"]["builder"],
+        )
+
+    def test_stop_network_resets_builder_fee_resolution(self):
+        # A reconnect must re-query the approval so mid-session approvals/revocations are picked up.
+        connector = self._build_connector()
+        connector._builder_fee_resolved = True
+        self.async_run_with_timeout(connector.stop_network())
+        self.assertFalse(connector._builder_fee_resolved)
+
+    @patch.object(HyperliquidExchange, "_api_post", new_callable=AsyncMock)
     def test_initialize_builder_fee_applies_approved(self, api_post_mock):
         api_post_mock.return_value = 10  # user approved 0.01% = 1 bps
         connector = self._build_connector()


### PR DESCRIPTION
## Description

The Hyperliquid builder fee (HGP-87) was only resolved in `start_network()`. Embedders like hummingbot-api start connector tasks without calling `start_network()`, so orders placed through them (e.g. grid executors deployed from Condor) never carried the builder code.

This adds `_ensure_builder_fee_resolved()` — a lock-guarded, once-per-session resolver — called from both `start_network()` and `_place_order()`, so the fee is resolved on the first order even when `start_network()` is skipped. Applied to both the spot (`hyperliquid_exchange.py`) and perpetual (`hyperliquid_perpetual_derivative.py`) connectors.

## Tests

- Added tests covering lazy resolution on first order placement in both connector test suites.
- `pytest test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_derivative.py test/hummingbot/connector/exchange/hyperliquid/test_hyperliquid_exchange.py` — 204 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)