### PR TITLE
fix(hyperliquid): allow reduce-only dust position closes

### DIFF
--- a/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_derivative.py
@@ -130,6 +130,10 @@ class HyperliquidPerpetualDerivative(PerpetualDerivativePyBase):
         return self._trading_required
 
     @property
+    def allow_reduce_only_orders_below_min_notional(self) -> bool:
+        return True
+
+    @property
     def funding_fee_poll_interval(self) -> int:
         return 120
 

--- a/hummingbot/connector/exchange_py_base.py
+++ b/hummingbot/connector/exchange_py_base.py
@@ -18,7 +18,7 @@ from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
 from hummingbot.core.api_throttler.async_throttler_base import AsyncThrottlerBase
 from hummingbot.core.api_throttler.data_types import RateLimit
 from hummingbot.core.data_type.cancellation_result import CancellationResult
-from hummingbot.core.data_type.common import OrderType, TradeType
+from hummingbot.core.data_type.common import OrderType, PositionAction, TradeType
 from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState, OrderUpdate, TradeUpdate
 from hummingbot.core.data_type.limit_order import LimitOrder
 from hummingbot.core.data_type.order_book import OrderBook
@@ -148,6 +148,10 @@ class ExchangePyBase(ExchangeBase, ABC):
     @abstractmethod
     def is_trading_required(self) -> bool:
         raise NotImplementedError
+
+    @property
+    def allow_reduce_only_orders_below_min_notional(self) -> bool:
+        return False
 
     @property
     def order_books(self) -> Dict[str, OrderBook]:
@@ -452,7 +456,9 @@ class ExchangePyBase(ExchangeBase, ABC):
                                      f"for the pair {trading_pair}. The order will not be created."))
             return
 
-        elif notional_size < trading_rule.min_notional_size:
+        elif (notional_size < trading_rule.min_notional_size
+              and not (self.allow_reduce_only_orders_below_min_notional
+                       and kwargs.get("position_action") == PositionAction.CLOSE)):
             self._update_order_after_failure(
                 order_id=order_id, trading_pair=trading_pair,
                 exception=ValueError(f"Order notional {notional_size} is lower than minimum notional size {trading_rule.min_notional_size}"

--- a/test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_derivative.py
@@ -17,6 +17,7 @@ import hummingbot.connector.derivative.hyperliquid_perpetual.hyperliquid_perpetu
 from hummingbot.connector.derivative.hyperliquid_perpetual.hyperliquid_perpetual_derivative import (
     HyperliquidPerpetualDerivative,
 )
+from hummingbot.connector.exchange_py_base import ExchangePyBase
 from hummingbot.connector.test_support.perpetual_derivative_test import AbstractPerpetualDerivativeTests
 from hummingbot.connector.trading_rule import TradingRule
 from hummingbot.connector.utils import combine_to_hb_trading_pair
@@ -1808,6 +1809,93 @@ class HyperliquidPerpetualDerivativeTests(AbstractPerpetualDerivativeTests.Perpe
                 min_base_amount_increment=Decimal(str(0.000001)),
             )
         }
+
+    async def test_close_order_below_min_notional_is_submitted_when_capability_enabled(self):
+        self._simulate_trading_rules_initialized()
+        self.exchange._trading_rules[self.trading_pair].min_notional_size = Decimal("10")
+        self.exchange._place_order_and_process_update = AsyncMock()
+
+        await self.exchange._create_order(
+            trade_type=TradeType.SELL,
+            order_id="OID1",
+            trading_pair=self.trading_pair,
+            amount=Decimal("0.02"),
+            order_type=OrderType.LIMIT,
+            position_action=PositionAction.CLOSE,
+            price=Decimal("100"),
+        )
+
+        self.exchange._place_order_and_process_update.assert_awaited_once()
+
+    async def test_open_order_below_min_notional_is_rejected_when_capability_enabled(self):
+        self._simulate_trading_rules_initialized()
+        self.exchange._trading_rules[self.trading_pair].min_notional_size = Decimal("10")
+        self.exchange._place_order_and_process_update = AsyncMock()
+
+        await self.exchange._create_order(
+            trade_type=TradeType.BUY,
+            order_id="OID1",
+            trading_pair=self.trading_pair,
+            amount=Decimal("0.02"),
+            order_type=OrderType.LIMIT,
+            position_action=PositionAction.OPEN,
+            price=Decimal("100"),
+        )
+        await asyncio.sleep(0.001)
+
+        self.exchange._place_order_and_process_update.assert_not_awaited()
+        self.assertNotIn("OID1", self.exchange.in_flight_orders)
+        self.assertEqual("OID1", self.order_failure_logger.event_log[0].order_id)
+
+    async def test_close_order_below_min_order_size_is_rejected(self):
+        self._simulate_trading_rules_initialized()
+        self.exchange._trading_rules[self.trading_pair].min_notional_size = Decimal("10")
+        self.exchange._place_order_and_process_update = AsyncMock()
+
+        await self.exchange._create_order(
+            trade_type=TradeType.SELL,
+            order_id="OID1",
+            trading_pair=self.trading_pair,
+            amount=Decimal("0.001"),
+            order_type=OrderType.LIMIT,
+            position_action=PositionAction.CLOSE,
+            price=Decimal("100"),
+        )
+        await asyncio.sleep(0.001)
+
+        self.exchange._place_order_and_process_update.assert_not_awaited()
+        self.assertNotIn("OID1", self.exchange.in_flight_orders)
+        self.assertEqual("OID1", self.order_failure_logger.event_log[0].order_id)
+
+    async def test_connector_without_capability_rejects_close_below_min_notional(self):
+        self._simulate_trading_rules_initialized()
+        self.exchange._trading_rules[self.trading_pair].min_notional_size = Decimal("10")
+        self.exchange._place_order_and_process_update = AsyncMock()
+
+        with patch.object(
+                HyperliquidPerpetualDerivative,
+                "allow_reduce_only_orders_below_min_notional",
+                ExchangePyBase.allow_reduce_only_orders_below_min_notional,
+        ):
+            await self.exchange._create_order(
+                trade_type=TradeType.SELL,
+                order_id="OID1",
+                trading_pair=self.trading_pair,
+                amount=Decimal("0.02"),
+                order_type=OrderType.LIMIT,
+                position_action=PositionAction.CLOSE,
+                price=Decimal("100"),
+            )
+        await asyncio.sleep(0.001)
+
+        self.exchange._place_order_and_process_update.assert_not_awaited()
+        self.assertNotIn("OID1", self.exchange.in_flight_orders)
+        self.assertEqual("OID1", self.order_failure_logger.event_log[0].order_id)
+
+    def test_reduce_only_and_min_notional_rejections_map_to_failed_order_state(self):
+        for rejection_status in ["reduceOnlyRejected", "minTradeNtlRejected"]:
+            with self.subTest(rejection_status=rejection_status):
+                self.assertEqual(OrderState.FAILED, CONSTANTS.ORDER_STATE[rejection_status])
 
     @aioresponses()
     def test_create_buy_limit_order_successfully(self, mock_api):


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] Tests all pass
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Hyperliquid perpetual positions can be left with less than the connector's 10 USD minimum notional after partial fills, fees, or amount quantization. Previously, `ExchangePyBase._create_order()` rejected these orders locally even when they were explicit `PositionAction.CLOSE` requests that Hyperliquid would submit as reduce-only.

This change:

- adds a default-disabled connector capability for reduce-only orders below `min_notional_size`;
- enables the capability only for `HyperliquidPerpetualDerivative`;
- bypasses only the notional check for explicit `PositionAction.CLOSE` orders;
- retains minimum amount, quantization, price precision, and order-type checks;
- preserves normal failed-order handling when Hyperliquid rejects `minTradeNtlRejected` or `reduceOnlyRejected` orders.

Normal open/increase orders and connectors that do not opt in keep their existing validation behavior.

**Tests performed by the developer**:

- `pytest test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_derivative.py -q`
  - 151 tests passed
  - 2 subtests passed
- `pre-commit run --files hummingbot/connector/exchange_py_base.py hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_derivative.py test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_derivative.py`
  - all checks passed
- Python static compilation completed for all three changed files.

The added tests cover:

- accepted `PositionAction.CLOSE` orders below `min_notional_size`;
- rejected `PositionAction.OPEN` orders below `min_notional_size`;
- continued enforcement of `min_order_size` for close orders;
- unchanged behavior for connectors that do not opt in;
- failed-state mappings for `minTradeNtlRejected` and `reduceOnlyRejected`.

**Tips for QA testing**:

On Hyperliquid perpetuals, create a position below 10 USD whose amount still satisfies the size increment. Submit an exact full-position `PositionAction.CLOSE` order and verify that the request reaches Hyperliquid with `reduceOnly=true`. A successful order should flatten the position; a venue rejection should emit the standard failed-order event and log. Also verify that an equivalent `PositionAction.OPEN` order is rejected locally.

**Verification evidence**:

<details>
<summary>Deterministic reproduction before the fix</summary>

Tested against the pre-fix revision with a `LONG 0.10 HYPE` position worth approximately 5.50 USD. The request was rejected by the local minimum-notional check before the exchange submission path, and the position remained unchanged.

```text
Reduce-only dust capability: False
Final pre-submit check OK: HYPE-USD LONG size=0.1, notional=$5.5008.
Observed local rejection: Order notional 5.22580 is lower than minimum notional size 10 for the pair HYPE-USD. The order will not be created.
PASS (bug reproduced): old revision rejected the dust close locally; position is unchanged.
```

</details>

<details>
<summary>Controlled Hyperliquid mainnet verification after the fix</summary>

Tested with a dedicated low-value account. The API wallet/account binding and final position were checked immediately before submission. No credentials or private signing material are included below.

```text
Reduce-only dust capability: True
API Wallet binding verified.
Final pre-submit check OK: HYPE-USD LONG size=0.1, notional=$5.4966.
Validated outbound payload: SELL 0.10 HYPE-USD, IOC limit=52.218, reduceOnly=true
PASS (fix verified): exchange order 514308197409 was accepted and HYPE-USD is flat.
```

</details>
