### PR TITLE
feat/hyperliquid: support native trigger and position TP/SL orders

### DIFF
--- a/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_auth.py
+++ b/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_auth.py
@@ -201,10 +201,23 @@ class HyperliquidPerpetualAuth(AuthBase):
         return payload
 
     def _sign_cancel_params(self, params, base_url, timestamp):
-        order_action = {
-            "type": "cancelByCloid",
-            "cancels": [params["cancels"]],
-        }
+        cancels = params["cancels"]
+        cancel_specs = cancels if isinstance(cancels, list) else [cancels]
+        if all("oid" in cancel_spec for cancel_spec in cancel_specs):
+            order_action = {
+                "type": "cancel",
+                "cancels": [
+                    {"a": cancel_spec["asset"], "o": cancel_spec["oid"]}
+                    for cancel_spec in cancel_specs
+                ],
+            }
+        elif all("cloid" in cancel_spec for cancel_spec in cancel_specs):
+            order_action = {
+                "type": "cancelByCloid",
+                "cancels": cancel_specs,
+            }
+        else:
+            raise ValueError("Cancel requests must use either oid or cloid consistently.")
         signature = self.sign_l1_action(
             self.wallet,
             order_action,
@@ -221,11 +234,12 @@ class HyperliquidPerpetualAuth(AuthBase):
         }
 
     def _sign_order_params(self, params, base_url, timestamp):
-        order = params["orders"]
+        orders = params["orders"]
+        order_specs = orders if isinstance(orders, list) else [orders]
         grouping = params["grouping"]
         order_action = {
             "type": "order",
-            "orders": [order_spec_to_order_wire(order)],
+            "orders": [order_spec_to_order_wire(order) for order in order_specs],
             "grouping": grouping,
         }
         # The builder field is part of the signed payload. It must be added to the action dict

--- a/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_constants.py
+++ b/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_constants.py
@@ -95,9 +95,26 @@ USEREVENT_ENDPOINT_NAME = "user"
 ORDER_STATE = {
     "open": OrderState.OPEN,
     "resting": OrderState.OPEN,
+    # A triggered order remains tracked until its activated child fills, rests, or is canceled.
+    "triggered": OrderState.OPEN,
     "filled": OrderState.FILLED,
     "canceled": OrderState.CANCELED,
     "rejected": OrderState.FAILED,
+    "marginCanceled": OrderState.CANCELED,
+    "vaultWithdrawalCanceled": OrderState.CANCELED,
+    "openInterestCapCanceled": OrderState.CANCELED,
+    "scheduledCancel": OrderState.CANCELED,
+    "tickRejected": OrderState.FAILED,
+    "iocCancelRejected": OrderState.FAILED,
+    "badTriggerPxRejected": OrderState.FAILED,
+    "marketOrderNoLiquidityRejected": OrderState.FAILED,
+    "positionIncreaseAtOpenInterestCapRejected": OrderState.FAILED,
+    "positionFlipAtOpenInterestCapRejected": OrderState.FAILED,
+    "tooAggressiveAtOpenInterestCapRejected": OrderState.FAILED,
+    "openInterestIncreaseRejected": OrderState.FAILED,
+    "insufficientSpotBalanceRejected": OrderState.FAILED,
+    "oracleRejected": OrderState.FAILED,
+    "perpMaxPositionRejected": OrderState.FAILED,
     "badAloPxRejected": OrderState.FAILED,
     "minTradeNtlRejected": OrderState.FAILED,
     "reduceOnlyCanceled": OrderState.CANCELED,
@@ -114,6 +131,11 @@ HEARTBEAT_TIME_INTERVAL = 30.0
 # frame) and forcing a keepalive ping / reconnection. Set above HEARTBEAT_TIME_INTERVAL so the periodic ping
 # (and its pong) keeps a healthy connection from timing out.
 WS_MESSAGE_TIMEOUT = 60.0
+
+# A placement request can reach Hyperliquid even when its response is lost. Keep the order pending while the
+# exchange propagates the cloid, and require repeated authoritative misses before treating it as rejected.
+TRIGGER_ORDER_RECONCILIATION_GRACE_SECONDS = 30.0
+TRIGGER_ORDER_RECONCILIATION_MIN_UNKNOWN_OID_RESPONSES = 3
 
 MAX_REQUEST = 1_200
 ALL_ENDPOINTS_LIMIT = "All"

--- a/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_derivative.py
@@ -1,5 +1,6 @@
 import asyncio
 import hashlib
+import re
 import time
 from decimal import ROUND_HALF_UP, Decimal
 from typing import Any, AsyncIterable, Dict, List, Literal, Optional, Tuple
@@ -26,7 +27,7 @@ from hummingbot.connector.trading_rule import TradingRule
 from hummingbot.connector.utils import combine_to_hb_trading_pair, get_new_client_order_id
 from hummingbot.core.api_throttler.data_types import RateLimit
 from hummingbot.core.data_type.common import OrderType, PositionAction, PositionMode, PositionSide, TradeType
-from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderUpdate, TradeUpdate
+from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState, OrderUpdate, TradeUpdate
 from hummingbot.core.data_type.order_book_tracker_data_source import OrderBookTrackerDataSource
 from hummingbot.core.data_type.trade_fee import TokenAmount, TradeFeeBase
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
@@ -71,6 +72,13 @@ class HyperliquidPerpetualDerivative(PerpetualDerivativePyBase):
         self._dex_markets: List[Dict] = []  # Store HIP-3 DEX market info separately
         self._is_hip3_market: Dict[str, bool] = {}  # Track which coins are HIP-3
         self._user_abstraction_mode: Optional[str] = None
+        self._pending_trigger_client_order_ids: set[str] = set()
+        self._native_trigger_client_order_ids: set[str] = set()
+        self._trigger_orders_requiring_reconciliation: set[str] = set()
+        self._trigger_reconciliation_started_at: Dict[str, float] = {}
+        self._trigger_reconciliation_unknown_oid_counts: Dict[str, int] = {}
+        # Trigger activation can produce a child oid while the client continues to own one cloid.
+        self._trigger_child_order_ids: Dict[str, str] = {}
         # Builder code (HGP-87). Fee starts at 0 and is resolved at startup (_initialize_builder_fee).
         self._builder_address: str = CONSTANTS.FOUNDATION_BUILDER_ADDRESS.lower()
         self._builder_fee_tenths_bps: int = 0
@@ -519,12 +527,25 @@ class HyperliquidPerpetualDerivative(PerpetualDerivativePyBase):
         symbol = await self.exchange_symbol_associated_to_pair(trading_pair=tracked_order.trading_pair)
         coin = symbol
 
+        trigger_child_order_ids = self._trigger_child_order_ids_for_client_order_id(order_id)
+        if not trigger_child_order_ids and order_id in self._trigger_orders_requiring_reconciliation:
+            reconciliation_update = await self._request_order_status(tracked_order)
+            await self._order_tracker.process_order_update(reconciliation_update)
+            if reconciliation_update.new_state in {
+                    OrderState.CANCELED, OrderState.FAILED, OrderState.FILLED}:
+                return True
+            trigger_child_order_ids = self._trigger_child_order_ids_for_client_order_id(order_id)
+        if trigger_child_order_ids:
+            cancel_specs = [
+                {"asset": self.coin_to_asset[coin], "oid": int(child_order_id)}
+                for child_order_id in trigger_child_order_ids
+            ]
+            cancels = cancel_specs[0] if len(cancel_specs) == 1 else cancel_specs
+        else:
+            cancels = {"asset": self.coin_to_asset[coin], "cloid": order_id}
         api_params = {
             "type": "cancel",
-            "cancels": {
-                "asset": self.coin_to_asset[coin],
-                "cloid": order_id
-            },
+            "cancels": cancels,
         }
         cancel_result = await self._api_post(
             path_url=CONSTANTS.CANCEL_ORDER_URL,
@@ -555,16 +576,34 @@ class HyperliquidPerpetualDerivative(PerpetualDerivativePyBase):
             raise IOError(f"Error cancelling order {order_id}: {response}")
 
         statuses = response.get("data", {}).get("statuses") or []
-        status = statuses[0] if statuses else None
-        if isinstance(status, dict) and "error" in status:
+        errors = [status["error"] for status in statuses if isinstance(status, dict) and "error" in status]
+        if errors:
             self.logger().debug(f"Hyperliquid Perpetuals did not cancel order {order_id}. "
                                 f"Raw response: {cancel_result}")
-            raise IOError(f"Error cancelling order {order_id}: {status['error']}")
-        if status != "success":
+            raise IOError(f"Error cancelling order {order_id}: {errors[0]}")
+        successful = bool(statuses) and all(
+            status == "success" or (isinstance(status, dict) and status.get("success") is True)
+            for status in statuses
+        )
+        if not successful:
             self.logger().warning(f"Unexpected cancelation status for order {order_id}. "
                                   f"Raw response: {cancel_result}")
-            return False
-        return True
+        return successful
+
+    async def _execute_order_cancel(self, order: InFlightOrder) -> Optional[str]:
+        if order.client_order_id not in self._trigger_reconciliation_started_at:
+            return await super()._execute_order_cancel(order)
+        try:
+            cancelled = await self._execute_order_cancel_and_process_update(order=order)
+            return order.client_order_id if cancelled else None
+        except asyncio.CancelledError:
+            raise
+        except Exception as exception:
+            self.logger().warning(
+                f"Could not cancel uncertain trigger order {order.client_order_id}: {exception}. "
+                "The order remains pending and will continue reconciliation by cloid."
+            )
+            return None
 
     # === Orders placing ===
 
@@ -643,6 +682,390 @@ class HyperliquidPerpetualDerivative(PerpetualDerivativePyBase):
             price=price,
             **kwargs))
         return hex_order_id
+
+    def place_trigger_order(
+            self,
+            trading_pair: str,
+            amount: Decimal,
+            side: TradeType,
+            trigger_price: Decimal,
+            trigger_kind: Literal["tp", "sl"],
+            is_market: bool,
+            limit_price: Optional[Decimal] = None,
+            client_order_id: Optional[str] = None,
+    ) -> str:
+        """Submit a fixed-size, reduce-only Hyperliquid trigger order through the standard tracker lifecycle."""
+        if trigger_kind not in {"tp", "sl"}:
+            raise ValueError("trigger_kind must be either 'tp' or 'sl'.")
+        if side not in {TradeType.BUY, TradeType.SELL}:
+            raise ValueError("side must be TradeType.BUY or TradeType.SELL.")
+        if is_market and limit_price is not None:
+            raise ValueError("limit_price must be omitted for market trigger orders.")
+        if client_order_id is not None:
+            self._validate_trigger_client_order_id(client_order_id)
+            client_order_id = client_order_id.lower()
+
+        order_id = client_order_id or self._new_hyperliquid_client_order_id(
+            trading_pair=trading_pair, side=side)
+        self._pending_trigger_client_order_ids.add(order_id)
+        self._native_trigger_client_order_ids.add(order_id)
+        self._start_tracking_trigger_order_intent(
+            order_id=order_id,
+            trading_pair=trading_pair,
+            amount=amount,
+            side=side,
+            price=trigger_price if limit_price is None else limit_price,
+            is_market=is_market,
+        )
+        safe_ensure_future(self._create_trigger_order(
+            order_id=order_id,
+            trading_pair=trading_pair,
+            amount=amount,
+            side=side,
+            trigger_price=trigger_price,
+            trigger_kind=trigger_kind,
+            is_market=is_market,
+            limit_price=limit_price,
+        ))
+        return order_id
+
+    def _validate_trigger_client_order_id(self, client_order_id: str):
+        if not isinstance(client_order_id, str) or re.fullmatch(r"0x[0-9a-fA-F]{32}", client_order_id) is None:
+            raise ValueError("client_order_id must be a 128-bit hexadecimal string prefixed with 0x.")
+        normalized_client_order_id = client_order_id.lower()
+        tracked_client_order_ids = {
+            tracked_client_order_id.lower()
+            for tracked_client_order_id in self._order_tracker.all_fillable_orders
+        }
+        if (normalized_client_order_id in self._pending_trigger_client_order_ids
+                or normalized_client_order_id in tracked_client_order_ids):
+            raise ValueError(f"client_order_id {client_order_id} has already been used.")
+
+    def _new_hyperliquid_client_order_id(self, trading_pair: str, side: TradeType) -> str:
+        order_id = get_new_client_order_id(
+            is_buy=side == TradeType.BUY,
+            trading_pair=trading_pair,
+            hbot_order_id_prefix=self.client_order_id_prefix,
+            max_id_len=self.client_order_id_max_length,
+        )
+        return f"0x{hashlib.md5(order_id.encode('utf-8')).hexdigest()}"
+
+    def _start_tracking_trigger_order_intent(
+            self,
+            order_id: str,
+            trading_pair: str,
+            amount: Decimal,
+            side: TradeType,
+            price: Decimal,
+            is_market: bool,
+    ):
+        self.start_tracking_order(
+            order_id=order_id,
+            exchange_order_id=None,
+            trading_pair=trading_pair,
+            trade_type=side,
+            price=price,
+            amount=amount,
+            order_type=OrderType.MARKET if is_market else OrderType.LIMIT,
+            position_action=PositionAction.CLOSE,
+        )
+
+    def _apply_trigger_order_quantization(self, order_id: str, amount: Decimal, price: Decimal):
+        tracked_order = self._order_tracker.active_orders.get(order_id)
+        if tracked_order is not None:
+            tracked_order.amount = amount
+            tracked_order.price = price
+
+    def _mark_trigger_order_for_reconciliation(self, order_id: str, reason: str):
+        reconciliation_started_at = self.current_timestamp
+        if reconciliation_started_at != reconciliation_started_at:  # NaN before the first clock tick
+            reconciliation_started_at = time.time()
+        self._native_trigger_client_order_ids.add(order_id)
+        self._trigger_orders_requiring_reconciliation.add(order_id)
+        self._trigger_reconciliation_started_at.setdefault(order_id, reconciliation_started_at)
+        self._trigger_reconciliation_unknown_oid_counts.setdefault(order_id, 0)
+        self.logger().warning(
+            f"Trigger order {order_id} has an uncertain submission result ({reason}); "
+            "it will remain tracked and be reconciled by cloid."
+        )
+
+    def _clear_trigger_submission_reconciliation(self, order_id: str):
+        self._trigger_orders_requiring_reconciliation.discard(order_id)
+        self._trigger_reconciliation_started_at.pop(order_id, None)
+        self._trigger_reconciliation_unknown_oid_counts.pop(order_id, None)
+
+    def _reset_trigger_unknown_oid_confirmations(self, order_id: str):
+        if order_id in self._trigger_reconciliation_started_at:
+            self._trigger_reconciliation_unknown_oid_counts[order_id] = 0
+
+    def place_position_protection_orders(
+            self,
+            trading_pair: str,
+            amount: Decimal,
+            close_side: TradeType,
+            take_profit_price: Decimal,
+            stop_loss_price: Decimal,
+            take_profit_is_market: bool = False,
+            stop_loss_is_market: bool = True,
+    ) -> Tuple[str, str]:
+        """Submit fixed-size TP and SL trigger orders in one Hyperliquid request."""
+        if close_side not in {TradeType.BUY, TradeType.SELL}:
+            raise ValueError("close_side must be TradeType.BUY or TradeType.SELL.")
+        take_profit_id = self._new_hyperliquid_client_order_id(trading_pair, close_side)
+        stop_loss_id = self._new_hyperliquid_client_order_id(trading_pair, close_side)
+        while stop_loss_id == take_profit_id:
+            stop_loss_id = self._new_hyperliquid_client_order_id(trading_pair, close_side)
+        self._native_trigger_client_order_ids.update((take_profit_id, stop_loss_id))
+        self._start_tracking_trigger_order_intent(
+            take_profit_id, trading_pair, amount, close_side, take_profit_price, take_profit_is_market)
+        self._start_tracking_trigger_order_intent(
+            stop_loss_id, trading_pair, amount, close_side, stop_loss_price, stop_loss_is_market)
+        safe_ensure_future(self._create_position_protection_orders(
+            trading_pair=trading_pair,
+            amount=amount,
+            close_side=close_side,
+            take_profit_price=take_profit_price,
+            stop_loss_price=stop_loss_price,
+            take_profit_is_market=take_profit_is_market,
+            stop_loss_is_market=stop_loss_is_market,
+            take_profit_id=take_profit_id,
+            stop_loss_id=stop_loss_id,
+        ))
+        return take_profit_id, stop_loss_id
+
+    async def _create_position_protection_orders(
+            self,
+            trading_pair: str,
+            amount: Decimal,
+            close_side: TradeType,
+            take_profit_price: Decimal,
+            stop_loss_price: Decimal,
+            take_profit_is_market: bool,
+            stop_loss_is_market: bool,
+            take_profit_id: str,
+            stop_loss_id: str,
+    ):
+        try:
+            quantized_amount = self.quantize_order_amount(trading_pair=trading_pair, amount=amount)
+            quantized_take_profit = self.quantize_order_price(trading_pair, take_profit_price)
+            quantized_stop_loss = self.quantize_order_price(trading_pair, stop_loss_price)
+            take_profit_limit = self._trigger_limit_price(
+                trading_pair, quantized_take_profit, close_side, take_profit_is_market)
+            stop_loss_limit = self._trigger_limit_price(
+                trading_pair, quantized_stop_loss, close_side, stop_loss_is_market)
+            legs = [
+                (take_profit_id, "tp", quantized_take_profit, take_profit_limit, take_profit_is_market),
+                (stop_loss_id, "sl", quantized_stop_loss, stop_loss_limit, stop_loss_is_market),
+            ]
+            for order_id, _, _, quantized_limit_price, _ in legs:
+                self._apply_trigger_order_quantization(order_id, quantized_amount, quantized_limit_price)
+
+            trading_rule = self._trading_rules[trading_pair]
+            validation_error = None
+            if quantized_amount < trading_rule.min_order_size:
+                validation_error = ValueError(
+                    f"Order amount {amount} is lower than minimum order size {trading_rule.min_order_size}.")
+            elif any(trigger_price <= Decimal("0") or limit_price <= Decimal("0")
+                     for _, _, trigger_price, limit_price, _ in legs):
+                validation_error = ValueError("Trigger and limit prices must be greater than zero.")
+            elif any(quantized_amount * limit_price < trading_rule.min_notional_size
+                     for _, _, _, limit_price, _ in legs):
+                validation_error = ValueError("Protection order notional is lower than the minimum notional size.")
+            if validation_error is not None:
+                for order_id in (take_profit_id, stop_loss_id):
+                    self._update_order_after_failure(order_id, trading_pair, validation_error)
+                return
+
+            coin = await self.exchange_symbol_associated_to_pair(trading_pair=trading_pair)
+            order_specs = [{
+                "asset": self.coin_to_asset[coin],
+                "isBuy": close_side == TradeType.BUY,
+                "limitPx": float(limit_price),
+                "sz": float(quantized_amount),
+                "reduceOnly": True,
+                "orderType": {"trigger": {
+                    "triggerPx": float(trigger_price),
+                    "tpsl": trigger_kind,
+                    "isMarket": is_market,
+                }},
+                "cloid": order_id,
+            } for order_id, trigger_kind, trigger_price, limit_price, is_market in legs]
+            # positionTpsl groups these as position-level TP/SL semantics; statuses remain authoritative per order.
+            api_params = {"type": "order", "grouping": "positionTpsl", "orders": order_specs}
+            builder_field = self._build_builder_field()
+            if builder_field is not None:
+                api_params["builder"] = builder_field
+        except asyncio.CancelledError:
+            raise
+        except Exception as exception:
+            for order_id in (take_profit_id, stop_loss_id):
+                self._update_order_after_failure(order_id, trading_pair, exception)
+            return
+        try:
+            result = await self._api_post(
+                path_url=CONSTANTS.CREATE_ORDER_URL, data=api_params, is_auth_required=True)
+        except asyncio.CancelledError:
+            for order_id in (take_profit_id, stop_loss_id):
+                self._mark_trigger_order_for_reconciliation(order_id, "placement task was canceled")
+            raise
+        except Exception as exception:
+            for order_id in (take_profit_id, stop_loss_id):
+                self._mark_trigger_order_for_reconciliation(order_id, exception.__class__.__name__)
+            return
+        if not isinstance(result, dict):
+            for order_id in (take_profit_id, stop_loss_id):
+                self._mark_trigger_order_for_reconciliation(order_id, "malformed placement response")
+            return
+        if result.get("status") == "err":
+            exception = IOError(f"Error submitting position protection orders: {result.get('response')}")
+            for order_id in (take_profit_id, stop_loss_id):
+                self._clear_trigger_submission_reconciliation(order_id)
+                self._update_order_after_failure(order_id, trading_pair, exception=exception)
+            return
+
+        response = result.get("response")
+        response_data = response.get("data") if isinstance(response, dict) else None
+        statuses = response_data.get("statuses") if isinstance(response_data, dict) else None
+        order_ids = (take_profit_id, stop_loss_id)
+        if not isinstance(statuses, list):
+            for order_id in order_ids:
+                self._mark_trigger_order_for_reconciliation(order_id, "malformed statuses field")
+            return
+        if len(statuses) > len(order_ids):
+            for order_id in order_ids:
+                self._mark_trigger_order_for_reconciliation(order_id, "oversized placement status list")
+            return
+        for index, order_id in enumerate(order_ids):
+            if index >= len(statuses):
+                self._mark_trigger_order_for_reconciliation(order_id, "placement response omitted its status")
+            else:
+                await self._process_trigger_order_status(order_id, trading_pair, statuses[index])
+        if len(statuses) != len(order_ids):
+            self.logger().warning(
+                f"Expected {len(order_ids)} protection statuses but received {len(statuses)}.")
+
+    def _trigger_limit_price(
+            self, trading_pair: str, trigger_price: Decimal, side: TradeType, is_market: bool) -> Decimal:
+        if not is_market:
+            return self.quantize_order_price(trading_pair, trigger_price)
+        slippage = Decimal(str(CONSTANTS.MARKET_ORDER_SLIPPAGE))
+        multiplier = Decimal("1") + slippage if side == TradeType.BUY else Decimal("1") - slippage
+        return self.quantize_order_price(trading_pair, trigger_price * multiplier)
+
+    async def _create_trigger_order(
+            self,
+            order_id: str,
+            trading_pair: str,
+            amount: Decimal,
+            side: TradeType,
+            trigger_price: Decimal,
+            trigger_kind: Literal["tp", "sl"],
+            is_market: bool,
+            limit_price: Optional[Decimal],
+    ):
+        try:
+            quantized_amount = self.quantize_order_amount(trading_pair=trading_pair, amount=amount)
+            quantized_trigger_price = self.quantize_order_price(trading_pair, trigger_price)
+            if limit_price is None:
+                quantized_limit_price = self._trigger_limit_price(
+                    trading_pair, quantized_trigger_price, side, is_market)
+            else:
+                quantized_limit_price = self.quantize_order_price(trading_pair, limit_price)
+            self._apply_trigger_order_quantization(order_id, quantized_amount, quantized_limit_price)
+
+            trading_rule = self._trading_rules[trading_pair]
+            if quantized_amount < trading_rule.min_order_size:
+                raise ValueError(
+                    f"Order amount {amount} is lower than minimum order size {trading_rule.min_order_size}.")
+            if quantized_trigger_price <= Decimal("0") or quantized_limit_price <= Decimal("0"):
+                raise ValueError("Trigger and limit prices must be greater than zero.")
+            if quantized_amount * quantized_limit_price < trading_rule.min_notional_size:
+                raise ValueError("Trigger order notional is lower than the minimum notional size.")
+
+            coin = await self.exchange_symbol_associated_to_pair(trading_pair=trading_pair)
+            order_spec = {
+                "asset": self.coin_to_asset[coin],
+                "isBuy": side == TradeType.BUY,
+                "limitPx": float(quantized_limit_price),
+                "sz": float(quantized_amount),
+                "reduceOnly": True,
+                "orderType": {"trigger": {
+                    "triggerPx": float(quantized_trigger_price),
+                    "tpsl": trigger_kind,
+                    "isMarket": is_market,
+                }},
+                "cloid": order_id,
+            }
+            api_params = {"type": "order", "grouping": "na", "orders": order_spec}
+            builder_field = self._build_builder_field()
+            if builder_field is not None:
+                api_params["builder"] = builder_field
+        except asyncio.CancelledError:
+            raise
+        except Exception as exception:
+            self._update_order_after_failure(order_id, trading_pair, exception)
+            return
+        finally:
+            self._pending_trigger_client_order_ids.discard(order_id)
+        try:
+            result = await self._api_post(
+                path_url=CONSTANTS.CREATE_ORDER_URL, data=api_params, is_auth_required=True)
+        except asyncio.CancelledError:
+            self._mark_trigger_order_for_reconciliation(order_id, "placement task was canceled")
+            raise
+        except Exception as exception:
+            self._mark_trigger_order_for_reconciliation(order_id, exception.__class__.__name__)
+            return
+        if not isinstance(result, dict):
+            self._mark_trigger_order_for_reconciliation(order_id, "malformed placement response")
+            return
+        if result.get("status") == "err":
+            self._clear_trigger_submission_reconciliation(order_id)
+            self._update_order_after_failure(
+                order_id, trading_pair, IOError(f"Error submitting trigger order: {result.get('response')}"))
+            return
+        response = result.get("response")
+        response_data = response.get("data") if isinstance(response, dict) else None
+        statuses = response_data.get("statuses") if isinstance(response_data, dict) else None
+        if not isinstance(statuses, list):
+            self._mark_trigger_order_for_reconciliation(order_id, "malformed statuses field")
+            return
+        if len(statuses) != 1:
+            self._mark_trigger_order_for_reconciliation(order_id, "unexpected placement status count")
+            return
+        await self._process_trigger_order_status(order_id, trading_pair, statuses[0])
+
+    async def _process_trigger_order_status(self, order_id: str, trading_pair: str, status: Dict[str, Any]):
+        if not isinstance(status, dict):
+            self._mark_trigger_order_for_reconciliation(order_id, "malformed placement status")
+            return
+        if "error" in status:
+            self._clear_trigger_submission_reconciliation(order_id)
+            self._update_order_after_failure(order_id, trading_pair, IOError(status["error"]))
+            return
+        status_data = status.get("resting") or status.get("filled")
+        if not isinstance(status_data, dict) or status_data.get("oid") is None:
+            self._mark_trigger_order_for_reconciliation(order_id, "unknown placement status")
+            return
+        tracked_order = self._order_tracker.active_orders.get(order_id)
+        if tracked_order is not None:
+            tracked_order.update_exchange_order_id(str(status_data["oid"]))
+        self._clear_trigger_submission_reconciliation(order_id)
+        open_update = OrderUpdate(
+            client_order_id=order_id,
+            exchange_order_id=str(status_data["oid"]),
+            trading_pair=trading_pair,
+            update_timestamp=self.current_timestamp,
+            new_state=OrderState.OPEN,
+        )
+        self._order_tracker.process_order_update(open_update)
+        if "filled" in status:
+            # Placement responses do not include a reliable trade id or fees. Pull authoritative fills before the
+            # terminal update so the standard tracker can emit a complete fill/completion sequence without duplicates.
+            await self._update_trade_history()
+            tracked_order = self._order_tracker.all_fillable_orders.get(order_id)
+            if tracked_order is not None and tracked_order.executed_amount_base >= abs(tracked_order.amount):
+                self._order_tracker.process_order_update(open_update._replace(new_state=OrderState.FILLED))
 
     async def _place_order(
             self,
@@ -741,7 +1164,12 @@ class HyperliquidPerpetualDerivative(PerpetualDerivativePyBase):
 
     async def _update_trade_history(self):
         orders = list(self._order_tracker.all_fillable_orders.values())
+        self._prune_trigger_tracking()
         all_fillable_orders = self._order_tracker.all_fillable_orders_by_exchange_order_id
+        for child_order_id, client_order_id in self._trigger_child_order_ids.items():
+            tracked_order = self._order_tracker.all_fillable_orders.get(client_order_id)
+            if tracked_order is not None:
+                all_fillable_orders[child_order_id] = tracked_order
         all_fills_response = []
         if len(orders) > 0:
             try:
@@ -763,37 +1191,29 @@ class HyperliquidPerpetualDerivative(PerpetualDerivativePyBase):
 
     def _process_trade_rs_event_message(self, order_fill: Dict[str, Any], all_fillable_order):
         exchange_order_id = str(order_fill.get("oid"))
+        trigger_client_order_id = self._trigger_child_order_ids.get(exchange_order_id)
         fillable_order = all_fillable_order.get(exchange_order_id)
         if fillable_order is not None:
-            fee_asset = fillable_order.quote_asset
-
-            position_action = PositionAction.OPEN if order_fill["dir"].split(" ")[0] == "Open" else PositionAction.CLOSE
-            fee = TradeFeeBase.new_perpetual_fee(
-                fee_schema=self.trade_fee_schema(),
-                position_action=position_action,
-                percent_token=fee_asset,
-                flat_fees=[TokenAmount(amount=Decimal(order_fill["fee"]), token=fee_asset)]
+            self._process_trade_fill(
+                trade=order_fill,
+                tracked_order=fillable_order,
+                trigger_client_order_id=trigger_client_order_id,
             )
-
-            trade_update = TradeUpdate(
-                trade_id=str(order_fill["tid"]),
-                client_order_id=fillable_order.client_order_id,
-                exchange_order_id=str(order_fill["oid"]),
-                trading_pair=fillable_order.trading_pair,
-                fee=fee,
-                fill_base_amount=Decimal(order_fill["sz"]),
-                fill_quote_amount=Decimal(order_fill["px"]) * Decimal(order_fill["sz"]),
-                fill_price=Decimal(order_fill["px"]),
-                fill_timestamp=order_fill["time"] * 1e-3,
-            )
-
-            self._order_tracker.process_trade_update(trade_update)
 
     async def _all_trade_updates_for_order(self, order: InFlightOrder) -> List[TradeUpdate]:
         # Use _update_trade_history instead
         pass
 
     async def _handle_update_error_for_active_order(self, order: InFlightOrder, error: Exception):
+        if isinstance(error, asyncio.CancelledError):
+            raise error
+        if order.client_order_id in self._trigger_reconciliation_started_at:
+            self._reset_trigger_unknown_oid_confirmations(order.client_order_id)
+            self.logger().warning(
+                f"Could not reconcile uncertain trigger order {order.client_order_id}: {error}. "
+                "The order remains pending and will be queried again."
+            )
+            return
         try:
             raise error
         except (asyncio.TimeoutError, KeyError):
@@ -814,31 +1234,157 @@ class HyperliquidPerpetualDerivative(PerpetualDerivativePyBase):
 
     async def _request_order_status(self, tracked_order: InFlightOrder) -> OrderUpdate:
         client_order_id = tracked_order.client_order_id
-        try:
-            if tracked_order.exchange_order_id:
-                exchange_order_id = tracked_order.exchange_order_id
-            else:
-                exchange_order_id = await tracked_order.get_exchange_order_id()
-        except asyncio.TimeoutError:
+        trigger_child_order_ids = self._trigger_child_order_ids_for_client_order_id(client_order_id)
+        submission_is_uncertain = client_order_id in self._trigger_reconciliation_started_at
+        if trigger_child_order_ids:
+            exchange_order_id = trigger_child_order_ids[0]
+        elif submission_is_uncertain:
             exchange_order_id = None
-        order_update = await self._api_post(
-            path_url=CONSTANTS.ORDER_URL,
-            data={
-                "type": CONSTANTS.ORDER_STATUS_TYPE,
-                "user": self.hyperliquid_perpetual_address,
-                "oid": int(exchange_order_id) if exchange_order_id else client_order_id
-            })
-        current_state = order_update["order"]["status"]
+        else:
+            try:
+                if tracked_order.exchange_order_id:
+                    exchange_order_id = tracked_order.exchange_order_id
+                else:
+                    exchange_order_id = await tracked_order.get_exchange_order_id()
+            except asyncio.TimeoutError:
+                exchange_order_id = None
+        try:
+            order_update = await self._api_post(
+                path_url=CONSTANTS.ORDER_URL,
+                data={
+                    "type": CONSTANTS.ORDER_STATUS_TYPE,
+                    "user": self.hyperliquid_perpetual_address,
+                    "oid": int(exchange_order_id) if exchange_order_id else client_order_id
+                })
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            if submission_is_uncertain:
+                self._reset_trigger_unknown_oid_confirmations(client_order_id)
+            raise
+        if not isinstance(order_update, dict):
+            if submission_is_uncertain:
+                self._reset_trigger_unknown_oid_confirmations(client_order_id)
+            raise IOError(f"Malformed order status response: {order_update}")
+        if order_update.get("status") == "unknownOid" and submission_is_uncertain:
+            return self._process_uncertain_trigger_unknown_oid(tracked_order)
+        order_container = order_update.get("order")
+        if not isinstance(order_container, dict):
+            if submission_is_uncertain:
+                self._reset_trigger_unknown_oid_confirmations(client_order_id)
+            raise IOError(f"Unexpected order status response: {order_update}")
+        current_state = order_container.get("status")
+        exchange_order = order_container.get("order")
+        exchange_order_id = exchange_order.get("oid") if isinstance(exchange_order, dict) else None
+        exchange_order_timestamp = exchange_order.get("timestamp") if isinstance(exchange_order, dict) else None
+        exchange_order_id_is_valid = (
+            isinstance(exchange_order_id, int)
+            and not isinstance(exchange_order_id, bool)
+            and exchange_order_id > 0
+        ) or (
+            isinstance(exchange_order_id, str)
+            and exchange_order_id.isdigit()
+            and int(exchange_order_id) > 0
+        )
+        exchange_order_timestamp_is_valid = (
+            isinstance(exchange_order_timestamp, (int, float))
+            and not isinstance(exchange_order_timestamp, bool)
+            and exchange_order_timestamp > 0
+        )
+        required_order_fields_present = (
+            isinstance(exchange_order, dict)
+            and exchange_order_id_is_valid
+            and exchange_order_timestamp_is_valid
+        )
+        if current_state not in CONSTANTS.ORDER_STATE or not required_order_fields_present:
+            if submission_is_uncertain:
+                self._reset_trigger_unknown_oid_confirmations(client_order_id)
+            raise IOError(f"Malformed order status response: {order_update}")
+        if tracked_order.exchange_order_id is None:
+            tracked_order.update_exchange_order_id(str(exchange_order["oid"]))
+        self._clear_trigger_submission_reconciliation(client_order_id)
+        if current_state == "triggered":
+            self._associate_trigger_child_orders(tracked_order, exchange_order)
+        new_state = CONSTANTS.ORDER_STATE[current_state]
+        if (new_state == OrderState.FILLED
+                and client_order_id in self._native_trigger_client_order_ids
+                and tracked_order.executed_amount_base < abs(tracked_order.amount)):
+            await self._update_trade_history()
+            if tracked_order.executed_amount_base < abs(tracked_order.amount):
+                new_state = OrderState.OPEN
         _exchange_order_id = str(tracked_order.exchange_order_id) if tracked_order.exchange_order_id else str(
-            order_update["order"]["order"]["oid"])
+            exchange_order["oid"])
         _order_update: OrderUpdate = OrderUpdate(
             trading_pair=tracked_order.trading_pair,
-            update_timestamp=order_update["order"]["order"]["timestamp"] * 1e-3,
-            new_state=CONSTANTS.ORDER_STATE[current_state],
-            client_order_id=order_update["order"]["order"]["cloid"] or client_order_id,
+            update_timestamp=exchange_order["timestamp"] * 1e-3,
+            new_state=new_state,
+            client_order_id=exchange_order.get("cloid") or client_order_id,
             exchange_order_id=_exchange_order_id,
         )
         return _order_update
+
+    def _process_uncertain_trigger_unknown_oid(self, tracked_order: InFlightOrder) -> OrderUpdate:
+        client_order_id = tracked_order.client_order_id
+        unknown_oid_count = self._trigger_reconciliation_unknown_oid_counts.get(client_order_id, 0) + 1
+        self._trigger_reconciliation_unknown_oid_counts[client_order_id] = unknown_oid_count
+        reconciliation_started_at = self._trigger_reconciliation_started_at[client_order_id]
+        grace_period_elapsed = (
+            self.current_timestamp - reconciliation_started_at
+            >= CONSTANTS.TRIGGER_ORDER_RECONCILIATION_GRACE_SECONDS
+        )
+        enough_confirmations = (
+            unknown_oid_count >= CONSTANTS.TRIGGER_ORDER_RECONCILIATION_MIN_UNKNOWN_OID_RESPONSES
+        )
+        new_state = tracked_order.current_state
+        if grace_period_elapsed and enough_confirmations:
+            new_state = OrderState.FAILED
+            self.logger().error(
+                f"Uncertain trigger order {client_order_id} was not found after "
+                f"{unknown_oid_count} successful queries and the reconciliation grace period."
+            )
+        return OrderUpdate(
+            trading_pair=tracked_order.trading_pair,
+            update_timestamp=self.current_timestamp,
+            new_state=new_state,
+            client_order_id=client_order_id,
+            exchange_order_id=tracked_order.exchange_order_id,
+        )
+
+    def _associate_trigger_child_orders(self, tracked_order: InFlightOrder, exchange_order: Dict[str, Any]):
+        """Associate activated child oids with the original cloid without replacing its cancel identity."""
+        self._native_trigger_client_order_ids.add(tracked_order.client_order_id)
+        self._clear_trigger_submission_reconciliation(tracked_order.client_order_id)
+        for child in exchange_order.get("children", []):
+            child_order = child.get("order", child) if isinstance(child, dict) else {}
+            child_order_id = child_order.get("oid")
+            if child_order_id is not None:
+                self._trigger_child_order_ids[str(child_order_id)] = tracked_order.client_order_id
+
+    def _clear_trigger_child_orders(self, client_order_id: str):
+        for order_id in self._trigger_child_order_ids_for_client_order_id(client_order_id):
+            del self._trigger_child_order_ids[order_id]
+        self._native_trigger_client_order_ids.discard(client_order_id)
+        self._clear_trigger_submission_reconciliation(client_order_id)
+
+    def _prune_trigger_tracking(self):
+        fillable_client_order_ids = set(self._order_tracker.all_fillable_orders)
+        updatable_client_order_ids = set(self._order_tracker.all_updatable_orders)
+        retained_client_order_ids = fillable_client_order_ids | self._pending_trigger_client_order_ids
+        self._native_trigger_client_order_ids.intersection_update(retained_client_order_ids)
+        self._trigger_orders_requiring_reconciliation.intersection_update(updatable_client_order_ids)
+        for client_order_id in list(self._trigger_reconciliation_started_at):
+            if client_order_id not in updatable_client_order_ids:
+                self._trigger_reconciliation_started_at.pop(client_order_id, None)
+                self._trigger_reconciliation_unknown_oid_counts.pop(client_order_id, None)
+        for child_order_id, client_order_id in list(self._trigger_child_order_ids.items()):
+            if client_order_id not in fillable_client_order_ids:
+                del self._trigger_child_order_ids[child_order_id]
+
+    def _trigger_child_order_ids_for_client_order_id(self, client_order_id: str) -> List[str]:
+        return [
+            order_id for order_id, associated_client_order_id in self._trigger_child_order_ids.items()
+            if associated_client_order_id == client_order_id
+        ]
 
     async def _iter_user_event_queue(self) -> AsyncIterable[Dict[str, any]]:
         while True:
@@ -897,7 +1443,13 @@ class HyperliquidPerpetualDerivative(PerpetualDerivativePyBase):
         Example Trade:
         """
         exchange_order_id = str(trade.get("oid", ""))
+        trigger_client_order_id = self._trigger_child_order_ids.get(exchange_order_id)
         tracked_order = self._order_tracker.all_fillable_orders_by_exchange_order_id.get(exchange_order_id)
+
+        if tracked_order is None:
+            client_order_id = trigger_client_order_id or client_order_id
+            if client_order_id is not None:
+                tracked_order = self._order_tracker.all_fillable_orders.get(client_order_id)
 
         if tracked_order is None:
             all_orders = self._order_tracker.all_fillable_orders
@@ -908,6 +1460,19 @@ class HyperliquidPerpetualDerivative(PerpetualDerivativePyBase):
                 self.logger().debug(f"Ignoring trade message with id {client_order_id}: not in in_flight_orders.")
                 return
             tracked_order = _cli_tracked_orders[0]
+
+        self._process_trade_fill(
+            trade=trade,
+            tracked_order=tracked_order,
+            trigger_client_order_id=trigger_client_order_id,
+        )
+
+    def _process_trade_fill(
+            self,
+            trade: Dict[str, Any],
+            tracked_order: InFlightOrder,
+            trigger_client_order_id: Optional[str],
+    ):
         trading_pair_base_coin = tracked_order.base_asset
         base = trade["coin"]
         if base.upper() == trading_pair_base_coin:
@@ -931,6 +1496,16 @@ class HyperliquidPerpetualDerivative(PerpetualDerivativePyBase):
                 fee=fee,
             )
             self._order_tracker.process_trade_update(trade_update)
+            if (trigger_client_order_id is not None
+                    and tracked_order.executed_amount_base >= abs(tracked_order.amount)):
+                self._order_tracker.process_order_update(OrderUpdate(
+                    trading_pair=tracked_order.trading_pair,
+                    update_timestamp=trade["time"] * 1e-3,
+                    new_state=OrderState.FILLED,
+                    client_order_id=tracked_order.client_order_id,
+                    exchange_order_id=str(trade["oid"]),
+                ))
+                self._clear_trigger_child_orders(tracked_order.client_order_id)
 
     def _process_order_message(self, order_msg: Dict[str, Any]):
         """
@@ -940,21 +1515,74 @@ class HyperliquidPerpetualDerivative(PerpetualDerivativePyBase):
 
         Example Order:
         """
-        client_order_id = str(order_msg["order"].get("cloid", ""))
+        exchange_order_id = str(order_msg["order"]["oid"])
+        cloid = order_msg["order"].get("cloid")
+        client_order_id = str(cloid) if cloid else self._trigger_child_order_ids.get(exchange_order_id, "")
+        is_trigger_child = cloid is None and client_order_id != ""
         tracked_order = self._order_tracker.all_updatable_orders.get(client_order_id)
         if not tracked_order:
             self.logger().debug(f"Ignoring order message with id {client_order_id}: not in in_flight_orders.")
             return
         current_state = order_msg["status"]
-        tracked_order.update_exchange_order_id(str(order_msg["order"]["oid"]))
+        if cloid is not None or tracked_order.exchange_order_id is None:
+            tracked_order.update_exchange_order_id(exchange_order_id)
+        if cloid is not None:
+            self._clear_trigger_submission_reconciliation(client_order_id)
+        if current_state == "triggered":
+            self._associate_trigger_child_orders(tracked_order, order_msg["order"])
+        new_state = CONSTANTS.ORDER_STATE[current_state]
+        if is_trigger_child and new_state == OrderState.FILLED:
+            new_state = OrderState.OPEN
         order_update: OrderUpdate = OrderUpdate(
             trading_pair=tracked_order.trading_pair,
             update_timestamp=order_msg["statusTimestamp"] * 1e-3,
-            new_state=CONSTANTS.ORDER_STATE[current_state],
-            client_order_id=order_msg["order"]["cloid"],
-            exchange_order_id=str(order_msg["order"]["oid"]),
+            new_state=new_state,
+            client_order_id=client_order_id,
+            exchange_order_id=tracked_order.exchange_order_id,
         )
         self._order_tracker.process_order_update(order_update=order_update)
+        if not is_trigger_child and new_state in {OrderState.CANCELED, OrderState.FILLED, OrderState.FAILED}:
+            self._clear_trigger_child_orders(client_order_id)
+
+    @property
+    def tracking_states(self) -> Dict[str, Any]:
+        states = super().tracking_states
+        for client_order_id, state in states.items():
+            if client_order_id in self._native_trigger_client_order_ids:
+                state["hyperliquid_order_type"] = "trigger"
+                state["hyperliquid_trigger_child_order_ids"] = (
+                    self._trigger_child_order_ids_for_client_order_id(client_order_id)
+                )
+            if client_order_id in self._trigger_reconciliation_started_at:
+                state["hyperliquid_submission_state"] = "uncertain"
+                state["hyperliquid_reconciliation_started_at"] = (
+                    self._trigger_reconciliation_started_at[client_order_id]
+                )
+                state["hyperliquid_reconciliation_unknown_oid_count"] = (
+                    self._trigger_reconciliation_unknown_oid_counts.get(client_order_id, 0)
+                )
+        return states
+
+    def restore_tracking_states(self, saved_states: Dict[str, Any]):
+        super().restore_tracking_states(saved_states)
+        for client_order_id, state in saved_states.items():
+            if state.get("hyperliquid_order_type") == "trigger":
+                self._native_trigger_client_order_ids.add(client_order_id)
+                child_order_ids = state.get("hyperliquid_trigger_child_order_ids", [])
+                for child_order_id in child_order_ids:
+                    self._trigger_child_order_ids[str(child_order_id)] = client_order_id
+                if state.get("hyperliquid_submission_state") == "uncertain":
+                    self._trigger_orders_requiring_reconciliation.add(client_order_id)
+                    self._trigger_reconciliation_started_at[client_order_id] = float(
+                        state.get("hyperliquid_reconciliation_started_at", self.current_timestamp)
+                    )
+                    self._trigger_reconciliation_unknown_oid_counts[client_order_id] = int(
+                        state.get("hyperliquid_reconciliation_unknown_oid_count", 0)
+                    )
+                elif not child_order_ids:
+                    # A restored trigger may have activated while Hummingbot was offline. Reconcile once before canceling
+                    # so any child oid can be used, but this is not an uncertain placement result.
+                    self._trigger_orders_requiring_reconciliation.add(client_order_id)
 
     async def _format_trading_rules(self, exchange_info_dict: List) -> List[TradingRule]:
         """

--- a/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_web_utils.py
+++ b/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_web_utils.py
@@ -155,9 +155,9 @@ def order_type_to_wire(order_type):
     elif "trigger" in order_type:
         return {
             "trigger": {
+                "isMarket": order_type["trigger"]["isMarket"],
                 "triggerPx": float_to_wire(order_type["trigger"]["triggerPx"]),
                 "tpsl": order_type["trigger"]["tpsl"],
-                "isMarket": order_type["trigger"]["isMarket"],
             }
         }
     raise ValueError("Invalid order type", order_type)

--- a/test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_auth.py
+++ b/test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_auth.py
@@ -111,6 +111,11 @@ class HyperliquidPerpetualAuthTests(TestCase):
         self.assertEqual(2, len(action["orders"]))
         self.assertEqual("tp", action["orders"][0]["t"]["trigger"]["tpsl"])
         self.assertEqual("sl", action["orders"][1]["t"]["trigger"]["tpsl"])
+        self.assertEqual(
+            ["isMarket", "triggerPx", "tpsl"],
+            list(action["orders"][0]["t"]["trigger"]),
+            "Trigger wire field order is part of Hyperliquid's msgpack signature hash.",
+        )
 
     def test_trigger_order_signing_preserves_vault_and_testnet_rules(self):
         order = {

--- a/test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_auth.py
+++ b/test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_auth.py
@@ -68,6 +68,88 @@ class HyperliquidPerpetualAuthTests(TestCase):
         self.assertEqual(None, params.get("vaultAddress"))
         self.assertEqual("order", params.get("action")["type"])
 
+    def test_sign_order_params_preserves_single_order_action(self):
+        order = {
+            "asset": 4, "isBuy": True, "limitPx": 1201, "sz": 0.01, "reduceOnly": False,
+            "orderType": {"limit": {"tif": "Gtc"}}, "cloid": "0x000000000000000000000000000ee056",
+        }
+        with patch.object(self.auth, "sign_l1_action", return_value={"signature": "test"}):
+            payload = self.auth._sign_order_params(
+                {"orders": order, "grouping": "na"}, "https://test.url/exchange", 123)
+
+        self.assertEqual(payload["action"], {
+            "type": "order",
+            "orders": [{
+                "a": 4, "b": True, "p": "1201", "s": "0.01", "r": False,
+                "t": {"limit": {"tif": "Gtc"}}, "c": "0x000000000000000000000000000ee056",
+            }],
+            "grouping": "na",
+        })
+
+    def test_sign_order_params_signs_order_list_with_grouping_and_builder(self):
+        orders = [
+            {
+                "asset": 4, "isBuy": False, "limitPx": 1100, "sz": 0.01, "reduceOnly": True,
+                "orderType": {"trigger": {"triggerPx": 1100, "tpsl": "tp", "isMarket": True}},
+                "cloid": "0x00000000000000000000000000000001",
+            },
+            {
+                "asset": 4, "isBuy": False, "limitPx": 900, "sz": 0.01, "reduceOnly": True,
+                "orderType": {"trigger": {"triggerPx": 900, "tpsl": "sl", "isMarket": True}},
+                "cloid": "0x00000000000000000000000000000002",
+            },
+        ]
+        builder = {"b": "0x0000000000000000000000000000000000000001", "f": 1}
+        with patch.object(self.auth, "sign_l1_action", return_value={"signature": "test"}):
+            payload = self.auth._sign_order_params(
+                {"orders": orders, "grouping": "positionTpsl", "builder": builder},
+                "https://test.url/exchange", 123)
+
+        action = payload["action"]
+        self.assertEqual("positionTpsl", action["grouping"])
+        self.assertEqual(builder, action["builder"])
+        self.assertEqual(2, len(action["orders"]))
+        self.assertEqual("tp", action["orders"][0]["t"]["trigger"]["tpsl"])
+        self.assertEqual("sl", action["orders"][1]["t"]["trigger"]["tpsl"])
+
+    def test_trigger_order_signing_preserves_vault_and_testnet_rules(self):
+        order = {
+            "asset": 4, "isBuy": False, "limitPx": 900, "sz": 0.01, "reduceOnly": True,
+            "orderType": {"trigger": {"triggerPx": 950, "tpsl": "sl", "isMarket": True}},
+            "cloid": "0x00000000000000000000000000000001",
+        }
+        vault_auth = HyperliquidPerpetualAuth(
+            api_address="0x0000000000000000000000000000000000000001",
+            api_secret=self.api_secret,
+            use_vault=True,
+        )
+        with patch.object(vault_auth, "sign_l1_action", return_value={"signature": "test"}) as sign_mock:
+            vault_payload = vault_auth._sign_order_params(
+                {"orders": order, "grouping": "na"}, "https://api.hyperliquid.xyz/exchange", 123)
+
+        self.assertEqual(vault_auth._vault_address, vault_payload["vaultAddress"])
+        self.assertTrue(sign_mock.call_args.args[-1])
+        self.assertEqual("sl", vault_payload["action"]["orders"][0]["t"]["trigger"]["tpsl"])
+
+        with patch.object(self.auth, "sign_l1_action", return_value={"signature": "test"}) as sign_mock:
+            testnet_payload = self.auth._sign_order_params(
+                {"orders": order, "grouping": "na"},
+                "https://api.hyperliquid-testnet.xyz/exchange", 123)
+
+        self.assertIsNone(testnet_payload["vaultAddress"])
+        self.assertFalse(sign_mock.call_args.args[-1])
+        self.assertNotIn("builder", testnet_payload["action"])
+
+    def test_sign_cancel_params_uses_oid_action_for_activated_trigger_child(self):
+        with patch.object(self.auth, "sign_l1_action", return_value={"signature": "test"}):
+            payload = self.auth._sign_cancel_params(
+                {"cancels": {"asset": 4, "oid": 202}}, "https://test.url/exchange", 123)
+
+        self.assertEqual({
+            "type": "cancel",
+            "cancels": [{"a": 4, "o": 202}],
+        }, payload["action"])
+
 
 class HyperliquidPerpetualAuthValidationTests(TestCase):
     """Construction-time validation of api_address and api_secret (issue #7866)."""

--- a/test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_derivative.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 from decimal import Decimal
 from typing import Any, Callable, List, Optional, Tuple
 from unittest import TestCase
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pandas as pd
 from aioresponses import aioresponses
@@ -22,7 +22,12 @@ from hummingbot.connector.trading_rule import TradingRule
 from hummingbot.connector.utils import combine_to_hb_trading_pair
 from hummingbot.core.data_type.cancellation_result import CancellationResult
 from hummingbot.core.data_type.common import OrderType, PositionAction, PositionMode, TradeType
-from hummingbot.core.data_type.in_flight_order import InFlightOrder, OrderState, OrderUpdate
+from hummingbot.core.data_type.in_flight_order import (
+    InFlightOrder,
+    OrderState,
+    OrderUpdate,
+    PerpetualDerivativeInFlightOrder,
+)
 from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee, TokenAmount, TradeFeeBase
 from hummingbot.core.event.events import BuyOrderCreatedEvent, MarketOrderFailureEvent, SellOrderCreatedEvent
 from hummingbot.core.network_iterator import NetworkStatus
@@ -2061,6 +2066,1236 @@ class HyperliquidPerpetualDerivativeTests(AbstractPerpetualDerivativeTests.Perpe
         self.assertEqual(self.trading_pair, create_event.trading_pair)
         self.assertEqual(OrderType.MARKET, create_event.type)
         self.assertEqual(order_id, create_event.order_id)
+
+    def test_place_sell_stop_market_trigger_tracks_reduce_only_order_with_downward_slippage(self):
+        self._simulate_trading_rules_initialized()
+        self.exchange._set_current_timestamp(1640780000)
+        self.exchange._perpetual_trading.set_leverage(self.trading_pair, 2)
+        self.exchange._api_post = AsyncMock(return_value={
+            "status": "ok",
+            "response": {"type": "order", "data": {"statuses": [
+                {"resting": {"oid": self.expected_exchange_order_id}},
+            ]}},
+        })
+
+        order_id = self.exchange.place_trigger_order(
+            trading_pair=self.trading_pair,
+            amount=Decimal("1"),
+            side=TradeType.SELL,
+            trigger_price=Decimal("100"),
+            trigger_kind="sl",
+            is_market=True,
+        )
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+
+        request = self.exchange._api_post.await_args.kwargs["data"]
+        order_spec = request["orders"]
+        self.assertEqual("na", request["grouping"])
+        self.assertEqual(order_id, order_spec["cloid"])
+        self.assertFalse(order_spec["isBuy"])
+        self.assertTrue(order_spec["reduceOnly"])
+        self.assertEqual(95.0, order_spec["limitPx"])
+        self.assertEqual({
+            "trigger": {"triggerPx": 100.0, "tpsl": "sl", "isMarket": True},
+        }, order_spec["orderType"])
+        tracked_order = self.exchange.in_flight_orders[order_id]
+        self.assertEqual(PositionAction.CLOSE, tracked_order.position)
+        self.assertEqual(OrderState.OPEN, tracked_order.current_state)
+
+    def test_place_buy_stop_market_trigger_uses_upward_slippage(self):
+        self._simulate_trading_rules_initialized()
+        self.exchange._perpetual_trading.set_leverage(self.trading_pair, 2)
+        self.exchange._api_post = AsyncMock(return_value={
+            "status": "ok",
+            "response": {"data": {"statuses": [
+                {"resting": {"oid": self.expected_exchange_order_id}},
+            ]}},
+        })
+
+        self.exchange.place_trigger_order(
+            trading_pair=self.trading_pair,
+            amount=Decimal("1"),
+            side=TradeType.BUY,
+            trigger_price=Decimal("100"),
+            trigger_kind="sl",
+            is_market=True,
+        )
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+
+        order_spec = self.exchange._api_post.await_args.kwargs["data"]["orders"]
+        self.assertTrue(order_spec["isBuy"])
+        self.assertEqual(105.0, order_spec["limitPx"])
+
+    def test_place_position_protection_orders_tracks_each_successful_leg(self):
+        self._simulate_trading_rules_initialized()
+        self.exchange._perpetual_trading.set_leverage(self.trading_pair, 2)
+        self.exchange._order_tracker.TRADE_FILLS_WAIT_TIMEOUT = 0
+        builder = {"b": "0x0000000000000000000000000000000000000001", "f": 10}
+        self.exchange._build_builder_field = MagicMock(return_value=builder)
+        self.exchange._api_post = AsyncMock(side_effect=[
+            {
+                "status": "ok",
+                "response": {"data": {"statuses": [
+                    {"resting": {"oid": 101}},
+                    {"filled": {"oid": 102, "totalSz": "1", "avgPx": "90"}},
+                ]}},
+            },
+            [{
+                "oid": 102,
+                "coin": self.base_asset,
+                "dir": "Close Long",
+                "fee": "0.01",
+                "tid": 303,
+                "time": 1640780000002,
+                "px": "90",
+                "sz": "1",
+            }, {
+                "oid": 102,
+                "coin": self.base_asset,
+                "dir": "Close Long",
+                "fee": "0.01",
+                "tid": 303,
+                "time": 1640780000002,
+                "px": "90",
+                "sz": "1",
+            }],
+        ])
+
+        take_profit_id, stop_loss_id = self.exchange.place_position_protection_orders(
+            trading_pair=self.trading_pair,
+            amount=Decimal("1"),
+            close_side=TradeType.SELL,
+            take_profit_price=Decimal("110"),
+            stop_loss_price=Decimal("90"),
+        )
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+
+        request = self.exchange._api_post.await_args_list[0].kwargs["data"]
+        self.assertEqual("positionTpsl", request["grouping"])
+        self.assertEqual(builder, request["builder"])
+        self.assertEqual(2, len(request["orders"]))
+        self.assertNotEqual(take_profit_id, stop_loss_id)
+        self.assertEqual([take_profit_id, stop_loss_id], [order["cloid"] for order in request["orders"]])
+        self.assertTrue(all(order["reduceOnly"] for order in request["orders"]))
+        self.assertEqual({
+            "triggerPx": 110.0, "tpsl": "tp", "isMarket": False,
+        }, request["orders"][0]["orderType"]["trigger"])
+        self.assertEqual(110.0, request["orders"][0]["limitPx"])
+        self.assertEqual({
+            "triggerPx": 90.0, "tpsl": "sl", "isMarket": True,
+        }, request["orders"][1]["orderType"]["trigger"])
+        self.assertEqual(85.5, request["orders"][1]["limitPx"])
+        self.assertEqual(OrderState.OPEN, self.exchange._order_tracker.all_orders[take_profit_id].current_state)
+        self.assertEqual(OrderState.FILLED, self.exchange._order_tracker.all_orders[stop_loss_id].current_state)
+        self.assertEqual(Decimal("1"),
+                         self.exchange._order_tracker.all_orders[stop_loss_id].executed_amount_base)
+        self.assertEqual(1, len(self.exchange._order_tracker.all_orders[stop_loss_id].order_fills))
+
+    def test_placement_filled_without_authoritative_fill_keeps_trigger_open(self):
+        self._simulate_trading_rules_initialized()
+        self.exchange._perpetual_trading.set_leverage(self.trading_pair, 2)
+        self.exchange._api_post = AsyncMock(side_effect=[
+            {
+                "status": "ok",
+                "response": {"data": {"statuses": [
+                    {"filled": {"oid": 102, "totalSz": "1", "avgPx": "90"}},
+                ]}},
+            },
+            [],
+        ])
+
+        order_id = self.exchange.place_trigger_order(
+            self.trading_pair, Decimal("1"), TradeType.SELL, Decimal("90"), "sl", True)
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+
+        tracked_order = self.exchange.in_flight_orders[order_id]
+        self.assertEqual(OrderState.OPEN, tracked_order.current_state)
+        self.assertEqual(Decimal("0"), tracked_order.executed_amount_base)
+        self.assertEqual(0, len(self.sell_order_completed_logger.event_log))
+
+    def test_open_trigger_order_can_be_cancelled_by_client_order_id(self):
+        self._simulate_trading_rules_initialized()
+        self.exchange._perpetual_trading.set_leverage(self.trading_pair, 2)
+        self.exchange._api_post = AsyncMock(side_effect=[
+            {
+                "status": "ok",
+                "response": {"data": {"statuses": [
+                    {"resting": {"oid": self.expected_exchange_order_id}},
+                ]}},
+            },
+            {
+                "status": "ok",
+                "response": {"data": {"statuses": [{"success": True}]}},
+            },
+        ])
+
+        order_id = self.exchange.place_trigger_order(
+            self.trading_pair, Decimal("1"), TradeType.SELL, Decimal("90"), "sl", True)
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+        self.exchange.cancel(self.trading_pair, order_id)
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+
+        placement_asset = self.exchange._api_post.await_args_list[0].kwargs["data"]["orders"]["asset"]
+        cancel_request = self.exchange._api_post.await_args_list[1].kwargs["data"]
+        self.assertEqual({
+            "type": "cancel",
+            "cancels": {"asset": placement_asset, "cloid": order_id},
+        }, cancel_request)
+        tracked_order = self.exchange._order_tracker.all_orders[order_id]
+        self.assertEqual(OrderState.CANCELED, tracked_order.current_state)
+        self.assertNotIn(order_id, self.exchange.in_flight_orders)
+
+    def test_triggered_status_keeps_order_open_and_associates_child_fill(self):
+        self._simulate_trading_rules_initialized()
+        order_id = "0x1234567890abcdef1234567890abcdef"
+        self.exchange.start_tracking_order(
+            order_id=order_id,
+            exchange_order_id="101",
+            trading_pair=self.trading_pair,
+            trade_type=TradeType.SELL,
+            price=Decimal("85.5"),
+            amount=Decimal("1"),
+            order_type=OrderType.MARKET,
+            position_action=PositionAction.CLOSE,
+        )
+        tracked_order = self.exchange.in_flight_orders[order_id]
+        self.exchange._api_post = AsyncMock(return_value={
+            "status": "order",
+            "order": {
+                "order": {
+                    "oid": 101,
+                    "cloid": order_id,
+                    "timestamp": 1640780000000,
+                    "children": [{"oid": 202}],
+                },
+                "status": "triggered",
+                "statusTimestamp": 1640780000001,
+            },
+        })
+
+        order_update = self.async_run_with_timeout(self.exchange._request_order_status(tracked_order))
+        self.exchange._order_tracker.process_order_update(order_update)
+        self.async_run_with_timeout(self.exchange._process_trade_message({
+            "oid": 202,
+            "coin": self.base_asset,
+            "dir": "Close Long",
+            "fee": "0.01",
+            "tid": 303,
+            "time": 1640780000002,
+            "px": "90",
+            "sz": "0.4",
+        }))
+
+        self.assertEqual(OrderState.OPEN, tracked_order.current_state)
+        self.assertEqual(Decimal("0.4"), tracked_order.executed_amount_base)
+
+    def test_triggered_child_fill_is_recovered_by_rest_trade_polling(self):
+        self._simulate_trading_rules_initialized()
+        order_id = "0x1234567890abcdef1234567890abcdef"
+        self.exchange.start_tracking_order(
+            order_id=order_id,
+            exchange_order_id="101",
+            trading_pair=self.trading_pair,
+            trade_type=TradeType.SELL,
+            price=Decimal("85.5"),
+            amount=Decimal("1"),
+            order_type=OrderType.MARKET,
+            position_action=PositionAction.CLOSE,
+        )
+        tracked_order = self.exchange.in_flight_orders[order_id]
+        self.exchange._api_post = AsyncMock(return_value={
+            "status": "order",
+            "order": {
+                "order": {
+                    "oid": 101,
+                    "cloid": order_id,
+                    "timestamp": 1640780000000,
+                    "children": [{"oid": 202}],
+                },
+                "status": "triggered",
+                "statusTimestamp": 1640780000001,
+            },
+        })
+
+        order_update = self.async_run_with_timeout(self.exchange._request_order_status(tracked_order))
+        self.exchange._order_tracker.process_order_update(order_update)
+        self.exchange._api_post = AsyncMock(return_value=[{
+            "oid": 202,
+            "coin": self.base_asset,
+            "dir": "Close Long",
+            "fee": "0.01",
+            "tid": 303,
+            "time": 1640780000002,
+            "px": "90",
+            "sz": "1",
+        }])
+
+        self.async_run_with_timeout(self.exchange._update_trade_history())
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+
+        self.assertEqual(Decimal("1"), tracked_order.executed_amount_base)
+        self.assertEqual(OrderState.FILLED, self.exchange._order_tracker.all_orders[order_id].current_state)
+
+    def test_triggered_child_terminal_state_is_polled_by_child_oid(self):
+        order_id = "0x1234567890abcdef1234567890abcdef"
+        serialized_order = PerpetualDerivativeInFlightOrder(
+            client_order_id=order_id,
+            exchange_order_id="101",
+            trading_pair=self.trading_pair,
+            trade_type=TradeType.SELL,
+            price=Decimal("85.5"),
+            amount=Decimal("1"),
+            order_type=OrderType.MARKET,
+            leverage=2,
+            position=PositionAction.CLOSE,
+            creation_timestamp=1640780000,
+        ).to_json()
+        self.exchange.restore_tracking_states({order_id: serialized_order})
+        tracked_order = self.exchange.in_flight_orders[order_id]
+        self.exchange._api_post = AsyncMock(side_effect=[
+            {
+                "status": "order",
+                "order": {
+                    "order": {
+                        "oid": 101,
+                        "cloid": order_id,
+                        "timestamp": 1640780000000,
+                        "children": [{"oid": 202}],
+                    },
+                    "status": "triggered",
+                    "statusTimestamp": 1640780000001,
+                },
+            },
+            {
+                "status": "order",
+                "order": {
+                    "order": {
+                        "oid": 202,
+                        "cloid": None,
+                        "timestamp": 1640780000002,
+                        "children": [],
+                    },
+                    "status": "canceled",
+                    "statusTimestamp": 1640780000003,
+                },
+            },
+        ])
+
+        triggered_update = self.async_run_with_timeout(self.exchange._request_order_status(tracked_order))
+        self.exchange._order_tracker.process_order_update(triggered_update)
+        child_update = self.async_run_with_timeout(self.exchange._request_order_status(tracked_order))
+        self.exchange._order_tracker.process_order_update(child_update)
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+
+        second_request = self.exchange._api_post.await_args_list[1].kwargs["data"]
+        self.assertEqual(202, second_request["oid"])
+        self.assertEqual(OrderState.CANCELED, self.exchange._order_tracker.all_orders[order_id].current_state)
+        self.assertEqual(order_id, self.exchange._trigger_child_order_ids["202"])
+
+    def test_activated_trigger_completes_from_full_child_fill(self):
+        self._simulate_trading_rules_initialized()
+        order_id = "0x1234567890abcdef1234567890abcdef"
+        self.exchange.start_tracking_order(
+            order_id=order_id,
+            exchange_order_id="101",
+            trading_pair=self.trading_pair,
+            trade_type=TradeType.SELL,
+            price=Decimal("85.5"),
+            amount=Decimal("1"),
+            order_type=OrderType.MARKET,
+            position_action=PositionAction.CLOSE,
+        )
+        self.exchange._process_order_message({
+            "order": {"oid": 101, "cloid": order_id, "children": [{"oid": 202}]},
+            "status": "triggered",
+            "statusTimestamp": 1640780000001,
+        })
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+
+        self.async_run_with_timeout(self.exchange._process_trade_message({
+            "oid": 202,
+            "coin": self.base_asset,
+            "dir": "Close Long",
+            "fee": "0.01",
+            "tid": 303,
+            "time": 1640780000002,
+            "px": "90",
+            "sz": "1",
+        }))
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+
+        self.assertEqual(OrderState.FILLED, self.exchange._order_tracker.all_orders[order_id].current_state)
+
+    def test_restored_trigger_order_cancels_activated_child_by_oid(self):
+        self._simulate_trading_rules_initialized()
+        order_id = "0x1234567890abcdef1234567890abcdef"
+        serialized_order = PerpetualDerivativeInFlightOrder(
+            client_order_id=order_id,
+            exchange_order_id="101",
+            trading_pair=self.trading_pair,
+            trade_type=TradeType.SELL,
+            price=Decimal("85.5"),
+            amount=Decimal("1"),
+            order_type=OrderType.MARKET,
+            leverage=2,
+            position=PositionAction.CLOSE,
+            creation_timestamp=1640780000,
+        ).to_json()
+        self.exchange.restore_tracking_states({order_id: serialized_order})
+        restored_order = self.exchange.in_flight_orders[order_id]
+        self.exchange._api_post = AsyncMock(side_effect=[
+            {
+                "status": "order",
+                "order": {
+                    "order": {
+                        "oid": 101,
+                        "cloid": order_id,
+                        "timestamp": 1640780000000,
+                        "children": [{"oid": 202}],
+                    },
+                    "status": "triggered",
+                    "statusTimestamp": 1640780000001,
+                },
+            },
+            {
+                "status": "ok",
+                "response": {"data": {"statuses": [{"success": True}]}},
+            },
+        ])
+
+        order_update = self.async_run_with_timeout(self.exchange._request_order_status(restored_order))
+        self.exchange._order_tracker.process_order_update(order_update)
+        self.exchange.cancel(self.trading_pair, order_id)
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+
+        cancel_request = self.exchange._api_post.await_args_list[1].kwargs["data"]
+        self.assertEqual({"asset": self.exchange.coin_to_asset[self.base_asset], "oid": 202},
+                         cancel_request["cancels"])
+        self.assertEqual(OrderState.CANCELED, self.exchange._order_tracker.all_orders[order_id].current_state)
+
+    def test_restored_trigger_order_resolves_activated_child_when_cancelled_before_polling(self):
+        self._simulate_trading_rules_initialized()
+        order_id = "0x1234567890abcdef1234567890abcdef"
+        serialized_order = PerpetualDerivativeInFlightOrder(
+            client_order_id=order_id,
+            exchange_order_id="101",
+            trading_pair=self.trading_pair,
+            order_type=OrderType.MARKET,
+            trade_type=TradeType.SELL,
+            price=Decimal("85.5"),
+            amount=Decimal("1"),
+            leverage=2,
+            position=PositionAction.CLOSE,
+            creation_timestamp=1640780000,
+        ).to_json()
+        serialized_order["hyperliquid_order_type"] = "trigger"
+        self.exchange.restore_tracking_states({order_id: serialized_order})
+        self.exchange._api_post = AsyncMock(side_effect=[
+            {
+                "status": "order",
+                "order": {
+                    "order": {
+                        "oid": 101,
+                        "cloid": order_id,
+                        "timestamp": 1640780000000,
+                        "children": [{"oid": 202}],
+                    },
+                    "status": "triggered",
+                    "statusTimestamp": 1640780000001,
+                },
+            },
+            {
+                "status": "ok",
+                "response": {"data": {"statuses": [{"success": True}]}},
+            },
+        ])
+
+        self.exchange.cancel(self.trading_pair, order_id)
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+
+        status_request = self.exchange._api_post.await_args_list[0].kwargs["data"]
+        cancel_request = self.exchange._api_post.await_args_list[1].kwargs["data"]
+        self.assertEqual(101, status_request["oid"])
+        self.assertEqual({"asset": self.exchange.coin_to_asset[self.base_asset], "oid": 202},
+                         cancel_request["cancels"])
+
+    def test_tracking_states_persists_trigger_lifecycle_metadata(self):
+        order_id = "0x1234567890abcdef1234567890abcdef"
+        self.exchange.start_tracking_order(
+            order_id=order_id,
+            exchange_order_id="101",
+            trading_pair=self.trading_pair,
+            trade_type=TradeType.SELL,
+            price=Decimal("85.5"),
+            amount=Decimal("1"),
+            order_type=OrderType.MARKET,
+            position_action=PositionAction.CLOSE,
+        )
+        self.exchange._native_trigger_client_order_ids.add(order_id)
+        self.exchange._trigger_child_order_ids["202"] = order_id
+        self.exchange._trigger_orders_requiring_reconciliation.add(order_id)
+        self.exchange._trigger_reconciliation_started_at[order_id] = 1640780000
+        self.exchange._trigger_reconciliation_unknown_oid_counts[order_id] = 2
+
+        serialized_order = self.exchange.tracking_states[order_id]
+
+        self.assertEqual("trigger", serialized_order["hyperliquid_order_type"])
+        self.assertEqual(["202"], serialized_order["hyperliquid_trigger_child_order_ids"])
+        self.assertEqual("uncertain", serialized_order["hyperliquid_submission_state"])
+        self.assertEqual(1640780000, serialized_order["hyperliquid_reconciliation_started_at"])
+        self.assertEqual(2, serialized_order["hyperliquid_reconciliation_unknown_oid_count"])
+
+    def test_restore_tracking_states_restores_reconciliation_metadata(self):
+        order_id = "0x1234567890abcdef1234567890abcdef"
+        serialized_order = PerpetualDerivativeInFlightOrder(
+            client_order_id=order_id,
+            exchange_order_id=None,
+            trading_pair=self.trading_pair,
+            trade_type=TradeType.SELL,
+            price=Decimal("85.5"),
+            amount=Decimal("1"),
+            order_type=OrderType.MARKET,
+            leverage=2,
+            position=PositionAction.CLOSE,
+            creation_timestamp=1640780000,
+        ).to_json()
+        serialized_order.update({
+            "hyperliquid_order_type": "trigger",
+            "hyperliquid_submission_state": "uncertain",
+            "hyperliquid_reconciliation_started_at": 1640780001,
+            "hyperliquid_reconciliation_unknown_oid_count": 2,
+        })
+
+        self.exchange.restore_tracking_states({order_id: serialized_order})
+
+        self.assertIn(order_id, self.exchange.in_flight_orders)
+        self.assertIn(order_id, self.exchange._trigger_orders_requiring_reconciliation)
+        self.assertEqual(1640780001, self.exchange._trigger_reconciliation_started_at[order_id])
+        self.assertEqual(2, self.exchange._trigger_reconciliation_unknown_oid_counts[order_id])
+
+    def test_triggered_user_stream_status_keeps_order_open(self):
+        order_id = "0x1234567890abcdef1234567890abcdef"
+        self.exchange.start_tracking_order(
+            order_id=order_id,
+            exchange_order_id="101",
+            trading_pair=self.trading_pair,
+            trade_type=TradeType.SELL,
+            price=Decimal("85.5"),
+            amount=Decimal("1"),
+            order_type=OrderType.MARKET,
+            position_action=PositionAction.CLOSE,
+        )
+
+        self.exchange._process_order_message({
+            "order": {"oid": 101, "cloid": order_id, "children": [{"oid": 202}]},
+            "status": "triggered",
+            "statusTimestamp": 1640780000001,
+        })
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+
+        self.assertEqual(OrderState.OPEN, self.exchange.in_flight_orders[order_id].current_state)
+        self.assertEqual(order_id, self.exchange._trigger_child_order_ids["202"])
+
+        self.exchange._process_order_message({
+            "order": {"oid": 202, "cloid": None},
+            "status": "canceled",
+            "statusTimestamp": 1640780000002,
+        })
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+        tracked_order = self.exchange._order_tracker.all_orders[order_id]
+        self.assertEqual(OrderState.CANCELED, tracked_order.current_state)
+        self.assertEqual("101", tracked_order.exchange_order_id)
+
+    def test_triggered_child_fill_status_waits_for_trade_before_completing_parent(self):
+        order_id = "0x1234567890abcdef1234567890abcdef"
+        self.exchange.start_tracking_order(
+            order_id=order_id,
+            exchange_order_id="101",
+            trading_pair=self.trading_pair,
+            trade_type=TradeType.SELL,
+            price=Decimal("85.5"),
+            amount=Decimal("1"),
+            order_type=OrderType.MARKET,
+            position_action=PositionAction.CLOSE,
+        )
+        tracked_order = self.exchange.in_flight_orders[order_id]
+
+        self.exchange._process_order_message({
+            "order": {"oid": 101, "cloid": order_id, "children": [{"oid": 202}]},
+            "status": "triggered",
+            "statusTimestamp": 1640780000001,
+        })
+        self.exchange._process_order_message({
+            "order": {"oid": 202, "cloid": None},
+            "status": "filled",
+            "statusTimestamp": 1640780000002,
+        })
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+
+        self.assertEqual(OrderState.OPEN, tracked_order.current_state)
+        self.assertEqual(order_id, self.exchange._trigger_child_order_ids["202"])
+
+        self.async_run_with_timeout(self.exchange._process_trade_message({
+            "oid": 202,
+            "coin": self.base_asset,
+            "dir": "Close Long",
+            "fee": "0.01",
+            "tid": 303,
+            "time": 1640780000003,
+            "px": "90",
+            "sz": "1",
+        }))
+
+        self.assertEqual(Decimal("1"), tracked_order.executed_amount_base)
+        self.assertEqual(OrderState.FILLED, tracked_order.current_state)
+        self.assertNotIn("202", self.exchange._trigger_child_order_ids)
+
+    def test_triggered_child_cancel_status_retains_mapping_for_late_partial_fill(self):
+        order_id = "0x1234567890abcdef1234567890abcdef"
+        self.exchange.start_tracking_order(
+            order_id=order_id,
+            exchange_order_id="101",
+            trading_pair=self.trading_pair,
+            trade_type=TradeType.SELL,
+            price=Decimal("85.5"),
+            amount=Decimal("1"),
+            order_type=OrderType.MARKET,
+            position_action=PositionAction.CLOSE,
+        )
+        tracked_order = self.exchange.in_flight_orders[order_id]
+        self.exchange._process_order_message({
+            "order": {"oid": 101, "cloid": order_id, "children": [{"oid": 202}]},
+            "status": "triggered",
+            "statusTimestamp": 1640780000001,
+        })
+        self.exchange._process_order_message({
+            "order": {"oid": 202, "cloid": None},
+            "status": "canceled",
+            "statusTimestamp": 1640780000002,
+        })
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+
+        self.assertEqual(OrderState.CANCELED, tracked_order.current_state)
+        self.assertEqual(order_id, self.exchange._trigger_child_order_ids["202"])
+
+        self.async_run_with_timeout(self.exchange._process_trade_message({
+            "oid": 202,
+            "coin": self.base_asset,
+            "dir": "Close Long",
+            "fee": "0.01",
+            "tid": 303,
+            "time": 1640780000003,
+            "px": "90",
+            "sz": "0.4",
+        }))
+
+        self.assertEqual(Decimal("0.4"), tracked_order.executed_amount_base)
+
+    def test_trigger_rejection_user_stream_statuses_fail_the_order(self):
+        for index, status in enumerate(("badTriggerPxRejected", "marketOrderNoLiquidityRejected")):
+            with self.subTest(status=status):
+                order_id = f"0x{index + 1:032x}"
+                self.exchange.start_tracking_order(
+                    order_id=order_id,
+                    exchange_order_id=str(101 + index),
+                    trading_pair=self.trading_pair,
+                    trade_type=TradeType.SELL,
+                    price=Decimal("85.5"),
+                    amount=Decimal("1"),
+                    order_type=OrderType.MARKET,
+                    position_action=PositionAction.CLOSE,
+                )
+
+                self.exchange._process_order_message({
+                    "order": {"oid": 101 + index, "cloid": order_id},
+                    "status": status,
+                    "statusTimestamp": 1640780000001,
+                })
+                self.async_run_with_timeout(asyncio.sleep(0.01))
+
+                self.assertEqual(OrderState.FAILED, self.exchange._order_tracker.all_orders[order_id].current_state)
+
+    def test_place_position_protection_orders_preserves_successful_leg_when_sibling_fails(self):
+        self._simulate_trading_rules_initialized()
+        self.exchange._perpetual_trading.set_leverage(self.trading_pair, 2)
+        self.exchange._api_post = AsyncMock(return_value={
+            "status": "ok",
+            "response": {"data": {"statuses": [
+                {"resting": {"oid": 101}},
+                {"error": "invalid trigger"},
+            ]}},
+        })
+
+        take_profit_id, stop_loss_id = self.exchange.place_position_protection_orders(
+            trading_pair=self.trading_pair,
+            amount=Decimal("1"),
+            close_side=TradeType.BUY,
+            take_profit_price=Decimal("90"),
+            stop_loss_price=Decimal("110"),
+        )
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+
+        self.assertEqual(OrderState.OPEN, self.exchange._order_tracker.all_orders[take_profit_id].current_state)
+        self.assertEqual(OrderState.FAILED, self.exchange._order_tracker.all_orders[stop_loss_id].current_state)
+        self.assertIn(take_profit_id, self.exchange.in_flight_orders)
+        self.assertNotIn(stop_loss_id, self.exchange.in_flight_orders)
+
+    def test_trigger_order_supports_tp_market_and_sl_limit_wire_shapes(self):
+        self._simulate_trading_rules_initialized()
+        self.exchange._perpetual_trading.set_leverage(self.trading_pair, 2)
+        self.exchange._api_post = AsyncMock(side_effect=[
+            {"status": "ok", "response": {"data": {"statuses": [{"resting": {"oid": 101}}]}}},
+            {"status": "ok", "response": {"data": {"statuses": [{"resting": {"oid": 102}}]}}},
+        ])
+
+        self.exchange.place_trigger_order(
+            self.trading_pair, Decimal("1"), TradeType.SELL, Decimal("110"), "tp", True)
+        self.exchange.place_trigger_order(
+            self.trading_pair, Decimal("1"), TradeType.BUY, Decimal("90"), "sl", False,
+            limit_price=Decimal("91"))
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+
+        tp_spec = self.exchange._api_post.await_args_list[0].kwargs["data"]["orders"]
+        sl_spec = self.exchange._api_post.await_args_list[1].kwargs["data"]["orders"]
+        self.assertEqual(
+            {"triggerPx": 110.0, "tpsl": "tp", "isMarket": True},
+            tp_spec["orderType"]["trigger"])
+        self.assertEqual(104.5, tp_spec["limitPx"])
+        self.assertEqual(
+            {"triggerPx": 90.0, "tpsl": "sl", "isMarket": False},
+            sl_spec["orderType"]["trigger"])
+        self.assertEqual(91.0, sl_spec["limitPx"])
+
+    def test_position_protection_batch_error_fails_both_tracked_legs(self):
+        self._simulate_trading_rules_initialized()
+        self.exchange._perpetual_trading.set_leverage(self.trading_pair, 2)
+        self.exchange._api_post = AsyncMock(return_value={"status": "err", "response": "rejected"})
+
+        take_profit_id, stop_loss_id = self.exchange.place_position_protection_orders(
+            self.trading_pair, Decimal("1"), TradeType.SELL, Decimal("110"), Decimal("90"))
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+
+        self.assertEqual(OrderState.FAILED, self.exchange._order_tracker.all_orders[take_profit_id].current_state)
+        self.assertEqual(OrderState.FAILED, self.exchange._order_tracker.all_orders[stop_loss_id].current_state)
+
+    def test_position_protection_local_preparation_error_fails_already_tracked_legs(self):
+        self.exchange.quantize_order_amount = MagicMock(side_effect=KeyError(self.trading_pair))
+        self.exchange._api_post = AsyncMock()
+
+        take_profit_id, stop_loss_id = self.exchange.place_position_protection_orders(
+            self.trading_pair, Decimal("1"), TradeType.SELL, Decimal("110"), Decimal("90"))
+
+        self.assertIn(take_profit_id, self.exchange.in_flight_orders)
+        self.assertIn(stop_loss_id, self.exchange.in_flight_orders)
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+        self.assertEqual(OrderState.FAILED, self.exchange._order_tracker.all_orders[take_profit_id].current_state)
+        self.assertEqual(OrderState.FAILED, self.exchange._order_tracker.all_orders[stop_loss_id].current_state)
+        self.exchange._api_post.assert_not_awaited()
+
+    def test_position_protection_missing_status_reconciles_only_unknown_order(self):
+        self._simulate_trading_rules_initialized()
+        self.exchange._perpetual_trading.set_leverage(self.trading_pair, 2)
+        self.exchange._api_post = AsyncMock(return_value={
+            "status": "ok", "response": {"data": {"statuses": [{"resting": {"oid": 101}}]}},
+        })
+
+        take_profit_id, stop_loss_id = self.exchange.place_position_protection_orders(
+            self.trading_pair, Decimal("1"), TradeType.SELL, Decimal("110"), Decimal("90"))
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+
+        self.assertEqual(OrderState.OPEN, self.exchange._order_tracker.all_orders[take_profit_id].current_state)
+        self.assertEqual(OrderState.PENDING_CREATE,
+                         self.exchange._order_tracker.all_orders[stop_loss_id].current_state)
+        self.assertNotIn(take_profit_id, self.exchange._trigger_orders_requiring_reconciliation)
+        self.assertIn(stop_loss_id, self.exchange._trigger_orders_requiring_reconciliation)
+
+    def test_position_protection_malformed_status_reconciles_only_unknown_order(self):
+        self._simulate_trading_rules_initialized()
+        self.exchange._perpetual_trading.set_leverage(self.trading_pair, 2)
+        self.exchange._api_post = AsyncMock(return_value={
+            "status": "ok",
+            "response": {"data": {"statuses": [
+                {"resting": {"oid": 101}},
+                None,
+            ]}},
+        })
+
+        take_profit_id, stop_loss_id = self.exchange.place_position_protection_orders(
+            self.trading_pair, Decimal("1"), TradeType.SELL, Decimal("110"), Decimal("90"))
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+
+        self.assertEqual(OrderState.OPEN, self.exchange._order_tracker.all_orders[take_profit_id].current_state)
+        self.assertEqual(OrderState.PENDING_CREATE,
+                         self.exchange._order_tracker.all_orders[stop_loss_id].current_state)
+        self.assertNotIn(take_profit_id, self.exchange._trigger_orders_requiring_reconciliation)
+        self.assertIn(stop_loss_id, self.exchange._trigger_orders_requiring_reconciliation)
+
+    def test_position_protection_malformed_statuses_container_reconciles_both_orders(self):
+        self._simulate_trading_rules_initialized()
+        self.exchange._perpetual_trading.set_leverage(self.trading_pair, 2)
+        self.exchange._api_post = AsyncMock(return_value={
+            "status": "ok",
+            "response": {"data": {"statuses": None}},
+        })
+
+        take_profit_id, stop_loss_id = self.exchange.place_position_protection_orders(
+            self.trading_pair, Decimal("1"), TradeType.SELL, Decimal("110"), Decimal("90"))
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+
+        self.assertEqual(OrderState.PENDING_CREATE,
+                         self.exchange._order_tracker.all_orders[take_profit_id].current_state)
+        self.assertEqual(OrderState.PENDING_CREATE,
+                         self.exchange._order_tracker.all_orders[stop_loss_id].current_state)
+        self.assertEqual(
+            {take_profit_id, stop_loss_id},
+            self.exchange._trigger_orders_requiring_reconciliation,
+        )
+
+    def test_position_protection_oversized_statuses_reconcile_both_orders(self):
+        self._simulate_trading_rules_initialized()
+        self.exchange._perpetual_trading.set_leverage(self.trading_pair, 2)
+        self.exchange._api_post = AsyncMock(return_value={
+            "status": "ok",
+            "response": {"data": {"statuses": [
+                {"resting": {"oid": 101}},
+                {"resting": {"oid": 102}},
+                {"resting": {"oid": 103}},
+            ]}},
+        })
+
+        take_profit_id, stop_loss_id = self.exchange.place_position_protection_orders(
+            self.trading_pair, Decimal("1"), TradeType.SELL, Decimal("110"), Decimal("90"))
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+
+        for order_id in (take_profit_id, stop_loss_id):
+            tracked_order = self.exchange._order_tracker.all_orders[order_id]
+            self.assertEqual(OrderState.PENDING_CREATE, tracked_order.current_state)
+            self.assertIsNone(tracked_order.exchange_order_id)
+            self.assertIn(order_id, self.exchange._trigger_orders_requiring_reconciliation)
+
+    def test_trigger_order_malformed_statuses_container_enters_reconciliation(self):
+        self._simulate_trading_rules_initialized()
+        self.exchange._perpetual_trading.set_leverage(self.trading_pair, 2)
+        self.exchange._api_post = AsyncMock(return_value={
+            "status": "ok",
+            "response": {"data": {"statuses": None}},
+        })
+
+        order_id = self.exchange.place_trigger_order(
+            self.trading_pair, Decimal("1"), TradeType.SELL, Decimal("90"), "sl", True)
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+
+        self.assertEqual(OrderState.PENDING_CREATE, self.exchange._order_tracker.all_orders[order_id].current_state)
+        self.assertIn(order_id, self.exchange._trigger_orders_requiring_reconciliation)
+
+    def test_position_protection_transport_error_enters_reconciliation_without_failure(self):
+        self._simulate_trading_rules_initialized()
+        self.exchange._perpetual_trading.set_leverage(self.trading_pair, 2)
+        self.exchange._api_post = AsyncMock(side_effect=asyncio.TimeoutError())
+
+        take_profit_id, stop_loss_id = self.exchange.place_position_protection_orders(
+            self.trading_pair, Decimal("1"), TradeType.SELL, Decimal("110"), Decimal("90"))
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+
+        self.assertEqual(OrderState.PENDING_CREATE,
+                         self.exchange._order_tracker.all_orders[take_profit_id].current_state)
+        self.assertEqual(OrderState.PENDING_CREATE,
+                         self.exchange._order_tracker.all_orders[stop_loss_id].current_state)
+        self.assertEqual(0, len(self.order_failure_logger.event_log))
+        self.assertEqual(
+            {take_profit_id, stop_loss_id},
+            self.exchange._trigger_orders_requiring_reconciliation,
+        )
+
+    def test_trigger_order_transport_error_enters_reconciliation_without_failure(self):
+        self._simulate_trading_rules_initialized()
+        self.exchange._perpetual_trading.set_leverage(self.trading_pair, 2)
+        self.exchange._api_post = AsyncMock(side_effect=ConnectionError("response lost"))
+
+        order_id = self.exchange.place_trigger_order(
+            self.trading_pair, Decimal("1"), TradeType.SELL, Decimal("90"), "sl", True)
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+
+        self.assertEqual(OrderState.PENDING_CREATE, self.exchange.in_flight_orders[order_id].current_state)
+        self.assertEqual(0, len(self.order_failure_logger.event_log))
+        self.assertIn(order_id, self.exchange._trigger_orders_requiring_reconciliation)
+
+    def test_uncertain_trigger_order_is_reconciled_by_cloid(self):
+        order_id = "0x1234567890abcdef1234567890abcdef"
+        self.exchange.start_tracking_order(
+            order_id=order_id,
+            exchange_order_id=None,
+            trading_pair=self.trading_pair,
+            trade_type=TradeType.SELL,
+            price=Decimal("85.5"),
+            amount=Decimal("1"),
+            order_type=OrderType.MARKET,
+            position_action=PositionAction.CLOSE,
+        )
+        self.exchange._mark_trigger_order_for_reconciliation(order_id, "missing placement status")
+        self.exchange._api_post = AsyncMock(return_value={
+            "status": "order",
+            "order": {
+                "order": {
+                    "oid": 101,
+                    "cloid": order_id,
+                    "timestamp": 1640780000000,
+                    "children": [],
+                },
+                "status": "open",
+                "statusTimestamp": 1640780000001,
+            },
+        })
+
+        order_update = self.async_run_with_timeout(
+            self.exchange._request_order_status(self.exchange.in_flight_orders[order_id]))
+        self.exchange._order_tracker.process_order_update(order_update)
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+
+        self.assertEqual(order_id, self.exchange._api_post.await_args.kwargs["data"]["oid"])
+        self.assertEqual("101", self.exchange.in_flight_orders[order_id].exchange_order_id)
+        self.assertEqual(OrderState.OPEN, self.exchange.in_flight_orders[order_id].current_state)
+        self.assertNotIn(order_id, self.exchange._trigger_orders_requiring_reconciliation)
+
+    def test_uncertain_trigger_order_fails_only_after_grace_period_and_three_unknown_oid_responses(self):
+        order_id = "0x1234567890abcdef1234567890abcdef"
+        self.exchange._set_current_timestamp(1640780000)
+        self.exchange.start_tracking_order(
+            order_id=order_id,
+            exchange_order_id=None,
+            trading_pair=self.trading_pair,
+            trade_type=TradeType.SELL,
+            price=Decimal("85.5"),
+            amount=Decimal("1"),
+            order_type=OrderType.MARKET,
+            position_action=PositionAction.CLOSE,
+        )
+        tracked_order = self.exchange.in_flight_orders[order_id]
+        self.exchange._mark_trigger_order_for_reconciliation(order_id, "placement timeout")
+        self.exchange._api_post = AsyncMock(return_value={"status": "unknownOid"})
+
+        first_update = self.async_run_with_timeout(self.exchange._request_order_status(tracked_order))
+        self.assertEqual(OrderState.PENDING_CREATE, first_update.new_state)
+
+        self.exchange._set_current_timestamp(
+            1640780000 + CONSTANTS.TRIGGER_ORDER_RECONCILIATION_GRACE_SECONDS)
+        second_update = self.async_run_with_timeout(self.exchange._request_order_status(tracked_order))
+        self.assertEqual(OrderState.PENDING_CREATE, second_update.new_state)
+        third_update = self.async_run_with_timeout(self.exchange._request_order_status(tracked_order))
+
+        self.assertEqual(OrderState.FAILED, third_update.new_state)
+        self.exchange._order_tracker.process_order_update(third_update)
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+        self.exchange._prune_trigger_tracking()
+        self.assertNotIn(order_id, self.exchange._trigger_orders_requiring_reconciliation)
+
+    def test_reconciliation_query_error_does_not_increment_unknown_oid_count(self):
+        order_id = "0x1234567890abcdef1234567890abcdef"
+        self.exchange.start_tracking_order(
+            order_id=order_id,
+            exchange_order_id=None,
+            trading_pair=self.trading_pair,
+            trade_type=TradeType.SELL,
+            price=Decimal("85.5"),
+            amount=Decimal("1"),
+            order_type=OrderType.MARKET,
+            position_action=PositionAction.CLOSE,
+        )
+        tracked_order = self.exchange.in_flight_orders[order_id]
+        self.exchange._mark_trigger_order_for_reconciliation(order_id, "placement timeout")
+
+        self.async_run_with_timeout(
+            self.exchange._handle_update_error_for_active_order(tracked_order, asyncio.TimeoutError()))
+
+        self.assertEqual(0, self.exchange._trigger_reconciliation_unknown_oid_counts[order_id])
+        self.assertNotIn(order_id, self.exchange._order_tracker._order_not_found_records)
+
+    def test_reconciliation_query_errors_reset_consecutive_unknown_oid_count(self):
+        order_id = "0x1234567890abcdef1234567890abcdef"
+        self.exchange._set_current_timestamp(1640780000)
+        self.exchange.start_tracking_order(
+            order_id=order_id,
+            exchange_order_id=None,
+            trading_pair=self.trading_pair,
+            trade_type=TradeType.SELL,
+            price=Decimal("85.5"),
+            amount=Decimal("1"),
+            order_type=OrderType.MARKET,
+            position_action=PositionAction.CLOSE,
+        )
+        tracked_order = self.exchange.in_flight_orders[order_id]
+        self.exchange._mark_trigger_order_for_reconciliation(order_id, "placement timeout")
+        self.exchange._set_current_timestamp(
+            1640780000 + CONSTANTS.TRIGGER_ORDER_RECONCILIATION_GRACE_SECONDS)
+        self.exchange._api_post = AsyncMock(side_effect=[
+            {"status": "unknownOid"},
+            asyncio.TimeoutError(),
+            {"status": "unknownOid"},
+            IOError("rate limited"),
+            {"status": "unknownOid"},
+            {"status": "unknownOid"},
+            {"status": "unknownOid"},
+        ])
+
+        first_update = self.async_run_with_timeout(self.exchange._request_order_status(tracked_order))
+        self.assertEqual(OrderState.PENDING_CREATE, first_update.new_state)
+        with self.assertRaises(asyncio.TimeoutError):
+            self.async_run_with_timeout(self.exchange._request_order_status(tracked_order))
+        self.async_run_with_timeout(
+            self.exchange._handle_update_error_for_active_order(tracked_order, asyncio.TimeoutError()))
+        self.assertEqual(0, self.exchange._trigger_reconciliation_unknown_oid_counts[order_id])
+
+        second_update = self.async_run_with_timeout(self.exchange._request_order_status(tracked_order))
+        self.assertEqual(OrderState.PENDING_CREATE, second_update.new_state)
+        with self.assertRaises(IOError):
+            self.async_run_with_timeout(self.exchange._request_order_status(tracked_order))
+        self.async_run_with_timeout(
+            self.exchange._handle_update_error_for_active_order(tracked_order, IOError("rate limited")))
+        self.assertEqual(0, self.exchange._trigger_reconciliation_unknown_oid_counts[order_id])
+
+        self.assertEqual(
+            OrderState.PENDING_CREATE,
+            self.async_run_with_timeout(self.exchange._request_order_status(tracked_order)).new_state,
+        )
+        self.assertEqual(
+            OrderState.PENDING_CREATE,
+            self.async_run_with_timeout(self.exchange._request_order_status(tracked_order)).new_state,
+        )
+        self.assertEqual(
+            OrderState.FAILED,
+            self.async_run_with_timeout(self.exchange._request_order_status(tracked_order)).new_state,
+        )
+
+    def test_public_cancel_not_found_keeps_uncertain_trigger_in_reconciliation(self):
+        self._simulate_trading_rules_initialized()
+        order_id = "0x1234567890abcdef1234567890abcdef"
+        self.exchange._set_current_timestamp(1640780000)
+        self.exchange.start_tracking_order(
+            order_id=order_id,
+            exchange_order_id=None,
+            trading_pair=self.trading_pair,
+            trade_type=TradeType.SELL,
+            price=Decimal("85.5"),
+            amount=Decimal("1"),
+            order_type=OrderType.MARKET,
+            position_action=PositionAction.CLOSE,
+        )
+        tracked_order = self.exchange.in_flight_orders[order_id]
+        self.exchange._mark_trigger_order_for_reconciliation(order_id, "placement timeout")
+        self.exchange._api_post = AsyncMock(side_effect=[
+            {"status": "unknownOid"},
+            {
+                "status": "ok",
+                "response": {"data": {"statuses": [{"error": CONSTANTS.UNKNOWN_ORDER_MESSAGE}]}},
+            },
+        ] * (self.exchange._order_tracker.lost_order_count_limit + 1))
+
+        for _ in range(self.exchange._order_tracker.lost_order_count_limit + 1):
+            self.async_run_with_timeout(self.exchange._execute_order_cancel(tracked_order))
+
+        self.assertEqual(OrderState.PENDING_CREATE, tracked_order.current_state)
+        self.assertIn(order_id, self.exchange._trigger_orders_requiring_reconciliation)
+        self.assertEqual(
+            self.exchange._order_tracker.lost_order_count_limit + 1,
+            self.exchange._trigger_reconciliation_unknown_oid_counts[order_id],
+        )
+        self.assertNotIn(order_id, self.exchange._order_tracker._order_not_found_records)
+
+    def test_public_cancel_malformed_status_resets_consecutive_unknown_oid_count(self):
+        self._simulate_trading_rules_initialized()
+        order_id = "0x1234567890abcdef1234567890abcdef"
+        self.exchange._set_current_timestamp(1640780000)
+        self.exchange.start_tracking_order(
+            order_id=order_id,
+            exchange_order_id=None,
+            trading_pair=self.trading_pair,
+            trade_type=TradeType.SELL,
+            price=Decimal("85.5"),
+            amount=Decimal("1"),
+            order_type=OrderType.MARKET,
+            position_action=PositionAction.CLOSE,
+        )
+        tracked_order = self.exchange.in_flight_orders[order_id]
+        self.exchange._mark_trigger_order_for_reconciliation(order_id, "placement timeout")
+        self.exchange._set_current_timestamp(
+            1640780000 + CONSTANTS.TRIGGER_ORDER_RECONCILIATION_GRACE_SECONDS)
+        self.exchange._api_post = AsyncMock(side_effect=[
+            {"status": "unknownOid"},
+            {"status": "unknownOid"},
+            {"status": "order", "order": {
+                "status": "open",
+                "order": {"oid": "", "timestamp": 1640780000000},
+            }},
+            {"status": "unknownOid"},
+        ])
+
+        for _ in range(2):
+            order_update = self.async_run_with_timeout(self.exchange._request_order_status(tracked_order))
+            self.assertEqual(OrderState.PENDING_CREATE, order_update.new_state)
+
+        self.assertIsNone(self.async_run_with_timeout(self.exchange._execute_order_cancel(tracked_order)))
+        self.assertEqual(0, self.exchange._trigger_reconciliation_unknown_oid_counts[order_id])
+        final_update = self.async_run_with_timeout(self.exchange._request_order_status(tracked_order))
+
+        self.assertEqual(OrderState.PENDING_CREATE, final_update.new_state)
+        self.assertEqual(1, self.exchange._trigger_reconciliation_unknown_oid_counts[order_id])
+
+    def test_restored_uncertain_trigger_reconciles_without_resubmitting(self):
+        order_id = "0x1234567890abcdef1234567890abcdef"
+        serialized_order = PerpetualDerivativeInFlightOrder(
+            client_order_id=order_id,
+            exchange_order_id=None,
+            trading_pair=self.trading_pair,
+            trade_type=TradeType.SELL,
+            price=Decimal("85.5"),
+            amount=Decimal("1"),
+            order_type=OrderType.MARKET,
+            leverage=2,
+            position=PositionAction.CLOSE,
+            creation_timestamp=1640780000,
+        ).to_json()
+        serialized_order.update({
+            "hyperliquid_order_type": "trigger",
+            "hyperliquid_submission_state": "uncertain",
+            "hyperliquid_reconciliation_started_at": 1640780001,
+            "hyperliquid_reconciliation_unknown_oid_count": 1,
+        })
+        self.exchange.restore_tracking_states({order_id: serialized_order})
+        self.exchange._api_post = AsyncMock(return_value={
+            "status": "order",
+            "order": {
+                "order": {
+                    "oid": 101,
+                    "cloid": order_id,
+                    "timestamp": 1640780000000,
+                    "children": [],
+                },
+                "status": "canceled",
+                "statusTimestamp": 1640780000001,
+            },
+        })
+
+        self.async_run_with_timeout(self.exchange._update_order_status())
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+
+        request = self.exchange._api_post.await_args.kwargs["data"]
+        self.assertEqual(CONSTANTS.ORDER_STATUS_TYPE, request["type"])
+        self.assertEqual(order_id, request["oid"])
+        self.assertEqual(OrderState.CANCELED, self.exchange._order_tracker.all_orders[order_id].current_state)
+
+    def test_trigger_order_rejects_invalid_kind_and_side(self):
+        with self.assertRaisesRegex(ValueError, "trigger_kind"):
+            self.exchange.place_trigger_order(
+                self.trading_pair, Decimal("1"), TradeType.SELL, Decimal("100"), "invalid", True)
+        with self.assertRaisesRegex(ValueError, "side"):
+            self.exchange.place_trigger_order(
+                self.trading_pair, Decimal("1"), "SELL", Decimal("100"), "sl", True)
+        with self.assertRaisesRegex(ValueError, "close_side"):
+            self.exchange.place_position_protection_orders(
+                self.trading_pair, Decimal("1"), "SELL", Decimal("110"), Decimal("90"))
+
+    def test_market_trigger_order_rejects_explicit_limit_price(self):
+        with self.assertRaisesRegex(ValueError, "limit_price must be omitted for market trigger orders"):
+            self.exchange.place_trigger_order(
+                trading_pair=self.trading_pair,
+                amount=Decimal("1"),
+                side=TradeType.SELL,
+                trigger_price=Decimal("100"),
+                trigger_kind="sl",
+                is_market=True,
+                limit_price=Decimal("99"),
+            )
+
+    def test_trigger_order_rejects_invalid_or_duplicate_custom_client_order_id(self):
+        invalid_order_id = "not-a-128-bit-cloid"
+        with self.assertRaisesRegex(ValueError, "128-bit hexadecimal"):
+            self.exchange.place_trigger_order(
+                self.trading_pair, Decimal("1"), TradeType.SELL, Decimal("100"), "sl", True,
+                client_order_id=invalid_order_id)
+
+        order_id = "0x1234567890abcdef1234567890abcdef"
+        self.exchange.start_tracking_order(
+            order_id=order_id,
+            exchange_order_id="101",
+            trading_pair=self.trading_pair,
+            trade_type=TradeType.SELL,
+            price=Decimal("95"),
+            amount=Decimal("1"),
+            order_type=OrderType.MARKET,
+            position_action=PositionAction.CLOSE,
+        )
+        with self.assertRaisesRegex(ValueError, "already been used"):
+            self.exchange.place_trigger_order(
+                self.trading_pair, Decimal("1"), TradeType.SELL, Decimal("100"), "sl", True,
+                client_order_id=order_id)
+
+    def test_trigger_order_reserves_custom_client_order_id_before_async_tracking_starts(self):
+        self._simulate_trading_rules_initialized()
+        self.exchange._perpetual_trading.set_leverage(self.trading_pair, 2)
+        self.exchange._api_post = AsyncMock(return_value={
+            "status": "ok",
+            "response": {"data": {"statuses": [{"resting": {"oid": 101}}]}},
+        })
+        order_id = "0xabcdefabcdefabcdefabcdefabcdefab"
+
+        returned_order_id = self.exchange.place_trigger_order(
+            self.trading_pair, Decimal("1"), TradeType.SELL, Decimal("100"), "sl", True,
+            client_order_id=order_id.upper().replace("0X", "0x"))
+
+        self.assertEqual(order_id, returned_order_id)
+        with self.assertRaisesRegex(ValueError, "already been used"):
+            self.exchange.place_trigger_order(
+                self.trading_pair, Decimal("1"), TradeType.SELL, Decimal("100"), "sl", True,
+                client_order_id=order_id)
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+        self.assertEqual(1, self.exchange._api_post.await_count)
+
+    def test_zero_amount_trigger_order_uses_standard_failure_flow(self):
+        self._simulate_trading_rules_initialized()
+        self.exchange._perpetual_trading.set_leverage(self.trading_pair, 2)
+        self.exchange._api_post = AsyncMock()
+
+        order_id = self.exchange.place_trigger_order(
+            self.trading_pair, Decimal("0"), TradeType.SELL, Decimal("100"), "sl", True)
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+
+        self.assertEqual(OrderState.FAILED, self.exchange._order_tracker.all_orders[order_id].current_state)
+        self.assertNotIn(order_id, self.exchange.in_flight_orders)
+        self.exchange._api_post.assert_not_awaited()
+
+    def test_trigger_order_local_preparation_error_fails_an_already_tracked_order(self):
+        self.exchange.quantize_order_amount = MagicMock(side_effect=KeyError(self.trading_pair))
+        self.exchange._api_post = AsyncMock()
+
+        order_id = self.exchange.place_trigger_order(
+            self.trading_pair, Decimal("1"), TradeType.SELL, Decimal("100"), "sl", True)
+
+        self.assertIn(order_id, self.exchange.in_flight_orders)
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+        self.assertEqual(OrderState.FAILED, self.exchange._order_tracker.all_orders[order_id].current_state)
+        self.assertNotIn(order_id, self.exchange.in_flight_orders)
+        self.exchange._api_post.assert_not_awaited()
+
+    def test_invalid_trigger_price_and_notional_use_standard_failure_flow(self):
+        self._simulate_trading_rules_initialized()
+        self.exchange._perpetual_trading.set_leverage(self.trading_pair, 2)
+        self.exchange._api_post = AsyncMock()
+
+        zero_price_order_id = self.exchange.place_trigger_order(
+            self.trading_pair, Decimal("1"), TradeType.SELL, Decimal("0"), "sl", True)
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+        self.assertEqual(
+            OrderState.FAILED,
+            self.exchange._order_tracker.all_orders[zero_price_order_id].current_state)
+
+        self.exchange._trading_rules[self.trading_pair].min_notional_size = Decimal("10")
+        small_notional_order_id = self.exchange.place_trigger_order(
+            self.trading_pair, Decimal("0.01"), TradeType.SELL, Decimal("100"), "sl", True)
+        self.async_run_with_timeout(asyncio.sleep(0.01))
+        self.assertEqual(
+            OrderState.FAILED,
+            self.exchange._order_tracker.all_orders[small_notional_order_id].current_state)
+        self.exchange._api_post.assert_not_awaited()
 
     @aioresponses()
     def test_create_limit_maker_order(self, mock_api):


### PR DESCRIPTION
## Description

Adds exchange-native Hyperliquid trigger orders to the perpetual connector without coupling the connector to a specific strategy.

This PR:

- adds a public API for individual reduce-only TP/SL trigger orders;
- adds a public API for paired position TP/SL orders using `positionTpsl` grouping;
- supports both SELL protection for long positions and BUY protection for short positions;
- signs both single-order and multi-order Hyperliquid actions while preserving builder, vault, and domain-specific behavior;
- tracks every returned client order ID before local preparation or network submission;
- handles per-leg success, rejection, malformed responses, and uncertain submission outcomes independently;
- reconciles uncertain submissions by the original `cloid`, including persistence across tracking-state restoration;
- requires a 30-second grace period and three consecutive authoritative `unknownOid` responses before failure;
- preserves standard fill accounting for placement responses that report an immediate fill.

The main failure mode addressed here is an ambiguous placement result: a request may reach Hyperliquid even when the response is lost or malformed. Such orders now remain tracked and are reconciled by their pre-generated `cloid`, instead of being failed or resubmitted prematurely.

Mainnet QA also exposed a signing compatibility issue specific to trigger orders: Hyperliquid hashes the msgpack-encoded action, so trigger wire field insertion order is signature-sensitive. The connector now emits `isMarket`, `triggerPx`, and `tpsl` in the same canonical order as the official Hyperliquid Python SDK. A regression test protects this ordering.

## Tests performed by the developer

- [x] Added connector unit coverage for trigger wire formats, signing, lifecycle transitions, partial batch results, response-shape validation, cancellation, immediate fills, and reconciliation behavior.
- [x] Rebased onto the latest `origin/development` and retained the upstream private-key/API-wallet validation and robust cancellation-response handling.
- [x] Focused connector suite after rebase: `261 passed, 5 warnings, 2 subtests passed`.
- [x] Trigger-signing regression verifies the official SDK wire field order: `isMarket`, `triggerPx`, `tpsl`.
- [x] Unit coverage verifies the shared connector's Testnet-specific signing rules (no builder field and no vault address regression).
- [x] `python -m compileall -q hummingbot/connector/derivative/hyperliquid_perpetual test/hummingbot/connector/derivative/hyperliquid_perpetual`
- [x] `pre-commit run --files` for every file changed by this PR.
- [x] `git diff --check`.
- [x] Global coverage report: `83.80%`.
- [x] Diff coverage against `origin/development`: `89%` (repository requirement: 80%).
- [x] Complete `make test` executed after rebase in an isolated Python 3.12 environment using the dependency constraints from `setup/environment.yml`: `8318 passed, 1 skipped, 2 failed`.
- [x] The two full-suite failures are outside this PR's diff:
  - `test_xrpl_transaction_pipeline.py::TestXRPLTransactionPipelineSubmit::test_submit_propagates_exception` — XRPL test cleanup raises `RuntimeError: cannot reuse already awaited coroutine`; it is deterministic on Python 3.10 and 3.12 and has been isolated to `assertRaises` clearing the exception traceback before the background pipeline is stopped.
  - `test_evedex_perpetual_rate_source.py::EvedexPerpetualRateSourceTest::test_get_evedex_perpetual_prices_handles_unknown_symbols` — failed only in the full-suite run and passed in 3/3 immediate isolated reruns, indicating a test-order/cache-isolation flake.

## Manual QA evidence

Temporary operator-only verifiers were used locally and are intentionally not included in this PR. Both runs used small HYPE positions on Hyperliquid Mainnet with paired `positionTpsl` orders.

### LONG position / SELL protection

- [x] Submitted paired reduce-only SELL TP/SL protection for a small HYPE long position.
- [x] Both legs reconciled from an ambiguous/malformed placement response to `OPEN` by their original `cloid` and received authoritative exchange order IDs.
- [x] Performed a real process exit/restart; restored both tracker states before networking, recovered the same client/exchange order IDs, and observed no duplicate placement attempt.
- [x] TP filled `0.21 HYPE` at `56.582 USD`; the sibling SL received authoritative status `siblingFilledCanceled` at the same exchange timestamp.
- [x] The sibling cancellation was not initiated by the verifier (`manual_cancel_requested=false`), and no HYPE trigger orders remained open afterward.

### SHORT position / BUY protection

- [x] Submitted paired reduce-only BUY TP/SL protection for a `0.23 HYPE` short position; each protection leg covered `0.21 HYPE`.
- [x] Both legs reconciled from an ambiguous/malformed placement response by their original `cloid` to authoritative exchange order IDs `515334948710` and `515334948711`.
- [x] The Stop Market BUY leg filled `0.21 HYPE` at `56.475 USD`.
- [x] The sibling Take Profit Limit BUY leg received authoritative status `siblingFilledCanceled`; both terminal statuses had exchange timestamp `1786552678133`.
- [x] The sibling cancellation was not initiated by the verifier (`manual_cancel_requested=false`), authoritative identity/side/type/size checks passed, and no HYPE orders remained open afterward.

## Tips for QA testing

The two connector names (`hyperliquid_perpetual` and `hyperliquid_perpetual_testnet`) share this implementation and select the network through the connector domain. Testnet-specific signing behavior is covered by unit tests; separate Testnet live trading was not required after both directional trigger-order flows were exercised on Mainnet.

The only remaining external check is:

- [ ] GitHub CI — workflow runs for this fork PR require approval from an upstream Hummingbot maintainer; no CI jobs have executed yet.

For any additional QA, verify through the Hyperliquid UI/API that orders are triggers, `reduceOnly=true`, trigger and limit prices are correctly rounded, and grouping is `positionTpsl`.
