### PR TITLE
(fix) align DCA simulator stage assignments

### DIFF
--- a/hummingbot/strategy_v2/backtesting/executors_simulator/dca_executor_simulator.py
+++ b/hummingbot/strategy_v2/backtesting/executors_simulator/dca_executor_simulator.py
@@ -122,14 +122,17 @@ class DCAExecutorSimulator(ExecutorSimulatorBase):
         close_type = None
 
         for i, dca_stage in enumerate(potential_dca_stages):
+            stage_entry_timestamp = dca_stage['entry_timestamp']
+            stage_index = df_filtered.loc[stage_entry_timestamp:].index
+            stage_returns = dca_stage['cumulative_returns'].reindex(stage_index).fillna(0)
+
+            df_filtered.loc[stage_index, f'filled_amount_quote_{i}'] = dca_stage['amount']
+            df_filtered.loc[stage_index, f'net_pnl_quote_{i}'] = stage_returns.to_numpy() * dca_stage['amount']
+            df_filtered.loc[stage_index, 'current_position_average_price'] = dca_stage['break_even_price']
+
             if dca_stage['close_type'] is None:
-                df_filtered.loc[entry_timestamp:, f'filled_amount_quote_{i}'] = dca_stage['amount']
-                df_filtered.loc[entry_timestamp:, f'net_pnl_quote_{i}'] = dca_stage['cumulative_returns'] * dca_stage['amount']
-                df_filtered.loc[entry_timestamp:, 'current_position_average_price'] = dca_stage['break_even_price']
+                continue
             else:
-                df_filtered.loc[entry_timestamp:, f'filled_amount_quote_{i}'] = dca_stage['amount']
-                df_filtered.loc[entry_timestamp:, f'net_pnl_quote_{i}'] = dca_stage['cumulative_returns'] * dca_stage['amount']
-                df_filtered.loc[entry_timestamp:, 'current_position_average_price'] = dca_stage['break_even_price']
                 close_type = dca_stage['close_type']
                 last_timestamp = dca_stage['close_timestamp']
                 break

--- a/test/hummingbot/strategy_v2/backtesting/executors_simulator/test_dca_executor_simulator.py
+++ b/test/hummingbot/strategy_v2/backtesting/executors_simulator/test_dca_executor_simulator.py
@@ -1,0 +1,46 @@
+from decimal import Decimal
+from pathlib import Path
+import sys
+import types
+
+import pandas as pd
+
+from hummingbot.core.data_type.common import TradeType
+
+# The backtesting package's public initializer imports the full client runtime,
+# including optional Cython extensions. The simulator itself only depends on the
+# backtesting submodules, so expose that package path without initializing the
+# client runtime for this focused unit test.
+backtesting_package = "hummingbot.strategy_v2.backtesting"
+if backtesting_package not in sys.modules:
+    module = types.ModuleType(backtesting_package)
+    module.__path__ = [str(Path(__file__).parents[5] / "hummingbot" / "strategy_v2" / "backtesting")]
+    sys.modules[backtesting_package] = module
+
+from hummingbot.strategy_v2.backtesting.executors_simulator.dca_executor_simulator import DCAExecutorSimulator
+from hummingbot.strategy_v2.executors.dca_executor.data_types import DCAExecutorConfig
+
+
+def test_dca_simulator_uses_each_stage_entry_timestamp():
+    config = DCAExecutorConfig(
+        id="test",
+        timestamp=100,
+        side=TradeType.BUY,
+        connector_name="binance",
+        trading_pair="ETH-USDT",
+        amounts_quote=[Decimal("10"), Decimal("20")],
+        prices=[Decimal("100"), Decimal("90")],
+    )
+    candles = pd.DataFrame(
+        {
+            "timestamp": [100, 200, 300],
+            "close": [100.0, 90.0, 95.0],
+            "low": [100.0, 90.0, 95.0],
+            "high": [100.0, 90.0, 95.0],
+        }
+    ).set_index("timestamp", drop=False)
+
+    simulation = DCAExecutorSimulator().simulate(candles, config, trade_cost=0)
+
+    assert simulation.executor_simulation.loc[100, "filled_amount_quote"] == 10
+    assert simulation.executor_simulation.loc[200, "filled_amount_quote"] == 30


### PR DESCRIPTION
## Summary
- assign each DCA stage from its recorded entry timestamp
- align cumulative returns to the target candle index before assignment
- add regression coverage for staggered DCA entries

## Root cause
The assignment loop reused the final stage's entry timestamp for every DCA stage, which could shift earlier positions and produce a Pandas length mismatch.

## Validation
- python -m compileall passed for the changed source and test
- Focused pytest collection is blocked locally because this Windows checkout lacks Hummingbot's compiled runtime modules; the regression test is included for CI.