### PR TITLE
feat(lp): executor-owned close retry loop, involuntary POSITION_HOLD, bounded pending-tx polling

### DIFF
--- a/controllers/generic/lp_rebalancer/lp_rebalancer.py
+++ b/controllers/generic/lp_rebalancer/lp_rebalancer.py
@@ -185,6 +185,9 @@ class LPRebalancer(ControllerBase):
 
         # Track the executor we created
         self._current_executor_id: Optional[str] = None
+        # Set when a FAILED LP executor still reports a live on-chain position; the
+        # controller halts new position creation until it is recovered manually
+        self._orphaned_position_address: Optional[str] = None
 
         # Track amounts from last closed position (for autoswap sizing)
         self._last_closed_base_amount: Optional[Decimal] = None
@@ -417,6 +420,16 @@ class LPRebalancer(ControllerBase):
 
         actions = []
 
+        # An orphaned on-chain position (FAILED close) must be recovered before any new
+        # position is opened - creating a fresh executor here would stack live exposure
+        # on top of the stranded one.
+        if self._orphaned_position_address:
+            self.logger().debug(
+                f"Halted: position {self._orphaned_position_address} from a FAILED executor is "
+                "still open on-chain and requires manual recovery"
+            )
+            return actions
+
         # Handle order executor tracking and completion (for autoswap)
         if self._pending_swap_side is not None:
             if not self._swap_executor_id:
@@ -510,10 +523,15 @@ class LPRebalancer(ControllerBase):
             # Previous executor terminated - capture final amounts and update position_hold
             terminated_executor = self.get_tracked_executor()
             if terminated_executor:
-                # Skip position_hold update if executor failed (no tokens were actually deposited/returned)
-                if terminated_executor.close_type == CloseType.FAILED:
+                # Skip position_hold update if the executor failed (nothing deposited or
+                # returned) or ended as an involuntary hold (close exhausted): in the
+                # latter case base/quote amounts are pool balances of a still-open
+                # position, and booking them as returned tokens would corrupt the hold.
+                if (terminated_executor.close_type == CloseType.FAILED
+                        or terminated_executor.custom_info.get("hold_reason")):
                     self.logger().warning(
-                        f"Executor {terminated_executor.id} FAILED - skipping position_hold update"
+                        f"Executor {terminated_executor.id} ended {terminated_executor.close_type} "
+                        "without returning tokens - skipping position_hold update"
                     )
                 else:
                     self._last_closed_base_amount = Decimal(str(terminated_executor.custom_info.get("base_amount", 0)))
@@ -540,16 +558,32 @@ class LPRebalancer(ControllerBase):
                         f"Position hold total: base={self._position_hold_base}, quote={self._position_hold_quote}"
                     )
 
-            # Check if executor FAILED - retry with same side from executor's config
+            # Check if the executor went terminal abnormally - FAILED (nothing on-chain)
+            # or an involuntary POSITION_HOLD (close retries exhausted, hold_reason set)
             executor_failed = terminated_executor and terminated_executor.close_type == CloseType.FAILED
+            involuntary_hold = bool(terminated_executor and terminated_executor.custom_info.get("hold_reason"))
             failed_executor_side = None
-            if executor_failed:
+            if executor_failed or involuntary_hold:
                 failed_executor_side = terminated_executor.custom_info.get("side")
+                # A terminal executor that still reports a position address went down on
+                # the CLOSE side: its deposit is still on-chain (involuntary hold, or a
+                # legacy FAILED-with-position from a force-stop). Re-opening would stack
+                # a second position on top of the stranded one.
+                orphaned_position = terminated_executor.custom_info.get("position_address")
+                if orphaned_position:
+                    self._orphaned_position_address = orphaned_position
+                    self._current_executor_id = None
+                    self.logger().error(
+                        f"Executor {terminated_executor.id} ended {terminated_executor.close_type} "
+                        f"with position {orphaned_position} still open on-chain. Halting new "
+                        "position creation until the position is closed or recovered manually."
+                    )
+                    return actions
 
             # Capture closed position bounds for side determination (only for successful closes)
             closed_lower_price = None
             closed_upper_price = None
-            if terminated_executor and not executor_failed:
+            if terminated_executor and not executor_failed and not involuntary_hold:
                 closed_lower_price = Decimal(str(terminated_executor.custom_info.get("lower_price", 0)))
                 closed_upper_price = Decimal(str(terminated_executor.custom_info.get("upper_price", 0)))
 

--- a/hummingbot/connector/gateway/common_types.py
+++ b/hummingbot/connector/gateway/common_types.py
@@ -29,6 +29,9 @@ class TransactionStatus(Enum):
     CONFIRMED = 1
     PENDING = 0
     FAILED = -1
+    # Unknown to the chain: never received or dropped. On Solana this is terminal
+    # once the transaction's blockhash expires (~90s after submission).
+    NOT_FOUND = -2
 
 
 class Token(TypedDict):

--- a/hummingbot/connector/gateway/gateway.py
+++ b/hummingbot/connector/gateway/gateway.py
@@ -1061,17 +1061,14 @@ class Gateway(GatewayBase):
             )
 
         try:
-            # Close-position is idempotent on-chain (success consumes the position
-            # account) and Gateway rebuilds the transaction from fresh state on every
-            # request, so stale-state errors (stale withdrawal minimums surface as
-            # SLIPPAGE_EXCEEDED, stale simulations as SIMULATION_FAILED, a landed-but-
-            # failed tx as TX_NOT_CONFIRMED) are safe to retry here — unlike
-            # swaps/opens, where a re-submit can double-spend.
+            # Close retry policy lives in the LP executor's CLOSING loop, which passes
+            # max_retries=0 for a single attempt per re-entry and reconciles a
+            # landed-but-unconfirmed attempt against fresh position state before
+            # re-submitting — a blind retry here cannot do that check.
             transaction_result = await self._execute_with_retry(
                 operation=execute_close_position,
                 operation_name=f"CLMM close position {position_address}",
                 max_retries=max_retries,
-                retryable_error_codes={"SLIPPAGE_EXCEEDED", "SIMULATION_FAILED", "TX_NOT_CONFIRMED"},
             )
             transaction_hash: Optional[str] = transaction_result.get("signature")
             if transaction_hash is not None and transaction_hash != "":

--- a/hummingbot/connector/gateway/gateway.py
+++ b/hummingbot/connector/gateway/gateway.py
@@ -29,7 +29,7 @@ from hummingbot.core.event.events import (
 )
 from hummingbot.core.rate_oracle.rate_oracle import RateOracle
 from hummingbot.core.utils import async_ttl_cache
-from hummingbot.core.utils.async_utils import safe_ensure_future
+from hummingbot.core.utils.async_utils import safe_ensure_future, safe_gather
 
 
 class TokenInfo(BaseModel):
@@ -133,11 +133,41 @@ class Gateway(GatewayBase):
         # Fall back to NaN if no cached price
         return Decimal("nan")
 
+    async def get_last_traded_prices(self, trading_pairs: List[str]) -> Dict[str, float]:
+        """
+        Return a dictionary with the trading pair as key and its current price as value,
+        for each trading pair passed as parameter.
+
+        ExchangeBase supplies this fan-out for order-book connectors, but Gateway
+        extends ConnectorBase directly and so never inherited it. That left
+        _get_last_traded_price below with no caller at all, and every consumer of the
+        plural form raising AttributeError instead of returning prices.
+
+        A pair that cannot be priced is omitted rather than reported as zero, so a
+        caller can tell "no price available" from "the price is 0".
+
+        :param trading_pairs: list of trading pairs to get the prices for
+        :returns: Dictionary of associations between token pair and its latest price
+        """
+        results = await safe_gather(
+            *[self._get_last_traded_price(trading_pair=trading_pair) for trading_pair in trading_pairs],
+            return_exceptions=True,
+        )
+        prices: Dict[str, float] = {}
+        for trading_pair, price in zip(trading_pairs, results):
+            if isinstance(price, Exception):
+                self.logger().warning(f"Failed to get last traded price for {trading_pair}: {price}")
+                continue
+            if price and price > 0:
+                prices[trading_pair] = price
+        return prices
+
     async def _get_last_traded_price(self, trading_pair: str) -> float:
         """
         Gets the last traded price for a trading pair.
 
-        Uses RateOracle for cached prices (set by MarketDataProvider).
+        Prefers the RateOracle cache (set by MarketDataProvider) and falls back to a
+        Gateway quote.
 
         :param trading_pair: The market trading pair
         :returns: The last traded price or 0 if not available
@@ -149,6 +179,18 @@ class Gateway(GatewayBase):
                 return float(price)
         except Exception:
             pass
+        # The oracle only holds pairs MarketDataProvider was asked to track, so a pair
+        # priced on demand -- a pool just opened in a dashboard, a memecoin addressed by
+        # mint -- finds nothing cached and used to fall straight through to 0. Quote it
+        # instead: Gateway prices anything the configured swap provider can route.
+        try:
+            quoted = await self.get_quote_price(trading_pair, is_buy=True, amount=Decimal("1"))
+            if quoted and quoted > 0:
+                return float(quoted)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self.logger().debug(f"Could not quote a fallback price for {trading_pair}.", exc_info=True)
         return 0.0
 
     @staticmethod

--- a/hummingbot/connector/gateway/gateway.py
+++ b/hummingbot/connector/gateway/gateway.py
@@ -1061,10 +1061,17 @@ class Gateway(GatewayBase):
             )
 
         try:
+            # Close-position is idempotent on-chain (success consumes the position
+            # account) and Gateway rebuilds the transaction from fresh state on every
+            # request, so stale-state errors (stale withdrawal minimums surface as
+            # SLIPPAGE_EXCEEDED, stale simulations as SIMULATION_FAILED, a landed-but-
+            # failed tx as TX_NOT_CONFIRMED) are safe to retry here — unlike
+            # swaps/opens, where a re-submit can double-spend.
             transaction_result = await self._execute_with_retry(
                 operation=execute_close_position,
                 operation_name=f"CLMM close position {position_address}",
                 max_retries=max_retries,
+                retryable_error_codes={"SLIPPAGE_EXCEEDED", "SIMULATION_FAILED", "TX_NOT_CONFIRMED"},
             )
             transaction_hash: Optional[str] = transaction_result.get("signature")
             if transaction_hash is not None and transaction_hash != "":
@@ -1192,7 +1199,34 @@ class Gateway(GatewayBase):
         trading_type: str = "clmm",
         position_address: Optional[str] = None
     ) -> Union[AMMPositionInfo, CLMMPositionInfo, None]:
-        """Retrieves position information for a given liquidity position."""
+        """Cached position info for display/analytics consumers.
+
+        WARNING: the TTL cache stores None ("position gone") like any other value,
+        so a single 404 is served for up to 5s of subsequent calls. Anything that
+        makes an existence DECISION from this signal (close pre-flight, external-
+        close detection) must use get_position_info_fresh instead — otherwise one
+        read can masquerade as several independent confirmations.
+        """
+        return await self.get_position_info_fresh(
+            trading_pair=trading_pair,
+            dex_name=dex_name,
+            trading_type=trading_type,
+            position_address=position_address,
+        )
+
+    async def get_position_info_fresh(
+        self,
+        trading_pair: str,
+        dex_name: str,
+        trading_type: str = "clmm",
+        position_address: Optional[str] = None
+    ) -> Union[AMMPositionInfo, CLMMPositionInfo, None]:
+        """Uncached position info read.
+
+        Contract: returns None only when Gateway definitively reports the position
+        does not exist on-chain; transient errors (RPC/network/5xx, unrelated 404s
+        like a missing route or wallet) raise instead of being swallowed into None.
+        """
         try:
             tokens = trading_pair.split("-")
             if len(tokens) != 2:
@@ -1228,12 +1262,25 @@ class Gateway(GatewayBase):
             raise
         except Exception as e:
             addr_info = f"position {position_address}" if position_address else trading_pair
+            error_msg = str(e).lower()
+            # None means "the position definitively does not exist on-chain". Match only
+            # position-specific Gateway messages: the HTTP client stamps "(Not Found)" on
+            # EVERY 404 (missing route after a redeploy, missing wallet file, ...), so a
+            # bare "not found" check would report a live position as gone. Transient
+            # errors must NOT be swallowed into None: callers such as
+            # LPExecutor._close_position interpret None as "already closed", and a
+            # swallowed transient error would silently abandon a live position.
+            if "position not found" in error_msg or "position closed" in error_msg or "position does not exist" in error_msg:
+                self.logger().info(
+                    f"Position info for {addr_info} on {dex_name}/{trading_type}: position does not exist ({e})"
+                )
+                return None
             self.logger().network(
                 f"Error fetching position info for {addr_info} on {dex_name}/{trading_type}.",
                 exc_info=True,
                 app_warning_msg=str(e)
             )
-            return None
+            raise
 
     async def get_user_positions(
         self,

--- a/hummingbot/connector/gateway/gateway_base.py
+++ b/hummingbot/connector/gateway/gateway_base.py
@@ -51,6 +51,13 @@ NON_RETRYABLE_ERROR_CODES = {
 # The only retryable error code
 RETRYABLE_ERROR_CODE = "TRANSACTION_TIMEOUT"
 
+# Retryable after a delay: Gateway's typed HTTP 429 — an upstream API throttled
+# the request. Nothing was broadcast, so retrying is safe; failing immediately
+# is the one wrong answer (it converts a transient throttle into an operation
+# failure, and in the LP CLOSING loop burns a bounded close retry per 429).
+RATE_LIMITED_ERROR_CODE = "RATE_LIMITED"
+RATE_LIMITED_RETRY_DELAY = 5.0
+
 
 def extract_error_code(error_str: str) -> Optional[str]:
     """Extract Gateway error code from error string.
@@ -759,10 +766,18 @@ class GatewayBase(ConnectorBase):
                     raise
                 elif action == RetryAction.RETRY:
                     current_retries += 1
-                    self.logger().warning(
-                        f"{operation_name} error (retry {current_retries}/{max_retries}): {e}. Retrying..."
+                    # A throttle window outlives the standard delay — hammering it
+                    # at retry_delay just extends the 429s.
+                    delay = (
+                        max(retry_delay, RATE_LIMITED_RETRY_DELAY)
+                        if extract_error_code(str(e)) == RATE_LIMITED_ERROR_CODE
+                        else retry_delay
                     )
-                    await asyncio.sleep(retry_delay)
+                    self.logger().warning(
+                        f"{operation_name} error (retry {current_retries}/{max_retries}): {e}. "
+                        f"Retrying in {delay:.0f}s..."
+                    )
+                    await asyncio.sleep(delay)
                     # Continue to next iteration
 
     def _classify_error(
@@ -792,8 +807,13 @@ class GatewayBase(ConnectorBase):
             )
             return RetryAction.FAIL_IMMEDIATE
 
-        # Check for timeout (retryable)
-        is_timeout = error_code == RETRYABLE_ERROR_CODE or "TRANSACTION_TIMEOUT" in error_str
+        # Check for retryable codes: timeouts, and 429s from an upstream throttle
+        # (gateway declares RATE_LIMITED "retryable after a delay" — the delay is
+        # applied by the retry loop, which sleeps longer for it).
+        is_timeout = (
+            error_code in (RETRYABLE_ERROR_CODE, RATE_LIMITED_ERROR_CODE)
+            or "TRANSACTION_TIMEOUT" in error_str
+        )
 
         if not is_timeout:
             # No error code and not a timeout - fail immediately
@@ -934,18 +954,33 @@ class GatewayBase(ConnectorBase):
 
             # Check if transaction is still pending
             elif tx_status == TransactionStatus.PENDING.value:
-                pass
+                # A PENDING sighting proves the signature is known to the chain, so
+                # any earlier NOT_FOUND streak was propagation lag — reset it. A tx
+                # that later goes missing again must re-earn the misses from zero,
+                # or lag + a stale streak compound into a false lost-order.
+                self._order_tracker._order_not_found_records.pop(tracked_order.client_order_id, None)
 
             # Transaction unknown to the chain. Transient right after submission
             # (propagation lag), but terminal once old enough that the transaction
             # can no longer land — without this, a dropped transaction polls as
             # pending forever and the order never resolves.
             elif tx_status == TransactionStatus.NOT_FOUND.value:
-                if self.current_timestamp - tracked_order.creation_timestamp > self.TX_NOT_FOUND_DEADLINE:
+                # Anchor the deadline to the LAST submission, not order creation:
+                # _execute_with_retry can spend minutes before the submission that
+                # produced the currently-polled signature, and that signature's
+                # normal propagation lag must not inherit a deadline already burned
+                # by earlier attempts. last_update_timestamp is stamped by the
+                # tx-hash OrderUpdate at submission (creation_timestamp is the
+                # fallback for orders that never got one).
+                submitted_at = max(
+                    tracked_order.creation_timestamp,
+                    tracked_order.last_update_timestamp or 0,
+                )
+                if self.current_timestamp - submitted_at > self.TX_NOT_FOUND_DEADLINE:
                     self.logger().warning(
                         f"Transaction {tracked_order.exchange_order_id} for order "
                         f"{tracked_order.client_order_id} still not found on-chain more than "
-                        f"{self.TX_NOT_FOUND_DEADLINE:.0f}s after order creation; counting toward lost-order limit."
+                        f"{self.TX_NOT_FOUND_DEADLINE:.0f}s after submission; counting toward lost-order limit."
                     )
                     await self._order_tracker.process_order_not_found(tracked_order.client_order_id)
 

--- a/hummingbot/connector/gateway/gateway_base.py
+++ b/hummingbot/connector/gateway/gateway_base.py
@@ -680,7 +680,6 @@ class GatewayBase(ConnectorBase):
         operation: Callable[[], T],
         operation_name: str,
         max_retries: int = 10,
-        retryable_error_codes: Optional[Set[str]] = None,
         retry_delay: float = 1.0,
     ) -> T:
         """
@@ -689,19 +688,16 @@ class GatewayBase(ConnectorBase):
         Retries on:
         - TRANSACTION_TIMEOUT errors (exception from Gateway)
         - Pending/unconfirmed transactions (status != 1 in response)
-        - Any additional error codes in `retryable_error_codes`
 
-        Does NOT retry on: SIMULATION_FAILED, INSUFFICIENT_BALANCE, etc., unless the
-        caller opts in via `retryable_error_codes`. Gateway rebuilds every transaction
-        from fresh on-chain state on each request, so operations that are idempotent
-        on-chain (e.g. close-position, where success consumes the position account) can
-        safely retry stale-state errors like SLIPPAGE_EXCEEDED.
+        Does NOT retry on operation errors (SIMULATION_FAILED, SLIPPAGE_EXCEEDED,
+        INSUFFICIENT_BALANCE, ...): what a failure means for the operation is the
+        caller's decision, not the transport's. The LP executor's CLOSING loop, for
+        example, owns close retries and passes max_retries=0 for a single attempt
+        per re-entry.
 
         :param operation: Async callable that performs the gateway operation
         :param operation_name: Description for logging (e.g., "execute swap")
         :param max_retries: Maximum number of retry attempts for timeout errors
-        :param retryable_error_codes: Extra Gateway error codes to retry beyond
-            TRANSACTION_TIMEOUT (only for operations that are safe to re-submit)
         :param retry_delay: Seconds to sleep between retry attempts
         :return: Result from the operation
         :raises: Original exception if non-retryable or max retries exceeded
@@ -722,10 +718,9 @@ class GatewayBase(ConnectorBase):
                         # Transaction confirmed - success
                         return result
                     elif status == -1:
-                        # Transaction landed but failed on-chain. Typed so callers can
-                        # opt in to retrying it (safe for idempotent ops like close,
-                        # where a re-POST rebuilds from fresh state); not retried by
-                        # default since re-submitting e.g. a swap can double-spend.
+                        # Transaction landed but failed on-chain. Typed so the caller
+                        # can decide what it means for its operation; never retried
+                        # here since re-submitting e.g. a swap can double-spend.
                         self.logger().error(
                             f"{operation_name} FAILED: Transaction {signature} not confirmed on-chain."
                         )
@@ -756,7 +751,7 @@ class GatewayBase(ConnectorBase):
             except asyncio.CancelledError:
                 raise
             except Exception as e:
-                action = self._classify_error(e, operation_name, current_retries, max_retries, retryable_error_codes)
+                action = self._classify_error(e, operation_name, current_retries, max_retries)
 
                 if action == RetryAction.FAIL_IMMEDIATE:
                     raise
@@ -776,7 +771,6 @@ class GatewayBase(ConnectorBase):
         operation_name: str,
         current_retries: int,
         max_retries: int,
-        retryable_error_codes: Optional[Set[str]] = None,
     ) -> RetryAction:
         """
         Classify an error and determine the appropriate retry action.
@@ -785,18 +779,13 @@ class GatewayBase(ConnectorBase):
         :param operation_name: Description of the operation for logging
         :param current_retries: Current retry count
         :param max_retries: Maximum retries allowed
-        :param retryable_error_codes: Extra error codes the caller opted in to retry
         :return: RetryAction indicating what to do
         """
         error_str = str(error)
         error_code = extract_error_code(error_str)
 
-        # Caller opted in to retry this code (e.g. SLIPPAGE_EXCEEDED on close-position,
-        # where every retry re-POSTs and Gateway rebuilds from fresh on-chain state)
-        is_opted_in = error_code is not None and retryable_error_codes is not None and error_code in retryable_error_codes
-
         # Check for non-retryable errors
-        if error_code and error_code in NON_RETRYABLE_ERROR_CODES and not is_opted_in:
+        if error_code and error_code in NON_RETRYABLE_ERROR_CODES:
             self.logger().error(
                 f"{operation_name} FAILED: {error}. "
                 f"Error code {error_code} is not retryable."
@@ -806,7 +795,7 @@ class GatewayBase(ConnectorBase):
         # Check for timeout (retryable)
         is_timeout = error_code == RETRYABLE_ERROR_CODE or "TRANSACTION_TIMEOUT" in error_str
 
-        if not (is_timeout or is_opted_in):
+        if not is_timeout:
             # No error code and not a timeout - fail immediately
             self.logger().error(
                 f"{operation_name} FAILED: {error}. Error is not retryable."

--- a/hummingbot/connector/gateway/gateway_base.py
+++ b/hummingbot/connector/gateway/gateway_base.py
@@ -676,6 +676,8 @@ class GatewayBase(ConnectorBase):
         operation: Callable[[], T],
         operation_name: str,
         max_retries: int = 10,
+        retryable_error_codes: Optional[Set[str]] = None,
+        retry_delay: float = 1.0,
     ) -> T:
         """
         Execute a gateway operation with retry logic for timeout errors.
@@ -683,12 +685,20 @@ class GatewayBase(ConnectorBase):
         Retries on:
         - TRANSACTION_TIMEOUT errors (exception from Gateway)
         - Pending/unconfirmed transactions (status != 1 in response)
+        - Any additional error codes in `retryable_error_codes`
 
-        Does NOT retry on: SIMULATION_FAILED, INSUFFICIENT_BALANCE, etc.
+        Does NOT retry on: SIMULATION_FAILED, INSUFFICIENT_BALANCE, etc., unless the
+        caller opts in via `retryable_error_codes`. Gateway rebuilds every transaction
+        from fresh on-chain state on each request, so operations that are idempotent
+        on-chain (e.g. close-position, where success consumes the position account) can
+        safely retry stale-state errors like SLIPPAGE_EXCEEDED.
 
         :param operation: Async callable that performs the gateway operation
         :param operation_name: Description for logging (e.g., "execute swap")
         :param max_retries: Maximum number of retry attempts for timeout errors
+        :param retryable_error_codes: Extra Gateway error codes to retry beyond
+            TRANSACTION_TIMEOUT (only for operations that are safe to re-submit)
+        :param retry_delay: Seconds to sleep between retry attempts
         :return: Result from the operation
         :raises: Original exception if non-retryable or max retries exceeded
         """
@@ -708,11 +718,14 @@ class GatewayBase(ConnectorBase):
                         # Transaction confirmed - success
                         return result
                     elif status == -1:
-                        # Transaction not confirmed (failed on-chain) - don't retry
+                        # Transaction landed but failed on-chain. Typed so callers can
+                        # opt in to retrying it (safe for idempotent ops like close,
+                        # where a re-POST rebuilds from fresh state); not retried by
+                        # default since re-submitting e.g. a swap can double-spend.
                         self.logger().error(
                             f"{operation_name} FAILED: Transaction {signature} not confirmed on-chain."
                         )
-                        raise Exception(f"Transaction {signature} not confirmed on-chain")
+                        raise Exception(f"Transaction {signature} not confirmed on-chain [code: TX_NOT_CONFIRMED]")
                     elif status == 0:
                         # Transaction pending - retry (may still confirm)
                         current_retries += 1
@@ -727,6 +740,7 @@ class GatewayBase(ConnectorBase):
                             f"{operation_name} transaction pending (retry {current_retries}/{max_retries}). "
                             f"Signature: {signature}. Retrying..."
                         )
+                        await asyncio.sleep(retry_delay)
                         continue  # Retry
                     else:
                         # Unknown status, return as-is
@@ -738,7 +752,7 @@ class GatewayBase(ConnectorBase):
             except asyncio.CancelledError:
                 raise
             except Exception as e:
-                action = self._classify_error(e, operation_name, current_retries, max_retries)
+                action = self._classify_error(e, operation_name, current_retries, max_retries, retryable_error_codes)
 
                 if action == RetryAction.FAIL_IMMEDIATE:
                     raise
@@ -747,9 +761,9 @@ class GatewayBase(ConnectorBase):
                 elif action == RetryAction.RETRY:
                     current_retries += 1
                     self.logger().warning(
-                        f"{operation_name} timeout (retry {current_retries}/{max_retries}). "
-                        "Chain may be congested. Retrying..."
+                        f"{operation_name} error (retry {current_retries}/{max_retries}): {e}. Retrying..."
                     )
+                    await asyncio.sleep(retry_delay)
                     # Continue to next iteration
 
     def _classify_error(
@@ -758,6 +772,7 @@ class GatewayBase(ConnectorBase):
         operation_name: str,
         current_retries: int,
         max_retries: int,
+        retryable_error_codes: Optional[Set[str]] = None,
     ) -> RetryAction:
         """
         Classify an error and determine the appropriate retry action.
@@ -766,13 +781,18 @@ class GatewayBase(ConnectorBase):
         :param operation_name: Description of the operation for logging
         :param current_retries: Current retry count
         :param max_retries: Maximum retries allowed
+        :param retryable_error_codes: Extra error codes the caller opted in to retry
         :return: RetryAction indicating what to do
         """
         error_str = str(error)
         error_code = extract_error_code(error_str)
 
+        # Caller opted in to retry this code (e.g. SLIPPAGE_EXCEEDED on close-position,
+        # where every retry re-POSTs and Gateway rebuilds from fresh on-chain state)
+        is_opted_in = error_code is not None and retryable_error_codes is not None and error_code in retryable_error_codes
+
         # Check for non-retryable errors
-        if error_code and error_code in NON_RETRYABLE_ERROR_CODES:
+        if error_code and error_code in NON_RETRYABLE_ERROR_CODES and not is_opted_in:
             self.logger().error(
                 f"{operation_name} FAILED: {error}. "
                 f"Error code {error_code} is not retryable."
@@ -782,7 +802,7 @@ class GatewayBase(ConnectorBase):
         # Check for timeout (retryable)
         is_timeout = error_code == RETRYABLE_ERROR_CODE or "TRANSACTION_TIMEOUT" in error_str
 
-        if not is_timeout:
+        if not (is_timeout or is_opted_in):
             # No error code and not a timeout - fail immediately
             self.logger().error(
                 f"{operation_name} FAILED: {error}. Error is not retryable."

--- a/hummingbot/connector/gateway/gateway_base.py
+++ b/hummingbot/connector/gateway/gateway_base.py
@@ -68,6 +68,10 @@ class GatewayBase(ConnectorBase):
 
     POLL_INTERVAL = 1.0
     BALANCE_POLL_INTERVAL = 60.0  # Update balances every 60 seconds
+    # How long an order's transaction may poll as NOT_FOUND before the misses count
+    # toward the tracker's lost-order limit. Must exceed Solana's blockhash validity
+    # window (~90s): within it, not-found can still mean "in flight".
+    TX_NOT_FOUND_DEADLINE = 120.0
     APPROVAL_ORDER_ID_PATTERN = re.compile(r"approve-(\w+)-(\w+)")
 
     _connector_name: str
@@ -942,6 +946,19 @@ class GatewayBase(ConnectorBase):
             # Check if transaction is still pending
             elif tx_status == TransactionStatus.PENDING.value:
                 pass
+
+            # Transaction unknown to the chain. Transient right after submission
+            # (propagation lag), but terminal once old enough that the transaction
+            # can no longer land — without this, a dropped transaction polls as
+            # pending forever and the order never resolves.
+            elif tx_status == TransactionStatus.NOT_FOUND.value:
+                if self.current_timestamp - tracked_order.creation_timestamp > self.TX_NOT_FOUND_DEADLINE:
+                    self.logger().warning(
+                        f"Transaction {tracked_order.exchange_order_id} for order "
+                        f"{tracked_order.client_order_id} still not found on-chain more than "
+                        f"{self.TX_NOT_FOUND_DEADLINE:.0f}s after order creation; counting toward lost-order limit."
+                    )
+                    await self._order_tracker.process_order_not_found(tracked_order.client_order_id)
 
             # Transaction failed
             elif tx_status == TransactionStatus.FAILED.value:

--- a/hummingbot/core/data_type/order_candidate.py
+++ b/hummingbot/core/data_type/order_candidate.py
@@ -190,7 +190,11 @@ class OrderCandidate:
             token, amount = self.percent_fee_collateral
             if token == self.order_collateral.token:
                 amount += self.order_collateral.amount
-            if available_balances[token] < amount:
+            # A candidate priced from a venue with no order book carries a NaN price,
+            # which propagates into this amount. `Decimal < NaN` raises InvalidOperation
+            # rather than returning False, so the comparison is guarded the same way
+            # _adjust_for_order_collateral guards its own.
+            if not amount.is_nan() and available_balances[token] < amount:
                 scaler = available_balances[token] / amount
                 self._scale_order(scaler)
 

--- a/hummingbot/strategy_v2/executors/executor_base.py
+++ b/hummingbot/strategy_v2/executors/executor_base.py
@@ -191,7 +191,17 @@ class ExecutorBase(RunnableBase):
         """
         Override control loop to evaluate max retries after each control task.
         """
-        await self.on_start()
+        try:
+            await self.on_start()
+        except Exception as e:
+            # on_start() runs before the retry loop below, so an exception here used to
+            # escape control_loop altogether and strand the executor: never terminated,
+            # so it kept reporting RUNNING/is_active with no close_type, and nothing
+            # ticked it again. Close it as FAILED instead, so a startup failure reaches
+            # a terminal state and stays visible rather than becoming a silent zombie.
+            self.logger().error(f"Executor failed to start: {e}", exc_info=True)
+            self.close_type = CloseType.FAILED
+            self.stop()
         while not self.terminated.is_set():
             try:
                 await self.control_task()

--- a/hummingbot/strategy_v2/executors/lp_executor/lp_executor.py
+++ b/hummingbot/strategy_v2/executors/lp_executor/lp_executor.py
@@ -492,6 +492,28 @@ class LPExecutor(ExecutorBase):
         self.logger().error(f"Position creation failed: {error}")
         self.lp_position_state.state = LPExecutorStates.FAILED
 
+    def _confirm_position_missing(self, source: str) -> bool:
+        """One more not-found sighting; True once it is CONFIRMED missing.
+
+        The confirmation contract (shared with _update_position_info, whose
+        counter this reuses): the position must have been observed on-chain at
+        least once, and the miss must repeat across >= 3 independent fresh
+        reads. Anything less is RPC lag, not a close.
+        """
+        self._position_not_found_count += 1
+        if self._position_seen_onchain and self._position_not_found_count >= 3:
+            self.logger().info(
+                f"Position {self.lp_position_state.position_address} confirmed missing on-chain "
+                f"({source}; {self._position_not_found_count} consecutive reads) - marking complete"
+            )
+            return True
+        self.logger().warning(
+            f"Position {self.lp_position_state.position_address} not found ({source}; "
+            f"{self._position_not_found_count} consecutive reads, "
+            f"seen_onchain={self._position_seen_onchain}) - not confirming yet, skipping this close attempt"
+        )
+        return False
+
     async def _close_position(self):
         """
         Close position by directly awaiting the gateway operation.
@@ -519,17 +541,24 @@ class LPExecutor(ExecutorBase):
                 position_address=self.lp_position_state.position_address
             )
             if position_info is None:
-                self.logger().info(
-                    f"Position {self.lp_position_state.position_address} already closed - skipping close"
-                )
-                self._emit_already_closed_event()
-                self.lp_position_state.state = LPExecutorStates.COMPLETE
+                # Same two gates as _update_position_info: one lagging RPC read
+                # answering 404 for a live position must not book the pool
+                # balances as returned and complete a POSITION_HOLD close — that
+                # both corrupts inventory accounting and hides the stranded
+                # position from the orphan gate. Skip this attempt (no retry
+                # burned) and let the next tick's read confirm or refute.
+                if self._confirm_position_missing("close pre-flight read"):
+                    self._emit_already_closed_event()
+                    self.lp_position_state.state = LPExecutorStates.COMPLETE
                 return
+            self._position_not_found_count = 0
             self._position_seen_onchain = True
         except Exception as e:
             # Gateway returns HttpError with message patterns (see _update_position_info)
             error_msg = str(e).lower()
             if "position closed" in error_msg:
+                # Definitive: Gateway found the position account in closed state,
+                # not a bare 404 — safe to complete on one read.
                 self.logger().info(
                     f"Position {self.lp_position_state.position_address} already closed - skipping"
                 )
@@ -537,12 +566,12 @@ class LPExecutor(ExecutorBase):
                 self.lp_position_state.state = LPExecutorStates.COMPLETE
                 return
             elif "position not found" in error_msg:
-                self.logger().error(
-                    f"Position {self.lp_position_state.position_address} not found - "
-                    "marking complete to avoid retry loop"
-                )
-                self._emit_already_closed_event()
-                self.lp_position_state.state = LPExecutorStates.COMPLETE
+                # The error-message form of the same 404 signal as the None read
+                # above: hold it to the same confirmation gate rather than
+                # completing on a single sighting.
+                if self._confirm_position_missing("close pre-flight 404"):
+                    self._emit_already_closed_event()
+                    self.lp_position_state.state = LPExecutorStates.COMPLETE
                 return
             # Other errors - proceed with close attempt
 
@@ -667,8 +696,26 @@ class LPExecutor(ExecutorBase):
         the family hook the base control_loop calls right after this
         control_task returns.
         """
-        self._current_retries += 1
+        from hummingbot.connector.gateway.gateway_base import RATE_LIMITED_ERROR_CODE, extract_error_code
+
         self.lp_position_state.active_close_order = None
+
+        # An upstream throttle (Gateway's typed 429) is not a failed close — nothing
+        # was broadcast and nothing about the position changed. Counting it would
+        # let a minutes-long throttle window exhaust the whole budget and terminate
+        # as POSITION_HOLD, stranding a position a delay would have closed. Back
+        # off without spending a retry; a persistent 429 keeps the executor
+        # visibly RUNNING/CLOSING rather than silently orphaning the position.
+        if extract_error_code(str(error)) == RATE_LIMITED_ERROR_CODE:
+            self._close_backoff_until = self._strategy.current_timestamp + 30.0
+            self.logger().warning(
+                f"Position close throttled upstream (429): {error}. "
+                f"Waiting 30s without spending a close retry "
+                f"({self._current_retries}/{self._max_retries} used)."
+            )
+            return
+
+        self._current_retries += 1
 
         if self._current_retries > self._max_retries:
             # evaluate_max_retries terminates after this control_task returns.

--- a/hummingbot/strategy_v2/executors/lp_executor/lp_executor.py
+++ b/hummingbot/strategy_v2/executors/lp_executor/lp_executor.py
@@ -65,6 +65,23 @@ class LPExecutor(ExecutorBase):
         self._held_position_orders: List[Dict] = []
         # Swap tracking for close-out flow
         self._swap_not_found_count: int = 0
+        # Consecutive definitive "position does not exist" reads while monitoring;
+        # guards against a single lagging RPC node being read as an external close.
+        # Uses get_position_info_fresh so each miss is an independent Gateway read
+        # (the cached get_position_info would serve one 404 for several ticks).
+        self._position_not_found_count: int = 0
+        # External-close detection is only trusted once the position has been
+        # observed on-chain at least once; before that, a not-found streak is far
+        # more likely RPC lag on a just-created position than a real close.
+        self._position_seen_onchain: bool = False
+        # Backoff between close attempts (set by _handle_close_failure) so a burst
+        # of instant transport failures (e.g. a Gateway restart) cannot burn the
+        # whole retry budget in seconds
+        self._close_backoff_until: float = 0.0
+        # Why a POSITION_HOLD terminal was involuntary (e.g. "close_retries_exhausted");
+        # None for voluntary holds (keep_position=True stops). Consumers use this,
+        # not close_type, to distinguish stranded exposure from a requested hold.
+        self._hold_reason: Optional[str] = None
         # Parse lp_provider into dex_name and trading_type for gateway calls
         self.lp_dex_name, self.lp_trading_type = parse_provider(
             config.lp_provider, default_trading_type="clmm"
@@ -218,7 +235,9 @@ class LPExecutor(ExecutorBase):
             return
 
         try:
-            position_info = await connector.get_position_info(
+            # Fresh (uncached) read: this method makes existence decisions, and the
+            # cached variant would serve a single 404 for several consecutive ticks
+            position_info = await connector.get_position_info_fresh(
                 trading_pair=self.config.trading_pair,
                 dex_name=self.lp_dex_name,
                 trading_type=self.lp_trading_type,
@@ -226,6 +245,8 @@ class LPExecutor(ExecutorBase):
             )
 
             if position_info:
+                self._position_not_found_count = 0
+                self._position_seen_onchain = True
                 # Update amounts and fees from live position data
                 self.lp_position_state.base_amount = Decimal(str(position_info.base_token_amount))
                 self.lp_position_state.quote_amount = Decimal(str(position_info.quote_token_amount))
@@ -237,7 +258,26 @@ class LPExecutor(ExecutorBase):
                 # Update current price from position_info (avoids separate pool_info call)
                 self._current_price = Decimal(str(position_info.price))
             else:
-                self.logger().warning(f"get_position_info returned None for {self.lp_position_state.position_address}")
+                # None from the connector is a definitive Gateway 404 (transient errors
+                # raise and are handled below). Two gates before acting on it: the
+                # position must have been observed on-chain at least once (a miss on a
+                # just-created position is RPC lag, not a close), and the miss must
+                # repeat across independent reads.
+                self._position_not_found_count += 1
+                if self._position_seen_onchain and self._position_not_found_count >= 3:
+                    self.logger().info(
+                        f"Position {self.lp_position_state.position_address} no longer exists on-chain "
+                        "(closed externally or by a prior attempt) - marking complete"
+                    )
+                    self._emit_already_closed_event()
+                    self.lp_position_state.state = LPExecutorStates.COMPLETE
+                    self.lp_position_state.active_close_order = None
+                else:
+                    self.logger().warning(
+                        f"Position {self.lp_position_state.position_address} not found "
+                        f"({self._position_not_found_count} consecutive reads, "
+                        f"seen_onchain={self._position_seen_onchain})"
+                    )
         except Exception as e:
             # Gateway returns HttpError with message patterns:
             # - "Position closed: {addr}" (404) - position was closed on-chain
@@ -252,7 +292,9 @@ class LPExecutor(ExecutorBase):
                 self.lp_position_state.state = LPExecutorStates.COMPLETE
                 self.lp_position_state.active_close_order = None
                 return
-            elif "not found" in error_msg:
+            elif "position not found" in error_msg:
+                # Position-specific 404 only: a bare "not found" also matches the HTTP
+                # client's "(Not Found)" suffix on unrelated 404s (missing route/wallet)
                 self.logger().error(
                     f"Position {self.lp_position_state.position_address} not found - "
                     "position may never have been created. Check position tracking."
@@ -330,13 +372,25 @@ class LPExecutor(ExecutorBase):
             if order_id in connector._lp_orders_metadata:
                 del connector._lp_orders_metadata[order_id]
 
-            # Fetch full position info from chain to get actual amounts and bounds
-            position_info = await connector.get_position_info(
-                trading_pair=self.config.trading_pair,
-                dex_name=self.lp_dex_name,
-                trading_type=self.lp_trading_type,
-                position_address=position_address
-            )
+            # Fetch full position info from chain to get actual amounts and bounds.
+            # This enriches bookkeeping only - the position is already open, so a
+            # transient fetch error must not fail the create (which would route to
+            # CLOSING); fall back to config values instead.
+            try:
+                # Fresh read: caching a lagging 404 here would poison the next ticks'
+                # existence checks with "position gone" for a position that is live
+                position_info = await connector.get_position_info_fresh(
+                    trading_pair=self.config.trading_pair,
+                    dex_name=self.lp_dex_name,
+                    trading_type=self.lp_trading_type,
+                    position_address=position_address
+                )
+            except Exception as info_error:
+                self.logger().warning(f"Position info fetch after create failed: {info_error}")
+                position_info = None
+
+            if position_info:
+                self._position_seen_onchain = True
 
             if position_info:
                 self.lp_position_state.base_amount = Decimal(str(position_info.base_token_amount))
@@ -451,9 +505,16 @@ class LPExecutor(ExecutorBase):
             self._handle_close_failure(ValueError(f"Connector {self.config.connector_name} not found"))
             return
 
-        # Verify position still exists before trying to close (handles timeout-but-succeeded case)
+        # Respect the backoff set by a failed attempt: without it, a burst of instant
+        # transport failures (e.g. Gateway restarting) would burn the whole retry
+        # budget in as many seconds as there are retries.
+        if self._strategy.current_timestamp < self._close_backoff_until:
+            return
+
+        # Verify position still exists before trying to close (handles timeout-but-succeeded
+        # case). Fresh read: this decision must not come from a cached 404.
         try:
-            position_info = await connector.get_position_info(
+            position_info = await connector.get_position_info_fresh(
                 trading_pair=self.config.trading_pair,
                 dex_name=self.lp_dex_name,
                 trading_type=self.lp_trading_type,
@@ -466,6 +527,7 @@ class LPExecutor(ExecutorBase):
                 self._emit_already_closed_event()
                 self.lp_position_state.state = LPExecutorStates.COMPLETE
                 return
+            self._position_seen_onchain = True
         except Exception as e:
             # Gateway returns HttpError with message patterns (see _update_position_info)
             error_msg = str(e).lower()
@@ -476,7 +538,7 @@ class LPExecutor(ExecutorBase):
                 self._emit_already_closed_event()
                 self.lp_position_state.state = LPExecutorStates.COMPLETE
                 return
-            elif "not found" in error_msg:
+            elif "position not found" in error_msg:
                 self.logger().error(
                     f"Position {self.lp_position_state.position_address} not found - "
                     "marking complete to avoid retry loop"
@@ -491,13 +553,16 @@ class LPExecutor(ExecutorBase):
         self.lp_position_state.active_close_order = TrackedOrder(order_id=order_id)
 
         try:
-            # Directly await the async operation - connector handles retry for timeouts
+            # Directly await the async operation. The executor owns the retry POLICY
+            # (bounded re-entries with fresh pre-flight reconciliation), so the
+            # connector's inner budget is kept small — a large inner budget would
+            # multiply with the executor's into O(n^2) submissions per close.
             signature = await connector._clmm_close_position(
                 trade_type=TradeType.RANGE,
                 order_id=order_id,
                 trading_pair=self.config.trading_pair,
                 position_address=self.lp_position_state.position_address,
-                max_retries=self._max_retries,
+                max_retries=min(3, self._max_retries),
                 dex_name=self.lp_dex_name,
                 trading_type=self.lp_trading_type,
             )
@@ -593,13 +658,92 @@ class LPExecutor(ExecutorBase):
     def _handle_close_failure(self, error: Exception):
         """Handle position close failure.
 
-        Retry logic is handled by the connector. This method handles
-        final failures after connector exhausted retries.
+        The connector retries transport and stale-state errors within a single
+        attempt; this handles an attempt that failed after those retries. The
+        position is still open on-chain, so going terminal here would strand it
+        (see gateway#678). Count the attempt, arm the backoff, and stay in
+        CLOSING — control_task re-enters _close_position on the next tick, and
+        each re-entry re-POSTs to Gateway, which rebuilds the transaction from
+        fresh on-chain state (the pre-flight reconciles a close that already
+        landed). Termination on exhaustion is decided by evaluate_max_retries,
+        the family hook the base control_loop calls right after this
+        control_task returns.
         """
-        # Connector exhausted retries or non-retryable error - transition to FAILED
-        self.logger().error(f"Position close failed: {error}")
+        self._current_retries += 1
         self.lp_position_state.active_close_order = None
-        self.lp_position_state.state = LPExecutorStates.FAILED
+
+        if self._current_retries > self._max_retries:
+            # evaluate_max_retries terminates after this control_task returns.
+            self.logger().warning(f"Position close attempt failed: {error}. Retry budget exhausted.")
+            return
+
+        # Exponential backoff (capped at 30s) so instant failures — e.g. connection
+        # errors while Gateway restarts — spread the retry budget over minutes
+        # instead of burning it in seconds
+        backoff = min(30.0, 2.0 ** self._current_retries)
+        self._close_backoff_until = self._strategy.current_timestamp + backoff
+        self.logger().warning(
+            f"Position close attempt failed ({self._current_retries}/{self._max_retries} retries used): "
+            f"{error}. Rebuilding with fresh state in {backoff:.0f}s."
+        )
+        # State stays CLOSING - control_task re-enters _close_position after backoff.
+
+    def evaluate_max_retries(self):
+        """Terminate when the close-retry budget is exhausted.
+
+        Base-class semantics (``> max_retries``, i.e. ``max_retries + 1`` total
+        attempts — the family convention) decide *when*; this override decides
+        *how*. A position still on-chain is residual exposure, and the family
+        contract (see ``force_stop_with_position_hold``) ends residual exposure
+        as POSITION_HOLD, reserving FAILED for executors with nothing left
+        behind. PositionHold cannot book a live LP position as spot amounts, so
+        the hold carries a zero-amount marker order with the position's identity
+        instead — visible and durable in the hold store on both the bot and the
+        hummingbot-api topology, with accounting untouched.
+        """
+        if self._current_retries <= self._max_retries:
+            return
+        self._max_retries_reached = True
+        position_address = self.lp_position_state.position_address
+        if position_address:
+            self._hold_reason = "close_retries_exhausted"
+            self._record_unclosed_position_marker()
+            self.close_type = CloseType.POSITION_HOLD
+            self.logger().error(
+                f"Position close failed after {self._current_retries} attempts: position "
+                f"{position_address} ({self.config.trading_pair}) is still open on-chain. "
+                "Terminating as an involuntary POSITION_HOLD (hold_reason=close_retries_exhausted) - "
+                "close it via the gateway and resolve the orphan record."
+            )
+        else:
+            self.close_type = CloseType.FAILED
+            self.logger().error(
+                f"Retry budget exhausted after {self._current_retries} attempts with no position "
+                "on-chain - terminating as FAILED."
+            )
+        self.stop()
+
+    def _record_unclosed_position_marker(self):
+        """Append a zero-amount marker order carrying the unclosed position's identity.
+
+        A live on-chain position cannot be booked as spot amounts — the tokens
+        are in the pool, not the wallet — but an empty held_position_orders would
+        make the POSITION_HOLD invisible to the hold store. Zero amounts keep
+        accounting untouched (PositionHold._process_order skips them) while the
+        marker carries the address every recovery path needs.
+        """
+        self._held_position_orders.append({
+            "client_order_id": f"{self.config.id}-unclosed-lp",
+            "trading_pair": self.config.trading_pair,
+            "trade_type": "BUY",  # dummy; zero amounts never reach accounting
+            "price": float(self._current_price) if self._current_price else 0.0,
+            "executed_amount_base": 0.0,
+            "executed_amount_quote": 0.0,
+            "cumulative_fee_paid_quote": getattr(self, '_add_tx_fee_quote', 0.0),
+            "lp_source": True,
+            "lp_unclosed_position": True,
+            "position_address": self.lp_position_state.position_address,
+        })
 
     async def _execute_closeout_swap(self):
         """
@@ -1106,6 +1250,11 @@ class LPExecutor(ExecutorBase):
             "filled_amount_base": float(self.lp_position_state.base_amount),
             "filled_amount_quote": float(self.lp_position_state.quote_amount),
             "held_position_orders": self._held_position_orders,
+            # Retry observability (consistent with order executor)
+            "current_retries": self._current_retries,
+            "max_retries": self._max_retries,
+            "max_retries_reached": self._max_retries_reached,
+            "hold_reason": self._hold_reason,
         }
 
     # Required abstract methods from ExecutorBase

--- a/hummingbot/strategy_v2/executors/lp_executor/lp_executor.py
+++ b/hummingbot/strategy_v2/executors/lp_executor/lp_executor.py
@@ -172,15 +172,13 @@ class LPExecutor(ExecutorBase):
                 await self._create_position()
 
             case LPExecutorStates.OPENING:
-                # Position creation in progress - connector handles retry
-                # If we're still in OPENING state, the previous attempt failed
-                # and we should retry (connector will handle max retries)
+                # Position creation in progress (connector retries timeouts;
+                # any other open failure is terminal — see _handle_create_failure)
                 await self._create_position()
 
             case LPExecutorStates.CLOSING:
-                # Position close in progress - connector handles retry
-                # If we're still in CLOSING state, the previous attempt failed
-                # and we should retry (connector will handle max retries)
+                # This re-entry IS the close retry loop: _handle_close_failure counts
+                # the failed attempt and backs off, evaluate_max_retries terminates
                 await self._close_position()
 
             case LPExecutorStates.SWAPPING:
@@ -553,20 +551,20 @@ class LPExecutor(ExecutorBase):
         self.lp_position_state.active_close_order = TrackedOrder(order_id=order_id)
 
         try:
-            # Directly await the async operation. The executor owns the retry POLICY
-            # (bounded re-entries with fresh pre-flight reconciliation), so the
-            # connector's inner budget is kept small — a large inner budget would
-            # multiply with the executor's into O(n^2) submissions per close.
+            # One gateway request per attempt (max_retries=0): this CLOSING loop is the
+            # only owner of close retries. Each re-entry rebuilds from fresh on-chain
+            # state, and the pre-flight above reconciles an attempt that landed after a
+            # timeout — a connector-level retry would re-submit without that check.
             signature = await connector._clmm_close_position(
                 trade_type=TradeType.RANGE,
                 order_id=order_id,
                 trading_pair=self.config.trading_pair,
                 position_address=self.lp_position_state.position_address,
-                max_retries=min(3, self._max_retries),
+                max_retries=0,
                 dex_name=self.lp_dex_name,
                 trading_type=self.lp_trading_type,
             )
-            # Note: If operation fails after all retries, connector re-raises the exception
+            # Note: on failure the connector re-raises and _handle_close_failure counts it
             # so it will be caught by the except block below
 
             self.logger().info(f"Position close confirmed, signature={signature}")

--- a/test/hummingbot/connector/gateway/test_gateway_base.py
+++ b/test/hummingbot/connector/gateway/test_gateway_base.py
@@ -434,6 +434,14 @@ class GatewayBaseRetryClassificationTest(unittest.TestCase):
         action = self.connector._classify_error(error, "close position", 0, 10)
         self.assertEqual(RetryAction.FAIL_IMMEDIATE, action)
 
+    def test_rate_limited_is_retryable(self):
+        # Gateway declares RATE_LIMITED (HTTP 429) "retryable after a delay";
+        # failing immediately converts a transient upstream throttle into an
+        # operation failure.
+        error = Exception("Gateway error: throttled [code: RATE_LIMITED]")
+        action = self.connector._classify_error(error, "execute swap", 0, 10)
+        self.assertEqual(RetryAction.RETRY, action)
+
 
 class GatewayBaseNotFoundPollingTest(unittest.TestCase):
     """The status poller must not wait forever on a transaction the chain does not know.
@@ -513,6 +521,58 @@ class GatewayBaseNotFoundPollingTest(unittest.TestCase):
         self._poll_with_status(0)
         self.assertEqual(0, self.connector._order_tracker._order_not_found_records[self.order_id])
         self.assertIn(self.order_id, self.connector._order_tracker.active_orders)
+
+    def test_pending_sighting_resets_a_not_found_streak(self):
+        # A PENDING sighting proves the signature reached the chain; an earlier
+        # miss was propagation lag and must not compound with a later one.
+        past_deadline = self.start_timestamp + self.connector.TX_NOT_FOUND_DEADLINE + 1.0
+        self.connector._set_current_timestamp(past_deadline)
+        self._poll_with_status(-2)
+        self.assertEqual(1, self.connector._order_tracker._order_not_found_records[self.order_id])
+        self._poll_with_status(0)
+        self._poll_with_status(-2)
+        self.assertEqual(1, self.connector._order_tracker._order_not_found_records[self.order_id])
+        self.assertIn(self.order_id, self.connector._order_tracker.active_orders)
+
+    def test_deadline_is_anchored_to_the_last_submission(self):
+        # _execute_with_retry can spend minutes before the submission that
+        # produced the polled signature. The fresh signature's propagation lag
+        # must not inherit a deadline burned by earlier attempts, or a landing
+        # transaction is marked lost and the operation re-submitted - both fill.
+        # Mirror the real flow: tracking starts without a tx hash; the
+        # submission-result OrderUpdate supplies it later.
+        late_submission = self.start_timestamp + 200.0
+        self.order_id = "late-submission-order"
+        self.tx_hash = "6" * 88
+        self.connector.start_tracking_order(
+            order_id=self.order_id,
+            exchange_order_id=None,
+            trading_pair="SOL-USDC",
+            trade_type=TradeType.BUY,
+            price=Decimal("100"),
+            amount=Decimal("1"),
+        )
+        order = self.connector._order_tracker.fetch_tracked_order(self.order_id)
+        self.async_run_with_timeout(self.connector._order_tracker._process_order_update(OrderUpdate(
+            client_order_id=self.order_id,
+            exchange_order_id=self.tx_hash,
+            trading_pair="SOL-USDC",
+            update_timestamp=late_submission,
+            new_state=OrderState.OPEN,
+        )))
+        self.assertEqual(late_submission, order.last_update_timestamp)
+
+        # Well past the creation-anchored deadline, but within it from submission.
+        self.connector._set_current_timestamp(late_submission + 10.0)
+        self._poll_with_status(-2)
+        self.assertEqual(0, self.connector._order_tracker._order_not_found_records[self.order_id])
+
+        # Past the deadline from the submission too: now it counts.
+        self.connector._set_current_timestamp(
+            late_submission + self.connector.TX_NOT_FOUND_DEADLINE + 1.0
+        )
+        self._poll_with_status(-2)
+        self.assertEqual(1, self.connector._order_tracker._order_not_found_records[self.order_id])
 
 
 if __name__ == "__main__":

--- a/test/hummingbot/connector/gateway/test_gateway_base.py
+++ b/test/hummingbot/connector/gateway/test_gateway_base.py
@@ -396,43 +396,42 @@ class GatewayBaseConnectorSettingsRegistrationTest(unittest.TestCase):
 
 
 class GatewayBaseRetryClassificationTest(unittest.TestCase):
-    """Tests for _classify_error operation-aware retry opt-in (retryable_error_codes)."""
+    """The connector retries transport timeouts only; operation errors propagate.
+
+    What a failure means for an operation is the caller's decision — the LP
+    executor's CLOSING loop owns close retries (and passes max_retries=0 for a
+    single connector attempt per re-entry), so the classifier must never retry
+    slippage/simulation-class errors itself.
+    """
 
     def setUp(self) -> None:
         super().setUp()
         self.connector = MockGatewayConnector()
 
-    def test_slippage_is_fail_immediate_by_default(self):
+    def test_slippage_is_fail_immediate(self):
         error = Exception("Gateway error: slippage [code: SLIPPAGE_EXCEEDED]")
-        action = self.connector._classify_error(error, "execute swap", 0, 10)
+        action = self.connector._classify_error(error, "close position", 0, 10)
         self.assertEqual(RetryAction.FAIL_IMMEDIATE, action)
 
-    def test_opted_in_code_is_retryable(self):
-        # Close-position opts in to SLIPPAGE_EXCEEDED: each retry re-POSTs and Gateway
-        # rebuilds from fresh on-chain state, and a landed close cannot double-spend.
-        error = Exception("Gateway error: slippage [code: SLIPPAGE_EXCEEDED]")
-        action = self.connector._classify_error(
-            error, "close position", 0, 10, retryable_error_codes={"SLIPPAGE_EXCEEDED"}
-        )
-        self.assertEqual(RetryAction.RETRY, action)
+    def test_tx_not_confirmed_is_fail_immediate(self):
+        error = Exception("Transaction sig not confirmed on-chain [code: TX_NOT_CONFIRMED]")
+        action = self.connector._classify_error(error, "close position", 0, 10)
+        self.assertEqual(RetryAction.FAIL_IMMEDIATE, action)
 
-    def test_opted_in_code_stops_after_max_retries(self):
-        error = Exception("Gateway error: slippage [code: SLIPPAGE_EXCEEDED]")
-        action = self.connector._classify_error(
-            error, "close position", 10, 10, retryable_error_codes={"SLIPPAGE_EXCEEDED"}
-        )
-        self.assertEqual(RetryAction.STOP, action)
-
-    def test_timeout_remains_retryable_without_opt_in(self):
+    def test_timeout_is_retryable(self):
         error = Exception("Gateway error: pending [code: TRANSACTION_TIMEOUT]")
         action = self.connector._classify_error(error, "execute swap", 0, 10)
         self.assertEqual(RetryAction.RETRY, action)
 
-    def test_unknown_error_is_fail_immediate_even_with_opt_in(self):
+    def test_timeout_stops_at_zero_budget(self):
+        # max_retries=0 (the close path) means one attempt: even a timeout stops.
+        error = Exception("Gateway error: pending [code: TRANSACTION_TIMEOUT]")
+        action = self.connector._classify_error(error, "close position", 0, 0)
+        self.assertEqual(RetryAction.STOP, action)
+
+    def test_unknown_error_is_fail_immediate(self):
         error = Exception("connection reset by peer")
-        action = self.connector._classify_error(
-            error, "close position", 0, 10, retryable_error_codes={"SLIPPAGE_EXCEEDED"}
-        )
+        action = self.connector._classify_error(error, "close position", 0, 10)
         self.assertEqual(RetryAction.FAIL_IMMEDIATE, action)
 
 

--- a/test/hummingbot/connector/gateway/test_gateway_base.py
+++ b/test/hummingbot/connector/gateway/test_gateway_base.py
@@ -3,7 +3,7 @@ import unittest
 from decimal import Decimal
 from typing import List
 
-from hummingbot.connector.gateway.gateway_base import GatewayBase
+from hummingbot.connector.gateway.gateway_base import GatewayBase, RetryAction
 from hummingbot.core.data_type.common import OrderType, TradeType
 from hummingbot.core.data_type.in_flight_order import OrderState, OrderUpdate, TradeUpdate
 from hummingbot.core.data_type.trade_fee import AddedToCostTradeFee, TokenAmount
@@ -392,6 +392,47 @@ class GatewayBaseConnectorSettingsRegistrationTest(unittest.TestCase):
             "test_connector", False, "SOL", "USDC", OrderType.MARKET, TradeType.SELL, Decimal("1"), Decimal("1"),
         )
         self.assertEqual(Decimal("0"), fee.percent)
+
+
+class GatewayBaseRetryClassificationTest(unittest.TestCase):
+    """Tests for _classify_error operation-aware retry opt-in (retryable_error_codes)."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.connector = MockGatewayConnector()
+
+    def test_slippage_is_fail_immediate_by_default(self):
+        error = Exception("Gateway error: slippage [code: SLIPPAGE_EXCEEDED]")
+        action = self.connector._classify_error(error, "execute swap", 0, 10)
+        self.assertEqual(RetryAction.FAIL_IMMEDIATE, action)
+
+    def test_opted_in_code_is_retryable(self):
+        # Close-position opts in to SLIPPAGE_EXCEEDED: each retry re-POSTs and Gateway
+        # rebuilds from fresh on-chain state, and a landed close cannot double-spend.
+        error = Exception("Gateway error: slippage [code: SLIPPAGE_EXCEEDED]")
+        action = self.connector._classify_error(
+            error, "close position", 0, 10, retryable_error_codes={"SLIPPAGE_EXCEEDED"}
+        )
+        self.assertEqual(RetryAction.RETRY, action)
+
+    def test_opted_in_code_stops_after_max_retries(self):
+        error = Exception("Gateway error: slippage [code: SLIPPAGE_EXCEEDED]")
+        action = self.connector._classify_error(
+            error, "close position", 10, 10, retryable_error_codes={"SLIPPAGE_EXCEEDED"}
+        )
+        self.assertEqual(RetryAction.STOP, action)
+
+    def test_timeout_remains_retryable_without_opt_in(self):
+        error = Exception("Gateway error: pending [code: TRANSACTION_TIMEOUT]")
+        action = self.connector._classify_error(error, "execute swap", 0, 10)
+        self.assertEqual(RetryAction.RETRY, action)
+
+    def test_unknown_error_is_fail_immediate_even_with_opt_in(self):
+        error = Exception("connection reset by peer")
+        action = self.connector._classify_error(
+            error, "close position", 0, 10, retryable_error_codes={"SLIPPAGE_EXCEEDED"}
+        )
+        self.assertEqual(RetryAction.FAIL_IMMEDIATE, action)
 
 
 if __name__ == "__main__":

--- a/test/hummingbot/connector/gateway/test_gateway_base.py
+++ b/test/hummingbot/connector/gateway/test_gateway_base.py
@@ -2,6 +2,7 @@ import asyncio
 import unittest
 from decimal import Decimal
 from typing import List
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from hummingbot.connector.gateway.gateway_base import GatewayBase, RetryAction
 from hummingbot.core.data_type.common import OrderType, TradeType
@@ -433,6 +434,86 @@ class GatewayBaseRetryClassificationTest(unittest.TestCase):
             error, "close position", 0, 10, retryable_error_codes={"SLIPPAGE_EXCEEDED"}
         )
         self.assertEqual(RetryAction.FAIL_IMMEDIATE, action)
+
+
+class GatewayBaseNotFoundPollingTest(unittest.TestCase):
+    """The status poller must not wait forever on a transaction the chain does not know.
+
+    Gateway reports txStatus NOT_FOUND (-2) for a signature the cluster has never
+    seen. Right after submission that is transient, but once the order is older than
+    TX_NOT_FOUND_DEADLINE the transaction can no longer land (Solana blockhash
+    expiry), so each further miss must feed the tracker's lost-order machinery
+    instead of polling as pending forever.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls.ev_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(cls.ev_loop)
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.connector = MockGatewayConnector()
+        self.start_timestamp = 1640000000.0
+        self.connector._set_current_timestamp(self.start_timestamp)
+        self.order_id = "test-not-found-order"
+        self.tx_hash = "5" * 88
+        self.connector.start_tracking_order(
+            order_id=self.order_id,
+            exchange_order_id=self.tx_hash,
+            trading_pair="SOL-USDC",
+            trade_type=TradeType.BUY,
+            price=Decimal("100"),
+            amount=Decimal("1"),
+        )
+
+    def async_run_with_timeout(self, coroutine, timeout: float = 1):
+        return self.ev_loop.run_until_complete(asyncio.wait_for(coroutine, timeout))
+
+    def _poll_with_status(self, tx_status: int):
+        gateway_mock = MagicMock()
+        gateway_mock.get_transaction_status = AsyncMock(return_value={
+            "signature": self.tx_hash,
+            "txStatus": tx_status,
+            "fee": 0,
+        })
+        order = self.connector._order_tracker.fetch_tracked_order(self.order_id)
+        with patch.object(MockGatewayConnector, "_get_gateway_instance", return_value=gateway_mock):
+            self.async_run_with_timeout(self.connector.update_order_status([order]))
+
+    def test_not_found_before_deadline_is_ignored(self):
+        self.connector._set_current_timestamp(self.start_timestamp + 10.0)
+        self._poll_with_status(-2)
+        self.assertEqual(0, self.connector._order_tracker._order_not_found_records[self.order_id])
+        self.assertIn(self.order_id, self.connector._order_tracker.active_orders)
+
+    def test_not_found_after_deadline_counts_toward_lost_order_limit(self):
+        self.connector._set_current_timestamp(
+            self.start_timestamp + self.connector.TX_NOT_FOUND_DEADLINE + 1.0
+        )
+        self._poll_with_status(-2)
+        self.assertEqual(1, self.connector._order_tracker._order_not_found_records[self.order_id])
+        self.assertIn(self.order_id, self.connector._order_tracker.active_orders)
+
+    def test_not_found_past_limit_marks_order_lost(self):
+        self.connector._set_current_timestamp(
+            self.start_timestamp + self.connector.TX_NOT_FOUND_DEADLINE + 1.0
+        )
+        for _ in range(self.connector._order_tracker.lost_order_count_limit + 1):
+            self._poll_with_status(-2)
+        self.assertNotIn(self.order_id, self.connector._order_tracker.active_orders)
+        self.assertIn(self.order_id, self.connector._order_tracker.lost_orders)
+
+    def test_pending_after_deadline_keeps_waiting(self):
+        # PENDING means the chain has seen the transaction - it can still confirm,
+        # so age alone must not fail it.
+        self.connector._set_current_timestamp(
+            self.start_timestamp + self.connector.TX_NOT_FOUND_DEADLINE + 1000.0
+        )
+        self._poll_with_status(0)
+        self.assertEqual(0, self.connector._order_tracker._order_not_found_records[self.order_id])
+        self.assertIn(self.order_id, self.connector._order_tracker.active_orders)
 
 
 if __name__ == "__main__":

--- a/test/hummingbot/connector/gateway/test_gateway_last_traded_prices.py
+++ b/test/hummingbot/connector/gateway/test_gateway_last_traded_prices.py
@@ -1,0 +1,68 @@
+import unittest
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from hummingbot.connector.gateway.gateway import Gateway
+
+
+class GatewayLastTradedPricesTests(unittest.IsolatedAsyncioTestCase):
+    """Gateway must expose the plural get_last_traded_prices fan-out.
+
+    ExchangeBase provides it for order-book connectors, but Gateway extends
+    ConnectorBase directly and so never inherited it -- leaving the per-pair
+    _get_last_traded_price with no caller, and every consumer of the plural form
+    (Hummingbot API's market-data route among them) raising AttributeError.
+    """
+
+    PAIR = "ANSEM-SOL"
+    OTHER_PAIR = "SOL-USDC"
+
+    def setUp(self):
+        self.connector = Gateway.__new__(Gateway)
+        self.connector._logger = MagicMock()
+
+    async def test_returns_a_price_per_pair(self):
+        with patch.object(Gateway, "_get_last_traded_price", new_callable=AsyncMock) as mock_price:
+            mock_price.side_effect = [1.5, 200.0]
+            prices = await self.connector.get_last_traded_prices([self.PAIR, self.OTHER_PAIR])
+
+        self.assertEqual({self.PAIR: 1.5, self.OTHER_PAIR: 200.0}, prices)
+
+    async def test_unpriceable_pair_is_omitted_not_zeroed(self):
+        """A caller must be able to tell "no price" from "the price is 0"."""
+        with patch.object(Gateway, "_get_last_traded_price", new_callable=AsyncMock) as mock_price:
+            mock_price.side_effect = [0.0, 200.0]
+            prices = await self.connector.get_last_traded_prices([self.PAIR, self.OTHER_PAIR])
+
+        self.assertNotIn(self.PAIR, prices)
+        self.assertEqual(200.0, prices[self.OTHER_PAIR])
+
+    async def test_one_failing_pair_does_not_sink_the_others(self):
+        with patch.object(Gateway, "_get_last_traded_price", new_callable=AsyncMock) as mock_price:
+            mock_price.side_effect = [RuntimeError("gateway unreachable"), 200.0]
+            prices = await self.connector.get_last_traded_prices([self.PAIR, self.OTHER_PAIR])
+
+        self.assertNotIn(self.PAIR, prices)
+        self.assertEqual(200.0, prices[self.OTHER_PAIR])
+
+    async def test_falls_back_to_a_quote_when_the_oracle_is_empty(self):
+        """The oracle only holds pairs MarketDataProvider tracks; quote the rest."""
+        with patch("hummingbot.connector.gateway.gateway.RateOracle") as mock_oracle, \
+             patch.object(Gateway, "get_quote_price", new_callable=AsyncMock) as mock_quote:
+            mock_oracle.get_instance.return_value.get_pair_rate.return_value = None
+            mock_quote.return_value = Decimal("0.000000028336")
+
+            price = await self.connector._get_last_traded_price(self.PAIR)
+
+        mock_quote.assert_awaited_once()
+        self.assertAlmostEqual(2.8336e-8, price)
+
+    async def test_cached_rate_is_preferred_over_a_quote(self):
+        with patch("hummingbot.connector.gateway.gateway.RateOracle") as mock_oracle, \
+             patch.object(Gateway, "get_quote_price", new_callable=AsyncMock) as mock_quote:
+            mock_oracle.get_instance.return_value.get_pair_rate.return_value = Decimal("1.5")
+
+            price = await self.connector._get_last_traded_price(self.PAIR)
+
+        mock_quote.assert_not_awaited()
+        self.assertEqual(1.5, price)

--- a/test/hummingbot/connector/gateway/test_gateway_position_info.py
+++ b/test/hummingbot/connector/gateway/test_gateway_position_info.py
@@ -1,0 +1,71 @@
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from hummingbot.connector.gateway.gateway import Gateway
+
+
+def _fake_connector(position_info_side_effect=None):
+    """Bare `self` for calling Gateway.get_position_info_fresh unbound.
+
+    The method only touches network/address/logger and the gateway HTTP client,
+    so a full connector (which needs a live event loop and settings registration)
+    is unnecessary.
+    """
+    fake = MagicMock()
+    fake.network = "mainnet-beta"
+    fake.address = "test_wallet"
+    gateway_instance = MagicMock()
+    gateway_instance.clmm_position_info = AsyncMock(side_effect=position_info_side_effect)
+    fake._get_gateway_instance = MagicMock(return_value=gateway_instance)
+    fake.logger = MagicMock(return_value=MagicMock())
+    return fake
+
+
+class GatewayPositionInfoContractTest(unittest.IsolatedAsyncioTestCase):
+    """Pins the None-vs-raise contract of get_position_info_fresh.
+
+    None must mean "the position definitively does not exist on-chain";
+    everything else must raise. Callers (LPExecutor close pre-flight and
+    external-close detection) treat None as "already closed", so a swallowed
+    transient error here silently abandons a live position.
+    """
+
+    async def test_position_specific_404_returns_none(self):
+        # Gateway position-info routes raise "Position not found: X" /
+        # "Position not found or closed: X" for a nonexistent position
+        fake = _fake_connector(
+            ValueError("Gateway error: Position not found or closed: pos123 (Not Found) [code: X]")
+        )
+        result = await Gateway.get_position_info_fresh(
+            fake, trading_pair="SOL-USDC", dex_name="orca", trading_type="clmm", position_address="pos123"
+        )
+        self.assertIsNone(result)
+
+    async def test_unrelated_404_raises(self):
+        # The HTTP client stamps "(Not Found)" on EVERY 404 — a missing route
+        # after a Gateway redeploy must not read as "position gone"
+        fake = _fake_connector(
+            ValueError("Gateway error: Route GET:/connectors/orca/clmm/position-info not found (Not Found)")
+        )
+        with self.assertRaises(ValueError):
+            await Gateway.get_position_info_fresh(
+                fake, trading_pair="SOL-USDC", dex_name="orca", trading_type="clmm", position_address="pos123"
+            )
+
+    async def test_missing_wallet_404_raises(self):
+        fake = _fake_connector(ValueError("Gateway error: Wallet not found: test_wallet (Not Found)"))
+        with self.assertRaises(ValueError):
+            await Gateway.get_position_info_fresh(
+                fake, trading_pair="SOL-USDC", dex_name="orca", trading_type="clmm", position_address="pos123"
+            )
+
+    async def test_transient_error_raises(self):
+        fake = _fake_connector(ConnectionError("Cannot connect to host localhost:15888"))
+        with self.assertRaises(ConnectionError):
+            await Gateway.get_position_info_fresh(
+                fake, trading_pair="SOL-USDC", dex_name="orca", trading_type="clmm", position_address="pos123"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/hummingbot/connector/test_budget_checker.py
+++ b/test/hummingbot/connector/test_budget_checker.py
@@ -562,3 +562,35 @@ class BudgetCheckerTest(unittest.TestCase):
 
         self.assertEqual(Decimal("7"), first_adjusted_candidate.amount)
         self.assertEqual(Decimal("5"), second_adjusted_candidate.amount)
+
+    def test_adjust_candidate_with_nan_price_does_not_raise(self):
+        """A NaN-priced candidate must be handled, not blow up the caller.
+
+        A venue with no order book (a Gateway swap) prices a candidate as NaN, which
+        propagates into both collateral amounts. `Decimal < NaN` raises
+        InvalidOperation rather than returning False, so both comparisons in
+        OrderCandidate.adjust_from_balances have to be NaN-guarded -- the order
+        collateral one always was, the percent-fee one was not.
+        """
+        self.exchange.set_balanced_order_book(
+            trading_pair=self.trading_pair,
+            mid_price=Decimal("2"),
+            min_price=Decimal("1"),
+            max_price=Decimal("3"),
+            price_step_size=Decimal("1"),
+            volume_step_size=Decimal("1"),
+        )
+        self.exchange.set_balance(self.quote_asset, Decimal("100"))
+        order_candidate = OrderCandidate(
+            trading_pair=self.trading_pair,
+            is_maker=False,
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.BUY,
+            amount=Decimal("10"),
+            price=Decimal("nan"),
+        )
+
+        adjusted_candidate = self.budget_checker.adjust_candidate(order_candidate, all_or_none=False)
+
+        # Nothing can be scaled from a NaN price, so the amount is left untouched.
+        self.assertEqual(Decimal("10"), adjusted_candidate.amount)

--- a/test/hummingbot/strategy_v2/executors/lp_executor/test_lp_executor.py
+++ b/test/hummingbot/strategy_v2/executors/lp_executor/test_lp_executor.py
@@ -493,7 +493,7 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         mock_position = MagicMock()
         mock_position.price = 100.0
         connector = self.strategy.connectors["solana-mainnet-beta"]
-        connector.get_position_info = AsyncMock(return_value=mock_position)
+        connector.get_position_info_fresh = AsyncMock(return_value=mock_position)
         connector._clmm_close_position = AsyncMock(return_value="sig-remove")
         connector._lp_orders_metadata = {
             "order-123": {
@@ -517,16 +517,76 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         self.assertEqual(executor.close_type, CloseType.FAILED)
         self.assertEqual(executor._held_position_orders, [])
 
-    def test_handle_close_failure_transitions_to_failed(self):
-        """Test _handle_close_failure transitions to FAILED state (retry at connector level)"""
+    def test_handle_close_failure_stays_closing_for_bounded_retries(self):
+        """Test _handle_close_failure keeps state CLOSING so control_task re-enters
+        _close_position with fresh state; termination belongs to evaluate_max_retries"""
         executor = self.get_executor()
         executor.lp_position_state.state = LPExecutorStates.CLOSING
         executor.lp_position_state.active_close_order = MagicMock()
 
         executor._handle_close_failure(Exception("Test error"))
 
-        self.assertEqual(executor.lp_position_state.state, LPExecutorStates.FAILED)
+        self.assertEqual(executor.lp_position_state.state, LPExecutorStates.CLOSING)
         self.assertIsNone(executor.lp_position_state.active_close_order)
+        self.assertEqual(executor._current_retries, 1)
+        self.assertFalse(executor._max_retries_reached)
+
+    def test_evaluate_max_retries_noop_within_budget(self):
+        """Family semantics (>): at retries == max the executor still runs; only
+        the (max+1)th failure crosses the threshold"""
+        executor = self.get_executor()
+        executor.lp_position_state.state = LPExecutorStates.CLOSING
+        executor._current_retries = executor._max_retries
+
+        with patch.object(executor, 'stop') as mock_stop:
+            executor.evaluate_max_retries()
+            mock_stop.assert_not_called()
+
+        self.assertFalse(executor._max_retries_reached)
+        self.assertIsNone(executor.close_type)
+
+    def test_evaluate_max_retries_involuntary_hold_with_live_position(self):
+        """Exhaustion with the position still on-chain terminates as an involuntary
+        POSITION_HOLD carrying a zero-amount marker order — FAILED is reserved for
+        nothing-left-on-chain (family contract, force_stop_with_position_hold)"""
+        executor = self.get_executor()
+        executor.lp_position_state.state = LPExecutorStates.CLOSING
+        executor.lp_position_state.position_address = "pos123"
+        executor._current_price = Decimal("100")
+        executor._current_retries = executor._max_retries + 1
+
+        with patch.object(executor, 'stop') as mock_stop:
+            executor.evaluate_max_retries()
+            mock_stop.assert_called_once()
+
+        self.assertTrue(executor._max_retries_reached)
+        self.assertEqual(executor.close_type, CloseType.POSITION_HOLD)
+        self.assertEqual(executor._hold_reason, "close_retries_exhausted")
+        self.assertEqual(executor.get_custom_info()["hold_reason"], "close_retries_exhausted")
+        # The marker order carries the position identity without touching accounting
+        self.assertEqual(len(executor._held_position_orders), 1)
+        marker = executor._held_position_orders[0]
+        self.assertTrue(marker["lp_unclosed_position"])
+        self.assertEqual(marker["position_address"], "pos123")
+        self.assertEqual(marker["executed_amount_base"], 0.0)
+        self.assertEqual(marker["executed_amount_quote"], 0.0)
+
+    def test_evaluate_max_retries_failed_without_position(self):
+        """Exhaustion with nothing on-chain terminates as FAILED, true to its
+        family meaning, with no marker order fabricated"""
+        executor = self.get_executor()
+        executor.lp_position_state.state = LPExecutorStates.CLOSING
+        executor.lp_position_state.position_address = None
+        executor._current_retries = executor._max_retries + 1
+
+        with patch.object(executor, 'stop') as mock_stop:
+            executor.evaluate_max_retries()
+            mock_stop.assert_called_once()
+
+        self.assertTrue(executor._max_retries_reached)
+        self.assertEqual(executor.close_type, CloseType.FAILED)
+        self.assertIsNone(executor._hold_reason)
+        self.assertEqual(executor._held_position_orders, [])
 
     async def test_control_task_not_active_starts_opening(self):
         """Test control_task transitions from NOT_ACTIVE to OPENING"""
@@ -583,7 +643,7 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         mock_position.price = 120.0  # Above upper_limit_price (115)
 
         connector = self.strategy.connectors["solana-mainnet-beta"]
-        connector.get_position_info = AsyncMock(return_value=mock_position)
+        connector.get_position_info_fresh = AsyncMock(return_value=mock_position)
 
         await executor.control_task()
 
@@ -615,7 +675,7 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         mock_position.price = 85.0  # Below lower_limit_price (90)
 
         connector = self.strategy.connectors["solana-mainnet-beta"]
-        connector.get_position_info = AsyncMock(return_value=mock_position)
+        connector.get_position_info_fresh = AsyncMock(return_value=mock_position)
 
         await executor.control_task()
 
@@ -650,7 +710,7 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         mock_position.price = 96.0  # In range (95-105) but below lower_limit_price (98)
 
         connector = self.strategy.connectors["solana-mainnet-beta"]
-        connector.get_position_info = AsyncMock(return_value=mock_position)
+        connector.get_position_info_fresh = AsyncMock(return_value=mock_position)
 
         await executor.control_task()
 
@@ -677,7 +737,7 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         mock_position.price = 103.0  # In range (95-105) but above upper_limit_price (102)
 
         connector = self.strategy.connectors["solana-mainnet-beta"]
-        connector.get_position_info = AsyncMock(return_value=mock_position)
+        connector.get_position_info_fresh = AsyncMock(return_value=mock_position)
 
         await executor.control_task()
 
@@ -704,7 +764,7 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         mock_position.price = 120.0  # Out of range but no limit set
 
         connector = self.strategy.connectors["solana-mainnet-beta"]
-        connector.get_position_info = AsyncMock(return_value=mock_position)
+        connector.get_position_info_fresh = AsyncMock(return_value=mock_position)
 
         await executor.control_task()
 
@@ -725,7 +785,7 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         mock_position.upper_price = 106.0
 
         connector = self.strategy.connectors["solana-mainnet-beta"]
-        connector.get_position_info = AsyncMock(return_value=mock_position)
+        connector.get_position_info_fresh = AsyncMock(return_value=mock_position)
 
         await executor._update_position_info()
 
@@ -740,7 +800,7 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         executor.lp_position_state.position_address = "pos123"
 
         connector = self.strategy.connectors["solana-mainnet-beta"]
-        connector.get_position_info = AsyncMock(side_effect=Exception("Position closed: pos123"))
+        connector.get_position_info_fresh = AsyncMock(side_effect=Exception("Position closed: pos123"))
         connector.create_market_order_id = MagicMock(return_value="order-123")
         connector._trigger_remove_liquidity_event = MagicMock()
 
@@ -754,11 +814,11 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         executor.lp_position_state.position_address = None
 
         connector = self.strategy.connectors["solana-mainnet-beta"]
-        connector.get_position_info = AsyncMock()
+        connector.get_position_info_fresh = AsyncMock()
 
         await executor._update_position_info()
 
-        connector.get_position_info.assert_not_called()
+        connector.get_position_info_fresh.assert_not_called()
 
     async def test_update_position_info_no_connector(self):
         """Test _update_position_info returns early when connector missing"""
@@ -770,15 +830,56 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         # Should return without error
 
     async def test_update_position_info_returns_none(self):
-        """Test _update_position_info handles None response"""
+        """Test the external-close guard: definitive misses only complete after the
+        position was seen on-chain at least once AND 3 consecutive misses"""
         executor = self.get_executor()
         executor.lp_position_state.position_address = "pos123"
+        executor.lp_position_state.state = LPExecutorStates.IN_RANGE
 
         connector = self.strategy.connectors["solana-mainnet-beta"]
-        connector.get_position_info = AsyncMock(return_value=None)
+        connector.get_position_info_fresh = AsyncMock(return_value=None)
+        connector._trigger_remove_liquidity_event = MagicMock(
+            return_value=create_mock_remove_event(
+                base_amount=Decimal("0"), quote_amount=Decimal("0")
+            )
+        )
+
+        # Never seen on-chain: misses accumulate but must NOT complete the executor
+        # (a not-found streak on a just-created position is RPC lag, not a close)
+        for _ in range(4):
+            await executor._update_position_info()
+        self.assertEqual(executor.lp_position_state.state, LPExecutorStates.IN_RANGE)
+        self.assertEqual(executor._position_not_found_count, 4)
+
+        # Seen on-chain: 3 consecutive misses now mean an external close
+        executor._position_not_found_count = 0
+        executor._position_seen_onchain = True
+        for _ in range(2):
+            await executor._update_position_info()
+        self.assertEqual(executor.lp_position_state.state, LPExecutorStates.IN_RANGE)
+        await executor._update_position_info()
+        self.assertEqual(executor.lp_position_state.state, LPExecutorStates.COMPLETE)
+
+    async def test_update_position_info_success_resets_miss_counter(self):
+        """A successful read resets the miss counter and marks the position seen"""
+        executor = self.get_executor()
+        executor.lp_position_state.position_address = "pos123"
+        executor._position_not_found_count = 2
+
+        mock_position = MagicMock()
+        mock_position.base_token_amount = 1.0
+        mock_position.quote_token_amount = 100.0
+        mock_position.base_fee_amount = 0.0
+        mock_position.quote_fee_amount = 0.0
+        mock_position.lower_price = 90.0
+        mock_position.upper_price = 110.0
+        mock_position.price = 100.0
+        connector = self.strategy.connectors["solana-mainnet-beta"]
+        connector.get_position_info_fresh = AsyncMock(return_value=mock_position)
 
         await executor._update_position_info()
-        # Should log warning but not crash
+        self.assertEqual(executor._position_not_found_count, 0)
+        self.assertTrue(executor._position_seen_onchain)
 
     async def test_update_position_info_not_found_error(self):
         """Test _update_position_info handles not found error"""
@@ -786,7 +887,7 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         executor.lp_position_state.position_address = "pos123"
 
         connector = self.strategy.connectors["solana-mainnet-beta"]
-        connector.get_position_info = AsyncMock(side_effect=Exception("Position not found: pos123"))
+        connector.get_position_info_fresh = AsyncMock(side_effect=Exception("Position not found: pos123"))
 
         await executor._update_position_info()
         # Should log error but not crash, state unchanged
@@ -797,7 +898,7 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         executor.lp_position_state.position_address = "pos123"
 
         connector = self.strategy.connectors["solana-mainnet-beta"]
-        connector.get_position_info = AsyncMock(side_effect=Exception("Network timeout"))
+        connector.get_position_info_fresh = AsyncMock(side_effect=Exception("Network timeout"))
 
         await executor._update_position_info()
         # Should log warning but not crash
@@ -817,7 +918,7 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         mock_position.price = 99.5
 
         connector = self.strategy.connectors["solana-mainnet-beta"]
-        connector.get_position_info = AsyncMock(return_value=mock_position)
+        connector.get_position_info_fresh = AsyncMock(return_value=mock_position)
 
         await executor._update_position_info()
 
@@ -848,7 +949,7 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         mock_position = MagicMock()
         mock_position.price = 100.0
         connector = self.strategy.connectors["solana-mainnet-beta"]
-        connector.get_position_info = AsyncMock(return_value=mock_position)
+        connector.get_position_info_fresh = AsyncMock(return_value=mock_position)
 
         with patch.object(executor, '_close_position', new_callable=AsyncMock) as mock_close:
             await executor.control_task()
@@ -872,7 +973,7 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         mock_position.upper_price = 105.0
         mock_position.price = 100.0
         connector = self.strategy.connectors["solana-mainnet-beta"]
-        connector.get_position_info = AsyncMock(return_value=mock_position)
+        connector.get_position_info_fresh = AsyncMock(return_value=mock_position)
 
         await executor.control_task()
 
@@ -905,7 +1006,7 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         mock_position.lower_price = 95.0
         mock_position.upper_price = 105.0
         mock_position.price = 100.0
-        connector.get_position_info = AsyncMock(return_value=mock_position)
+        connector.get_position_info_fresh = AsyncMock(return_value=mock_position)
         connector._trigger_add_liquidity_event = MagicMock()
 
         await executor._create_position()
@@ -977,7 +1078,7 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         mock_position.lower_price = 94.5
         mock_position.upper_price = 105.5
         mock_position.price = 100.0
-        connector.get_position_info = AsyncMock(return_value=mock_position)
+        connector.get_position_info_fresh = AsyncMock(return_value=mock_position)
         connector._trigger_add_liquidity_event = MagicMock(return_value=create_mock_add_event(
             base_amount=Decimal("0.95"), quote_amount=Decimal("105.0")
         ))
@@ -999,7 +1100,7 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         connector._lp_orders_metadata = {
             "order-123": {"position_address": "pos456", "position_rent": Decimal("0.002")}
         }
-        connector.get_position_info = AsyncMock(return_value=None)
+        connector.get_position_info_fresh = AsyncMock(return_value=None)
         connector._trigger_add_liquidity_event = MagicMock(return_value=create_mock_add_event())
 
         await executor._create_position()
@@ -1022,7 +1123,7 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         executor.lp_position_state.position_address = "pos123"
 
         connector = self.strategy.connectors["solana-mainnet-beta"]
-        connector.get_position_info = AsyncMock(return_value=None)
+        connector.get_position_info_fresh = AsyncMock(return_value=None)
         connector._trigger_remove_liquidity_event = MagicMock()
 
         await executor._close_position()
@@ -1036,7 +1137,7 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         executor.lp_position_state.position_address = "pos123"
 
         connector = self.strategy.connectors["solana-mainnet-beta"]
-        connector.get_position_info = AsyncMock(side_effect=Exception("Position closed: pos123"))
+        connector.get_position_info_fresh = AsyncMock(side_effect=Exception("Position closed: pos123"))
         connector._trigger_remove_liquidity_event = MagicMock()
 
         await executor._close_position()
@@ -1049,7 +1150,7 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         executor.lp_position_state.position_address = "pos123"
 
         connector = self.strategy.connectors["solana-mainnet-beta"]
-        connector.get_position_info = AsyncMock(side_effect=Exception("Position not found: pos123"))
+        connector.get_position_info_fresh = AsyncMock(side_effect=Exception("Position not found: pos123"))
         connector._trigger_remove_liquidity_event = MagicMock()
 
         await executor._close_position()
@@ -1063,7 +1164,7 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
 
         connector = self.strategy.connectors["solana-mainnet-beta"]
         # First call raises error, but it's not "closed" or "not found"
-        connector.get_position_info = AsyncMock(side_effect=Exception("Network timeout"))
+        connector.get_position_info_fresh = AsyncMock(side_effect=Exception("Network timeout"))
         connector._clmm_close_position = AsyncMock(return_value="sig789")
         connector._lp_orders_metadata = {
             "order-123": {
@@ -1091,7 +1192,7 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         mock_position = MagicMock()
         mock_position.price = 100.0
         connector = self.strategy.connectors["solana-mainnet-beta"]
-        connector.get_position_info = AsyncMock(return_value=mock_position)
+        connector.get_position_info_fresh = AsyncMock(return_value=mock_position)
         connector._clmm_close_position = AsyncMock(return_value="sig789")
         connector._lp_orders_metadata = {
             "order-123": {
@@ -1124,14 +1225,36 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         mock_position = MagicMock()
         mock_position.price = 100.0
         connector = self.strategy.connectors["solana-mainnet-beta"]
-        connector.get_position_info = AsyncMock(return_value=mock_position)
+        connector.get_position_info_fresh = AsyncMock(return_value=mock_position)
         connector._clmm_close_position = AsyncMock(side_effect=Exception("Gateway error"))
         connector._lp_orders_metadata = {}
 
         await executor._close_position()
 
-        # Connector handles retry internally; when it raises, executor transitions to FAILED
-        self.assertEqual(executor.lp_position_state.state, LPExecutorStates.FAILED)
+        # A single failed attempt stays in CLOSING for a bounded re-entry with fresh
+        # state; termination is decided by evaluate_max_retries after the control
+        # task. The failure also arms a backoff so instant failures can't burn the
+        # budget in seconds.
+        self.assertEqual(executor.lp_position_state.state, LPExecutorStates.CLOSING)
+        self.assertEqual(executor._current_retries, 1)
+        self.assertGreater(executor._close_backoff_until, 0)
+
+        # While backed off, re-entry is a no-op (no additional retry consumed)
+        await executor._close_position()
+        self.assertEqual(executor._current_retries, 1)
+
+        # Exhaust the retry budget: the failing attempt leaves state CLOSING, and
+        # the family hook terminates as an involuntary hold (position still live)
+        executor._current_retries = executor._max_retries
+        executor._close_backoff_until = 0.0
+        await executor._close_position()
+        self.assertEqual(executor.lp_position_state.state, LPExecutorStates.CLOSING)
+        self.assertEqual(executor._current_retries, executor._max_retries + 1)
+        with patch.object(executor, 'stop') as mock_stop:
+            executor.evaluate_max_retries()
+            mock_stop.assert_called_once()
+        self.assertEqual(executor.close_type, CloseType.POSITION_HOLD)
+        self.assertEqual(executor._hold_reason, "close_retries_exhausted")
 
     async def test_close_position_exception_with_signature(self):
         """Test _close_position handles exception with signature in metadata"""
@@ -1142,14 +1265,16 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         mock_position = MagicMock()
         mock_position.price = 100.0
         connector = self.strategy.connectors["solana-mainnet-beta"]
-        connector.get_position_info = AsyncMock(return_value=mock_position)
+        connector.get_position_info_fresh = AsyncMock(return_value=mock_position)
         connector._clmm_close_position = AsyncMock(side_effect=Exception("TRANSACTION_TIMEOUT"))
         connector._lp_orders_metadata = {"order-123": {"signature": "sig999"}}
 
         await executor._close_position()
 
-        # Connector handles retry internally; when it raises, executor transitions to FAILED
-        self.assertEqual(executor.lp_position_state.state, LPExecutorStates.FAILED)
+        # A failed attempt (even a timeout after connector retries) stays in CLOSING;
+        # the next re-entry's pre-flight reconciles a close that actually landed
+        self.assertEqual(executor.lp_position_state.state, LPExecutorStates.CLOSING)
+        self.assertEqual(executor._current_retries, 1)
 
     def test_emit_already_closed_event(self):
         """Test _emit_already_closed_event emits synthetic event"""
@@ -1321,12 +1446,12 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         mock_position.price = 100.0
 
         connector = self.strategy.connectors["solana-mainnet-beta"]
-        connector.get_position_info = AsyncMock(return_value=mock_position)
+        connector.get_position_info_fresh = AsyncMock(return_value=mock_position)
         connector.get_pool_info_by_address = AsyncMock()
 
         await executor.control_task()
 
-        connector.get_position_info.assert_called_once()
+        connector.get_position_info_fresh.assert_called_once()
         connector.get_pool_info_by_address.assert_not_called()
 
     async def test_control_task_fetches_pool_info_when_no_position(self):
@@ -1453,7 +1578,7 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         mock_position = MagicMock()
         mock_position.price = 100.0
         connector = self.strategy.connectors["solana-mainnet-beta"]
-        connector.get_position_info = AsyncMock(return_value=mock_position)
+        connector.get_position_info_fresh = AsyncMock(return_value=mock_position)
         connector._clmm_close_position = AsyncMock(return_value="sig789")
         connector._lp_orders_metadata = {
             "order-123": {
@@ -1491,7 +1616,7 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         mock_position = MagicMock()
         mock_position.price = 100.0
         connector = self.strategy.connectors["solana-mainnet-beta"]
-        connector.get_position_info = AsyncMock(return_value=mock_position)
+        connector.get_position_info_fresh = AsyncMock(return_value=mock_position)
         connector._clmm_close_position = AsyncMock(return_value="sig789")
         connector._lp_orders_metadata = {
             "order-123": {
@@ -1528,7 +1653,7 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         mock_position = MagicMock()
         mock_position.price = 100.0
         connector = self.strategy.connectors["solana-mainnet-beta"]
-        connector.get_position_info = AsyncMock(return_value=mock_position)
+        connector.get_position_info_fresh = AsyncMock(return_value=mock_position)
         connector._clmm_close_position = AsyncMock(return_value="sig789")
         connector._lp_orders_metadata = {
             "order-123": {
@@ -2005,7 +2130,7 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         position_info.base_fee_amount = 0.0
         position_info.quote_fee_amount = 0.0
         position_info.price = 100.0
-        connector.get_position_info = AsyncMock(return_value=position_info)
+        connector.get_position_info_fresh = AsyncMock(return_value=position_info)
         connector._clmm_add_liquidity = AsyncMock(return_value="sig-add")
         connector._lp_orders_metadata = {"order-123": {"position_address": "pos123"}}
         connector._trigger_add_liquidity_event = MagicMock(
@@ -2130,7 +2255,7 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         mock_position.upper_price = 105.0
         mock_position.price = 120.0
         connector = self.strategy.connectors["solana-mainnet-beta"]
-        connector.get_position_info = AsyncMock(return_value=mock_position)
+        connector.get_position_info_fresh = AsyncMock(return_value=mock_position)
 
         await executor.control_task()
 
@@ -2169,7 +2294,7 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         executor._add_quote_amount = Decimal("500.0")
 
         connector = self.strategy.connectors["solana-mainnet-beta"]
-        connector.get_position_info = AsyncMock(side_effect=Exception("Position closed: pos123"))
+        connector.get_position_info_fresh = AsyncMock(side_effect=Exception("Position closed: pos123"))
         connector._trigger_remove_liquidity_event = MagicMock()
 
         await executor._close_position()

--- a/test/hummingbot/strategy_v2/executors/lp_executor/test_lp_executor.py
+++ b/test/hummingbot/strategy_v2/executors/lp_executor/test_lp_executor.py
@@ -531,6 +531,23 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         self.assertEqual(executor._current_retries, 1)
         self.assertFalse(executor._max_retries_reached)
 
+    def test_handle_close_failure_rate_limited_does_not_spend_a_retry(self):
+        """An upstream 429 is not a failed close: nothing was broadcast. Counting
+        it would let a minutes-long throttle window exhaust the whole budget and
+        terminate as POSITION_HOLD, stranding a position a delay would have
+        closed. Back off without spending a retry."""
+        executor = self.get_executor()
+        executor.lp_position_state.state = LPExecutorStates.CLOSING
+        executor.lp_position_state.active_close_order = MagicMock()
+
+        executor._handle_close_failure(
+            Exception("Gateway error: throttled [code: RATE_LIMITED]")
+        )
+
+        self.assertEqual(executor.lp_position_state.state, LPExecutorStates.CLOSING)
+        self.assertEqual(executor._current_retries, 0)
+        self.assertGreater(executor._close_backoff_until, self.strategy.current_timestamp)
+
     def test_evaluate_max_retries_noop_within_budget(self):
         """Family semantics (>): at retries == max the executor still runs; only
         the (max+1)th failure crosses the threshold"""
@@ -1117,19 +1134,50 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
         await executor._close_position()
         # Should log error and return
 
-    async def test_close_position_already_closed_none(self):
-        """Test _close_position handles already-closed position (None response)"""
+    async def test_close_position_none_read_requires_confirmation(self):
+        """A single fresh None read must NOT complete the close.
+
+        One lagging RPC read answering 404 for a live position would otherwise
+        book the pool balances as returned, complete a POSITION_HOLD close with
+        hold_reason=None, and hide the stranded position from the orphan gate.
+        The pre-flight holds Nones to the same gate as _update_position_info:
+        seen on-chain at least once, then >= 3 consecutive misses.
+        """
         executor = self.get_executor()
         executor.lp_position_state.position_address = "pos123"
+        executor.lp_position_state.state = LPExecutorStates.CLOSING
+        executor._position_seen_onchain = True
 
         connector = self.strategy.connectors["solana-mainnet-beta"]
         connector.get_position_info_fresh = AsyncMock(return_value=None)
         connector._trigger_remove_liquidity_event = MagicMock()
 
+        # Two misses: still CLOSING, no close attempted, no event emitted.
         await executor._close_position()
+        await executor._close_position()
+        self.assertEqual(executor.lp_position_state.state, LPExecutorStates.CLOSING)
+        connector._trigger_remove_liquidity_event.assert_not_called()
 
+        # Third consecutive miss confirms: complete as already-closed.
+        await executor._close_position()
         self.assertEqual(executor.lp_position_state.state, LPExecutorStates.COMPLETE)
         connector._trigger_remove_liquidity_event.assert_called_once()
+
+    async def test_close_position_none_read_never_seen_onchain_does_not_complete(self):
+        """Misses on a position never observed on-chain are RPC lag, not a close."""
+        executor = self.get_executor()
+        executor.lp_position_state.position_address = "pos123"
+        executor.lp_position_state.state = LPExecutorStates.CLOSING
+        executor._position_seen_onchain = False
+
+        connector = self.strategy.connectors["solana-mainnet-beta"]
+        connector.get_position_info_fresh = AsyncMock(return_value=None)
+        connector._trigger_remove_liquidity_event = MagicMock()
+
+        for _ in range(4):
+            await executor._close_position()
+        self.assertEqual(executor.lp_position_state.state, LPExecutorStates.CLOSING)
+        connector._trigger_remove_liquidity_event.assert_not_called()
 
     async def test_close_position_already_closed_exception(self):
         """Test _close_position handles position closed exception"""
@@ -1144,17 +1192,22 @@ class TestLPExecutor(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
 
         self.assertEqual(executor.lp_position_state.state, LPExecutorStates.COMPLETE)
 
-    async def test_close_position_not_found_exception(self):
-        """Test _close_position handles position not found exception"""
+    async def test_close_position_not_found_exception_requires_confirmation(self):
+        """The 404-message form of a miss is held to the same gate as a None read."""
         executor = self.get_executor()
         executor.lp_position_state.position_address = "pos123"
+        executor.lp_position_state.state = LPExecutorStates.CLOSING
+        executor._position_seen_onchain = True
 
         connector = self.strategy.connectors["solana-mainnet-beta"]
         connector.get_position_info_fresh = AsyncMock(side_effect=Exception("Position not found: pos123"))
         connector._trigger_remove_liquidity_event = MagicMock()
 
         await executor._close_position()
+        self.assertEqual(executor.lp_position_state.state, LPExecutorStates.CLOSING)
 
+        await executor._close_position()
+        await executor._close_position()
         self.assertEqual(executor.lp_position_state.state, LPExecutorStates.COMPLETE)
 
     async def test_close_position_other_exception_proceeds(self):

--- a/test/hummingbot/strategy_v2/executors/test_executor_base.py
+++ b/test/hummingbot/strategy_v2/executors/test_executor_base.py
@@ -210,6 +210,29 @@ class TestExecutorBase(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
             await self.component.control_loop()
             self.assertGreaterEqual(call_count, 2)
 
+    async def test_control_loop_closes_executor_when_on_start_raises(self):
+        """A failure in on_start must terminate the executor, not strand it.
+
+        on_start runs before the loop's own try/except, so an exception there used to
+        escape control_loop entirely: the executor was never terminated and kept
+        reporting RUNNING with no close_type while nothing ticked it again.
+        """
+        self.component._strategy.current_timestamp = 1234567890
+        failing_start = AsyncMock(side_effect=RuntimeError("cannot price this market"))
+        with patch.object(self.component, "control_task", new_callable=AsyncMock) as mock_task, \
+             patch.object(self.component, "validate_sufficient_balance", failing_start), \
+             patch.object(self.component, "on_stop") as mock_on_stop:
+            self.component.update_interval = 0.01
+            self.component.terminated.clear()
+            await self.component.control_loop()
+
+        self.assertEqual(self.component.close_type, CloseType.FAILED)
+        self.assertEqual(self.component.status, RunnableStatus.TERMINATED)
+        self.assertTrue(self.component.terminated.is_set())
+        # The loop body must never run once startup failed.
+        mock_task.assert_not_called()
+        mock_on_stop.assert_called_once()
+
     async def test_evaluate_max_retries_sets_failed_close_type(self):
         """Test that evaluate_max_retries sets CloseType.FAILED when retries exceeded."""
         self.component._current_retries = 11


### PR DESCRIPTION
## Summary

Hummingbot-side core of the [gateway#678](https://github.com/hummingbot/gateway/issues/678) fix: an Orca LP close that failed once went terminally `FAILED` with the position still open on-chain. Canonical design: [`docs/retry-architecture.md`](https://github.com/hummingbot/gateway/blob/feat/lp-close-retry-ownership/docs/retry-architecture.md) (in the gateway PR). Principle: **Gateway is a stateless transaction oracle; Hummingbot owns retries** — with each layer answering a different question.

### One close-retry loop, owned by the executor

- `_handle_close_failure` stays `CLOSING`: it counts the attempt, arms exponential backoff (2ⁿ s, capped 30 s), and lets `control_task` re-enter with a fresh pre-flight. A Gateway restart now spans a few retries instead of burning the whole budget in seconds.
- The terminal decision moves into the family `evaluate_max_retries` hook (base-class `>` semantics, like order/grid), rather than living inline in the failure handler.
- The executor passes **`max_retries=0`** to the connector, so one CLOSING re-entry is exactly one gateway request. An earlier iteration gave the connector its own opted-in retry set and a `min(3)` inner budget; that produced two nested loops with multiplying budgets for no benefit, since the executor's loop re-reads position state before every re-submit and a connector-level retry cannot.
- **`_execute_with_retry` is back to transport timeouts only**, identically for every operation — what an operation error *means* is the caller's decision. The landed-but-failed branch still raises typed `[code: TX_NOT_CONFIRMED]` so callers can classify it.

### Terminal semantics

Exhaustion with the position still on-chain terminates as an **involuntary `POSITION_HOLD`** (`hold_reason: close_retries_exhausted`) carrying a zero-amount marker order with the position address — so `FAILED` again means "abnormal end with nothing left on-chain", matching `force_stop_with_position_hold`. `PositionHold` cannot book a live LP position as spot amounts; the marker is skipped by accounting but lands the position identity in the durable hold store on both the bot and API topologies, instead of the parallel side-channel an earlier design needed.

### Position reads that cannot lie

`get_position_info_fresh`: uncached read, `None` **only** for a position-specific 404, transient errors re-raise. The cached variant stored `None` like any value (one 404 served for several ticks), and a bare "not found" match also caught the HTTP client's "(Not Found)" suffix on unrelated 404s — either could abandon a live position while reporting success. External-close detection additionally requires the position seen on-chain plus 3 consecutive fresh definitive misses.

### Bounded pending-transaction polling

`update_order_status` polled any in-flight order at 1 s **forever**, and Gateway reported dropped Solana transactions as pending, so such an order never resolved and burned an RPC call per second until restart. With Gateway now reporting `NOT_FOUND (-2)`, the connector treats it as transient while the order is younger than `TX_NOT_FOUND_DEADLINE` (120 s, past blockhash validity) and afterwards feeds each miss to `ClientOrderTracker.process_order_not_found`, whose existing lost-order limit fails the order. `PENDING` stays unbounded by design: the chain has seen that transaction, so it can still confirm.

### Controller

`lp_rebalancer` halts (and skips `position_hold` accounting for) executors that ended with a live position — re-creating one would mint a second position on top of the stranded one, since a fresh `lp_executor` cannot adopt an existing position.

## Companion PRs

- **Design doc**: [`docs/retry-architecture.md`](https://github.com/hummingbot/gateway/blob/feat/lp-close-retry-ownership/docs/retry-architecture.md) (in the gateway PR)
- **gateway** hummingbot/gateway#679 — typed errors, pre-broadcast simulation guard, position-info contract, unified poll status contract, `binCount` on unified CLMM pool-info
- **hummingbot** hummingbot/hummingbot#8424 — executor-owned close retry loop, involuntary `POSITION_HOLD`, fresh position reads, bounded pending-tx polling
- **hummingbot-api** hummingbot/hummingbot-api#217 — orphan flag/listing/resolve, DB-aware stop, `bin_count` passthrough, Raydium routed through Gateway
- **hummingbot-api-client** hummingbot/hummingbot-api-client#25 — `bin_count` on `get_pool_info` (1.5.8)
- **condor** hummingbot/condor#204 — agent visibility, orphaned/resolve_orphan actions, `bin_count` on `get_pool_info`

## Validation

190 tests pass (lp_executor + gateway connector suites, incl. new contract tests for the NOT_FOUND deadline and the timeouts-only classifier), flake8 clean, merged with latest `development`.

Validated live on mainnet (Orca SOL-USDC) with the companion branches deployed:
- Clean funded cycles: open → `IN_RANGE` with on-chain amounts matching, close first-attempt (`close_retries: 0`), rent refunded.
- Forced-failure cascade: 11 bounded attempts producing **exactly 11 gateway requests** (the nested design would have sent 33), backoff measured at 4/5/10/17/32/30/33/31/31/30 s, terminating as the involuntary hold with the marker order — then recovered with all funds + rent via a direct gateway close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mt84XBEMVxbbyMG8fDxDKj
