### PR TITLE
fix/hyperliquid funding rate in websocket updates

### DIFF
--- a/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_api_order_book_data_source.py
+++ b/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_api_order_book_data_source.py
@@ -288,7 +288,7 @@ class HyperliquidPerpetualAPIOrderBookDataSource(PerpetualAPIOrderBookDataSource
                 index_price=Decimal(str(ctx.get("oraclePx", "0"))),
                 mark_price=Decimal(str(ctx.get("markPx", "0"))),
                 next_funding_utc_timestamp=self._next_funding_time(),
-                rate=Decimal(str(ctx.get("openInterest", ctx.get("funding", "0")))),
+                rate=Decimal(str(ctx.get("funding", "0"))),
             )
 
             message_queue.put_nowait(funding_info)

--- a/test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_api_order_book_data_source.py
@@ -553,7 +553,7 @@ class HyperliquidPerpetualAPIOrderBookDataSourceTests(IsolatedAsyncioWrapperTest
                 "ctx": {
                     "oraclePx": "36717.0",
                     "markPx": "36733.0",
-                    "openInterest": "0.00001793",  # This is used as the rate
+                    "openInterest": "34.37756",
                     "funding": "0.00001793"
                 }
             }


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [x] Your code builds clean without any errors or warnings
- [x] Tests all pass
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

Existing deprecation warnings are unrelated to this change.

**A description of the changes proposed in the pull request**:

Fixes #8413.

The Hyperliquid WebSocket funding info parser was using `openInterest` as the funding rate when processing asset context updates. This caused the reported funding rate to contain the open interest value instead of the actual funding rate.

This change updates `FundingInfoUpdate.rate` to use the `funding` field and updates the regression test so `openInterest` and `funding` have distinct values.

**Tests performed by the developer**:

Ran:

`pytest test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_api_order_book_data_source.py`

Result: 30 passed.

**Tips for QA testing**:

Verify that Hyperliquid perpetual funding info updates report the value from the `funding` field rather than `openInterest`.