### PR TITLE
Update Derive Perpetual private key prompt to session private key

### DIFF
--- a/hummingbot/connector/derivative/derive_perpetual/derive_perpetual_utils.py
+++ b/hummingbot/connector/derivative/derive_perpetual/derive_perpetual_utils.py
@@ -33,7 +33,7 @@ class DerivePerpetualConfigMap(BaseConnectorConfigMap):
     derive_perpetual_api_secret: SecretStr = Field(
         default=...,
         json_schema_extra={
-            "prompt": "Enter your wallet private key",
+            "prompt": "Enter your session private key",
             "is_secure": True,
             "is_connect_key": True,
             "prompt_on_new": True,
@@ -81,7 +81,7 @@ class DerivePerpetualTestnetConfigMap(BaseConnectorConfigMap):
     derive_perpetual_testnet_api_secret: SecretStr = Field(
         default=...,
         json_schema_extra={
-            "prompt": "Enter your wallet private key",
+            "prompt": "Enter your session private key",
             "is_secure": True,
             "is_connect_key": True,
             "prompt_on_new": True,


### PR DESCRIPTION
## Summary
- Derive's `connect derive_perpetual` flow asks users for a **session private key**, not their wallet private key. Update the CLI prompt text for both the mainnet and testnet connector config maps to say "Enter your session private key" instead of "Enter your wallet private key".

## Test plan
- [x] Ran `connect derive_perpetual` locally and confirmed the updated prompt text displays as expected.
- [x] No behavioral/logic changes — only the prompt string was updated.
