### PR TITLE
(fix) align DCA stage simulation timestamps

### DIFF
--- a/hummingbot/strategy_v2/backtesting/executors_simulator/dca_executor_simulator.py
+++ b/hummingbot/strategy_v2/backtesting/executors_simulator/dca_executor_simulator.py
@@ -122,14 +122,15 @@ class DCAExecutorSimulator(ExecutorSimulatorBase):
         close_type = None
 
         for i, dca_stage in enumerate(potential_dca_stages):
-            if dca_stage['close_type'] is None:
-                df_filtered.loc[entry_timestamp:, f'filled_amount_quote_{i}'] = dca_stage['amount']
-                df_filtered.loc[entry_timestamp:, f'net_pnl_quote_{i}'] = dca_stage['cumulative_returns'] * dca_stage['amount']
-                df_filtered.loc[entry_timestamp:, 'current_position_average_price'] = dca_stage['break_even_price']
-            else:
-                df_filtered.loc[entry_timestamp:, f'filled_amount_quote_{i}'] = dca_stage['amount']
-                df_filtered.loc[entry_timestamp:, f'net_pnl_quote_{i}'] = dca_stage['cumulative_returns'] * dca_stage['amount']
-                df_filtered.loc[entry_timestamp:, 'current_position_average_price'] = dca_stage['break_even_price']
+            stage_entry_timestamp = dca_stage['entry_timestamp']
+            stage_index = df_filtered.loc[stage_entry_timestamp:].index
+            stage_returns = dca_stage['cumulative_returns'].to_numpy()
+
+            df_filtered.loc[stage_index, f'filled_amount_quote_{i}'] = dca_stage['amount']
+            df_filtered.loc[stage_index, f'net_pnl_quote_{i}'] = stage_returns * dca_stage['amount']
+            df_filtered.loc[stage_index, 'current_position_average_price'] = dca_stage['break_even_price']
+
+            if dca_stage['close_type'] is not None:
                 close_type = dca_stage['close_type']
                 last_timestamp = dca_stage['close_timestamp']
                 break

--- a/test/hummingbot/strategy_v2/backtesting/executors_simulator/test_dca_executor_simulator.py
+++ b/test/hummingbot/strategy_v2/backtesting/executors_simulator/test_dca_executor_simulator.py
@@ -1,0 +1,43 @@
+import unittest
+from decimal import Decimal
+
+import pandas as pd
+
+from hummingbot.core.data_type.common import TradeType
+from hummingbot.strategy_v2.backtesting.executors_simulator.dca_executor_simulator import DCAExecutorSimulator
+from hummingbot.strategy_v2.executors.dca_executor.data_types import DCAExecutorConfig
+
+
+class TestDCAExecutorSimulator(unittest.TestCase):
+
+    def test_each_stage_uses_its_own_entry_timestamp(self):
+        timestamps = [1000.0, 1001.0, 1002.0, 1003.0, 1004.0]
+        close_prices = [105.0, 100.0, 95.0, 90.0, 92.0]
+        df = pd.DataFrame(
+            {
+                "timestamp": timestamps,
+                "open": close_prices,
+                "high": [price + 1 for price in close_prices],
+                "low": [price - 1 for price in close_prices],
+                "close": close_prices,
+                "volume": [1.0] * len(timestamps),
+            },
+            index=timestamps,
+        )
+        config = DCAExecutorConfig(
+            id="test",
+            timestamp=timestamps[0],
+            connector_name="binance",
+            trading_pair="ETH-USDT",
+            side=TradeType.BUY,
+            amounts_quote=[Decimal("10"), Decimal("10")],
+            prices=[Decimal("100"), Decimal("90")],
+            stop_loss=Decimal("0.5"),
+        )
+
+        result = DCAExecutorSimulator().simulate(df, config, trade_cost=0).executor_simulation
+
+        self.assertEqual(10.0, result.loc[1001.0, "filled_amount_quote_0"])
+        self.assertEqual(0.0, result.loc[1001.0, "filled_amount_quote_1"])
+        self.assertEqual(10.0, result.loc[1003.0, "filled_amount_quote_0"])
+        self.assertEqual(10.0, result.loc[1003.0, "filled_amount_quote_1"])


### PR DESCRIPTION
## Description

Use each DCA stage's stored entry timestamp when writing its simulated fills and PnL.

The simulator first records a separate `entry_timestamp` for every potential stage. Its second loop currently uses the `entry_timestamp` local left over from the final first-loop iteration for every stage. Earlier stages therefore appear to enter only when the last stage enters, and their cumulative-return Series may not match the selected pandas slice.

This change selects the target index from `dca_stage['entry_timestamp']` and assigns the corresponding cumulative-return values to that exact index. It does not change DCA barrier or close logic.

## Related Issue

Fixes #8405.

## Tests

Added `TestDCAExecutorSimulator.test_each_stage_uses_its_own_entry_timestamp` with two levels entering at different timestamps. It asserts that the first level is filled before the second and that both are filled after the second entry.

Local verification performed:

- isolated red/green execution of the actual simulator source;
- a full Cython `build_ext --inplace` of all 60 Hummingbot extensions;
- focused pytest in that built environment: `1 passed`;
- `isort --check-only`, `flake8`, and the repository's selected `autopep8`
  rules for both changed files;
- `git diff --check`.

## Checklist

- [x] The change is scoped to the reported simulator bug.
- [x] A regression test is included.
- [x] No strategy parameters or trading decisions are changed.
- [x] Focused pytest passes with the project's Cython extensions built.
