### PR TITLE
fix(gateway): stop Gateway executor startup failures from stranding executors

### DIFF
--- a/hummingbot/connector/gateway/gateway.py
+++ b/hummingbot/connector/gateway/gateway.py
@@ -29,7 +29,7 @@ from hummingbot.core.event.events import (
 )
 from hummingbot.core.rate_oracle.rate_oracle import RateOracle
 from hummingbot.core.utils import async_ttl_cache
-from hummingbot.core.utils.async_utils import safe_ensure_future
+from hummingbot.core.utils.async_utils import safe_ensure_future, safe_gather
 
 
 class TokenInfo(BaseModel):
@@ -133,11 +133,41 @@ class Gateway(GatewayBase):
         # Fall back to NaN if no cached price
         return Decimal("nan")
 
+    async def get_last_traded_prices(self, trading_pairs: List[str]) -> Dict[str, float]:
+        """
+        Return a dictionary with the trading pair as key and its current price as value,
+        for each trading pair passed as parameter.
+
+        ExchangeBase supplies this fan-out for order-book connectors, but Gateway
+        extends ConnectorBase directly and so never inherited it. That left
+        _get_last_traded_price below with no caller at all, and every consumer of the
+        plural form raising AttributeError instead of returning prices.
+
+        A pair that cannot be priced is omitted rather than reported as zero, so a
+        caller can tell "no price available" from "the price is 0".
+
+        :param trading_pairs: list of trading pairs to get the prices for
+        :returns: Dictionary of associations between token pair and its latest price
+        """
+        results = await safe_gather(
+            *[self._get_last_traded_price(trading_pair=trading_pair) for trading_pair in trading_pairs],
+            return_exceptions=True,
+        )
+        prices: Dict[str, float] = {}
+        for trading_pair, price in zip(trading_pairs, results):
+            if isinstance(price, Exception):
+                self.logger().warning(f"Failed to get last traded price for {trading_pair}: {price}")
+                continue
+            if price and price > 0:
+                prices[trading_pair] = price
+        return prices
+
     async def _get_last_traded_price(self, trading_pair: str) -> float:
         """
         Gets the last traded price for a trading pair.
 
-        Uses RateOracle for cached prices (set by MarketDataProvider).
+        Prefers the RateOracle cache (set by MarketDataProvider) and falls back to a
+        Gateway quote.
 
         :param trading_pair: The market trading pair
         :returns: The last traded price or 0 if not available
@@ -149,6 +179,18 @@ class Gateway(GatewayBase):
                 return float(price)
         except Exception:
             pass
+        # The oracle only holds pairs MarketDataProvider was asked to track, so a pair
+        # priced on demand -- a pool just opened in a dashboard, a memecoin addressed by
+        # mint -- finds nothing cached and used to fall straight through to 0. Quote it
+        # instead: Gateway prices anything the configured swap provider can route.
+        try:
+            quoted = await self.get_quote_price(trading_pair, is_buy=True, amount=Decimal("1"))
+            if quoted and quoted > 0:
+                return float(quoted)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self.logger().debug(f"Could not quote a fallback price for {trading_pair}.", exc_info=True)
         return 0.0
 
     @staticmethod

--- a/hummingbot/core/data_type/order_candidate.py
+++ b/hummingbot/core/data_type/order_candidate.py
@@ -190,7 +190,11 @@ class OrderCandidate:
             token, amount = self.percent_fee_collateral
             if token == self.order_collateral.token:
                 amount += self.order_collateral.amount
-            if available_balances[token] < amount:
+            # A candidate priced from a venue with no order book carries a NaN price,
+            # which propagates into this amount. `Decimal < NaN` raises InvalidOperation
+            # rather than returning False, so the comparison is guarded the same way
+            # _adjust_for_order_collateral guards its own.
+            if not amount.is_nan() and available_balances[token] < amount:
                 scaler = available_balances[token] / amount
                 self._scale_order(scaler)
 

--- a/hummingbot/strategy_v2/executors/executor_base.py
+++ b/hummingbot/strategy_v2/executors/executor_base.py
@@ -191,7 +191,17 @@ class ExecutorBase(RunnableBase):
         """
         Override control loop to evaluate max retries after each control task.
         """
-        await self.on_start()
+        try:
+            await self.on_start()
+        except Exception as e:
+            # on_start() runs before the retry loop below, so an exception here used to
+            # escape control_loop altogether and strand the executor: never terminated,
+            # so it kept reporting RUNNING/is_active with no close_type, and nothing
+            # ticked it again. Close it as FAILED instead, so a startup failure reaches
+            # a terminal state and stays visible rather than becoming a silent zombie.
+            self.logger().error(f"Executor failed to start: {e}", exc_info=True)
+            self.close_type = CloseType.FAILED
+            self.stop()
         while not self.terminated.is_set():
             try:
                 await self.control_task()

--- a/test/hummingbot/connector/gateway/test_gateway_last_traded_prices.py
+++ b/test/hummingbot/connector/gateway/test_gateway_last_traded_prices.py
@@ -1,0 +1,68 @@
+import unittest
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from hummingbot.connector.gateway.gateway import Gateway
+
+
+class GatewayLastTradedPricesTests(unittest.IsolatedAsyncioTestCase):
+    """Gateway must expose the plural get_last_traded_prices fan-out.
+
+    ExchangeBase provides it for order-book connectors, but Gateway extends
+    ConnectorBase directly and so never inherited it -- leaving the per-pair
+    _get_last_traded_price with no caller, and every consumer of the plural form
+    (Hummingbot API's market-data route among them) raising AttributeError.
+    """
+
+    PAIR = "ANSEM-SOL"
+    OTHER_PAIR = "SOL-USDC"
+
+    def setUp(self):
+        self.connector = Gateway.__new__(Gateway)
+        self.connector._logger = MagicMock()
+
+    async def test_returns_a_price_per_pair(self):
+        with patch.object(Gateway, "_get_last_traded_price", new_callable=AsyncMock) as mock_price:
+            mock_price.side_effect = [1.5, 200.0]
+            prices = await self.connector.get_last_traded_prices([self.PAIR, self.OTHER_PAIR])
+
+        self.assertEqual({self.PAIR: 1.5, self.OTHER_PAIR: 200.0}, prices)
+
+    async def test_unpriceable_pair_is_omitted_not_zeroed(self):
+        """A caller must be able to tell "no price" from "the price is 0"."""
+        with patch.object(Gateway, "_get_last_traded_price", new_callable=AsyncMock) as mock_price:
+            mock_price.side_effect = [0.0, 200.0]
+            prices = await self.connector.get_last_traded_prices([self.PAIR, self.OTHER_PAIR])
+
+        self.assertNotIn(self.PAIR, prices)
+        self.assertEqual(200.0, prices[self.OTHER_PAIR])
+
+    async def test_one_failing_pair_does_not_sink_the_others(self):
+        with patch.object(Gateway, "_get_last_traded_price", new_callable=AsyncMock) as mock_price:
+            mock_price.side_effect = [RuntimeError("gateway unreachable"), 200.0]
+            prices = await self.connector.get_last_traded_prices([self.PAIR, self.OTHER_PAIR])
+
+        self.assertNotIn(self.PAIR, prices)
+        self.assertEqual(200.0, prices[self.OTHER_PAIR])
+
+    async def test_falls_back_to_a_quote_when_the_oracle_is_empty(self):
+        """The oracle only holds pairs MarketDataProvider tracks; quote the rest."""
+        with patch("hummingbot.connector.gateway.gateway.RateOracle") as mock_oracle, \
+             patch.object(Gateway, "get_quote_price", new_callable=AsyncMock) as mock_quote:
+            mock_oracle.get_instance.return_value.get_pair_rate.return_value = None
+            mock_quote.return_value = Decimal("0.000000028336")
+
+            price = await self.connector._get_last_traded_price(self.PAIR)
+
+        mock_quote.assert_awaited_once()
+        self.assertAlmostEqual(2.8336e-8, price)
+
+    async def test_cached_rate_is_preferred_over_a_quote(self):
+        with patch("hummingbot.connector.gateway.gateway.RateOracle") as mock_oracle, \
+             patch.object(Gateway, "get_quote_price", new_callable=AsyncMock) as mock_quote:
+            mock_oracle.get_instance.return_value.get_pair_rate.return_value = Decimal("1.5")
+
+            price = await self.connector._get_last_traded_price(self.PAIR)
+
+        mock_quote.assert_not_awaited()
+        self.assertEqual(1.5, price)

--- a/test/hummingbot/connector/test_budget_checker.py
+++ b/test/hummingbot/connector/test_budget_checker.py
@@ -562,3 +562,35 @@ class BudgetCheckerTest(unittest.TestCase):
 
         self.assertEqual(Decimal("7"), first_adjusted_candidate.amount)
         self.assertEqual(Decimal("5"), second_adjusted_candidate.amount)
+
+    def test_adjust_candidate_with_nan_price_does_not_raise(self):
+        """A NaN-priced candidate must be handled, not blow up the caller.
+
+        A venue with no order book (a Gateway swap) prices a candidate as NaN, which
+        propagates into both collateral amounts. `Decimal < NaN` raises
+        InvalidOperation rather than returning False, so both comparisons in
+        OrderCandidate.adjust_from_balances have to be NaN-guarded -- the order
+        collateral one always was, the percent-fee one was not.
+        """
+        self.exchange.set_balanced_order_book(
+            trading_pair=self.trading_pair,
+            mid_price=Decimal("2"),
+            min_price=Decimal("1"),
+            max_price=Decimal("3"),
+            price_step_size=Decimal("1"),
+            volume_step_size=Decimal("1"),
+        )
+        self.exchange.set_balance(self.quote_asset, Decimal("100"))
+        order_candidate = OrderCandidate(
+            trading_pair=self.trading_pair,
+            is_maker=False,
+            order_type=OrderType.LIMIT,
+            order_side=TradeType.BUY,
+            amount=Decimal("10"),
+            price=Decimal("nan"),
+        )
+
+        adjusted_candidate = self.budget_checker.adjust_candidate(order_candidate, all_or_none=False)
+
+        # Nothing can be scaled from a NaN price, so the amount is left untouched.
+        self.assertEqual(Decimal("10"), adjusted_candidate.amount)

--- a/test/hummingbot/strategy_v2/executors/test_executor_base.py
+++ b/test/hummingbot/strategy_v2/executors/test_executor_base.py
@@ -210,6 +210,29 @@ class TestExecutorBase(IsolatedAsyncioWrapperTestCase, LoggerMixinForTest):
             await self.component.control_loop()
             self.assertGreaterEqual(call_count, 2)
 
+    async def test_control_loop_closes_executor_when_on_start_raises(self):
+        """A failure in on_start must terminate the executor, not strand it.
+
+        on_start runs before the loop's own try/except, so an exception there used to
+        escape control_loop entirely: the executor was never terminated and kept
+        reporting RUNNING with no close_type while nothing ticked it again.
+        """
+        self.component._strategy.current_timestamp = 1234567890
+        failing_start = AsyncMock(side_effect=RuntimeError("cannot price this market"))
+        with patch.object(self.component, "control_task", new_callable=AsyncMock) as mock_task, \
+             patch.object(self.component, "validate_sufficient_balance", failing_start), \
+             patch.object(self.component, "on_stop") as mock_on_stop:
+            self.component.update_interval = 0.01
+            self.component.terminated.clear()
+            await self.component.control_loop()
+
+        self.assertEqual(self.component.close_type, CloseType.FAILED)
+        self.assertEqual(self.component.status, RunnableStatus.TERMINATED)
+        self.assertTrue(self.component.terminated.is_set())
+        # The loop body must never run once startup failed.
+        mock_task.assert_not_called()
+        mock_on_stop.assert_called_once()
+
     async def test_evaluate_max_retries_sets_failed_close_type(self):
         """Test that evaluate_max_retries sets CloseType.FAILED when retries exceeded."""
         self.component._current_retries = 11


### PR DESCRIPTION
## Problem

An `OrderExecutor` created against a Gateway swap connector died on creation, leaving a
permanently stuck record: `status=RUNNING`, `is_active=true`, `close_type=null`,
`order_id=null`, `current_retries=0/10`. It placed no order and never retried. Nothing in
the executor's own state said anything was wrong — the failure was only visible in the API
logs, as a single unhandled-background-task line.

```
hummingbot.core.utils.async_utils - ERROR - Unhandled error in background task
  executor_base.py:194 in control_loop   -> await self.on_start()
  executor_base.py:182 in on_start       -> await self.validate_sufficient_balance()
  order_executor.py:376                  -> self.adjust_order_candidates(...)
  budget_checker.py:99                   -> order_candidate.adjust_from_balances(...)
  order_candidate.py:193 _adjust_for_percent_fee_collateral
    if available_balances[token] < amount:
decimal.InvalidOperation
```

Three independent faults line up to produce it:

1. **`Gateway.get_price_by_type` returns `Decimal("nan")`** when the `RateOracle` has no
   cached rate for the pair — which is always the case for a pair priced on demand.
2. **`_adjust_for_percent_fee_collateral` does not guard against NaN**, while
   `_adjust_for_order_collateral` twelve lines above it does. `Decimal < NaN` raises
   `InvalidOperation` rather than returning `False`.
3. **`control_loop` awaits `on_start()` outside its `try/except`**, so the exception escapes
   the coroutine entirely. The executor is never terminated and never reaches a close type.

#8377 (`a86a5babe`) fixed the immediate trigger by skipping the `BudgetChecker` for
`GatewayBase` connectors. That is correct and is what makes Gateway swaps work today. This
PR fixes the three faults underneath it, so the next startup failure — from any cause, on
any connector — announces itself instead of leaving an executor to be autopsied.

## Changes

**`fix(executors)` — close the executor as FAILED when `on_start` raises.**
Wraps `on_start()` and sets `CloseType.FAILED`. `stop()` sets `terminated`, so the loop body
is skipped and `on_stop()` still runs: the failure path exits exactly like a normal shutdown.

**`fix(order-candidate)` — guard the percent-fee collateral comparison against NaN.**
Applies the same `not amount.is_nan()` guard its sibling already has.

**`fix(gateway)` — expose the plural `get_last_traded_prices` fan-out.**
`ExchangeBase` supplies this for order-book connectors; `Gateway` extends `ConnectorBase`
directly and never inherited it, which left the `_get_last_traded_price` it *does* define
with no caller at all, and every consumer of the plural form raising `AttributeError`.
Unpriceable pairs are omitted rather than reported as `0.0`, so a caller can distinguish
"no price available" from "the price is 0", and one pair's failure does not sink the batch.

Also gives `_get_last_traded_price` a quote fallback. It only read the `RateOracle`, which
`MarketDataProvider` populates for pairs it was asked to track — so a pair priced on demand
found nothing cached and fell through to `0`. Gateway can quote anything the configured swap
provider routes.

## Testing

`441 passed` across `test/hummingbot/strategy_v2/executors/`,
`test/hummingbot/connector/gateway/`, `test/hummingbot/connector/test_budget_checker.py`
and `test/hummingbot/connector/derivative/test_perpetual_budget_checker.py`. flake8 clean.

New tests, and confirmation they are real regression tests: reverting each of the first two
fixes turns its test red and restoring it turns it green (verified individually, not
assumed). The Gateway tests cover new surface, so there is nothing to regress against; they
cover the fan-out, omit-vs-zero, partial failure, oracle-hit and quote-fallback paths.

## Notes for reviewers

- **`RunnableBase.control_loop` has the identical shape** (`runnable_base.py:66`). Left
  alone deliberately: it has no `close_type`, so the fix there would differ, and widening
  scope silently seemed wrong. Worth a follow-up.
- **The quote fallback costs a network round-trip** per uncached pair, quoting
  `amount=Decimal("1")`. On a very thin pool a 1-unit quote may return nothing, degrading to
  the current `0.0`. If that latency is unwelcome, the fan-out alone still fixes the
  `AttributeError` — the fallback is a separable hunk.

## Verification against a live network

Reproduced and fixed against `solana-mainnet-beta` with a pump.fun memecoin addressed by
mint (`tw2tCHuurgg...pump-SOL`). The crash reproduced identically via the mint-form and
symbol-form pair, with the frontend out of the loop. After upgrading to `20260729`, the same
payload filled: 1,023,797.94 tokens for 0.029010595 SOL, tx `4avH73dT...`, executor closing
cleanly as `POSITION_HOLD` with retries 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
