### PR TITLE
(derive) rename config keys to reflect session-key auth

### DIFF
--- a/hummingbot/connector/derivative/derive_perpetual/derive_perpetual_api_user_stream_data_source.py
+++ b/hummingbot/connector/derivative/derive_perpetual/derive_perpetual_api_user_stream_data_source.py
@@ -87,7 +87,7 @@ class DerivePerpetualAPIUserStreamDataSource(UserStreamTrackerDataSource):
         return ws
 
     async def _subscribe_channels(self, websocket_assistant: WSAssistant):
-        subaccount_id = self._connector._sub_id
+        subaccount_id = self._connector._subacct_id
         try:
             await self._authenticate(websocket_assistant)  # Authenticate once
 

--- a/hummingbot/connector/derivative/derive_perpetual/derive_perpetual_auth.py
+++ b/hummingbot/connector/derivative/derive_perpetual/derive_perpetual_auth.py
@@ -22,15 +22,15 @@ class DerivePerpetualAuth(AuthBase):
     Auth class required by DerivePerpetual API
     """
 
-    def __init__(self, api_key: str, api_secret: str, sub_id: int, trading_required: bool, domain: str):
-        self._api_key: str = api_key
-        self._api_secret: str = api_secret
-        self._sub_id: int = sub_id
+    def __init__(self, wallet_address: str, session_private_key: str, subacct_id: int, trading_required: bool, domain: str):
+        self._wallet_address: str = wallet_address
+        self._session_private_key: str = session_private_key
+        self._subacct_id: int = subacct_id
         self._trading_required: bool = trading_required
         self._w3 = Web3()
         self._domain = domain
         if trading_required:
-            self.session_key_wallet = Web3().eth.account.from_key(self._api_secret)
+            self.session_key_wallet = Web3().eth.account.from_key(self._session_private_key)
 
     async def ws_authenticate(self, request: WSRequest) -> WSRequest:
         """
@@ -62,14 +62,14 @@ class DerivePerpetualAuth(AuthBase):
         payload = {}
         timestamp = str(self.utc_now_ms())
         signature = to_0x_hex(self._w3.eth.account.sign_message(
-            encode_defunct(text=timestamp), private_key=self._api_secret
+            encode_defunct(text=timestamp), private_key=self._session_private_key
         ).signature)
         """
         This method is intended to configure a websocket request to be authenticated. Dexalot does not use this
         functionality
         """
         payload["accept"] = 'application/json'
-        payload["wallet"] = self._api_key
+        payload["wallet"] = self._wallet_address
         payload["timestamp"] = timestamp
         payload["signature"] = signature
         return payload
@@ -97,8 +97,8 @@ class DerivePerpetualAuth(AuthBase):
         domain_seperator = CONSTANTS.DOMAIN_SEPARATOR if "testnet" not in self._domain else CONSTANTS.TESTNET_DOMAIN_SEPARATOR
         action_typehash = CONSTANTS.ACTION_TYPEHASH if "testnet" not in self._domain else CONSTANTS.TESTNET_ACTION_TYPEHASH
         action = SignedAction(
-            subaccount_id=int(self._sub_id),
-            owner=self._api_key,
+            subaccount_id=int(self._subacct_id),
+            owner=self._wallet_address,
             signer=self.session_key_wallet.address,
             signature_expiry_sec=MAX_INT_32,
             nonce=get_action_nonce(),
@@ -125,12 +125,12 @@ class DerivePerpetualAuth(AuthBase):
     def header_for_authentication(self) -> Dict[str, str]:
         timestamp = str(self.utc_now_ms())
         signature = to_0x_hex(self._w3.eth.account.sign_message(
-            encode_defunct(text=timestamp), private_key=self._api_secret
+            encode_defunct(text=timestamp), private_key=self._session_private_key
         ).signature)
         payload = {}
 
         payload["accept"] = 'application/json'
-        payload["X-LyraWallet"] = self._api_key
+        payload["X-LyraWallet"] = self._wallet_address
         payload["X-LyraTimestamp"] = timestamp
         payload["X-LyraSignature"] = signature
         return payload

--- a/hummingbot/connector/derivative/derive_perpetual/derive_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/derive_perpetual/derive_perpetual_derivative.py
@@ -45,17 +45,17 @@ class DerivePerpetualDerivative(PerpetualDerivativePyBase):
             self,
             balance_asset_limit: Optional[Dict[str, Dict[str, Decimal]]] = None,
             rate_limits_share_pct: Decimal = Decimal("100"),
-            derive_perpetual_api_secret: str = None,
-            sub_id: int = None,
+            session_private_key: str = None,
+            subacct_id: int = None,
             account_type: str = None,
-            derive_perpetual_api_key: str = None,
+            derive_perpetual_wallet_address: str = None,
             trading_pairs: Optional[List[str]] = None,
             trading_required: bool = True,
             domain: str = CONSTANTS.DEFAULT_DOMAIN,
     ):
-        self.derive_perpetual_api_key = derive_perpetual_api_key
-        self.derive_perpetual_secret_key = derive_perpetual_api_secret
-        self._sub_id = sub_id
+        self.derive_perpetual_wallet_address = derive_perpetual_wallet_address
+        self.session_private_key = session_private_key
+        self._subacct_id = subacct_id
         self._trading_required = trading_required
         self._trading_pairs = trading_pairs
         self._domain = domain
@@ -79,9 +79,9 @@ class DerivePerpetualDerivative(PerpetualDerivativePyBase):
     @property
     def authenticator(self) -> DerivePerpetualAuth:
         return DerivePerpetualAuth(
-            self.derive_perpetual_api_key,
-            self.derive_perpetual_secret_key,
-            self._sub_id,
+            self.derive_perpetual_wallet_address,
+            self.session_private_key,
+            self._subacct_id,
             self._trading_required,
             self._domain)
 
@@ -360,7 +360,7 @@ class DerivePerpetualDerivative(PerpetualDerivativePyBase):
         api_params = {
             "instrument_name": symbol,
             "order_id": oid,
-            "subaccount_id": int(self._sub_id)
+            "subaccount_id": int(self._subacct_id)
         }
         cancel_result = await self._api_post(
             path_url=CONSTANTS.CANCEL_ORDER_URL,
@@ -502,7 +502,7 @@ class DerivePerpetualDerivative(PerpetualDerivativePyBase):
             "referral_code": CONSTANTS.REFERRAL_CODE,
             "mmp": False,
             "time_in_force": param_order_type,
-            "recipient_id": self._sub_id,
+            "recipient_id": self._subacct_id,
         }
 
         order_result = await self._api_post(
@@ -528,7 +528,7 @@ class DerivePerpetualDerivative(PerpetualDerivativePyBase):
                 all_fills_response = await self._api_get(
                     path_url=CONSTANTS.MY_TRADES_PATH_URL,
                     params={
-                        "subaccount_id": self._sub_id
+                        "subaccount_id": self._subacct_id
                     },
                     is_auth_required=True,
                     limit_id=CONSTANTS.MY_TRADES_PATH_URL)
@@ -593,8 +593,8 @@ class DerivePerpetualDerivative(PerpetualDerivativePyBase):
         Traders, Orders, and Balance updates from the WS.
         """
         user_channels = [
-            f"{self._sub_id}.{CONSTANTS.USER_ORDERS_ENDPOINT_NAME}",
-            f"{self._sub_id}.{CONSTANTS.USEREVENT_ENDPOINT_NAME}",
+            f"{self._subacct_id}.{CONSTANTS.USER_ORDERS_ENDPOINT_NAME}",
+            f"{self._subacct_id}.{CONSTANTS.USEREVENT_ENDPOINT_NAME}",
             "positions",
             "collaterals",
         ]
@@ -829,7 +829,7 @@ class DerivePerpetualDerivative(PerpetualDerivativePyBase):
 
         account_info = await self._api_post(
             path_url=CONSTANTS.ACCOUNTS_PATH_URL,
-            data={"subaccount_id": self._sub_id},
+            data={"subaccount_id": self._subacct_id},
             is_auth_required=True)
         if "error" in account_info:
             self.logger().error(f"Error fetching account balances: {account_info['error']['message']}")
@@ -855,7 +855,7 @@ class DerivePerpetualDerivative(PerpetualDerivativePyBase):
         order_update = await self._api_post(
             path_url=CONSTANTS.ORDER_STATUS_PAATH_URL,
             data={
-                "subaccount_id": self._sub_id,
+                "subaccount_id": self._subacct_id,
                 "order_id": oid
             },
             is_auth_required=True)
@@ -881,7 +881,7 @@ class DerivePerpetualDerivative(PerpetualDerivativePyBase):
                 params={
                     "instrument_name": trading_pair,
                     "order_id": exchange_order_id,
-                    "subaccount_id": self._sub_id
+                    "subaccount_id": self._subacct_id
                 },
                 is_auth_required=True,
                 limit_id=CONSTANTS.MY_TRADES_PATH_URL)
@@ -943,7 +943,7 @@ class DerivePerpetualDerivative(PerpetualDerivativePyBase):
 
     async def _update_positions(self):
         positions = await self._api_post(path_url=CONSTANTS.POSITION_INFORMATION_URL,
-                                         data={"subaccount_id": self._sub_id},
+                                         data={"subaccount_id": self._subacct_id},
                                          is_auth_required=True,
                                          limit_id=CONSTANTS.POSITION_INFORMATION_URL)
         if "result" in positions:
@@ -1003,7 +1003,7 @@ class DerivePerpetualDerivative(PerpetualDerivativePyBase):
                 "page_size": 100,
                 "start_timestamp": self._last_funding_time(),
                 "instrument_name": symbol,
-                "subaccount_id": self._sub_id
+                "subaccount_id": self._subacct_id
             },
             is_auth_required=True,
             limit_id=CONSTANTS.GET_LAST_FUNDING_RATE_PATH_URL)

--- a/hummingbot/connector/derivative/derive_perpetual/derive_perpetual_utils.py
+++ b/hummingbot/connector/derivative/derive_perpetual/derive_perpetual_utils.py
@@ -21,7 +21,7 @@ BROKER_ID = "HBOT"
 
 class DerivePerpetualConfigMap(BaseConnectorConfigMap):
     connector: str = "derive_perpetual"
-    derive_perpetual_api_key: SecretStr = Field(
+    derive_perpetual_wallet_address: SecretStr = Field(
         default=...,
         json_schema_extra={
             "prompt": "Enter your DerivePerpetual Wallet address",
@@ -30,16 +30,16 @@ class DerivePerpetualConfigMap(BaseConnectorConfigMap):
             "prompt_on_new": True,
         }
     )
-    derive_perpetual_api_secret: SecretStr = Field(
+    session_private_key: SecretStr = Field(
         default=...,
         json_schema_extra={
-            "prompt": "Enter your wallet private key",
+            "prompt": "Enter your session private key",
             "is_secure": True,
             "is_connect_key": True,
             "prompt_on_new": True,
         }
     )
-    sub_id: SecretStr = Field(
+    subacct_id: SecretStr = Field(
         default=...,
         json_schema_extra={
             "prompt": "Enter your Subaccount Id",
@@ -69,7 +69,7 @@ OTHER_DOMAINS_DEFAULT_FEES = {"derive_perpetual_testnet": [0, 0.025]}
 
 class DerivePerpetualTestnetConfigMap(BaseConnectorConfigMap):
     connector: str = "derive_perpetual_testnet"
-    derive_perpetual_testnet_api_key: SecretStr = Field(
+    derive_perpetual_testnet_wallet_address: SecretStr = Field(
         default=...,
         json_schema_extra={
             "prompt": "Enter your DerivePerpetual Wallet address",
@@ -78,16 +78,16 @@ class DerivePerpetualTestnetConfigMap(BaseConnectorConfigMap):
             "prompt_on_new": True,
         }
     )
-    derive_perpetual_testnet_api_secret: SecretStr = Field(
+    session_private_key: SecretStr = Field(
         default=...,
         json_schema_extra={
-            "prompt": "Enter your wallet private key",
+            "prompt": "Enter your session private key",
             "is_secure": True,
             "is_connect_key": True,
             "prompt_on_new": True,
         }
     )
-    sub_id: SecretStr = Field(
+    subacct_id: SecretStr = Field(
         default=...,
         json_schema_extra={
             "prompt": "Enter your Subaccount Id",

--- a/hummingbot/connector/exchange/derive/derive_api_user_stream_data_source.py
+++ b/hummingbot/connector/exchange/derive/derive_api_user_stream_data_source.py
@@ -89,7 +89,7 @@ class DeriveAPIUserStreamDataSource(UserStreamTrackerDataSource):
 
         :param websocket_assistant: the websocket assistant used to connect to the exchange
         """
-        subaccount_id = self._connector._sub_id
+        subaccount_id = self._connector._subacct_id
         try:
             orders_change_payload = {
                 "method": "subscribe",

--- a/hummingbot/connector/exchange/derive/derive_auth.py
+++ b/hummingbot/connector/exchange/derive/derive_auth.py
@@ -19,15 +19,15 @@ class DeriveAuth(AuthBase):
     Auth class required by Derive API
     """
 
-    def __init__(self, api_key: str, api_secret: str, sub_id: int, trading_required: bool, domain: str):
-        self._api_key: str = api_key
-        self._api_secret: str = api_secret
-        self._sub_id: int = sub_id
+    def __init__(self, wallet_address: str, session_private_key: str, subacct_id: int, trading_required: bool, domain: str):
+        self._wallet_address: str = wallet_address
+        self._session_private_key: str = session_private_key
+        self._subacct_id: int = subacct_id
         self._trading_required: bool = trading_required
         self._w3 = Web3()
         self._domain = domain
         if trading_required:
-            self.session_key_wallet = Web3().eth.account.from_key(self._api_secret)
+            self.session_key_wallet = Web3().eth.account.from_key(self._session_private_key)
 
     async def ws_authenticate(self, request: WSRequest) -> WSRequest:
         """
@@ -59,14 +59,14 @@ class DeriveAuth(AuthBase):
         payload = {}
         timestamp = str(self.utc_now_ms())
         signature = to_0x_hex(self._w3.eth.account.sign_message(
-            encode_defunct(text=timestamp), private_key=self._api_secret
+            encode_defunct(text=timestamp), private_key=self._session_private_key
         ).signature)
         """
         This method is intended to configure a websocket request to be authenticated. Dexalot does not use this
         functionality
         """
         payload["accept"] = 'application/json'
-        payload["wallet"] = self._api_key
+        payload["wallet"] = self._wallet_address
         payload["timestamp"] = timestamp
         payload["signature"] = signature
         return payload
@@ -94,8 +94,8 @@ class DeriveAuth(AuthBase):
         domain_seperator = CONSTANTS.DOMAIN_SEPARATOR if "testnet" not in self._domain else CONSTANTS.TESTNET_DOMAIN_SEPARATOR
         action_typehash = CONSTANTS.ACTION_TYPEHASH if "testnet" not in self._domain else CONSTANTS.TESTNET_ACTION_TYPEHASH
         action = SignedAction(
-            subaccount_id=int(self._sub_id),
-            owner=self._api_key,
+            subaccount_id=int(self._subacct_id),
+            owner=self._wallet_address,
             signer=self.session_key_wallet.address,
             signature_expiry_sec=MAX_INT_32,
             nonce=get_action_nonce(),
@@ -122,12 +122,12 @@ class DeriveAuth(AuthBase):
     def header_for_authentication(self) -> Dict[str, str]:
         timestamp = str(self.utc_now_ms())
         signature = to_0x_hex(self._w3.eth.account.sign_message(
-            encode_defunct(text=timestamp), private_key=self._api_secret
+            encode_defunct(text=timestamp), private_key=self._session_private_key
         ).signature)
         payload = {}
 
         payload["accept"] = 'application/json'
-        payload["X-LyraWallet"] = self._api_key
+        payload["X-LyraWallet"] = self._wallet_address
         payload["X-LyraTimestamp"] = timestamp
         payload["X-LyraSignature"] = signature
         return payload

--- a/hummingbot/connector/exchange/derive/derive_exchange.py
+++ b/hummingbot/connector/exchange/derive/derive_exchange.py
@@ -38,17 +38,17 @@ class DeriveExchange(ExchangePyBase):
             self,
             balance_asset_limit: Optional[Dict[str, Dict[str, Decimal]]] = None,
             rate_limits_share_pct: Decimal = Decimal("100"),
-            derive_api_secret: str = None,
-            sub_id: int = None,
+            session_private_key: str = None,
+            subacct_id: int = None,
             account_type: str = None,
-            derive_api_key: str = None,
+            derive_wallet_address: str = None,
             trading_pairs: Optional[List[str]] = None,
             trading_required: bool = True,
             domain: str = CONSTANTS.DEFAULT_DOMAIN,
     ):
-        self.derive_api_key = derive_api_key
-        self.derive_secret_key = derive_api_secret
-        self._sub_id = sub_id
+        self.derive_wallet_address = derive_wallet_address
+        self.session_private_key = session_private_key
+        self._subacct_id = subacct_id
         self._account_type = account_type
         self._trading_required = trading_required
         self._trading_pairs = trading_pairs
@@ -71,7 +71,7 @@ class DeriveExchange(ExchangePyBase):
 
     @property
     def authenticator(self) -> DeriveAuth:
-        return DeriveAuth(self.derive_api_key, self.derive_secret_key, self._sub_id, self._trading_required, self._domain)
+        return DeriveAuth(self.derive_wallet_address, self.session_private_key, self._subacct_id, self._trading_required, self._domain)
 
     @property
     def rate_limits_rules(self) -> List[RateLimit]:
@@ -239,7 +239,7 @@ class DeriveExchange(ExchangePyBase):
         api_params = {
             "instrument_name": symbol,
             "order_id": oid,
-            "subaccount_id": int(self._sub_id)
+            "subaccount_id": int(self._subacct_id)
         }
         cancel_result = await self._api_post(
             path_url=CONSTANTS.CANCEL_ORDER_URL,
@@ -380,7 +380,7 @@ class DeriveExchange(ExchangePyBase):
             "order_type": price_type,
             "mmp": False,
             "time_in_force": param_order_type,
-            "recipient_id": self._sub_id,
+            "recipient_id": self._subacct_id,
         }
 
         order_result = await self._api_post(
@@ -409,7 +409,7 @@ class DeriveExchange(ExchangePyBase):
                 all_fills_response = await self._api_get(
                     path_url=CONSTANTS.MY_TRADES_PATH_URL,
                     params={
-                        "subaccount_id": self._sub_id
+                        "subaccount_id": self._subacct_id
                     },
                     is_auth_required=True,
                     limit_id=CONSTANTS.MY_TRADES_PATH_URL)
@@ -519,8 +519,8 @@ class DeriveExchange(ExchangePyBase):
         Traders, Orders, and Balance updates from the WS.
         """
         user_channels = [
-            f"{self._sub_id}.{CONSTANTS.USER_ORDERS_ENDPOINT_NAME}",
-            f"{self._sub_id}.{CONSTANTS.USEREVENT_ENDPOINT_NAME}",
+            f"{self._subacct_id}.{CONSTANTS.USER_ORDERS_ENDPOINT_NAME}",
+            f"{self._subacct_id}.{CONSTANTS.USEREVENT_ENDPOINT_NAME}",
         ]
         async for event_message in self._iter_user_event_queue():
             try:
@@ -706,7 +706,7 @@ class DeriveExchange(ExchangePyBase):
 
         account_info = await self._api_post(
             path_url=CONSTANTS.ACCOUNTS_PATH_URL,
-            data={"subaccount_id": self._sub_id},
+            data={"subaccount_id": self._subacct_id},
             is_auth_required=True)
         if "error" in account_info:
             self.logger().error(f"Error fetching account balances: {account_info['error']['message']}")
@@ -732,7 +732,7 @@ class DeriveExchange(ExchangePyBase):
         order_update = await self._api_post(
             path_url=CONSTANTS.ORDER_STATUS_PAATH_URL,
             data={
-                "subaccount_id": self._sub_id,
+                "subaccount_id": self._subacct_id,
                 "order_id": oid
             },
             is_auth_required=True)
@@ -776,7 +776,7 @@ class DeriveExchange(ExchangePyBase):
             for trading_pair in trading_pairs:
                 params = {
                     "instrument_name": trading_pair,
-                    "subaccount_id": self._sub_id,
+                    "subaccount_id": self._subacct_id,
                 }
                 if self._last_poll_timestamp > 0:
                     params["from_timestamp"] = query_time
@@ -861,7 +861,7 @@ class DeriveExchange(ExchangePyBase):
                 params={
                     "instrument_name": trading_pair,
                     "order_id": exchange_order_id,
-                    "subaccount_id": self._sub_id
+                    "subaccount_id": self._subacct_id
                 },
                 is_auth_required=True,
                 limit_id=CONSTANTS.MY_TRADES_PATH_URL)

--- a/hummingbot/connector/exchange/derive/derive_utils.py
+++ b/hummingbot/connector/exchange/derive/derive_utils.py
@@ -21,7 +21,7 @@ BROKER_ID = "HBOT"
 
 class DeriveConfigMap(BaseConnectorConfigMap):
     connector: str = "derive"
-    derive_api_key: SecretStr = Field(
+    derive_wallet_address: SecretStr = Field(
         default=...,
         json_schema_extra={
             "prompt": "Enter your Derive Wallet address",
@@ -30,16 +30,16 @@ class DeriveConfigMap(BaseConnectorConfigMap):
             "prompt_on_new": True,
         }
     )
-    derive_api_secret: SecretStr = Field(
+    session_private_key: SecretStr = Field(
         default=...,
         json_schema_extra={
-            "prompt": "Enter your wallet private key",
+            "prompt": "Enter your session private key",
             "is_secure": True,
             "is_connect_key": True,
             "prompt_on_new": True,
         }
     )
-    sub_id: SecretStr = Field(
+    subacct_id: SecretStr = Field(
         default=...,
         json_schema_extra={
             "prompt": "Enter your Subaccount Id",
@@ -69,7 +69,7 @@ OTHER_DOMAINS_DEFAULT_FEES = {"derive_testnet": [0, 0.025]}
 
 class DeriveTestnetConfigMap(BaseConnectorConfigMap):
     connector: str = "derive_testnet"
-    derive_testnet_api_key: SecretStr = Field(
+    derive_testnet_wallet_address: SecretStr = Field(
         default=...,
         json_schema_extra={
             "prompt": "Enter your Derive Wallet address",
@@ -78,16 +78,16 @@ class DeriveTestnetConfigMap(BaseConnectorConfigMap):
             "prompt_on_new": True,
         }
     )
-    derive_testnet_api_secret: SecretStr = Field(
+    session_private_key: SecretStr = Field(
         default=...,
         json_schema_extra={
-            "prompt": "Enter your wallet private key",
+            "prompt": "Enter your session private key",
             "is_secure": True,
             "is_connect_key": True,
             "prompt_on_new": True,
         }
     )
-    sub_id: SecretStr = Field(
+    subacct_id: SecretStr = Field(
         default=...,
         json_schema_extra={
             "prompt": "Enter your Subaccount Id",

--- a/hummingbot/core/rate_oracle/sources/derive_rate_source.py
+++ b/hummingbot/core/rate_oracle/sources/derive_rate_source.py
@@ -50,9 +50,9 @@ class DeriveRateSource(RateSourceBase):
         from hummingbot.connector.exchange.derive.derive_exchange import DeriveExchange
 
         return DeriveExchange(
-            derive_api_secret="",
+            session_private_key="",
             trading_pairs=[],
-            sub_id = "",
-            derive_api_key="",
+            subacct_id="",
+            derive_wallet_address="",
             trading_required=False,
         )

--- a/test/hummingbot/connector/derivative/derive_perpetual/test_derive_perpetual_api_order_book_data_source.py
+++ b/test/hummingbot/connector/derivative/derive_perpetual/test_derive_perpetual_api_order_book_data_source.py
@@ -45,9 +45,9 @@ class DeriveAPIOrderBookDataSourceTests(IsolatedAsyncioWrapperTestCase):
         client_config_map = ClientConfigAdapter(ClientConfigMap())
         self.connector = DerivePerpetualDerivative(
             client_config_map,
-            derive_perpetual_api_key="testkey",
-            derive_perpetual_api_secret="13e56ca9cceebf1f33065c2c5376ab38570a114bc1b003b60d838f92be9d7930",  # noqa: mock
-            sub_id="45686",
+            derive_perpetual_wallet_address="testkey",
+            session_private_key="13e56ca9cceebf1f33065c2c5376ab38570a114bc1b003b60d838f92be9d7930",  # noqa: mock
+            subacct_id="45686",
             trading_pairs=[self.trading_pair],
         )
         self.data_source = DerivePerpetualAPIOrderBookDataSource(

--- a/test/hummingbot/connector/derivative/derive_perpetual/test_derive_perpetual_api_user_stream_data_source.py
+++ b/test/hummingbot/connector/derivative/derive_perpetual/test_derive_perpetual_api_user_stream_data_source.py
@@ -30,11 +30,11 @@ class TestDerivePerpetualAPIUserStreamDataSource(IsolatedAsyncioWrapperTestCase)
         cls.quote_asset = "USDC"
         cls.trading_pair = f"{cls.base_asset}-{cls.quote_asset}"
         cls.ex_trading_pair = f"{cls.base_asset}_{cls.quote_asset}"
-        cls.api_key = "someKey"  # noqa: mock
-        cls.sub_id = 37799
+        cls.wallet_address = "someKey"  # noqa: mock
+        cls.subacct_id = 37799
         cls.domain = "derive_perpetual_testnet"
         cls.trading_required = False
-        cls.api_secret_key = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"  # noqa: mock
+        cls.session_private_key = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"  # noqa: mock
 
     def setUp(self) -> None:
         super().setUp()
@@ -50,9 +50,9 @@ class TestDerivePerpetualAPIUserStreamDataSource(IsolatedAsyncioWrapperTestCase)
             self.mock_time_provider = MagicMock()
             self.mock_time_provider.time.return_value = 1738096054575
             self.auth = DerivePerpetualAuth(
-                api_key=self.api_key,
-                api_secret=self.api_secret_key,
-                sub_id=self.sub_id,
+                wallet_address=self.wallet_address,
+                session_private_key=self.session_private_key,
+                subacct_id=self.subacct_id,
                 trading_required=self.trading_required,
                 domain=self.domain
             )
@@ -61,9 +61,9 @@ class TestDerivePerpetualAPIUserStreamDataSource(IsolatedAsyncioWrapperTestCase)
 
             # Initialize connector and data source
             self.connector = DerivePerpetualDerivative(
-                derive_perpetual_api_key=self.api_key,
-                derive_perpetual_api_secret=self.api_secret_key,
-                sub_id=self.sub_id,
+                derive_perpetual_wallet_address=self.wallet_address,
+                session_private_key=self.session_private_key,
+                subacct_id=self.subacct_id,
                 trading_pairs=[]
             )
             self.connector._web_assistants_factory._auth = self.auth
@@ -96,7 +96,7 @@ class TestDerivePerpetualAPIUserStreamDataSource(IsolatedAsyncioWrapperTestCase)
     def get_ws_auth_payload(self):
         return {
             "accept": "application/json",
-            "wallet": self.api_key,
+            "wallet": self.wallet_address,
             "timestamp": "1738096054575",
             "signature": "0x67e1aa8bde8ce8eadeb055587525274b00961d113bdaad226cf17ba43c7ae3556b79ef36506f2429be165874558237044108d2b6b00086b4a5e366c8a0e257371c"  # noqa: mock
         }
@@ -209,18 +209,18 @@ class TestDerivePerpetualAPIUserStreamDataSource(IsolatedAsyncioWrapperTestCase)
         self.assertEqual(expected_login_subscription, sent_subscription_messages[0])
         expected_positions_subscription = {
             "method": "private/get_subaccount",
-            "params": {"subaccount_id": int(self.sub_id)}
+            "params": {"subaccount_id": int(self.subacct_id)}
         }
         self.assertEqual(expected_positions_subscription, sent_subscription_messages[1])
         expected_positions_subscription = {
             "method": "private/get_positions",
-            "params": {"subaccount_id": int(self.sub_id)}
+            "params": {"subaccount_id": int(self.subacct_id)}
         }
         self.assertEqual(expected_positions_subscription, sent_subscription_messages[2])
         expected_trades_subscription = {
             "method": "subscribe",
             "params": {
-                "channels": [f"{self.sub_id}.orders", f"{self.sub_id}.trades"],
+                "channels": [f"{self.subacct_id}.orders", f"{self.subacct_id}.trades"],
             }
         }
         self.assertEqual(expected_trades_subscription, sent_subscription_messages[3])

--- a/test/hummingbot/connector/derivative/derive_perpetual/test_derive_perpetual_auth.py
+++ b/test/hummingbot/connector/derivative/derive_perpetual/test_derive_perpetual_auth.py
@@ -14,13 +14,13 @@ from hummingbot.core.web_assistant.connections.data_types import RESTMethod, RES
 class DerivePerpetualAuthTests(TestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.api_key = "0x1234567890abcdef1234567890abcdef12345678"
-        self.api_secret = "13e56ca9cceebf1f33065c2c5376ab38570a114bc1b003b60d838f92be9d7930"  # noqa: mock
-        self.sub_id = "45686"  # noqa: mock
+        self.wallet_address = "0x1234567890abcdef1234567890abcdef12345678"
+        self.session_private_key = "13e56ca9cceebf1f33065c2c5376ab38570a114bc1b003b60d838f92be9d7930"  # noqa: mock
+        self.subacct_id = "45686"  # noqa: mock
         self.domain = "derive_perpetual_testnet"  # noqa: mock
-        self.auth = DerivePerpetualAuth(api_key=self.api_key,
-                                        api_secret=self.api_secret,
-                                        sub_id=self.sub_id,
+        self.auth = DerivePerpetualAuth(wallet_address=self.wallet_address,
+                                        session_private_key=self.session_private_key,
+                                        subacct_id=self.subacct_id,
                                         trading_required=True,
                                         domain=self.domain)
 
@@ -29,9 +29,9 @@ class DerivePerpetualAuthTests(TestCase):
         return ret
 
     def test_initialization(self):
-        self.assertEqual(self.auth._api_key, self.api_key)
-        self.assertEqual(self.auth._api_secret, self.api_secret)
-        self.assertEqual(self.auth._sub_id, self.sub_id)
+        self.assertEqual(self.auth._wallet_address, self.wallet_address)
+        self.assertEqual(self.auth._session_private_key, self.session_private_key)
+        self.assertEqual(self.auth._subacct_id, self.subacct_id)
         self.assertTrue(self.auth._trading_required)
         self.assertIsInstance(self.auth._w3, Web3)
 
@@ -47,7 +47,7 @@ class DerivePerpetualAuthTests(TestCase):
         headers = self.auth.header_for_authentication()
 
         self.assertEqual(headers["accept"], "application/json")
-        self.assertEqual(headers["X-LyraWallet"], self.api_key)
+        self.assertEqual(headers["X-LyraWallet"], self.wallet_address)
         self.assertEqual(headers["X-LyraTimestamp"], "1234567890")
         self.assertEqual(headers["X-LyraSignature"], mock_signature)
 
@@ -114,7 +114,7 @@ class DerivePerpetualAuthTests(TestCase):
         payload = self.auth.get_ws_auth_payload()
 
         self.assertEqual(payload["accept"], "application/json")
-        self.assertEqual(payload["wallet"], self.api_key)
+        self.assertEqual(payload["wallet"], self.wallet_address)
         self.assertEqual(payload["timestamp"], "1234567890")
         self.assertEqual(payload["signature"], mock_signature)
 

--- a/test/hummingbot/connector/derivative/derive_perpetual/test_derive_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/derive_perpetual/test_derive_perpetual_derivative.py
@@ -45,9 +45,9 @@ class DerivePerpetualDerivativeTests(AbstractPerpetualDerivativeTests.PerpetualD
     @classmethod
     def setUpClass(cls) -> None:
         super().setUpClass()
-        cls.api_key = "0x79d7511382b5dFd1185F6AF268923D3F9FC31B53"  # noqa: mock
-        cls.api_secret = "13e56ca9cceebf1f33065c2c5376ab38570a114bc1b003b60d838f92be9d7930"  # noqa: mock
-        cls.sub_id = "45686"  # noqa: mock
+        cls.wallet_address = "0x79d7511382b5dFd1185F6AF268923D3F9FC31B53"  # noqa: mock
+        cls.session_private_key = "13e56ca9cceebf1f33065c2c5376ab38570a114bc1b003b60d838f92be9d7930"  # noqa: mock
+        cls.subacct_id = "45686"  # noqa: mock
         cls.base_asset = "BTC"
         cls.quote_asset = "USDC"
         cls.domain = CONSTANTS.DEFAULT_DOMAIN
@@ -66,9 +66,9 @@ class DerivePerpetualDerivativeTests(AbstractPerpetualDerivativeTests.PerpetualD
         self.throttler = AsyncThrottler(CONSTANTS.RATE_LIMITS)
 
         self.exchange = DerivePerpetualDerivative(
-            derive_perpetual_api_key=self.api_key,
-            derive_perpetual_api_secret=self.api_secret,
-            sub_id=self.sub_id,
+            derive_perpetual_wallet_address=self.wallet_address,
+            session_private_key=self.session_private_key,
+            subacct_id=self.subacct_id,
             trading_pairs=[self.trading_pair],
         )
 
@@ -698,9 +698,9 @@ class DerivePerpetualDerivativeTests(AbstractPerpetualDerivativeTests.PerpetualD
 
     def create_exchange_instance(self):
         exchange = DerivePerpetualDerivative(
-            derive_perpetual_api_secret=self.api_secret,  # noqa: mock
-            derive_perpetual_api_key=self.api_key,  # noqa: mock
-            sub_id=self.sub_id,
+            session_private_key=self.session_private_key,  # noqa: mock
+            derive_perpetual_wallet_address=self.wallet_address,  # noqa: mock
+            subacct_id=self.subacct_id,
             trading_pairs=[self.trading_pair],
         )
         # exchange._last_trade_history_timestamp = self.latest_trade_hist_timestamp
@@ -727,7 +727,7 @@ class DerivePerpetualDerivativeTests(AbstractPerpetualDerivativeTests.PerpetualD
     def validate_trades_request(self, order: InFlightOrder, request_call: RequestCall):
         request_params = request_call.kwargs["data"]
         data = json.loads(request_params)
-        self.assertEqual(self.sub_id, data["subaccount_id"])
+        self.assertEqual(self.subacct_id, data["subaccount_id"])
 
     def _configure_balance_response(
             self,
@@ -1055,7 +1055,7 @@ class DerivePerpetualDerivativeTests(AbstractPerpetualDerivativeTests.PerpetualD
 
     def order_event_for_new_order_websocket_update(self, order: InFlightOrder):
         return {
-            'channel': f"{self.sub_id}.{CONSTANTS.USER_ORDERS_ENDPOINT_NAME}",
+            'channel': f"{self.subacct_id}.{CONSTANTS.USER_ORDERS_ENDPOINT_NAME}",
             'data': [{
                 'subaccount_id': 37799,
                 'order_id': order.exchange_order_id or "1640b725-75e9-407d-bea9-aae4fc666d33",  # noqa: mock
@@ -1084,7 +1084,7 @@ class DerivePerpetualDerivativeTests(AbstractPerpetualDerivativeTests.PerpetualD
 
     def order_event_for_canceled_order_websocket_update(self, order: InFlightOrder):
         return {
-            'channel': f"{self.sub_id}.{CONSTANTS.USER_ORDERS_ENDPOINT_NAME}",
+            'channel': f"{self.subacct_id}.{CONSTANTS.USER_ORDERS_ENDPOINT_NAME}",
             'data': [{
                 'subaccount_id': 37799,
                 'order_id': order.exchange_order_id or "1640b725-75e9-407d-bea9-aae4fc666d33",  # noqa: mock
@@ -1114,7 +1114,7 @@ class DerivePerpetualDerivativeTests(AbstractPerpetualDerivativeTests.PerpetualD
     def order_event_for_full_fill_websocket_update(self, order: InFlightOrder):
         self._simulate_trading_rules_initialized()
         return {
-            'channel': f"{self.sub_id}.{CONSTANTS.USER_ORDERS_ENDPOINT_NAME}",
+            'channel': f"{self.subacct_id}.{CONSTANTS.USER_ORDERS_ENDPOINT_NAME}",
             'data': [{
                 'subaccount_id': 37799,
                 'order_id': order.exchange_order_id or "1640b725-75e9-407d-bea9-aae4fc666d33",  # noqa: mock
@@ -1145,7 +1145,7 @@ class DerivePerpetualDerivativeTests(AbstractPerpetualDerivativeTests.PerpetualD
         self._simulate_trading_rules_initialized()
         return {
             'channel':
-                f"{self.sub_id}.{CONSTANTS.USEREVENT_ENDPOINT_NAME}",
+                f"{self.subacct_id}.{CONSTANTS.USEREVENT_ENDPOINT_NAME}",
                 'data': [
                     {
                         'subaccount_id': 37799,
@@ -1546,9 +1546,9 @@ class DerivePerpetualDerivativeTests(AbstractPerpetualDerivativeTests.PerpetualD
 
     def test_supported_position_modes(self):
         linear_connector = DerivePerpetualDerivative(
-            derive_perpetual_api_key=self.api_key,
-            derive_perpetual_api_secret=self.api_secret,
-            sub_id=self.sub_id,
+            derive_perpetual_wallet_address=self.wallet_address,
+            session_private_key=self.session_private_key,
+            subacct_id=self.subacct_id,
             trading_pairs=[self.trading_pair],
         )
 
@@ -2665,7 +2665,7 @@ class DerivePerpetualDerivativeTests(AbstractPerpetualDerivativeTests.PerpetualD
         request = self._all_executed_requests(mock_api, url)[0]
         self.validate_auth_credentials_present(request)
         request_params = request.kwargs["params"]
-        self.assertEqual(self.sub_id, request_params["subaccount_id"])
+        self.assertEqual(self.subacct_id, request_params["subaccount_id"])
 
         fill_event: OrderFilledEvent = self.order_filled_logger.event_log[0]
         self.assertEqual(self.exchange.current_timestamp, fill_event.timestamp)

--- a/test/hummingbot/connector/exchange/derive/test_derive_api_order_book_data_source.py
+++ b/test/hummingbot/connector/exchange/derive/test_derive_api_order_book_data_source.py
@@ -38,9 +38,9 @@ class DeriveAPIOrderBookDataSourceTests(IsolatedAsyncioWrapperTestCase):
         client_config_map = ClientConfigAdapter(ClientConfigMap())
         self.connector = DeriveExchange(
             client_config_map,
-            derive_api_key="testkey",
-            derive_api_secret="13e56ca9cceebf1f33065c2c5376ab38570a114bc1b003b60d838f92be9d7930",  # noqa: mock
-            sub_id="45686",
+            derive_wallet_address="testkey",
+            session_private_key="13e56ca9cceebf1f33065c2c5376ab38570a114bc1b003b60d838f92be9d7930",  # noqa: mock
+            subacct_id="45686",
             domain="derive_testnet",
             account_type="market_maker",
             trading_required=True,

--- a/test/hummingbot/connector/exchange/derive/test_derive_api_user_stream_data_source.py
+++ b/test/hummingbot/connector/exchange/derive/test_derive_api_user_stream_data_source.py
@@ -28,12 +28,12 @@ class TestDeriveAPIUserStreamDataSource(IsolatedAsyncioWrapperTestCase):
         cls.quote_asset = "USDC"
         cls.trading_pair = f"{cls.base_asset}-{cls.quote_asset}"
         cls.ex_trading_pair = f"{cls.base_asset}-{cls.quote_asset}"
-        cls.api_key = "someKey"  # noqa: mock
-        cls.sub_id = 45686
+        cls.wallet_address = "someKey"  # noqa: mock
+        cls.subacct_id = 45686
         cls.domain = "derive_testnet"
         cls.account_type = "market_maker"
         cls.trading_required = False
-        cls.api_secret_key = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"  # noqa: mock
+        cls.session_private_key = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"  # noqa: mock
 
     def setUp(self) -> None:
         super().setUp()
@@ -49,9 +49,9 @@ class TestDeriveAPIUserStreamDataSource(IsolatedAsyncioWrapperTestCase):
             self.mock_time_provider = MagicMock()
             self.mock_time_provider.time.return_value = 1738096054575
             self.auth = DeriveAuth(
-                api_key=self.api_key,
-                api_secret=self.api_secret_key,
-                sub_id=self.sub_id,
+                wallet_address=self.wallet_address,
+                session_private_key=self.session_private_key,
+                subacct_id=self.subacct_id,
                 trading_required=self.trading_required,
                 domain=self.domain
             )
@@ -60,9 +60,9 @@ class TestDeriveAPIUserStreamDataSource(IsolatedAsyncioWrapperTestCase):
 
             # Initialize connector and data source
             self.connector = DeriveExchange(
-                derive_api_key=self.api_key,
-                derive_api_secret=self.api_secret_key,
-                sub_id=self.sub_id,
+                derive_wallet_address=self.wallet_address,
+                session_private_key=self.session_private_key,
+                subacct_id=self.subacct_id,
                 account_type=self.account_type,
                 trading_required=self.trading_required,
                 domain=self.domain,
@@ -98,7 +98,7 @@ class TestDeriveAPIUserStreamDataSource(IsolatedAsyncioWrapperTestCase):
     def get_ws_auth_payload(self):
         return {
             "accept": "application/json",
-            "wallet": self.api_key,
+            "wallet": self.wallet_address,
             "timestamp": "1738096054575",
             "signature": "0x67e1aa8bde8ce8eadeb055587525274b00961d113bdaad226cf17ba43c7ae3556b79ef36506f2429be165874558237044108d2b6b00086b4a5e366c8a0e257371c"  # noqa: mock
         }
@@ -160,14 +160,14 @@ class TestDeriveAPIUserStreamDataSource(IsolatedAsyncioWrapperTestCase):
         expected_orders_subscription = {
             "method": "subscribe",
             "params": {
-                "channels": [f"{self.sub_id}.orders"],
+                "channels": [f"{self.subacct_id}.orders"],
             }
         }
         self.assertEqual(expected_orders_subscription, sent_subscription_messages[1])
         expected_trades_subscription = {
             "method": "subscribe",
             "params": {
-                "channels": [f"{self.sub_id}.trades"],
+                "channels": [f"{self.subacct_id}.trades"],
             }
         }
         self.assertEqual(expected_trades_subscription, sent_subscription_messages[2])

--- a/test/hummingbot/connector/exchange/derive/test_derive_auth.py
+++ b/test/hummingbot/connector/exchange/derive/test_derive_auth.py
@@ -12,20 +12,20 @@ from hummingbot.core.web_assistant.connections.data_types import RESTMethod, RES
 class DeriveAuthTests(TestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.api_key = "0x1234567890abcdef1234567890abcdef12345678"  # noqa: mock
-        self.api_secret = "13e56ca9cceebf1f33065c2c5376ab38570a114bc1b003b60d838f92be9d7930"  # noqa: mock
-        self.sub_id = "45686"  # noqa: mock
+        self.wallet_address = "0x1234567890abcdef1234567890abcdef12345678"  # noqa: mock
+        self.session_private_key = "13e56ca9cceebf1f33065c2c5376ab38570a114bc1b003b60d838f92be9d7930"  # noqa: mock
+        self.subacct_id = "45686"  # noqa: mock
         self.domain = "derive_testnet"  # noqa: mock
-        self.auth = DeriveAuth(api_key=self.api_key,
-                               api_secret=self.api_secret,
-                               sub_id=self.sub_id,
+        self.auth = DeriveAuth(wallet_address=self.wallet_address,
+                               session_private_key=self.session_private_key,
+                               subacct_id=self.subacct_id,
                                trading_required=True,
                                domain=self.domain)
 
     def test_initialization(self):
-        self.assertEqual(self.auth._api_key, self.api_key)
-        self.assertEqual(self.auth._api_secret, self.api_secret)
-        self.assertEqual(self.auth._sub_id, self.sub_id)
+        self.assertEqual(self.auth._wallet_address, self.wallet_address)
+        self.assertEqual(self.auth._session_private_key, self.session_private_key)
+        self.assertEqual(self.auth._subacct_id, self.subacct_id)
         self.assertTrue(self.auth._trading_required)
         self.assertIsInstance(self.auth._w3, Web3)
 
@@ -41,7 +41,7 @@ class DeriveAuthTests(TestCase):
         headers = self.auth.header_for_authentication()
 
         self.assertEqual(headers["accept"], "application/json")
-        self.assertEqual(headers["X-LyraWallet"], self.api_key)
+        self.assertEqual(headers["X-LyraWallet"], self.wallet_address)
         self.assertEqual(headers["X-LyraTimestamp"], "1234567890")
         self.assertEqual(headers["X-LyraSignature"], mock_signature)
 
@@ -105,7 +105,7 @@ class DeriveAuthTests(TestCase):
         payload = self.auth.get_ws_auth_payload()
 
         self.assertEqual(payload["accept"], "application/json")
-        self.assertEqual(payload["wallet"], self.api_key)
+        self.assertEqual(payload["wallet"], self.wallet_address)
         self.assertEqual(payload["timestamp"], "1234567890")
         self.assertEqual(payload["signature"], mock_signature)
 

--- a/test/hummingbot/connector/exchange/derive/test_derive_exchange.py
+++ b/test/hummingbot/connector/exchange/derive/test_derive_exchange.py
@@ -36,9 +36,9 @@ class DeriveExchangeTests(AbstractExchangeConnectorTests.ExchangeConnectorTests)
     @classmethod
     def setUpClass(cls) -> None:
         super().setUpClass()
-        cls.api_key = "0x79d7511382b5dFd1185F6AF268923D3F9FC31B53"  # noqa: mock
-        cls.api_secret = "13e56ca9cceebf1f33065c2c5376ab38570a114bc1b003b60d838f92be9d7930"  # noqa: mock
-        cls.sub_id = 45686  # noqa: mock
+        cls.wallet_address = "0x79d7511382b5dFd1185F6AF268923D3F9FC31B53"  # noqa: mock
+        cls.session_private_key = "13e56ca9cceebf1f33065c2c5376ab38570a114bc1b003b60d838f92be9d7930"  # noqa: mock
+        cls.subacct_id = 45686  # noqa: mock
         cls.domain = "derive_testnet"  # noqa: mock
         cls.base_asset = "BTC"
         cls.quote_asset = "USDC"
@@ -498,10 +498,10 @@ class DeriveExchangeTests(AbstractExchangeConnectorTests.ExchangeConnectorTests)
 
     def create_exchange_instance(self):
         exchange = DeriveExchange(
-            derive_api_secret=self.api_secret,  # noqa: mock
-            sub_id=self.sub_id,
+            session_private_key=self.session_private_key,  # noqa: mock
+            subacct_id=self.subacct_id,
             account_type=self.account_type,
-            derive_api_key=self.api_key,  # noqa: mock
+            derive_wallet_address=self.wallet_address,  # noqa: mock
             trading_pairs=[self.trading_pair],
         )
         # exchange._last_trade_history_timestamp = self.latest_trade_hist_timestamp
@@ -528,7 +528,7 @@ class DeriveExchangeTests(AbstractExchangeConnectorTests.ExchangeConnectorTests)
     def validate_trades_request(self, order: InFlightOrder, request_call: RequestCall):
         request_params = request_call.kwargs["data"]
         data = json.loads(request_params)
-        self.assertEqual(self.sub_id, data["subaccount_id"])
+        self.assertEqual(self.subacct_id, data["subaccount_id"])
 
     def _configure_balance_response(
             self,
@@ -779,7 +779,7 @@ class DeriveExchangeTests(AbstractExchangeConnectorTests.ExchangeConnectorTests)
 
     def order_event_for_new_order_websocket_update(self, order: InFlightOrder):
         return {
-            'channel': f"{self.sub_id}.{CONSTANTS.USER_ORDERS_ENDPOINT_NAME}",
+            'channel': f"{self.subacct_id}.{CONSTANTS.USER_ORDERS_ENDPOINT_NAME}",
             'data': [{
                 'subaccount_id': 37799,
                 'order_id': order.exchange_order_id or "1640b725-75e9-407d-bea9-aae4fc666d33",  # noqa: mock
@@ -808,7 +808,7 @@ class DeriveExchangeTests(AbstractExchangeConnectorTests.ExchangeConnectorTests)
 
     def order_event_for_canceled_order_websocket_update(self, order: InFlightOrder):
         return {
-            'channel': f"{self.sub_id}.{CONSTANTS.USER_ORDERS_ENDPOINT_NAME}",
+            'channel': f"{self.subacct_id}.{CONSTANTS.USER_ORDERS_ENDPOINT_NAME}",
             'data': [{
                 'subaccount_id': 37799,
                 'order_id': order.exchange_order_id or "1640b725-75e9-407d-bea9-aae4fc666d33",  # noqa: mock
@@ -838,7 +838,7 @@ class DeriveExchangeTests(AbstractExchangeConnectorTests.ExchangeConnectorTests)
     def order_event_for_full_fill_websocket_update(self, order: InFlightOrder):
         self._simulate_trading_rules_initialized()
         return {
-            'channel': f"{self.sub_id}.{CONSTANTS.USER_ORDERS_ENDPOINT_NAME}",
+            'channel': f"{self.subacct_id}.{CONSTANTS.USER_ORDERS_ENDPOINT_NAME}",
             'data': [{
                 'subaccount_id': 37799,
                 'order_id': order.exchange_order_id or "1640b725-75e9-407d-bea9-aae4fc666d33",  # noqa: mock
@@ -869,7 +869,7 @@ class DeriveExchangeTests(AbstractExchangeConnectorTests.ExchangeConnectorTests)
         self._simulate_trading_rules_initialized()
         return {
             'channel':
-                f"{self.sub_id}.{CONSTANTS.USEREVENT_ENDPOINT_NAME}",
+                f"{self.subacct_id}.{CONSTANTS.USEREVENT_ENDPOINT_NAME}",
                 'data': [
                     {
                         'subaccount_id': 37799,
@@ -1778,7 +1778,7 @@ class DeriveExchangeTests(AbstractExchangeConnectorTests.ExchangeConnectorTests)
         request = self._all_executed_requests(mock_api, url)[0]
         self.validate_auth_credentials_present(request)
         request_params = request.kwargs["params"]
-        self.assertEqual(self.sub_id, request_params["subaccount_id"])
+        self.assertEqual(self.subacct_id, request_params["subaccount_id"])
 
         fill_event: OrderFilledEvent = self.order_filled_logger.event_log[0]
         self.assertEqual(self.exchange.current_timestamp, fill_event.timestamp)
@@ -1916,7 +1916,7 @@ class DeriveExchangeTests(AbstractExchangeConnectorTests.ExchangeConnectorTests)
         request = self._all_executed_requests(mock_api, url)[0]
         self.validate_auth_credentials_present(request)
         request_params = request.kwargs["params"]
-        self.assertEqual(self.sub_id, request_params["subaccount_id"])
+        self.assertEqual(self.subacct_id, request_params["subaccount_id"])
 
         self.assertEqual(1, len(self.order_filled_logger.event_log))
         fill_event: OrderFilledEvent = self.order_filled_logger.event_log[0]

--- a/test/hummingbot/core/rate_oracle/sources/test_derive_rate_source.py
+++ b/test/hummingbot/core/rate_oracle/sources/test_derive_rate_source.py
@@ -39,9 +39,9 @@ class DeriveRateSourceTest(unittest.TestCase):
 
     def create_exchange_instance(self):
         return DeriveExchange(
-            derive_api_key="testAPIKey",
-            derive_api_secret="testSecret",
-            sub_id="45465",
+            derive_wallet_address="testAPIKey",
+            session_private_key="testSecret",
+            subacct_id="45465",
             trading_required = False,
             trading_pairs=[self.trading_pair],
         )


### PR DESCRIPTION
Derive authenticates with a **session key** that signs on behalf of a wallet address — not with an API key/secret pair. The old config key names described neither the value the user supplies nor how it's used, and `sub_id` collided with the protocol's own asset sub-id field.

## Renames

Applied across **spot and perpetual**, in all four config maps (mainnet and testnet for each):

| Old | New |
|---|---|
| `derive_api_key` / `derive_perpetual_api_key` | `derive_wallet_address` / `derive_perpetual_wallet_address` |
| `derive_api_secret` / `derive_perpetual_api_secret` | `session_private_key` |
| `sub_id` | `subacct_id` |

The private-key prompt now reads **"Enter your session private key"** instead of "Enter your wallet private key", which is what the connector actually expects.

The rename is carried through the auth layer — `DeriveAuth` / `DerivePerpetualAuth` took `api_key, api_secret, sub_id` — and through the connectors' internal `_sub_id` attribute. That removes a real ambiguity in `sign()`, which previously used `sub_id` for both the subaccount and the asset sub-id two lines apart:

```python
subaccount_id=int(self._subacct_id),   # the account
...
    sub_id=int(params["sub_id"]),      # the asset
```

## Notes for reviewers

**`session_private_key` and `subacct_id` are intentionally unprefixed in the testnet config maps.** `ConnectorSetting.conn_init_parameters` maps sub-domain keys onto the parent connector via `k.replace(self.name, self.parent_name)`, so a prefixed `derive_testnet_session_private_key` would be rewritten to `derive_session_private_key` and fail to bind. This matches the existing `account_type` field.

**The protocol's asset sub-id is untouched** — `TradeModuleData.sub_id` (ABI-encoded, position 2), the `base_asset_sub_id` exchange-info field, and the `params["sub_id"]` lookups in `sign()` all keep their names.

## ⚠️ Breaking change for existing users

Users must re-run `connect derive` / `connect derive_perpetual`.

Connector config maps set `extra="forbid"`, and `Security.decrypt_all()` → `load_connector_config_map_from_file` has no error handling, so a saved `conf/connectors/derive.yml` holding the old key names raises a pydantic `ValidationError` at password unlock — which takes down client startup, not just the derive connector. Worth calling out in the release notes.

## Verification

- **203 tests pass** across the derive spot, perpetual, rate-oracle, and common-utils suites
- **flake8 clean** on all 18 changed files
- Instantiated all four domains (spot/perp × mainnet/testnet) from their config maps through `conn_init_parameters` and asserted each authenticator receives the right values under the new names — confirms testnet prefix-stripping still resolves correctly
- Confirmed `AbstractExchangeConnectorTests` / `AbstractPerpetualDerivativeTests` never reference `api_key` / `api_secret` / `sub_id`, so renaming the subclass test fixtures was safe

🤖 Generated with [Claude Code](https://claude.com/claude-code)
