### PR TITLE
fix/Update Lighter SDK to 1.1.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ def main():
         "web3",
         "xrpl-py>=4.4.0",
         "PyYaml>=0.2.5",
-        "lighter-sdk==1.0.8"
+        "lighter-sdk==1.1.2"
     ]
 
     # --- 1. Define Flags (But don't pass them to Cython yet) ---

--- a/setup/environment.yml
+++ b/setup/environment.yml
@@ -71,4 +71,4 @@ dependencies:
     - decibel-python-sdk==0.2.1
     - aptos-sdk>=0.8.0
     - solders>=0.19.0
-    - lighter-sdk==1.0.8
+    - lighter-sdk==1.1.2


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] Tests all pass
- [x] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:

Update the Lighter Python SDK pin from 1.0.8 to 1.1.2 in both supported installation paths:

- `setup.py`
- `setup/environment.yml`

Version 1.1.2 is the current PyPI release. The signer APIs used by the Lighter spot and perpetual connectors remain backward-compatible.

**Tests performed by the developer**:

- Installed `lighter-sdk==1.1.2` in an isolated Python 3.12 environment.
- Verified the installed package imports and reports version 1.1.2.
- Verified the `SignerClient` constructor and the `create_order`, `create_market_order`, `cancel_order`, `update_leverage`, and `create_auth_token_with_expiry` signatures accept Hummingbot's existing calls.
- Verified dependency resolution with Hummingbot's `urllib3<2.0` constraint using `pip check`.
- Verified both dependency pins and ran `git diff --check`.
- The full Hummingbot test suite was not run locally; CI is expected to provide the project-wide validation.

**Tips for QA testing**:

Install the development environment and run the Lighter spot and perpetual connector test suites. No connector code or runtime behavior changed beyond selecting SDK 1.1.2.