### PR TITLE
fix/gate io perpetual candle initialization regression test

### DIFF
--- a/test/hummingbot/data_feed/candles_feed/gate_io_perpetual_candles/test_gate_io_perpetual_candles.py
+++ b/test/hummingbot/data_feed/candles_feed/gate_io_perpetual_candles/test_gate_io_perpetual_candles.py
@@ -171,3 +171,20 @@ class TestGateioPerpetualCandles(TestCandlesBase):
         mock_api.get(url=regex_url, body=json.dumps({"quanto_multiplier": "0.0005"}))
         await self.data_feed.initialize_exchange_data()
         self.assertEqual(self.data_feed.quanto_multiplier, 0.0005)
+
+    @aioresponses()
+    async def test_fetch_candles_initializes_quanto_multiplier_before_parsing(self, mock_api):
+        self.data_feed.quanto_multiplier = None
+        self.data_feed._exchange_data_initialized = False
+        contract_info_url = re.compile(
+            f"^{CONSTANTS.REST_URL}{CONSTANTS.CONTRACT_INFO_URL.format(contract=self.ex_trading_pair)}"
+        )
+        candles_url = re.compile(f"^{self.data_feed.candles_url}")
+        mock_api.get(contract_info_url, body=json.dumps({"quanto_multiplier": "0.0001"}))
+        mock_api.get(candles_url, body=json.dumps(self.get_candles_rest_data_mock()))
+
+        candles = await self.data_feed.fetch_candles(end_time=int(self.end_time), limit=1)
+
+        self.assertTrue(self.data_feed._exchange_data_initialized)
+        self.assertEqual(self.data_feed.quanto_multiplier, 0.0001)
+        self.assertEqual(candles[0][5], 9.7151)


### PR DESCRIPTION
## Summary

- add a Gate.io perpetual regression test for direct `fetch_candles()` calls before exchange data is initialized
- verify the feed fetches the contract `quanto_multiplier` before parsing candles
- verify base volume uses the exchange multiplier instead of an implicit unit fallback

## Context

Issue #8351 reports a `NoneType` multiplication when consumers call `fetch_candles()` immediately after constructing the feed.

The current `development` branch already routes direct fetches through `initialize_exchange_data()` via #8304. This PR does not duplicate that production fix or default the multiplier to `1`, which could silently corrupt volume. It adds connector-level regression coverage for the exact Gate.io lifecycle and volume invariant.

Closes #8351.

## Scope

Only the Gate.io perpetual candle test module changes. No connector behavior, shared candle lifecycle, or other exchange is modified.

## Validation

- `python -m compileall` on the changed test: passed
- `flake8` on the changed test: passed
- `git diff --check`: passed
- focused pytest collection is blocked locally because this checkout does not have Hummingbot's Cython extension `hummingbot.core.network_iterator` built; CI should run the test in the supported project environment
