### PR TITLE
(okx_perpetual) fix private websocket ping heartbeat

### DIFF
--- a/hummingbot/connector/derivative/okx_perpetual/okx_perpetual_user_stream_data_source.py
+++ b/hummingbot/connector/derivative/okx_perpetual/okx_perpetual_user_stream_data_source.py
@@ -7,7 +7,7 @@ from hummingbot.connector.derivative.okx_perpetual import (
 )
 from hummingbot.connector.derivative.okx_perpetual.okx_perpetual_auth import OkxPerpetualAuth
 from hummingbot.core.data_type.user_stream_tracker_data_source import UserStreamTrackerDataSource
-from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest, WSResponse
+from hummingbot.core.web_assistant.connections.data_types import WSJSONRequest, WSPlainTextRequest, WSResponse
 from hummingbot.core.web_assistant.web_assistants_factory import WebAssistantsFactory
 from hummingbot.core.web_assistant.ws_assistant import WSAssistant
 from hummingbot.logger import HummingbotLogger
@@ -160,7 +160,7 @@ class OkxPerpetualUserStreamDataSource(UserStreamTrackerDataSource):
                     websocket_assistant=websocket_assistant,
                     queue=queue)
             except asyncio.TimeoutError:
-                ping_request = WSJSONRequest(payload={"ping"})
+                ping_request = WSPlainTextRequest(payload="ping")
                 await websocket_assistant.send(ping_request)
 
     async def _subscribe_channels(self, websocket_assistant: WSAssistant):

--- a/test/hummingbot/connector/derivative/okx_perpetual/test_okx_perpetual_user_stream_data_source.py
+++ b/test/hummingbot/connector/derivative/okx_perpetual/test_okx_perpetual_user_stream_data_source.py
@@ -3,6 +3,8 @@ import json
 from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from aiohttp import WSMessage, WSMsgType
+
 import hummingbot.connector.derivative.okx_perpetual.okx_perpetual_constants as CONSTANTS
 import hummingbot.connector.derivative.okx_perpetual.okx_perpetual_web_utils as web_utils
 from hummingbot.connector.derivative.okx_perpetual.okx_perpetual_auth import OkxPerpetualAuth
@@ -146,6 +148,38 @@ class OkxPerpetualUserStreamDataSourceTests(IsolatedAsyncioWrapperTestCase):
         self.assertEqual(expected_payload, subscription_wallet_request)
 
         self.assertGreater(self.data_source.last_recv_time, initial_last_recv_time)
+
+    @patch("aiohttp.ClientSession.ws_connect", new_callable=AsyncMock)
+    async def test_listen_for_user_stream_sends_plain_text_ping_on_timeout(
+            self,
+            ws_connect_mock):
+
+        ws_connect_mock.return_value = self.mocking_assistant.create_websocket_mock()
+        ws_connect_mock.return_value.receive.side_effect = [
+            WSMessage(
+                type=WSMsgType.TEXT,
+                data=self._authentication_response(True),
+                extra=None,
+            ),
+            asyncio.TimeoutError("Test timeout"),
+            asyncio.CancelledError,
+        ]
+
+        messages = asyncio.Queue()
+
+        try:
+            await self.data_source._listen_for_user_stream_on_url(
+                "test_url",
+                messages,
+            )
+        except asyncio.CancelledError:
+            pass
+
+        sent_messages = self.mocking_assistant.text_messages_sent_through_websocket(
+            websocket_mock=ws_connect_mock.return_value
+        )
+
+        self.assertEqual("ping", sent_messages[0])
 
     @patch("aiohttp.ClientSession.ws_connect", new_callable=AsyncMock)
     async def test_listen_for_user_stream_authentication_failure(self, ws_connect_mock):


### PR DESCRIPTION
Fixes #8296.

The OKX perpetual private user stream constructed its idle-timeout heartbeat as a WSJSONRequest containing a Python set (`{"ping"}`). That value cannot be JSON-serialized, causing the otherwise healthy private WebSocket listener to fail and enter its reconnect loop.

This changes the heartbeat to the OKX-required plain-text `ping` using `WSPlainTextRequest`.

Verification:
- Added regression test for timeout -> plain-text ping
- Regression test failed before the fix and passes after it
- OKX perpetual connector suite: 121 passed
- Pre-commit hooks passed