### PR TITLE
fix(lp_rebalancer): account for pre-existing LP positions at startup

### DIFF
--- a/controllers/generic/lp_rebalancer/lp_rebalancer.py
+++ b/controllers/generic/lp_rebalancer/lp_rebalancer.py
@@ -1,6 +1,6 @@
 import logging
 from decimal import Decimal
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 from pydantic import Field, field_validator, model_validator
 
@@ -266,9 +266,11 @@ class LPRebalancer(ControllerBase):
         self._startup_reconciled: bool = False
         self._startup_halted: Optional[str] = None
         self._startup_recover_attempts: int = 0
-        # position address -> timestamp of the close submitted for it, so a
-        # close that has not settled yet is waited on rather than re-submitted
-        self._startup_closes_in_flight: Dict[str, float] = {}
+        # position address -> (timestamp of the last close attempt, whether the
+        # submission was accepted). Both outcomes pace the next attempt: a close
+        # that has not settled must not be re-submitted, and a submission that
+        # failed must not be retried at the controller's tick rate either.
+        self._startup_close_attempts: Dict[str, Tuple[float, bool]] = {}
         self._startup_last_wait_log: float = 0.0
 
         # Initialize rate sources
@@ -1010,9 +1012,9 @@ class LPRebalancer(ControllerBase):
 
         if not positions:
             self._startup_reconciled = True
-            if self._startup_closes_in_flight:
+            if self._startup_close_attempts:
                 self._pending_balance_update = True
-                self._startup_closes_in_flight.clear()
+                self._startup_close_attempts.clear()
                 self.logger().info(
                     "Startup reconciliation: all stray positions closed; capital returned to the wallet."
                 )
@@ -1069,17 +1071,24 @@ class LPRebalancer(ControllerBase):
 
         position = positions[0]
         now = self.market_data_provider.time()
-        submitted_at = self._startup_closes_in_flight.get(position.address)
+        last_attempt = self._startup_close_attempts.get(position.address)
 
-        if submitted_at is not None:
-            # A close is already in flight. Closes settle asynchronously, so a
-            # position that is still visible does not mean the close failed -
-            # re-submitting here would burn every attempt within seconds of
-            # startup and halt a controller whose close actually succeeded.
-            if now - submitted_at < self.config.startup_close_confirm_timeout:
+        if last_attempt is not None:
+            # A close has already been attempted for this position. Closes
+            # settle asynchronously, so a position that is still visible does
+            # not mean the close failed; and a submission that was rejected
+            # says nothing about the next one. Either way, acting again before
+            # the timeout would burn every attempt within seconds of startup
+            # and halt a controller whose close may yet succeed.
+            attempted_at, submitted = last_attempt
+            if now - attempted_at < self.config.startup_close_confirm_timeout:
+                waited = int(now - attempted_at)
+                timeout = self.config.startup_close_confirm_timeout
                 self._log_startup_wait(
-                    f"waiting for the close of {position.address} to settle "
-                    f"({int(now - submitted_at)}s of {self.config.startup_close_confirm_timeout}s)."
+                    f"waiting for the close of {position.address} to settle ({waited}s of {timeout}s)."
+                    if submitted else
+                    f"waiting to retry the close of {position.address}, whose submission was "
+                    f"rejected ({waited}s of {timeout}s)."
                 )
                 return
             self._startup_recover_attempts += 1
@@ -1114,14 +1123,17 @@ class LPRebalancer(ControllerBase):
                 trading_type=self.lp_trading_type,
             )
             signature = response.get("signature") if isinstance(response, dict) else response
-            self._startup_closes_in_flight[position.address] = now
+            self._startup_close_attempts[position.address] = (now, True)
             self.logger().info(
                 f"Startup reconciliation: submitted close for {position.address} "
                 f"signature={signature}. Waiting for it to settle before trading."
             )
         except Exception as e:
-            # Submission itself failed, so nothing is in flight; the next tick
-            # retries. Only unconfirmed closes consume attempts.
+            # Record the failed attempt too. Leaving it unrecorded would let the
+            # next tick, a second later, treat the previous attempt as timed out
+            # and consume another attempt immediately - exhausting them all in a
+            # few seconds while Gateway is briefly unavailable.
+            self._startup_close_attempts[position.address] = (now, False)
             self.logger().error(
                 f"Startup reconciliation: failed to submit close for {position.address}: {e}"
             )

--- a/controllers/generic/lp_rebalancer/lp_rebalancer.py
+++ b/controllers/generic/lp_rebalancer/lp_rebalancer.py
@@ -1011,17 +1011,39 @@ class LPRebalancer(ControllerBase):
             return
 
         if not positions:
-            self._startup_reconciled = True
             if self._startup_close_attempts:
+                # The chain says the position is gone, so the tokens it returned
+                # exist - but the connector's cached wallet balance is still the
+                # pre-close reading, and nothing here compensates for it: a
+                # reconciliation close goes straight through Gateway and never
+                # touches the executor bookkeeping the controller relies on to
+                # cover that lag. Releasing the gate now sizes the first
+                # position off a stale balance and fails with
+                # INSUFFICIENT_BALANCE, costing a full rebalance interval.
+                # Refresh before trading, and stay blocked if the refresh fails
+                # rather than sizing off a number known to be out of date.
+                try:
+                    connector = self.market_data_provider.get_connector(self.config.connector_name)
+                    if hasattr(connector, "update_balances"):
+                        await connector.update_balances()
+                except Exception as e:
+                    self._log_startup_wait(
+                        f"positions are closed but the wallet balance could not be refreshed ({e}); "
+                        f"holding rather than sizing off a stale reading."
+                    )
+                    return
                 self._pending_balance_update = True
                 self._startup_close_attempts.clear()
+                self._startup_reconciled = True
                 self.logger().info(
-                    "Startup reconciliation: all stray positions closed; capital returned to the wallet."
+                    "Startup reconciliation: all stray positions closed, capital returned and "
+                    "wallet balance refreshed."
                 )
-            else:
-                self.logger().info(
-                    "Startup reconciliation: no pre-existing position in this pool - starting clean."
-                )
+                return
+            self._startup_reconciled = True
+            self.logger().info(
+                "Startup reconciliation: no pre-existing position in this pool - starting clean."
+            )
             return
 
         summary = ", ".join(

--- a/controllers/generic/lp_rebalancer/lp_rebalancer.py
+++ b/controllers/generic/lp_rebalancer/lp_rebalancer.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 from pydantic import Field, field_validator, model_validator
 
 from hummingbot.core.data_type.common import MarketDict, TradeType
+from hummingbot.core.gateway.gateway_http_client import GatewayHttpClient
 from hummingbot.core.utils.async_utils import safe_ensure_future
 from hummingbot.data_feed.candles_feed.data_types import CandlesConfig
 from hummingbot.logger import HummingbotLogger
@@ -81,6 +82,24 @@ class LPRebalancerConfig(ControllerConfigBase):
     # Connector-specific params (optional)
     strategy_type: Optional[int] = Field(default=None, json_schema_extra={"is_updatable": True})
 
+    # Startup reconciliation: what to do about positions that already exist
+    # on-chain when the controller starts.
+    startup_position_policy: str = Field(
+        default="recover",
+        description="How to handle a pre-existing on-chain position in this pool at startup. "
+                    "The controller keeps no state across restarts, so without this it opens a "
+                    "second position and the first is left unmanaged. "
+                    "'recover': close the stray position, returning its liquidity and uncollected "
+                    "fees to the wallet, then start clean. "
+                    "'halt': do not trade until the position is dealt with manually. "
+                    "'ignore': leave it and open anyway (previous behaviour; orphans capital)."
+    )
+    startup_recover_max_attempts: int = Field(
+        default=3, ge=1,
+        description="Consecutive failed recovery attempts before falling back to halting. "
+                    "A position is never opened while a stray one remains unaccounted for."
+    )
+
     # Auto-swap feature: swap tokens if balance insufficient for position
     autoswap: bool = Field(
         default=False,
@@ -92,6 +111,15 @@ class LPRebalancerConfig(ControllerConfigBase):
         json_schema_extra={"is_updatable": True},
         description="Extra % to swap beyond deficit to account for slippage (e.g., 0.01 = 0.01%)"
     )
+
+    @field_validator("startup_position_policy", mode="before")
+    @classmethod
+    def validate_startup_position_policy(cls, v):
+        """Reject unknown policies rather than silently falling back."""
+        allowed = ("recover", "halt", "ignore")
+        if v not in allowed:
+            raise ValueError(f"startup_position_policy must be one of {allowed}, got {v!r}")
+        return v
 
     @field_validator("sell_price_min", "sell_price_max", "buy_price_min", "buy_price_max", mode="before")
     @classmethod
@@ -213,6 +241,13 @@ class LPRebalancer(ControllerBase):
 
         # Track if initial position has been created (after that, always use side 1 or 2)
         self._initial_position_created: bool = False
+
+        # Startup reconciliation: until the controller has established what is
+        # already on-chain, it must not open anything.
+        self._startup_reconciled: bool = False
+        self._startup_halted: Optional[str] = None
+        self._startup_recover_attempts: int = 0
+        self._startup_wait_logged: bool = False
 
         # Initialize rate sources
         self.market_data_provider.initialize_rate_sources([
@@ -403,6 +438,11 @@ class LPRebalancer(ControllerBase):
         - Active executor: just wait for it to auto-close via limit prices
         - No manual OUT_OF_RANGE monitoring or timer logic needed
         """
+        # Nothing may be opened until pre-existing on-chain positions have been
+        # accounted for; opening now is what orphans their capital.
+        if self._startup_blocks_trading():
+            return []
+
         # Capture initial balances on first run
         if self._initial_base_balance is None:
             try:
@@ -903,6 +943,130 @@ class LPRebalancer(ControllerBase):
 
         return TradeType.BUY  # Default to BUY
 
+    async def _fetch_pool_positions(self) -> Optional[List]:
+        """On-chain positions this wallet holds in the configured pool.
+
+        Returns None when the question could not be answered. None is NOT the
+        same as "no positions": callers must keep waiting rather than assume a
+        clean slate.
+        """
+        try:
+            connector = self.market_data_provider.get_connector(self.config.connector_name)
+            positions = await connector.get_user_positions(
+                dex_name=self.lp_dex_name,
+                trading_type=self.lp_trading_type,
+                pool_address=self.config.pool_address,
+            )
+            return list(positions or [])
+        except Exception as e:
+            self.logger().warning(f"Startup reconciliation: could not read on-chain positions ({e})")
+            return None
+
+    async def _reconcile_startup_positions(self):
+        """Account for pre-existing on-chain positions before trading.
+
+        The controller keeps no state across restarts: executors_info starts
+        empty and _initial_position_created starts False, so a position opened
+        by a previous process is invisible to it. Left unhandled, the next tick
+        opens a second position while the first stops being rebalanced,
+        fee-harvested or closed, and the wallet no longer holds enough to size
+        the new one. Any restart with a position open reaches this - a deploy,
+        a crash, a machine reboot.
+
+        Runs each tick until it reaches a definite answer. Until it does, the
+        controller opens nothing.
+        """
+        if self._startup_reconciled or self._startup_halted:
+            return
+
+        positions = await self._fetch_pool_positions()
+        if positions is None:
+            # Could not read the chain. Do not guess - opening blind is exactly
+            # the failure this exists to prevent.
+            if not self._startup_wait_logged:
+                self.logger().info("Startup reconciliation: waiting for position data before trading.")
+                self._startup_wait_logged = True
+            return
+
+        if not positions:
+            self._startup_reconciled = True
+            self.logger().info("Startup reconciliation: no pre-existing position in this pool - starting clean.")
+            return
+
+        summary = ", ".join(
+            f"{p.address[:8]}... [{p.lower_price:.6f}-{p.upper_price:.6f}] "
+            f"{p.base_token_amount} base + {p.quote_token_amount} quote "
+            f"(uncollected fees {p.base_fee_amount}/{p.quote_fee_amount})"
+            for p in positions
+        )
+        policy = self.config.startup_position_policy
+
+        if policy == "ignore":
+            self._startup_reconciled = True
+            self.logger().warning(
+                f"Startup reconciliation: {len(positions)} pre-existing position(s) left as-is by "
+                f"startup_position_policy=ignore. They will NOT be managed by this controller "
+                f"and their capital is effectively orphaned: {summary}"
+            )
+            return
+
+        if policy == "halt":
+            self._startup_halted = f"{len(positions)} pre-existing position(s), startup_position_policy=halt"
+            self.logger().error(
+                f"Startup reconciliation: halted. {len(positions)} pre-existing position(s) in this pool; "
+                f"no position will be opened until they are dealt with: {summary}"
+            )
+            return
+
+        # policy == "recover": close the strays so their liquidity and fees
+        # return to the wallet, then start from a known-flat state.
+        self._startup_recover_attempts += 1
+        self.logger().warning(
+            f"Startup reconciliation: recovering {len(positions)} pre-existing position(s) "
+            f"(attempt {self._startup_recover_attempts}/{self.config.startup_recover_max_attempts}): {summary}"
+        )
+
+        connector = self.market_data_provider.get_connector(self.config.connector_name)
+        for position in positions:
+            try:
+                response = await GatewayHttpClient.get_instance().clmm_close_position(
+                    network=connector.network,
+                    wallet_address=connector.address,
+                    position_address=position.address,
+                    dex=self.lp_dex_name,
+                    trading_type=self.lp_trading_type,
+                )
+                signature = response.get("signature") if isinstance(response, dict) else response
+                self.logger().info(
+                    f"Startup reconciliation: closed stray position {position.address[:8]}... "
+                    f"signature={signature}"
+                )
+            except Exception as e:
+                self.logger().error(
+                    f"Startup reconciliation: failed to close {position.address[:8]}...: {e}"
+                )
+
+        # Confirm against the chain rather than trusting the close responses.
+        remaining = await self._fetch_pool_positions()
+        if remaining is not None and not remaining:
+            self._startup_reconciled = True
+            self._pending_balance_update = True
+            self.logger().info(
+                "Startup reconciliation: all stray positions closed; capital returned to the wallet."
+            )
+            return
+
+        if self._startup_recover_attempts >= self.config.startup_recover_max_attempts:
+            self._startup_halted = f"recovery failed after {self._startup_recover_attempts} attempts"
+            self.logger().error(
+                "Startup reconciliation: halted. Could not close pre-existing position(s) after "
+                f"{self._startup_recover_attempts} attempts; refusing to open a position on top of them."
+            )
+
+    def _startup_blocks_trading(self) -> bool:
+        """True while pre-existing positions are unresolved."""
+        return self._startup_halted is not None or not self._startup_reconciled
+
     async def update_processed_data(self):
         """Called every tick - fetch pool price."""
         try:
@@ -918,6 +1082,8 @@ class LPRebalancer(ControllerBase):
         except Exception as e:
             self.logger().debug(f"Could not fetch pool price: {e}")
 
+        await self._reconcile_startup_positions()
+
     def to_format_status(self) -> List[str]:
         """Format status for display."""
         status = []
@@ -929,6 +1095,12 @@ class LPRebalancer(ControllerBase):
         header = f"| LP Rebalancer: {self.config.trading_pair} on {self.config.connector_name}"
         status.append(header + " " * (box_width - len(header) + 1) + "|")
         status.append("+" + "-" * box_width + "+")
+
+        # Startup reconciliation - surfaced because it blocks all trading
+        if self._startup_blocks_trading():
+            reason = self._startup_halted or "checking for pre-existing positions"
+            line = f"| NOT TRADING - startup reconciliation: {reason}"
+            status.append(line + " " * (box_width - len(line) + 1) + "|")
 
         # Config summary
         line = f"| Network: {self.config.connector_name} | LP: {self.config.lp_provider}"

--- a/controllers/generic/lp_rebalancer/lp_rebalancer.py
+++ b/controllers/generic/lp_rebalancer/lp_rebalancer.py
@@ -1,6 +1,6 @@
 import logging
 from decimal import Decimal
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from pydantic import Field, field_validator, model_validator
 
@@ -84,20 +84,39 @@ class LPRebalancerConfig(ControllerConfigBase):
 
     # Startup reconciliation: what to do about positions that already exist
     # on-chain when the controller starts.
+    #
+    # The default is 'halt' rather than 'recover' because position ownership
+    # cannot be established. Gateway reports positions per wallet, not per
+    # controller, and there is no on-chain marker tying a position to the
+    # workflow that opened it. A wallet may be shared with other controllers in
+    # the same instance or with manual liquidity, so closing "the" position in
+    # this pool can withdraw someone else's. Halting is always safe: it never
+    # touches funds, and it never opens a second position on top of the first,
+    # which is the capital-orphaning bug this reconciliation exists to fix.
     startup_position_policy: str = Field(
-        default="recover",
+        default="halt",
         description="How to handle a pre-existing on-chain position in this pool at startup. "
                     "The controller keeps no state across restarts, so without this it opens a "
                     "second position and the first is left unmanaged. "
-                    "'recover': close the stray position, returning its liquidity and uncollected "
-                    "fees to the wallet, then start clean. "
-                    "'halt': do not trade until the position is dealt with manually. "
+                    "'halt' (default): do not trade until the position is dealt with manually. "
+                    "'recover': close the pre-existing position, returning its liquidity and "
+                    "uncollected fees to the wallet, then start clean. This acts on whatever this "
+                    "wallet holds in this pool, not only on positions this controller opened, so "
+                    "it is only safe when the wallet is dedicated to this controller. "
                     "'ignore': leave it and open anyway (previous behaviour; orphans capital)."
     )
     startup_recover_max_attempts: int = Field(
         default=3, ge=1,
-        description="Consecutive failed recovery attempts before falling back to halting. "
-                    "A position is never opened while a stray one remains unaccounted for."
+        description="How many times a close may be re-submitted for a position that is still "
+                    "present after startup_close_confirm_timeout, before halting. A position is "
+                    "never opened while a stray one remains unaccounted for."
+    )
+    startup_close_confirm_timeout: int = Field(
+        default=120, ge=1,
+        description="Seconds to wait for a submitted close to be reflected on-chain before "
+                    "treating it as failed. Closes are asynchronous: without a wait, an "
+                    "unconfirmed close reads as a failure, re-submits, and can exhaust every "
+                    "attempt within seconds of startup."
     )
 
     # Auto-swap feature: swap tokens if balance insufficient for position
@@ -247,7 +266,10 @@ class LPRebalancer(ControllerBase):
         self._startup_reconciled: bool = False
         self._startup_halted: Optional[str] = None
         self._startup_recover_attempts: int = 0
-        self._startup_wait_logged: bool = False
+        # position address -> timestamp of the close submitted for it, so a
+        # close that has not settled yet is waited on rather than re-submitted
+        self._startup_closes_in_flight: Dict[str, float] = {}
+        self._startup_last_wait_log: float = 0.0
 
         # Initialize rate sources
         self.market_data_provider.initialize_rate_sources([
@@ -946,8 +968,8 @@ class LPRebalancer(ControllerBase):
     async def _fetch_pool_positions(self) -> Optional[List]:
         """On-chain positions this wallet holds in the configured pool.
 
-        Returns None when the question could not be answered. None is NOT the
-        same as "no positions": callers must keep waiting rather than assume a
+        Returns None when the question could not be answered, which is not the
+        same as an empty result: callers must keep waiting rather than assume a
         clean slate.
         """
         try:
@@ -983,18 +1005,25 @@ class LPRebalancer(ControllerBase):
         if positions is None:
             # Could not read the chain. Do not guess - opening blind is exactly
             # the failure this exists to prevent.
-            if not self._startup_wait_logged:
-                self.logger().info("Startup reconciliation: waiting for position data before trading.")
-                self._startup_wait_logged = True
+            self._log_startup_wait("waiting for position data before trading.")
             return
 
         if not positions:
             self._startup_reconciled = True
-            self.logger().info("Startup reconciliation: no pre-existing position in this pool - starting clean.")
+            if self._startup_closes_in_flight:
+                self._pending_balance_update = True
+                self._startup_closes_in_flight.clear()
+                self.logger().info(
+                    "Startup reconciliation: all stray positions closed; capital returned to the wallet."
+                )
+            else:
+                self.logger().info(
+                    "Startup reconciliation: no pre-existing position in this pool - starting clean."
+                )
             return
 
         summary = ", ".join(
-            f"{p.address[:8]}... [{p.lower_price:.6f}-{p.upper_price:.6f}] "
+            f"{p.address} [{p.lower_price:.6f}-{p.upper_price:.6f}] "
             f"{p.base_token_amount} base + {p.quote_token_amount} quote "
             f"(uncollected fees {p.base_fee_amount}/{p.quote_fee_amount})"
             for p in positions
@@ -1005,7 +1034,7 @@ class LPRebalancer(ControllerBase):
             self._startup_reconciled = True
             self.logger().warning(
                 f"Startup reconciliation: {len(positions)} pre-existing position(s) left as-is by "
-                f"startup_position_policy=ignore. They will NOT be managed by this controller "
+                f"startup_position_policy=ignore. They will not be managed by this controller, "
                 f"and their capital is effectively orphaned: {summary}"
             )
             return
@@ -1018,50 +1047,97 @@ class LPRebalancer(ControllerBase):
             )
             return
 
-        # policy == "recover": close the strays so their liquidity and fees
-        # return to the wallet, then start from a known-flat state.
-        self._startup_recover_attempts += 1
-        self.logger().warning(
-            f"Startup reconciliation: recovering {len(positions)} pre-existing position(s) "
-            f"(attempt {self._startup_recover_attempts}/{self.config.startup_recover_max_attempts}): {summary}"
-        )
-
-        connector = self.market_data_provider.get_connector(self.config.connector_name)
-        for position in positions:
-            try:
-                response = await GatewayHttpClient.get_instance().clmm_close_position(
-                    network=connector.network,
-                    wallet_address=connector.address,
-                    position_address=position.address,
-                    dex=self.lp_dex_name,
-                    trading_type=self.lp_trading_type,
-                )
-                signature = response.get("signature") if isinstance(response, dict) else response
-                self.logger().info(
-                    f"Startup reconciliation: closed stray position {position.address[:8]}... "
-                    f"signature={signature}"
-                )
-            except Exception as e:
-                self.logger().error(
-                    f"Startup reconciliation: failed to close {position.address[:8]}...: {e}"
-                )
-
-        # Confirm against the chain rather than trusting the close responses.
-        remaining = await self._fetch_pool_positions()
-        if remaining is not None and not remaining:
-            self._startup_reconciled = True
-            self._pending_balance_update = True
-            self.logger().info(
-                "Startup reconciliation: all stray positions closed; capital returned to the wallet."
+        # policy == "recover".
+        #
+        # Ownership cannot be verified: Gateway reports positions per wallet and
+        # nothing on-chain ties a position to the workflow that opened it. A
+        # single position is the expected shape for a dedicated wallet after a
+        # restart; several means the wallet is shared with something else, and
+        # guessing which one is ours risks withdrawing another workflow's
+        # liquidity. Halt instead.
+        if len(positions) > 1:
+            self._startup_halted = (
+                f"{len(positions)} positions found in this pool; ownership cannot be determined"
+            )
+            self.logger().error(
+                f"Startup reconciliation: halted. Expected at most one pre-existing position but found "
+                f"{len(positions)}, so this wallet is shared and recovery could close liquidity "
+                f"belonging to another controller or opened manually. Close the correct position "
+                f"yourself, or set startup_position_policy=ignore to leave them alone: {summary}"
             )
             return
 
-        if self._startup_recover_attempts >= self.config.startup_recover_max_attempts:
-            self._startup_halted = f"recovery failed after {self._startup_recover_attempts} attempts"
-            self.logger().error(
-                "Startup reconciliation: halted. Could not close pre-existing position(s) after "
-                f"{self._startup_recover_attempts} attempts; refusing to open a position on top of them."
+        position = positions[0]
+        now = self.market_data_provider.time()
+        submitted_at = self._startup_closes_in_flight.get(position.address)
+
+        if submitted_at is not None:
+            # A close is already in flight. Closes settle asynchronously, so a
+            # position that is still visible does not mean the close failed -
+            # re-submitting here would burn every attempt within seconds of
+            # startup and halt a controller whose close actually succeeded.
+            if now - submitted_at < self.config.startup_close_confirm_timeout:
+                self._log_startup_wait(
+                    f"waiting for the close of {position.address} to settle "
+                    f"({int(now - submitted_at)}s of {self.config.startup_close_confirm_timeout}s)."
+                )
+                return
+            self._startup_recover_attempts += 1
+            if self._startup_recover_attempts >= self.config.startup_recover_max_attempts:
+                self._startup_halted = (
+                    f"close of {position.address} unconfirmed after "
+                    f"{self._startup_recover_attempts} attempts"
+                )
+                self.logger().error(
+                    f"Startup reconciliation: halted. Position {position.address} is still open "
+                    f"after {self._startup_recover_attempts} close attempts; refusing to open a "
+                    f"position on top of it."
+                )
+                return
+            self.logger().warning(
+                f"Startup reconciliation: close of {position.address} not reflected after "
+                f"{self.config.startup_close_confirm_timeout}s, re-submitting "
+                f"(attempt {self._startup_recover_attempts + 1}/{self.config.startup_recover_max_attempts})."
             )
+        else:
+            self.logger().warning(
+                f"Startup reconciliation: recovering pre-existing position: {summary}"
+            )
+
+        connector = self.market_data_provider.get_connector(self.config.connector_name)
+        try:
+            response = await GatewayHttpClient.get_instance().clmm_close_position(
+                network=connector.network,
+                wallet_address=connector.address,
+                position_address=position.address,
+                dex=self.lp_dex_name,
+                trading_type=self.lp_trading_type,
+            )
+            signature = response.get("signature") if isinstance(response, dict) else response
+            self._startup_closes_in_flight[position.address] = now
+            self.logger().info(
+                f"Startup reconciliation: submitted close for {position.address} "
+                f"signature={signature}. Waiting for it to settle before trading."
+            )
+        except Exception as e:
+            # Submission itself failed, so nothing is in flight; the next tick
+            # retries. Only unconfirmed closes consume attempts.
+            self.logger().error(
+                f"Startup reconciliation: failed to submit close for {position.address}: {e}"
+            )
+
+    def _log_startup_wait(self, message: str):
+        """Throttled logging for the reconciliation wait states.
+
+        update_processed_data runs on the controller's update_interval, which
+        defaults to one second, so an unthrottled message here would flood the
+        log while waiting on the chain.
+        """
+        now = self.market_data_provider.time()
+        if now - self._startup_last_wait_log < 30:
+            return
+        self._startup_last_wait_log = now
+        self.logger().info(f"Startup reconciliation: {message}")
 
     def _startup_blocks_trading(self) -> bool:
         """True while pre-existing positions are unresolved."""
@@ -1099,7 +1175,7 @@ class LPRebalancer(ControllerBase):
         # Startup reconciliation - surfaced because it blocks all trading
         if self._startup_blocks_trading():
             reason = self._startup_halted or "checking for pre-existing positions"
-            line = f"| NOT TRADING - startup reconciliation: {reason}"
+            line = f"| Startup reconciliation: not trading - {reason}"
             status.append(line + " " * (box_width - len(line) + 1) + "|")
 
         # Config summary

--- a/test/hummingbot/strategy_v2/controllers/test_lp_rebalancer_startup_reconciliation.py
+++ b/test/hummingbot/strategy_v2/controllers/test_lp_rebalancer_startup_reconciliation.py
@@ -249,7 +249,6 @@ class TestLPRebalancerStartupReconciliation(TestCase):
         self.assertTrue(controller._startup_blocks_trading())
 
     def test_failed_submission_does_not_consume_an_attempt(self):
-        """Nothing is in flight if submission threw, so the next tick retries."""
         controller = self._make_controller(
             positions=[MockPosition()], startup_position_policy="recover")
         gateway = self._gateway(close_error=RuntimeError("gateway down"))
@@ -257,6 +256,36 @@ class TestLPRebalancerStartupReconciliation(TestCase):
         self._tick(controller, gateway)
 
         self.assertEqual(controller._startup_recover_attempts, 0)
-        self.assertEqual(controller._startup_closes_in_flight, {})
         self.assertFalse(controller._startup_reconciled)
+        self.assertIsNone(controller._startup_halted)
+        # The failed attempt is still recorded, so the retry is paced.
+        _, submitted = controller._startup_close_attempts[MockPosition().address]
+        self.assertFalse(submitted)
+
+    def test_repeated_submission_failures_are_paced_not_ticked(self):
+        """A failing submission must not burn attempts at the tick rate.
+
+        Recording only successful submissions would leave the previous attempt
+        looking timed out, so every subsequent tick - one second apart - would
+        consume an attempt and halt the controller within seconds while Gateway
+        was briefly unavailable.
+        """
+        controller = self._make_controller(
+            positions=[MockPosition()], startup_position_policy="recover",
+            startup_close_confirm_timeout=60, startup_recover_max_attempts=3)
+        gateway = self._gateway(close_error=RuntimeError("gateway down"))
+
+        self._tick(controller, gateway)           # first attempt, submission fails
+        for _ in range(10):                       # ten ticks, one second apart
+            self.now += 1
+            self._tick(controller, gateway)
+
+        self.assertEqual(gateway.clmm_close_position.await_count, 1)
+        self.assertEqual(controller._startup_recover_attempts, 0)
+        self.assertIsNone(controller._startup_halted)
+
+        self.now += 61                            # past the timeout: one retry
+        self._tick(controller, gateway)
+        self.assertEqual(gateway.clmm_close_position.await_count, 2)
+        self.assertEqual(controller._startup_recover_attempts, 1)
         self.assertIsNone(controller._startup_halted)

--- a/test/hummingbot/strategy_v2/controllers/test_lp_rebalancer_startup_reconciliation.py
+++ b/test/hummingbot/strategy_v2/controllers/test_lp_rebalancer_startup_reconciliation.py
@@ -1,0 +1,222 @@
+import asyncio
+from decimal import Decimal
+from unittest import TestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from controllers.generic.lp_rebalancer.lp_rebalancer import LPRebalancer, LPRebalancerConfig
+from hummingbot.data_feed.market_data_provider import MarketDataProvider
+
+
+class MockPosition:
+    """Stand-in for CLMMPositionInfo, with only the fields the controller reads."""
+
+    def __init__(self, address="PoSiTiOnAddress1234567890"):
+        self.address = address
+        self.lower_price = 100.0
+        self.upper_price = 110.0
+        self.base_token_amount = 1.5
+        self.quote_token_amount = 400.0
+        self.base_fee_amount = 0.001
+        self.quote_fee_amount = 0.25
+
+
+class TestLPRebalancerStartupReconciliation(TestCase):
+    """Tests for startup handling of positions that already exist on-chain.
+
+    The controller keeps no state across restarts, so a position opened by a
+    previous process is invisible to it. Without reconciliation the next tick
+    opens a second position and the first is never rebalanced, fee-harvested or
+    closed - its capital is orphaned on-chain.
+    """
+
+    def _make_controller(self, positions=None, positions_after_close=None,
+                         **config_overrides) -> LPRebalancer:
+        config_kwargs = dict(
+            id="test",
+            connector_name="solana-mainnet-beta",
+            lp_provider="meteora/clmm",
+            trading_pair="SOL-USDC",
+            pool_address="PoolAddress123",
+        )
+        config_kwargs.update(config_overrides)
+        config = LPRebalancerConfig(**config_kwargs)
+
+        market_data_provider = MagicMock(spec=MarketDataProvider)
+        connector = MagicMock()
+        connector.network = "mainnet-beta"
+        connector.address = "WalletAddress123"
+        market_data_provider.get_connector.return_value = connector
+
+        controller = LPRebalancer(
+            config=config,
+            market_data_provider=market_data_provider,
+            actions_queue=AsyncMock(spec=asyncio.Queue),
+        )
+        controller.executors_info = []
+
+        # First call returns the pre-close view; later calls return the
+        # post-close view, so a recovery attempt can be observed end to end.
+        self._fetch_calls = []
+        views = [positions] if positions_after_close is None else [positions, positions_after_close]
+
+        async def fake_fetch():
+            self._fetch_calls.append(1)
+            index = min(len(self._fetch_calls) - 1, len(views) - 1)
+            return views[index]
+
+        controller._fetch_pool_positions = fake_fetch
+        return controller
+
+    @staticmethod
+    def _run(coro):
+        return asyncio.run(coro)
+
+    def test_no_existing_position_allows_trading(self):
+        controller = self._make_controller(positions=[])
+        self._run(controller._reconcile_startup_positions())
+        self.assertTrue(controller._startup_reconciled)
+        self.assertFalse(controller._startup_blocks_trading())
+
+    def test_unreadable_chain_blocks_trading(self):
+        """A failed read must not be mistaken for an empty wallet."""
+        controller = self._make_controller(positions=None)
+        self._run(controller._reconcile_startup_positions())
+        self.assertFalse(controller._startup_reconciled)
+        self.assertTrue(controller._startup_blocks_trading())
+
+    def test_recover_closes_existing_position_then_allows_trading(self):
+        controller = self._make_controller(
+            positions=[MockPosition()], positions_after_close=[])
+        gateway = MagicMock()
+        gateway.clmm_close_position = AsyncMock(return_value={"signature": "SIG"})
+        with patch(
+            "controllers.generic.lp_rebalancer.lp_rebalancer.GatewayHttpClient.get_instance",
+            return_value=gateway,
+        ):
+            self._run(controller._reconcile_startup_positions())
+
+        gateway.clmm_close_position.assert_awaited_once()
+        kwargs = gateway.clmm_close_position.await_args.kwargs
+        self.assertEqual(kwargs["position_address"], MockPosition().address)
+        self.assertEqual(kwargs["dex"], "meteora")
+        self.assertTrue(controller._startup_reconciled)
+        self.assertFalse(controller._startup_blocks_trading())
+        self.assertTrue(controller._pending_balance_update)
+
+    def test_recover_keeps_blocking_while_position_remains(self):
+        """Closing is verified against the chain, not assumed from the response."""
+        controller = self._make_controller(
+            positions=[MockPosition()], positions_after_close=[MockPosition()])
+        gateway = MagicMock()
+        gateway.clmm_close_position = AsyncMock(return_value={"signature": "SIG"})
+        with patch(
+            "controllers.generic.lp_rebalancer.lp_rebalancer.GatewayHttpClient.get_instance",
+            return_value=gateway,
+        ):
+            self._run(controller._reconcile_startup_positions())
+
+        self.assertFalse(controller._startup_reconciled)
+        self.assertTrue(controller._startup_blocks_trading())
+        self.assertIsNone(controller._startup_halted)
+
+    def test_recover_halts_after_max_attempts(self):
+        controller = self._make_controller(
+            positions=[MockPosition()], positions_after_close=[MockPosition()],
+            startup_recover_max_attempts=2)
+        gateway = MagicMock()
+        gateway.clmm_close_position = AsyncMock(return_value={"signature": "SIG"})
+        with patch(
+            "controllers.generic.lp_rebalancer.lp_rebalancer.GatewayHttpClient.get_instance",
+            return_value=gateway,
+        ):
+            self._run(controller._reconcile_startup_positions())
+            self._run(controller._reconcile_startup_positions())
+
+        self.assertIsNotNone(controller._startup_halted)
+        self.assertTrue(controller._startup_blocks_trading())
+
+    def test_failed_close_does_not_mark_reconciled(self):
+        controller = self._make_controller(
+            positions=[MockPosition()], positions_after_close=[MockPosition()])
+        gateway = MagicMock()
+        gateway.clmm_close_position = AsyncMock(side_effect=RuntimeError("boom"))
+        with patch(
+            "controllers.generic.lp_rebalancer.lp_rebalancer.GatewayHttpClient.get_instance",
+            return_value=gateway,
+        ):
+            self._run(controller._reconcile_startup_positions())
+
+        self.assertFalse(controller._startup_reconciled)
+        self.assertTrue(controller._startup_blocks_trading())
+
+    def test_halt_policy_does_not_close_anything(self):
+        controller = self._make_controller(
+            positions=[MockPosition()], startup_position_policy="halt")
+        gateway = MagicMock()
+        gateway.clmm_close_position = AsyncMock()
+        with patch(
+            "controllers.generic.lp_rebalancer.lp_rebalancer.GatewayHttpClient.get_instance",
+            return_value=gateway,
+        ):
+            self._run(controller._reconcile_startup_positions())
+
+        gateway.clmm_close_position.assert_not_awaited()
+        self.assertIsNotNone(controller._startup_halted)
+        self.assertTrue(controller._startup_blocks_trading())
+
+    def test_ignore_policy_preserves_previous_behaviour(self):
+        controller = self._make_controller(
+            positions=[MockPosition()], startup_position_policy="ignore")
+        self._run(controller._reconcile_startup_positions())
+        self.assertTrue(controller._startup_reconciled)
+        self.assertFalse(controller._startup_blocks_trading())
+
+    def test_reconciliation_runs_once(self):
+        controller = self._make_controller(positions=[])
+        self._run(controller._reconcile_startup_positions())
+        calls_after_first = len(self._fetch_calls)
+        self._run(controller._reconcile_startup_positions())
+        self.assertEqual(len(self._fetch_calls), calls_after_first)
+
+    def test_determine_executor_actions_creates_nothing_while_blocked(self):
+        controller = self._make_controller(positions=[MockPosition()])
+        self.assertTrue(controller._startup_blocks_trading())
+        self.assertEqual(controller.determine_executor_actions(), [])
+
+    def test_determine_executor_actions_resumes_after_reconciliation(self):
+        """The gate must open again - it guards startup, not normal operation."""
+        controller = self._make_controller(positions=[])
+        self._run(controller._reconcile_startup_positions())
+        self.assertFalse(controller._startup_blocks_trading())
+
+        # Past the gate the usual startup path runs: with no pool price known
+        # yet the controller waits rather than opening, but it is no longer
+        # short-circuited by reconciliation.
+        controller._pool_price = None
+        self.assertEqual(controller.determine_executor_actions(), [])
+        self.assertIsNotNone(controller._initial_base_balance)
+
+    def test_invalid_policy_is_rejected(self):
+        with self.assertRaises(Exception) as ctx:
+            LPRebalancerConfig(
+                id="test",
+                connector_name="solana-mainnet-beta",
+                lp_provider="meteora/clmm",
+                trading_pair="SOL-USDC",
+                pool_address="PoolAddress123",
+                startup_position_policy="bogus",
+            )
+        self.assertIn("startup_position_policy", str(ctx.exception))
+
+    def test_defaults_are_safe(self):
+        """The default must not be the capital-orphaning behaviour."""
+        config = LPRebalancerConfig(
+            id="test",
+            connector_name="solana-mainnet-beta",
+            lp_provider="meteora/clmm",
+            trading_pair="SOL-USDC",
+            pool_address="PoolAddress123",
+        )
+        self.assertNotEqual(config.startup_position_policy, "ignore")
+        self.assertGreaterEqual(config.startup_recover_max_attempts, 1)
+        self.assertIsInstance(config.swap_buffer_pct, Decimal)

--- a/test/hummingbot/strategy_v2/controllers/test_lp_rebalancer_startup_reconciliation.py
+++ b/test/hummingbot/strategy_v2/controllers/test_lp_rebalancer_startup_reconciliation.py
@@ -1,10 +1,11 @@
 import asyncio
-from decimal import Decimal
 from unittest import TestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from controllers.generic.lp_rebalancer.lp_rebalancer import LPRebalancer, LPRebalancerConfig
 from hummingbot.data_feed.market_data_provider import MarketDataProvider
+
+CLOSE_PATH = "controllers.generic.lp_rebalancer.lp_rebalancer.GatewayHttpClient.get_instance"
 
 
 class MockPosition:
@@ -29,8 +30,10 @@ class TestLPRebalancerStartupReconciliation(TestCase):
     closed - its capital is orphaned on-chain.
     """
 
-    def _make_controller(self, positions=None, positions_after_close=None,
-                         **config_overrides) -> LPRebalancer:
+    def setUp(self):
+        self.now = 1000.0
+
+    def _make_controller(self, positions=None, **config_overrides) -> LPRebalancer:
         config_kwargs = dict(
             id="test",
             connector_name="solana-mainnet-beta",
@@ -42,6 +45,7 @@ class TestLPRebalancerStartupReconciliation(TestCase):
         config = LPRebalancerConfig(**config_kwargs)
 
         market_data_provider = MagicMock(spec=MarketDataProvider)
+        market_data_provider.time.side_effect = lambda: self.now
         connector = MagicMock()
         connector.network = "mainnet-beta"
         connector.address = "WalletAddress123"
@@ -54,129 +58,54 @@ class TestLPRebalancerStartupReconciliation(TestCase):
         )
         controller.executors_info = []
 
-        # First call returns the pre-close view; later calls return the
-        # post-close view, so a recovery attempt can be observed end to end.
-        self._fetch_calls = []
-        views = [positions] if positions_after_close is None else [positions, positions_after_close]
+        # Tests drive what the chain reports by assigning to _chain_positions.
+        controller._chain_positions = positions
+        self.fetch_count = 0
 
         async def fake_fetch():
-            self._fetch_calls.append(1)
-            index = min(len(self._fetch_calls) - 1, len(views) - 1)
-            return views[index]
+            self.fetch_count += 1
+            return controller._chain_positions
 
         controller._fetch_pool_positions = fake_fetch
         return controller
 
     @staticmethod
-    def _run(coro):
-        return asyncio.run(coro)
+    def _gateway(close_result=None, close_error=None):
+        gateway = MagicMock()
+        gateway.clmm_close_position = AsyncMock(
+            return_value=close_result if close_result is not None else {"signature": "SIG"},
+            side_effect=close_error,
+        )
+        return gateway
+
+    def _tick(self, controller, gateway=None):
+        """Run one reconciliation pass, as update_processed_data would."""
+        gateway = gateway or self._gateway()
+        with patch(CLOSE_PATH, return_value=gateway):
+            asyncio.run(controller._reconcile_startup_positions())
+        return gateway
+
+    # -- policy-independent behaviour --------------------------------------
 
     def test_no_existing_position_allows_trading(self):
         controller = self._make_controller(positions=[])
-        self._run(controller._reconcile_startup_positions())
+        self._tick(controller)
         self.assertTrue(controller._startup_reconciled)
         self.assertFalse(controller._startup_blocks_trading())
 
     def test_unreadable_chain_blocks_trading(self):
         """A failed read must not be mistaken for an empty wallet."""
         controller = self._make_controller(positions=None)
-        self._run(controller._reconcile_startup_positions())
+        self._tick(controller)
         self.assertFalse(controller._startup_reconciled)
         self.assertTrue(controller._startup_blocks_trading())
-
-    def test_recover_closes_existing_position_then_allows_trading(self):
-        controller = self._make_controller(
-            positions=[MockPosition()], positions_after_close=[])
-        gateway = MagicMock()
-        gateway.clmm_close_position = AsyncMock(return_value={"signature": "SIG"})
-        with patch(
-            "controllers.generic.lp_rebalancer.lp_rebalancer.GatewayHttpClient.get_instance",
-            return_value=gateway,
-        ):
-            self._run(controller._reconcile_startup_positions())
-
-        gateway.clmm_close_position.assert_awaited_once()
-        kwargs = gateway.clmm_close_position.await_args.kwargs
-        self.assertEqual(kwargs["position_address"], MockPosition().address)
-        self.assertEqual(kwargs["dex"], "meteora")
-        self.assertTrue(controller._startup_reconciled)
-        self.assertFalse(controller._startup_blocks_trading())
-        self.assertTrue(controller._pending_balance_update)
-
-    def test_recover_keeps_blocking_while_position_remains(self):
-        """Closing is verified against the chain, not assumed from the response."""
-        controller = self._make_controller(
-            positions=[MockPosition()], positions_after_close=[MockPosition()])
-        gateway = MagicMock()
-        gateway.clmm_close_position = AsyncMock(return_value={"signature": "SIG"})
-        with patch(
-            "controllers.generic.lp_rebalancer.lp_rebalancer.GatewayHttpClient.get_instance",
-            return_value=gateway,
-        ):
-            self._run(controller._reconcile_startup_positions())
-
-        self.assertFalse(controller._startup_reconciled)
-        self.assertTrue(controller._startup_blocks_trading())
-        self.assertIsNone(controller._startup_halted)
-
-    def test_recover_halts_after_max_attempts(self):
-        controller = self._make_controller(
-            positions=[MockPosition()], positions_after_close=[MockPosition()],
-            startup_recover_max_attempts=2)
-        gateway = MagicMock()
-        gateway.clmm_close_position = AsyncMock(return_value={"signature": "SIG"})
-        with patch(
-            "controllers.generic.lp_rebalancer.lp_rebalancer.GatewayHttpClient.get_instance",
-            return_value=gateway,
-        ):
-            self._run(controller._reconcile_startup_positions())
-            self._run(controller._reconcile_startup_positions())
-
-        self.assertIsNotNone(controller._startup_halted)
-        self.assertTrue(controller._startup_blocks_trading())
-
-    def test_failed_close_does_not_mark_reconciled(self):
-        controller = self._make_controller(
-            positions=[MockPosition()], positions_after_close=[MockPosition()])
-        gateway = MagicMock()
-        gateway.clmm_close_position = AsyncMock(side_effect=RuntimeError("boom"))
-        with patch(
-            "controllers.generic.lp_rebalancer.lp_rebalancer.GatewayHttpClient.get_instance",
-            return_value=gateway,
-        ):
-            self._run(controller._reconcile_startup_positions())
-
-        self.assertFalse(controller._startup_reconciled)
-        self.assertTrue(controller._startup_blocks_trading())
-
-    def test_halt_policy_does_not_close_anything(self):
-        controller = self._make_controller(
-            positions=[MockPosition()], startup_position_policy="halt")
-        gateway = MagicMock()
-        gateway.clmm_close_position = AsyncMock()
-        with patch(
-            "controllers.generic.lp_rebalancer.lp_rebalancer.GatewayHttpClient.get_instance",
-            return_value=gateway,
-        ):
-            self._run(controller._reconcile_startup_positions())
-
-        gateway.clmm_close_position.assert_not_awaited()
-        self.assertIsNotNone(controller._startup_halted)
-        self.assertTrue(controller._startup_blocks_trading())
-
-    def test_ignore_policy_preserves_previous_behaviour(self):
-        controller = self._make_controller(
-            positions=[MockPosition()], startup_position_policy="ignore")
-        self._run(controller._reconcile_startup_positions())
-        self.assertTrue(controller._startup_reconciled)
-        self.assertFalse(controller._startup_blocks_trading())
 
     def test_reconciliation_runs_once(self):
         controller = self._make_controller(positions=[])
-        self._run(controller._reconcile_startup_positions())
-        calls_after_first = len(self._fetch_calls)
-        self._run(controller._reconcile_startup_positions())
-        self.assertEqual(len(self._fetch_calls), calls_after_first)
+        self._tick(controller)
+        settled = self.fetch_count
+        self._tick(controller)
+        self.assertEqual(self.fetch_count, settled)
 
     def test_determine_executor_actions_creates_nothing_while_blocked(self):
         controller = self._make_controller(positions=[MockPosition()])
@@ -186,15 +115,40 @@ class TestLPRebalancerStartupReconciliation(TestCase):
     def test_determine_executor_actions_resumes_after_reconciliation(self):
         """The gate must open again - it guards startup, not normal operation."""
         controller = self._make_controller(positions=[])
-        self._run(controller._reconcile_startup_positions())
+        self._tick(controller)
         self.assertFalse(controller._startup_blocks_trading())
 
-        # Past the gate the usual startup path runs: with no pool price known
-        # yet the controller waits rather than opening, but it is no longer
-        # short-circuited by reconciliation.
         controller._pool_price = None
         self.assertEqual(controller.determine_executor_actions(), [])
         self.assertIsNotNone(controller._initial_base_balance)
+
+    # -- policies ----------------------------------------------------------
+
+    def test_default_policy_is_halt(self):
+        """Ownership cannot be verified, so the default must not close anything."""
+        config = LPRebalancerConfig(
+            id="test",
+            connector_name="solana-mainnet-beta",
+            lp_provider="meteora/clmm",
+            trading_pair="SOL-USDC",
+            pool_address="PoolAddress123",
+        )
+        self.assertEqual(config.startup_position_policy, "halt")
+
+    def test_halt_policy_does_not_close_anything(self):
+        controller = self._make_controller(positions=[MockPosition()])
+        gateway = self._tick(controller)
+        gateway.clmm_close_position.assert_not_awaited()
+        self.assertIsNotNone(controller._startup_halted)
+        self.assertTrue(controller._startup_blocks_trading())
+
+    def test_ignore_policy_preserves_previous_behaviour(self):
+        controller = self._make_controller(
+            positions=[MockPosition()], startup_position_policy="ignore")
+        gateway = self._tick(controller)
+        gateway.clmm_close_position.assert_not_awaited()
+        self.assertTrue(controller._startup_reconciled)
+        self.assertFalse(controller._startup_blocks_trading())
 
     def test_invalid_policy_is_rejected(self):
         with self.assertRaises(Exception) as ctx:
@@ -208,15 +162,101 @@ class TestLPRebalancerStartupReconciliation(TestCase):
             )
         self.assertIn("startup_position_policy", str(ctx.exception))
 
-    def test_defaults_are_safe(self):
-        """The default must not be the capital-orphaning behaviour."""
-        config = LPRebalancerConfig(
-            id="test",
-            connector_name="solana-mainnet-beta",
-            lp_provider="meteora/clmm",
-            trading_pair="SOL-USDC",
-            pool_address="PoolAddress123",
-        )
-        self.assertNotEqual(config.startup_position_policy, "ignore")
-        self.assertGreaterEqual(config.startup_recover_max_attempts, 1)
-        self.assertIsInstance(config.swap_buffer_pct, Decimal)
+    # -- recover -----------------------------------------------------------
+
+    def test_recover_halts_when_several_positions_exist(self):
+        """Several positions mean a shared wallet: closing could take someone else's."""
+        controller = self._make_controller(
+            positions=[MockPosition("AAA"), MockPosition("BBB")],
+            startup_position_policy="recover")
+        gateway = self._tick(controller)
+        gateway.clmm_close_position.assert_not_awaited()
+        self.assertIsNotNone(controller._startup_halted)
+        self.assertTrue(controller._startup_blocks_trading())
+
+    def test_recover_submits_close_then_waits(self):
+        controller = self._make_controller(
+            positions=[MockPosition()], startup_position_policy="recover")
+        gateway = self._tick(controller)
+
+        gateway.clmm_close_position.assert_awaited_once()
+        kwargs = gateway.clmm_close_position.await_args.kwargs
+        self.assertEqual(kwargs["position_address"], MockPosition().address)
+        self.assertEqual(kwargs["dex"], "meteora")
+        # Submitted, not yet confirmed: trading stays blocked.
+        self.assertFalse(controller._startup_reconciled)
+        self.assertTrue(controller._startup_blocks_trading())
+
+    def test_recover_completes_once_the_position_clears(self):
+        controller = self._make_controller(
+            positions=[MockPosition()], startup_position_policy="recover")
+        self._tick(controller)
+
+        controller._chain_positions = []  # close settled
+        self._tick(controller)
+
+        self.assertTrue(controller._startup_reconciled)
+        self.assertFalse(controller._startup_blocks_trading())
+        self.assertTrue(controller._pending_balance_update)
+
+    def test_recover_does_not_resubmit_while_close_is_in_flight(self):
+        """An unsettled close is not a failed close.
+
+        Reconciliation runs on the controller's update_interval, one second by
+        default. Re-submitting on every tick would duplicate the close and burn
+        every attempt within seconds of startup.
+        """
+        controller = self._make_controller(
+            positions=[MockPosition()], startup_position_policy="recover")
+        gateway = self._gateway()
+
+        self._tick(controller, gateway)
+        for _ in range(5):
+            self.now += 1
+            self._tick(controller, gateway)
+
+        gateway.clmm_close_position.assert_awaited_once()
+        self.assertEqual(controller._startup_recover_attempts, 0)
+        self.assertIsNone(controller._startup_halted)
+
+    def test_recover_resubmits_after_the_confirm_timeout(self):
+        controller = self._make_controller(
+            positions=[MockPosition()], startup_position_policy="recover",
+            startup_close_confirm_timeout=60)
+        gateway = self._gateway()
+
+        self._tick(controller, gateway)
+        self.now += 61
+        self._tick(controller, gateway)
+
+        self.assertEqual(gateway.clmm_close_position.await_count, 2)
+        self.assertEqual(controller._startup_recover_attempts, 1)
+        self.assertIsNone(controller._startup_halted)
+
+    def test_recover_halts_after_max_attempts(self):
+        controller = self._make_controller(
+            positions=[MockPosition()], startup_position_policy="recover",
+            startup_close_confirm_timeout=60, startup_recover_max_attempts=2)
+        gateway = self._gateway()
+
+        self._tick(controller, gateway)   # first submission
+        self.now += 61
+        self._tick(controller, gateway)   # attempt 1, re-submits
+        self.now += 61
+        self._tick(controller, gateway)   # attempt 2, gives up
+
+        self.assertIsNotNone(controller._startup_halted)
+        self.assertTrue(controller._startup_blocks_trading())
+
+    def test_failed_submission_does_not_consume_an_attempt(self):
+        """Nothing is in flight if submission threw, so the next tick retries."""
+        controller = self._make_controller(
+            positions=[MockPosition()], startup_position_policy="recover")
+        gateway = self._gateway(close_error=RuntimeError("gateway down"))
+
+        self._tick(controller, gateway)
+
+        self.assertEqual(controller._startup_recover_attempts, 0)
+        self.assertEqual(controller._startup_closes_in_flight, {})
+        self.assertFalse(controller._startup_reconciled)
+        self.assertIsNone(controller._startup_halted)

--- a/test/hummingbot/strategy_v2/controllers/test_lp_rebalancer_startup_reconciliation.py
+++ b/test/hummingbot/strategy_v2/controllers/test_lp_rebalancer_startup_reconciliation.py
@@ -33,7 +33,8 @@ class TestLPRebalancerStartupReconciliation(TestCase):
     def setUp(self):
         self.now = 1000.0
 
-    def _make_controller(self, positions=None, **config_overrides) -> LPRebalancer:
+    def _make_controller(self, positions=None, refresh_fails=False,
+                         **config_overrides) -> LPRebalancer:
         config_kwargs = dict(
             id="test",
             connector_name="solana-mainnet-beta",
@@ -49,6 +50,9 @@ class TestLPRebalancerStartupReconciliation(TestCase):
         connector = MagicMock()
         connector.network = "mainnet-beta"
         connector.address = "WalletAddress123"
+        connector.update_balances = AsyncMock(
+            side_effect=RuntimeError("balance rpc down") if refresh_fails else None)
+        self.connector = connector
         market_data_provider.get_connector.return_value = connector
 
         controller = LPRebalancer(
@@ -163,6 +167,43 @@ class TestLPRebalancerStartupReconciliation(TestCase):
         self.assertIn("startup_position_policy", str(ctx.exception))
 
     # -- recover -----------------------------------------------------------
+
+    def test_recover_refreshes_balances_before_releasing_the_gate(self):
+        """A reconciliation close goes straight through Gateway and never
+        touches the executor bookkeeping that covers balance-poll lag, so the
+        cached wallet reading is still pre-close. Sizing the first position off
+        it fails with INSUFFICIENT_BALANCE and costs a full rebalance interval.
+        """
+        controller = self._make_controller(
+            positions=[MockPosition()], startup_position_policy="recover")
+        gateway = self._gateway()
+        self._tick(controller, gateway)      # submits the close
+        controller._chain_positions = []     # the close settles on-chain
+        self._tick(controller, gateway)
+
+        self.connector.update_balances.assert_awaited_once()
+        self.assertTrue(controller._startup_reconciled)
+        self.assertFalse(controller._startup_blocks_trading())
+
+    def test_recover_stays_blocked_if_the_balance_refresh_fails(self):
+        """Better to wait than to size a position off a known-stale balance."""
+        controller = self._make_controller(
+            positions=[MockPosition()], refresh_fails=True,
+            startup_position_policy="recover")
+        gateway = self._gateway()
+        self._tick(controller, gateway)
+        controller._chain_positions = []
+        self._tick(controller, gateway)
+
+        self.assertFalse(controller._startup_reconciled)
+        self.assertTrue(controller._startup_blocks_trading())
+
+    def test_no_refresh_when_nothing_was_closed(self):
+        """A clean start has no stale reading to correct."""
+        controller = self._make_controller(positions=[])
+        self._tick(controller)
+        self.connector.update_balances.assert_not_awaited()
+        self.assertTrue(controller._startup_reconciled)
 
     def test_recover_halts_when_several_positions_exist(self):
         """Several positions mean a shared wallet: closing could take someone else's."""


### PR DESCRIPTION
## Problem

`LPRebalancer` keeps no state across restarts. `executors_info` starts empty and `_initial_position_created` starts `False`, so a position opened by a previous process is invisible to the controller — and the first tick after a restart opens a second one.

The original position is then orphaned on-chain:

- nothing rebalances it,
- nothing closes it when price crosses its limit prices,
- its fees are never collected,
- and the wallet no longer holds enough to size the replacement correctly, so the new position is opened undersized or fails outright.

Any restart while a position is open reaches this — a config deploy, a crash, or a machine reboot. It is silent: the logs show a normal startup, and the only symptom is capital sitting in a pool that nothing is managing any more.

I hit this on a live Meteora DLMM deployment. A restart with ~$575 deployed left the position stranded while the controller opened a new one from the ~$48 still in the wallet.

## Change

A startup reconciliation pass. Before opening anything, the controller asks the connector which positions the wallet already holds in its configured pool, and acts on a new `startup_position_policy`:

| policy | behaviour |
| --- | --- |
| `recover` (default) | close the stray position, returning its liquidity and uncollected fees to the wallet, then start clean |
| `halt` | refuse to trade until it is dealt with manually |
| `ignore` | previous behaviour, kept as an escape hatch |

The failure paths are the point:

- **An unreadable chain is not an empty wallet.** If the position query fails, the controller waits rather than assuming a clean slate — opening blind is precisely the failure being prevented.
- **Recovery is verified, not assumed.** Positions are re-read after closing rather than trusting the close response.
- **It gives up safely.** After `startup_recover_max_attempts` failures it halts instead of opening on top of a position it could not clear.
- **The gate is startup-only.** Once reconciled, normal operation is untouched (covered by a test).

Reconciliation state appears in `to_format_status`, since it blocks trading.

## On the default

I chose `recover` because it keeps the controller autonomous, which is the reason to run it unattended, and closing a position is something this controller does routinely anyway — liquidity and fees both return to the wallet, so the cost is gas plus a few seconds out of market.

`halt` is the more conservative choice and I am happy to switch the default if maintainers prefer that a controller never take an unprompted on-chain action. The important part is that the default is no longer `ignore`.

## Testing

`test/hummingbot/strategy_v2/controllers/test_lp_rebalancer_startup_reconciliation.py` — 13 tests covering each policy, the unreadable-chain case, verification-after-close, retry-then-halt, a failing close, idempotence, config validation, and that trading resumes once reconciled.

```
13 passed
```

`flake8` clean against the repo config.

Beyond unit tests, the same logic has been running on a live mainnet Meteora SOL/USDC deployment. Restarting the bot with a position open now produces:

```
Startup reconciliation: recovering 1 pre-existing position(s) (attempt 1/3): Dg2Fw4BZ... [105.573239-108.093890] 2.5107 base + 306.74 quote (uncollected fees 0.00037/0.0529)
Startup reconciliation: closed stray position Dg2Fw4BZ... signature=4PRb6TXmPJ8Cc6JEx7ss8aaTRdDZZvG3rcCRiL3ftvnB59TacRahdW7PiR9XF2cVJjqAV1q7VuFymwfVhSpaJGCM
Startup reconciliation: all stray positions closed; capital returned to the wallet
Position created: 3eD8SVhf... base 2.689679 quote 287.499525
```

Full capital recovered and redeployed in about three seconds, where previously it would have been stranded.

## Possible follow-up

`LPExecutorConfig` has no field for an existing position, so an executor can only ever create one — which is why `recover` closes and reopens rather than resuming. Adding an `existing_position_address` and an adoption path would let a restart carry on managing the live position with no round-trip cost or time out of market. That touches executor state initialisation and P&L baselines for a position whose entry amounts are unknown, so it seemed better as its own change than bundled here. Happy to pick it up if there is interest.
