### PR TITLE
feat(gateway): add token discovery client method

### DIFF
--- a/hummingbot/core/gateway/gateway_http_client.py
+++ b/hummingbot/core/gateway/gateway_http_client.py
@@ -1751,6 +1751,16 @@ class GatewayHttpClient:
             }
         )
 
+    async def add_token_by_address(
+        self,
+        address: str,
+        chain: str,
+        network: str
+    ) -> Dict[str, Any]:
+        """Discover a token's metadata and add it to Gateway by address."""
+        query = urlencode({"chainNetwork": self._to_chain_network(network, chain)})
+        return await self.api_request("post", f"tokens/save/{address}?{query}")
+
     async def remove_token(
         self,
         address: str,

--- a/test/hummingbot/connector/gateway/test_gateway_http_client_token_routes.py
+++ b/test/hummingbot/connector/gateway/test_gateway_http_client_token_routes.py
@@ -1,0 +1,24 @@
+from test.isolated_asyncio_wrapper_test_case import IsolatedAsyncioWrapperTestCase
+from unittest.mock import AsyncMock, patch
+
+from hummingbot.core.gateway.gateway_http_client import GatewayHttpClient
+
+
+class GatewayHttpClientTokenRouteTest(IsolatedAsyncioWrapperTestCase):
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.client = GatewayHttpClient.get_instance()
+
+    async def test_add_token_by_address_uses_save_route_with_chain_network_query(self):
+        address = "A7bdiYdS5GjqGFtxf17ppRHtDKPkkRqbKtR27dxvQXaS"
+        response = {"message": "saved", "token": {"address": address, "symbol": "ZEC"}}
+
+        with patch.object(self.client, "api_request", new=AsyncMock(return_value=response)) as mock_request:
+            result = await self.client.add_token_by_address(address, "solana", "mainnet-beta")
+
+        self.assertEqual(response, result)
+        mock_request.assert_awaited_once_with(
+            "post",
+            f"tokens/save/{address}?chainNetwork=solana-mainnet-beta",
+        )


### PR DESCRIPTION
## Summary

- add GatewayHttpClient.add_token_by_address for Gateway token discovery and persistence
- send chainNetwork in the URL query required by POST /tokens/save/{address}
- cover the route, full chain-network conversion, and returned response with a focused client test

## Why

Gateway can discover token metadata from the token address and persist it through its save endpoint, but the Hummingbot Gateway client only exposed metadata-explicit add_token. The new method exposes the address-only workflow without changing the existing method contract.

## Tests

- conda run -n hummingbot pytest -q test/hummingbot/connector/gateway/test_gateway_http_client_token_routes.py test/hummingbot/connector/gateway/test_gateway_http_client_swap_routes.py test/hummingbot/connector/gateway/test_gateway_http_client_lp_routes.py
- conda run -n hummingbot pre-commit run --files hummingbot/core/gateway/gateway_http_client.py test/hummingbot/connector/gateway/test_gateway_http_client_token_routes.py

Result: 26 passed; all repository hooks passed.