### PR TITLE
fix(lp_rebalancer): ignore autoswap deficits too small to route

### DIFF
--- a/controllers/generic/lp_rebalancer/lp_rebalancer.py
+++ b/controllers/generic/lp_rebalancer/lp_rebalancer.py
@@ -92,6 +92,14 @@ class LPRebalancerConfig(ControllerConfigBase):
         json_schema_extra={"is_updatable": True},
         description="Extra % to swap beyond deficit to account for slippage (e.g., 0.01 = 0.01%)"
     )
+    min_autoswap_quote: Decimal = Field(
+        default=Decimal("1"), ge=0,
+        json_schema_extra={"is_updatable": True},
+        description="Skip autoswaps worth less than this in quote terms. A deficit far below one "
+                    "unit of the quote asset is rounding, not a funding gap, and routers cannot "
+                    "execute a swap that small - the order fails and the controller retries it "
+                    "forever without ever opening a position. Set to 0 to attempt any deficit."
+    )
 
     @field_validator("sell_price_min", "sell_price_max", "buy_price_min", "buy_price_max", mode="before")
     @classmethod
@@ -327,6 +335,38 @@ class LPRebalancer(ControllerBase):
 
         # Buffer multiplier only applied to swap amount
         buffer_multiplier = Decimal("1") + (self.config.swap_buffer_pct / Decimal("100"))
+
+        # Ignore deficits too small to be worth a swap.
+        #
+        # Wallet balances rarely land exactly on total_amount_quote: fees, gas
+        # and rounding leave the wallet a fraction short, and any positive
+        # deficit used to produce a swap. A deficit of a few millionths of a
+        # token is not a funding gap, and no router will quote it - the order
+        # fails, and because the controller retries on the next tick it fails
+        # again, forever, without ever opening a position. That is a silent
+        # outage: the strategy is running, holds its full capital, and simply
+        # never trades.
+        #
+        # Skipping the swap is the right response because the position is then
+        # sized from the balance that is actually present, which differs from
+        # the target by less than min_autoswap_quote.
+        base_deficit_quote = base_deficit * current_price
+        if Decimal("0") < base_deficit_quote < self.config.min_autoswap_quote:
+            self.logger().info(
+                f"Autoswap: ignoring a {base_deficit:.9f} {self._base_token} deficit "
+                f"(~{base_deficit_quote:.6f} {self._quote_token}, below the "
+                f"{self.config.min_autoswap_quote} floor) - rounding, not a funding gap"
+            )
+            base_deficit = Decimal("0")
+        if Decimal("0") < quote_deficit < self.config.min_autoswap_quote:
+            self.logger().info(
+                f"Autoswap: ignoring a {quote_deficit:.9f} {self._quote_token} deficit "
+                f"(below the {self.config.min_autoswap_quote} floor) - rounding, not a funding gap"
+            )
+            quote_deficit = Decimal("0")
+
+        if base_deficit <= 0 and quote_deficit <= 0:
+            return None
 
         # If any deficit, swap
         if base_deficit > 0 and quote_deficit <= 0:
@@ -637,6 +677,42 @@ class LPRebalancer(ControllerBase):
         # No action needed - executor will auto-close via limit prices
         return actions
 
+    def _fit_amounts_to_balance(self, base_amt: Decimal, quote_amt: Decimal,
+                                current_price: Decimal) -> tuple:
+        """Trim a request that overshoots the wallet by less than the swap floor.
+
+        Deficits below min_autoswap_quote are deliberately not swapped for, so
+        the request can exceed the wallet by up to that much. Asking for it
+        anyway fails the open with INSUFFICIENT_BALANCE, which would just trade
+        one retry loop for another. Only sub-floor gaps are absorbed; a real
+        shortfall is left alone so it still surfaces rather than silently
+        opening a smaller position than configured.
+        """
+        for token, amount, is_base in ((self._base_token, base_amt, True),
+                                       (self._quote_token, quote_amt, False)):
+            if amount <= 0:
+                continue
+            try:
+                available = Decimal(str(
+                    self.market_data_provider.get_balance(self.config.connector_name, token)))
+            except Exception as e:
+                self.logger().debug(f"Could not read {token} balance while sizing: {e}")
+                continue
+            shortfall = amount - available
+            if shortfall <= 0:
+                continue
+            shortfall_quote = shortfall * current_price if is_base else shortfall
+            if shortfall_quote < self.config.min_autoswap_quote:
+                self.logger().info(
+                    f"Sizing {token} down to the wallet balance {available} "
+                    f"(short by {shortfall}, ~{shortfall_quote:.6f} {self._quote_token} of rounding)"
+                )
+                if is_base:
+                    base_amt = available
+                else:
+                    quote_amt = available
+        return base_amt, quote_amt
+
     def _create_executor_config(self, side: TradeType) -> Optional[LPExecutorConfig]:
         """
         Create executor config with limit prices for auto-close.
@@ -665,6 +741,7 @@ class LPRebalancer(ControllerBase):
 
         # Calculate amounts based on final side
         base_amt, quote_amt = self._calculate_amounts(side, current_price)
+        base_amt, quote_amt = self._fit_amounts_to_balance(base_amt, quote_amt, current_price)
 
         # Calculate limit prices for auto-close
         threshold = self.config.rebalance_threshold_pct / Decimal("100")

--- a/test/hummingbot/strategy_v2/controllers/test_lp_rebalancer_autoswap_dust_floor.py
+++ b/test/hummingbot/strategy_v2/controllers/test_lp_rebalancer_autoswap_dust_floor.py
@@ -1,0 +1,133 @@
+import asyncio
+from decimal import Decimal
+from unittest import TestCase
+from unittest.mock import AsyncMock, MagicMock
+
+from controllers.generic.lp_rebalancer.lp_rebalancer import LPRebalancer, LPRebalancerConfig
+from hummingbot.core.data_type.common import TradeType
+from hummingbot.data_feed.market_data_provider import MarketDataProvider
+
+
+class TestLPRebalancerAutoswapDustFloor(TestCase):
+    """Autoswap must ignore deficits too small for a router to execute.
+
+    Wallet balances rarely land exactly on total_amount_quote - fees, gas and
+    rounding leave them a fraction short - and any positive deficit used to
+    trigger a swap. A deficit of a few millionths of a token cannot be routed,
+    so the order fails, and because the controller retries on the next tick it
+    fails again indefinitely without ever opening a position.
+    """
+
+    def _make_controller(self, base_balance="10", quote_balance="1000",
+                         **config_overrides) -> LPRebalancer:
+        config_kwargs = dict(
+            id="test",
+            connector_name="solana-mainnet-beta",
+            lp_provider="meteora/clmm",
+            trading_pair="SOL-USDC",
+            pool_address="PoolAddress123",
+            autoswap=True,
+            total_amount_quote=Decimal("575"),
+        )
+        config_kwargs.update(config_overrides)
+        config = LPRebalancerConfig(**config_kwargs)
+
+        market_data_provider = MagicMock(spec=MarketDataProvider)
+        market_data_provider.time.return_value = 1000.0
+        balances = {"SOL": Decimal(base_balance), "USDC": Decimal(quote_balance)}
+        market_data_provider.get_balance.side_effect = \
+            lambda _conn, token: balances.get(token, Decimal("0"))
+        connector = MagicMock()
+        connector.native_currency = "SOL"
+        connector.get_native_currency_buffer.return_value = Decimal("0")
+        market_data_provider.get_connector.return_value = connector
+
+        controller = LPRebalancer(
+            config=config,
+            market_data_provider=market_data_provider,
+            actions_queue=AsyncMock(spec=asyncio.Queue),
+        )
+        controller.executors_info = []
+        controller._pool_price = Decimal("100")
+        return controller
+
+    # -- the outage ---------------------------------------------------------
+
+    def test_dust_quote_deficit_produces_no_swap(self):
+        """The observed failure: 574.999944 USDC against a 575 target.
+
+        A shortfall of 0.000056 asked the router to sell 0.000001 SOL. Nothing
+        can route that, so the swap failed on every tick for hours while the
+        strategy held its full capital and never opened a position.
+        """
+        controller = self._make_controller(
+            base_balance="0.388", quote_balance="574.999944",
+            side=TradeType.BUY, position_offset_pct=Decimal("0.01"))
+        swap = controller._check_autoswap_needed(TradeType.BUY, Decimal("100"))
+        self.assertIsNone(swap)
+
+    def test_dust_base_deficit_produces_no_swap(self):
+        controller = self._make_controller(
+            base_balance="5.749999", quote_balance="0",
+            side=TradeType.SELL, position_offset_pct=Decimal("0.01"))
+        swap = controller._check_autoswap_needed(TradeType.SELL, Decimal("100"))
+        self.assertIsNone(swap)
+
+    # -- real deficits still swap -------------------------------------------
+
+    def test_real_quote_deficit_still_swaps(self):
+        controller = self._make_controller(
+            base_balance="10", quote_balance="100",
+            side=TradeType.BUY, position_offset_pct=Decimal("0.01"))
+        swap = controller._check_autoswap_needed(TradeType.BUY, Decimal("100"))
+        self.assertIsNotNone(swap)
+        self.assertEqual(swap.side, TradeType.SELL)
+
+    def test_floor_of_zero_restores_previous_behaviour(self):
+        """Opt back in to attempting any deficit, however small."""
+        controller = self._make_controller(
+            base_balance="0.388", quote_balance="574.999944",
+            side=TradeType.BUY, position_offset_pct=Decimal("0.01"),
+            min_autoswap_quote=Decimal("0"))
+        swap = controller._check_autoswap_needed(TradeType.BUY, Decimal("100"))
+        self.assertIsNotNone(swap)
+
+    # -- sizing absorbs what the swap declined to fix ------------------------
+
+    def test_sub_floor_shortfall_is_absorbed_by_sizing(self):
+        """Skipping the dust swap must not just move the failure downstream."""
+        controller = self._make_controller(quote_balance="574.999944")
+        base, quote = controller._fit_amounts_to_balance(
+            Decimal("0"), Decimal("575"), Decimal("100"))
+        self.assertEqual(quote, Decimal("574.999944"))
+        self.assertEqual(base, Decimal("0"))
+
+    def test_real_shortfall_is_not_absorbed(self):
+        """A genuine funding gap must still surface, not silently shrink."""
+        controller = self._make_controller(quote_balance="400")
+        _, quote = controller._fit_amounts_to_balance(
+            Decimal("0"), Decimal("575"), Decimal("100"))
+        self.assertEqual(quote, Decimal("575"))
+
+    def test_funded_request_is_untouched(self):
+        controller = self._make_controller(base_balance="10", quote_balance="1000")
+        base, quote = controller._fit_amounts_to_balance(
+            Decimal("2"), Decimal("300"), Decimal("100"))
+        self.assertEqual((base, quote), (Decimal("2"), Decimal("300")))
+
+    def test_unreadable_balance_leaves_amounts_alone(self):
+        controller = self._make_controller()
+        controller.market_data_provider.get_balance.side_effect = RuntimeError("rpc down")
+        base, quote = controller._fit_amounts_to_balance(
+            Decimal("2"), Decimal("300"), Decimal("100"))
+        self.assertEqual((base, quote), (Decimal("2"), Decimal("300")))
+
+    def test_default_floor_is_one_quote_unit(self):
+        config = LPRebalancerConfig(
+            id="test",
+            connector_name="solana-mainnet-beta",
+            lp_provider="meteora/clmm",
+            trading_pair="SOL-USDC",
+            pool_address="PoolAddress123",
+        )
+        self.assertEqual(config.min_autoswap_quote, Decimal("1"))


### PR DESCRIPTION
## Problem

`_check_autoswap_needed` triggers on **any** positive deficit:

```python
if base_deficit > 0 and quote_deficit <= 0:
```

Wallet balances rarely land exactly on `total_amount_quote` — fees, gas and rounding leave them a fraction short — so a deficit of a few millionths of a token is routine. Each one produces a swap order that no router will quote.

The order fails. The controller retries on the next tick. It fails again. Nothing recovers, because the shortfall that caused it is still there.

The result is a **silent outage**: the strategy is running, holds its full capital, reports no unusual state, and simply never opens a position. The only symptom is router errors in the log.

## Observed

On a live mainnet Meteora SOL/USDC deployment. The wallet held `574.999944` USDC against a `total_amount_quote` of `575` — a shortfall of **$0.000056**:

```
Autoswap check: need quote=575.000000, have=574.999944, deficit=0.000056
Autoswap: SELL 0.000001 SOL for ~0.000056 USDC
swap SELL 0.000000 on SOL-USDC FAILED: No route found for SOL -> USDC (ExactIn).
  Jupiter API error: No routes found [code: NO_ROUTE_FOUND]. Error code NO_ROUTE_FOUND is not retryable.
```

That repeated roughly **12,000 times over three hours** while $575 sat idle. No transactions were submitted and no gas was spent — it fails at routing — but the strategy earned nothing for the duration and there was no signal that anything was wrong beyond the log.

## Change

Ignore deficits worth less than `min_autoswap_quote` (default `1`, in quote terms) and size the position from the balance that is actually present — which, by definition, differs from the target by less than that floor.

Both halves are needed. Skipping the swap alone would leave the request larger than the wallet and simply trade `NO_ROUTE_FOUND` for `INSUFFICIENT_BALANCE`, so `_fit_amounts_to_balance` trims a request that overshoots by a sub-floor amount. A **real** funding shortfall is deliberately left alone, so genuine underfunding still surfaces instead of quietly opening a smaller position than configured.

`min_autoswap_quote: 0` restores the previous behaviour for anyone who wants it.

## Testing

`test/hummingbot/strategy_v2/controllers/test_lp_rebalancer_autoswap_dust_floor.py` — 9 tests covering the exact observed numbers (574.999944 against 575), the base-side equivalent, real deficits still swapping, a floor of 0 restoring old behaviour, sizing absorbing a sub-floor shortfall, a real shortfall *not* being absorbed, unreadable balances leaving amounts untouched, and the default.

```
9 passed
```

`flake8` clean against the repo config.

## Note on scope

This is independent of #8440 and can be reviewed on its own — different failure, different code path, no shared state. Both touch `lp_rebalancer.py`, so whichever merges second may need a trivial rebase in the config block; happy to do that whenever it is useful.

One thing I noticed while debugging but have **not** changed here: `swap_buffer_pct` defaults to `0.01`, and per its own description that means 0.01%, not 1%. As a slippage buffer that is close to no buffer at all, and it is why the swap kept landing a hair short of the target in the first place. Raising the default seems reasonable but it changes behaviour for existing users, so I left it alone rather than bundle it. Happy to open that separately if maintainers agree.
