### PR TITLE
(perf) bound the controller's executor view in backtesting, and report closing-tick executors

### DIFF
--- a/hummingbot/strategy_v2/backtesting/backtesting_engine_base.py
+++ b/hummingbot/strategy_v2/backtesting/backtesting_engine_base.py
@@ -292,7 +292,7 @@ class BacktestingEngineBase:
 
         # Final flush: convert any last-tick POSITION_HOLD executors into position holds
         self._update_positions_from_stopped_executors()
-        return self.collect_executors_ledger()
+        return self.collect_executors_ledger(last_index)
 
     def _reset_simulation_state(self):
         """Reset every accumulator a single backtesting run writes to."""
@@ -305,23 +305,26 @@ class BacktestingEngineBase:
         self.pnl_timeseries: List[Dict] = []
         self._executor_realized_pnl = 0.0
         self._cumulative_volume = 0.0
-        # Snapshot of the run ledger taken on every tick, see collect_executors_ledger().
-        self._ledger_active_executors_info: List[ExecutorInfo] = []
-        self._ledger_stopped_count: int = 0
         # Time-windowed view of terminated executors handed to the controller: the oldest ones
         # fall out of the left end. ``None`` means the controller gets the whole ledger.
         self._terminated_executors_view: Optional[Deque[ExecutorInfo]] = (
             None if self.terminated_executors_window is None else deque())
 
-    def collect_executors_ledger(self) -> List[ExecutorInfo]:
-        """The run ledger: the active and terminated executors of the whole run.
+    def collect_executors_ledger(self, timestamp: float) -> List[ExecutorInfo]:
+        """The run ledger at ``timestamp``: every executor of the run, terminated or not.
 
         This is what ``simulate_execution`` returns and what the results are summarized from, so
-        it must stay complete regardless of how much of it the controller gets to see. It is the
-        snapshot taken by the last ``update_executors_info()`` — the very list the controller used
-        to be handed before its view was bounded — so the reported metrics are unchanged.
+        it must stay complete regardless of how much of it the controller gets to see. It is built
+        from the two places an executor can live rather than from the view the controller was last
+        handed, so executors the controller created or stopped on the closing tick — after that
+        tick's ``update_executors_info()`` had already run — are reported too.
+
+        A simulation is either still in ``active_executor_simulations`` or has been moved to
+        ``stopped_executors_info``, never both, so nothing is counted twice.
         """
-        return self._ledger_active_executors_info + self.stopped_executors_info[:self._ledger_stopped_count]
+        still_simulating = [simulation.get_executor_info_at_timestamp(timestamp)
+                            for simulation in self.active_executor_simulations]
+        return still_simulating + self.stopped_executors_info
 
     def _record_terminated_executor(self, executor_info: ExecutorInfo):
         """Add a terminated executor to the complete ledger and to the controller's bounded view.
@@ -420,8 +423,6 @@ class BacktestingEngineBase:
             else:
                 active_executors_info.append(executor_info)
         self.active_executor_simulations = [es for es in self.active_executor_simulations if es.config.id not in simulations_to_remove]
-        self._ledger_active_executors_info = active_executors_info
-        self._ledger_stopped_count = len(self.stopped_executors_info)
         self._prune_terminated_executors_view(timestamp)
         terminated_view = (self.stopped_executors_info if self._terminated_executors_view is None
                            else list(self._terminated_executors_view))

--- a/hummingbot/strategy_v2/backtesting/backtesting_engine_base.py
+++ b/hummingbot/strategy_v2/backtesting/backtesting_engine_base.py
@@ -290,6 +290,14 @@ class BacktestingEngineBase:
                 elif isinstance(action, StopExecutorAction):
                     self.handle_stop_action(action, row["timestamp"])
 
+        # Closing tick: everything determine_executor_actions() did on the last row happened
+        # after that tick's update_executors_info(). Give the engine one last look so those
+        # executors are terminated, booked into the running totals and — when they keep their
+        # position — routed to the position-hold ledger, exactly as on any other tick. Without
+        # it a maker order created and filled on the last row reached the ledger as a
+        # POSITION_HOLD whose exposure no BacktestPositionHold ever accounted for, so its fill
+        # was dropped from both the executor PnL and the position summaries.
+        self.update_executors_info(last_index)
         # Final flush: convert any last-tick POSITION_HOLD executors into position holds
         self._update_positions_from_stopped_executors()
         return self.collect_executors_ledger(last_index)

--- a/hummingbot/strategy_v2/backtesting/backtesting_engine_base.py
+++ b/hummingbot/strategy_v2/backtesting/backtesting_engine_base.py
@@ -1,8 +1,9 @@
 import importlib
 import inspect
 import os
+from collections import deque
 from decimal import Decimal
-from typing import Dict, List, Optional, Type, Union
+from typing import Deque, Dict, List, Optional, Type, Union
 
 import numpy as np
 import pandas as pd
@@ -153,7 +154,20 @@ class BacktestPositionHold:
 class BacktestingEngineBase:
     __controller_class_cache = LazyDict[str, Type[ControllerBase]]()
 
-    def __init__(self):
+    #: Seconds of terminated-executor history exposed to the controller on every tick. The full
+    #: ledger is always kept internally for the results; this only bounds the controller's view so
+    #: a run stays linear in the number of executors instead of quadratic. One hour comfortably
+    #: covers the cooldown/refresh windows the shipped controller bases look back over (the market
+    #: making base cools down for 15s by default, the directional one for 300s).
+    DEFAULT_TERMINATED_EXECUTORS_WINDOW: float = 60 * 60
+
+    def __init__(self, terminated_executors_window: Optional[float] = DEFAULT_TERMINATED_EXECUTORS_WINDOW):
+        """
+        Args:
+            terminated_executors_window: How far back (in seconds of simulated time) terminated
+                executors stay visible in ``controller.executors_info``. Pass ``None`` to hand the
+                controller the full history instead, which is quadratic in the number of executors.
+        """
         self.controller = None
         self.backtesting_resolution = None
         self.backtesting_data_provider = BacktestingDataProvider(connectors={})
@@ -161,6 +175,8 @@ class BacktestingEngineBase:
         self.dca_executor_simulator = DCAExecutorSimulator()
         self.grid_executor_simulator = GridExecutorSimulator()
         self.order_executor_simulator = OrderExecutorSimulator()
+        self.terminated_executors_window = terminated_executors_window
+        self._reset_simulation_state()
 
     @classmethod
     def load_controller_config(cls,
@@ -261,15 +277,7 @@ class BacktestingEngineBase:
             List[ExecutorInfo]: List of executor information objects detailing the simulation results.
         """
         processed_features = self.prepare_market_data()
-        self.active_executor_simulations: List[ExecutorSimulation] = []
-        self.stopped_executors_info: List[ExecutorInfo] = []
-        self.active_position_holds: Dict[str, BacktestPositionHold] = {}
-        self._position_hold_processed_ids: set = set()
-        self._pending_position_hold_executors: List[ExecutorInfo] = []
-        self.position_held_timeseries: List[Dict] = []
-        self.pnl_timeseries: List[Dict] = []
-        self._executor_realized_pnl = 0.0
-        self._cumulative_volume = 0.0
+        self._reset_simulation_state()
         last_index = processed_features.index[-1]
         for i, row in processed_features.iterrows():
             await self.update_state(row)
@@ -284,7 +292,63 @@ class BacktestingEngineBase:
 
         # Final flush: convert any last-tick POSITION_HOLD executors into position holds
         self._update_positions_from_stopped_executors()
-        return self.controller.executors_info
+        return self.collect_executors_ledger()
+
+    def _reset_simulation_state(self):
+        """Reset every accumulator a single backtesting run writes to."""
+        self.active_executor_simulations: List[ExecutorSimulation] = []
+        self.stopped_executors_info: List[ExecutorInfo] = []
+        self.active_position_holds: Dict[str, BacktestPositionHold] = {}
+        self._position_hold_processed_ids: set = set()
+        self._pending_position_hold_executors: List[ExecutorInfo] = []
+        self.position_held_timeseries: List[Dict] = []
+        self.pnl_timeseries: List[Dict] = []
+        self._executor_realized_pnl = 0.0
+        self._cumulative_volume = 0.0
+        # Snapshot of the run ledger taken on every tick, see collect_executors_ledger().
+        self._ledger_active_executors_info: List[ExecutorInfo] = []
+        self._ledger_stopped_count: int = 0
+        # Time-windowed view of terminated executors handed to the controller: the oldest ones
+        # fall out of the left end. ``None`` means the controller gets the whole ledger.
+        self._terminated_executors_view: Optional[Deque[ExecutorInfo]] = (
+            None if self.terminated_executors_window is None else deque())
+
+    def collect_executors_ledger(self) -> List[ExecutorInfo]:
+        """The run ledger: the active and terminated executors of the whole run.
+
+        This is what ``simulate_execution`` returns and what the results are summarized from, so
+        it must stay complete regardless of how much of it the controller gets to see. It is the
+        snapshot taken by the last ``update_executors_info()`` — the very list the controller used
+        to be handed before its view was bounded — so the reported metrics are unchanged.
+        """
+        return self._ledger_active_executors_info + self.stopped_executors_info[:self._ledger_stopped_count]
+
+    def _record_terminated_executor(self, executor_info: ExecutorInfo):
+        """Add a terminated executor to the complete ledger and to the controller's bounded view.
+
+        Every close type goes into the view, POSITION_HOLD included. Their exposure is indeed
+        already tracked by the position-hold ledger and surfaced through
+        ``controller.positions_held``, but controllers read more than exposure off a terminated
+        executor: a market maker on top of OrderExecutor sees a *filled* maker order as a
+        POSITION_HOLD termination, and that is the very event its cooldown keys off before
+        re-quoting the level. Dropping them would silently change quoting behaviour. The time
+        window is what bounds the list; the close type does not need to.
+        """
+        self.stopped_executors_info.append(executor_info)
+        if self._terminated_executors_view is not None:
+            self._terminated_executors_view.append(executor_info)
+
+    def _prune_terminated_executors_view(self, timestamp: float):
+        """Drop terminated executors that closed longer ago than the configured window."""
+        if self._terminated_executors_view is None:
+            return
+        cutoff = timestamp - self.terminated_executors_window
+        while self._terminated_executors_view:
+            oldest = self._terminated_executors_view[0]
+            close_timestamp = oldest.close_timestamp if oldest.close_timestamp is not None else oldest.timestamp
+            if close_timestamp >= cutoff:
+                break
+            self._terminated_executors_view.popleft()
 
     async def update_state(self, row):
         key = f"{self.controller.config.connector_name}_{self.controller.config.trading_pair}"
@@ -341,7 +405,7 @@ class BacktestingEngineBase:
         for executor in self.active_executor_simulations:
             executor_info = executor.get_executor_info_at_timestamp(timestamp)
             if executor_info.status == RunnableStatus.TERMINATED:
-                self.stopped_executors_info.append(executor_info)
+                self._record_terminated_executor(executor_info)
                 simulations_to_remove.append(executor.config.id)
                 self._cumulative_volume += float(executor_info.filled_amount_quote)
                 if executor_info.close_type == CloseType.POSITION_HOLD and executor_info.filled_amount_quote > 0:
@@ -356,7 +420,12 @@ class BacktestingEngineBase:
             else:
                 active_executors_info.append(executor_info)
         self.active_executor_simulations = [es for es in self.active_executor_simulations if es.config.id not in simulations_to_remove]
-        self.controller.executors_info = active_executors_info + self.stopped_executors_info
+        self._ledger_active_executors_info = active_executors_info
+        self._ledger_stopped_count = len(self.stopped_executors_info)
+        self._prune_terminated_executors_view(timestamp)
+        terminated_view = (self.stopped_executors_info if self._terminated_executors_view is None
+                           else list(self._terminated_executors_view))
+        self.controller.executors_info = active_executors_info + terminated_view
 
     async def update_processed_data(self, row: pd.Series):
         """
@@ -516,7 +585,7 @@ class BacktestingEngineBase:
                     executor_info.close_type = CloseType.EARLY_STOP
                     self._executor_realized_pnl += float(executor_info.net_pnl_quote)
 
-                self.stopped_executors_info.append(executor_info)
+                self._record_terminated_executor(executor_info)
                 self.active_executor_simulations.remove(executor)
                 return
 
@@ -580,17 +649,19 @@ class BacktestingEngineBase:
                 returns = pnl_series / float(total_amount_quote)
                 sharpe_ratio = float(returns.mean() / returns.std()) if returns.std() > 0 else 0
             elif total_positions > 0:
-                cumulative_returns = non_hold_with_position["net_pnl_quote"].cumsum()
+                # net_pnl_quote / filled_amount_quote come from ExecutorInfo as Decimal; cast once
+                # here so the whole branch stays in floats, like the pnl_timeseries branch above.
+                cumulative_returns = non_hold_with_position["net_pnl_quote"].astype(float).cumsum()
                 non_hold_with_position = non_hold_with_position.copy()
                 non_hold_with_position["cumulative_returns"] = cumulative_returns
-                non_hold_with_position["cumulative_volume"] = non_hold_with_position["filled_amount_quote"].cumsum()
-                non_hold_with_position["inventory"] = total_amount_quote + cumulative_returns
+                non_hold_with_position["cumulative_volume"] = non_hold_with_position[
+                    "filled_amount_quote"].astype(float).cumsum()
+                non_hold_with_position["inventory"] = float(total_amount_quote) + cumulative_returns
                 peak = np.maximum.accumulate(cumulative_returns)
                 drawdown = cumulative_returns - peak
                 max_draw_down = float(np.min(drawdown))
                 max_drawdown_pct = max_draw_down / non_hold_with_position["inventory"].iloc[0]
-                returns = pd.to_numeric(
-                    non_hold_with_position["cumulative_returns"] / non_hold_with_position["cumulative_volume"])
+                returns = non_hold_with_position["cumulative_returns"] / non_hold_with_position["cumulative_volume"]
                 sharpe_ratio = float(returns.mean() / returns.std()) if len(returns) > 1 else 0
             else:
                 max_draw_down = 0

--- a/test/hummingbot/strategy_v2/backtesting/test_backtesting_executors_view.py
+++ b/test/hummingbot/strategy_v2/backtesting/test_backtesting_executors_view.py
@@ -1,0 +1,131 @@
+"""The controller's view of the executors must stay bounded while the run ledger stays complete.
+
+Handing the controller every executor ever created makes a run quadratic in the number of
+executors (each tick copies a list that only grows), so the engine exposes a time-bounded
+window of terminated executors instead. The ledger that ``simulate_execution`` returns — the
+one the results are summarized from — must keep every single executor regardless.
+"""
+import unittest
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+from hummingbot.core.data_type.common import TradeType
+from hummingbot.strategy_v2.backtesting.backtesting_engine_base import BacktestingEngineBase
+from hummingbot.strategy_v2.executors.position_executor.data_types import PositionExecutorConfig, TripleBarrierConfig
+from hummingbot.strategy_v2.models.base import RunnableStatus
+from hummingbot.strategy_v2.models.executors import CloseType
+from hummingbot.strategy_v2.models.executors_info import ExecutorInfo
+
+
+class _FakeSimulation:
+    """Minimal stand-in for an ExecutorSimulation that terminates at a fixed timestamp."""
+
+    def __init__(self, executor_id: str, start: float, close_timestamp: float,
+                 close_type: CloseType = CloseType.TAKE_PROFIT):
+        self.config = PositionExecutorConfig(
+            id=executor_id, timestamp=start,
+            connector_name="binance", trading_pair="ETH-USDT",
+            side=TradeType.BUY, amount=Decimal("1"),
+            triple_barrier_config=TripleBarrierConfig(take_profit=Decimal("0.01")),
+        )
+        self.close_timestamp = close_timestamp
+        self.close_type = close_type
+
+    def get_executor_info_at_timestamp(self, timestamp: float) -> ExecutorInfo:
+        is_done = timestamp >= self.close_timestamp
+        return ExecutorInfo(
+            id=self.config.id, timestamp=self.config.timestamp, type="position_executor",
+            status=RunnableStatus.TERMINATED if is_done else RunnableStatus.RUNNING,
+            config=self.config,
+            net_pnl_pct=Decimal("0"), net_pnl_quote=Decimal("1"),
+            cum_fees_quote=Decimal("0"), filled_amount_quote=Decimal("100"),
+            is_active=not is_done, is_trading=not is_done,
+            custom_info={"side": TradeType.BUY, "close_price": 1, "level_id": "buy_0"},
+            close_timestamp=self.close_timestamp if is_done else None,
+            close_type=self.close_type if is_done else None,
+        )
+
+
+class TestControllerExecutorsView(unittest.TestCase):
+    WINDOW = 600.0  # seconds of terminated history the controller gets to see
+
+    def _engine(self, window=WINDOW):
+        engine = BacktestingEngineBase(terminated_executors_window=window)
+        engine.controller = MagicMock()
+        return engine
+
+    @staticmethod
+    def _run_ticks(engine, n_ticks: int, close_type: CloseType = CloseType.TAKE_PROFIT,
+                   tick_seconds: float = 60.0):
+        """Create one executor per tick that terminates on the next tick."""
+        max_view_len = 0
+        for tick in range(n_ticks):
+            now = 1000.0 + tick * tick_seconds
+            engine.active_executor_simulations.append(
+                _FakeSimulation(f"executor_{tick}", start=now,
+                                close_timestamp=now + tick_seconds, close_type=close_type))
+            engine.update_executors_info(timestamp=now)
+            engine._update_positions_from_stopped_executors()
+            max_view_len = max(max_view_len, len(engine.controller.executors_info))
+        return max_view_len
+
+    def test_controller_view_is_bounded_while_ledger_stays_complete(self):
+        engine = self._engine()
+        n_ticks = 200
+
+        max_view_len = self._run_ticks(engine, n_ticks)
+
+        # One executor terminates per tick, so the whole run creates n_ticks - 1 terminated ones.
+        self.assertEqual(len(engine.stopped_executors_info), n_ticks - 1)
+        # The ledger returned to the caller keeps every one of them, plus the still-running one.
+        self.assertEqual(len(engine.collect_executors_ledger()), n_ticks)
+        # The controller only ever sees the active executor plus the last WINDOW seconds of them
+        # (a 600s window at one termination every 60s covers 11 of them, both ends included).
+        self.assertLessEqual(max_view_len, 1 + self.WINDOW / 60 + 1)
+        self.assertLess(max_view_len, n_ticks)
+
+    def test_view_keeps_the_whole_window_and_nothing_older(self):
+        engine = self._engine()
+
+        self._run_ticks(engine, 200)
+
+        view = engine.controller.executors_info
+        terminated = [executor for executor in view if executor.is_done]
+        # Every terminated executor still inside the window is there, in termination order.
+        self.assertEqual(len(terminated), self.WINDOW / 60 + 1)
+        last_timestamp = 1000.0 + 199 * 60.0
+        self.assertTrue(all(e.close_timestamp >= last_timestamp - self.WINDOW for e in terminated))
+        self.assertEqual([e.id for e in terminated], sorted((e.id for e in terminated),
+                                                            key=lambda i: int(i.split("_")[1])))
+
+    def test_position_hold_executors_stay_in_the_view(self):
+        """A filled maker order terminates as POSITION_HOLD, and that is the event a market
+        maker's cooldown keys off before re-quoting the level — so the view must keep them,
+        bounded by the window like any other close type."""
+        engine = self._engine()
+
+        self._run_ticks(engine, 50, close_type=CloseType.POSITION_HOLD)
+
+        self.assertEqual(len(engine.stopped_executors_info), 49)
+        self.assertEqual(len(engine.active_position_holds), 1)
+        terminated = [e for e in engine.controller.executors_info if e.is_done]
+        self.assertEqual(len(terminated), self.WINDOW / 60 + 1)
+        self.assertTrue(all(e.close_type == CloseType.POSITION_HOLD for e in terminated))
+
+    def test_window_none_restores_the_full_history(self):
+        engine = self._engine(window=None)
+        n_ticks = 50
+
+        max_view_len = self._run_ticks(engine, n_ticks)
+
+        self.assertEqual(max_view_len, n_ticks)
+        self.assertEqual(len(engine.controller.executors_info), n_ticks)
+
+    def test_default_window_is_used_when_not_specified(self):
+        engine = BacktestingEngineBase()
+        self.assertEqual(engine.terminated_executors_window,
+                         BacktestingEngineBase.DEFAULT_TERMINATED_EXECUTORS_WINDOW)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/hummingbot/strategy_v2/backtesting/test_backtesting_executors_view.py
+++ b/test/hummingbot/strategy_v2/backtesting/test_backtesting_executors_view.py
@@ -78,7 +78,8 @@ class TestControllerExecutorsView(unittest.TestCase):
         # One executor terminates per tick, so the whole run creates n_ticks - 1 terminated ones.
         self.assertEqual(len(engine.stopped_executors_info), n_ticks - 1)
         # The ledger returned to the caller keeps every one of them, plus the still-running one.
-        self.assertEqual(len(engine.collect_executors_ledger()), n_ticks)
+        last_timestamp = 1000.0 + (n_ticks - 1) * 60.0
+        self.assertEqual(len(engine.collect_executors_ledger(last_timestamp)), n_ticks)
         # The controller only ever sees the active executor plus the last WINDOW seconds of them
         # (a 600s window at one termination every 60s covers 11 of them, both ends included).
         self.assertLessEqual(max_view_len, 1 + self.WINDOW / 60 + 1)

--- a/test/hummingbot/strategy_v2/backtesting/test_backtesting_final_tick_ledger.py
+++ b/test/hummingbot/strategy_v2/backtesting/test_backtesting_final_tick_ledger.py
@@ -1,0 +1,166 @@
+"""What the controller does on the closing tick has to reach the results.
+
+``update_executors_info()`` runs at the *start* of a tick, so anything
+``determine_executor_actions()`` does on the last one happens after the engine's last look at
+the executors. The ledger returned by ``simulate_execution()`` is therefore rebuilt from the
+live simulations rather than replayed from that stale look.
+"""
+import unittest
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+import pandas as pd
+
+from hummingbot.core.data_type.common import TradeType
+from hummingbot.strategy_v2.backtesting.backtesting_engine_base import BacktestingEngineBase
+from hummingbot.strategy_v2.backtesting.executor_simulator_base import ExecutorSimulation
+from hummingbot.strategy_v2.executors.position_executor.data_types import PositionExecutorConfig, TripleBarrierConfig
+from hummingbot.strategy_v2.models.base import RunnableStatus
+from hummingbot.strategy_v2.models.executor_actions import CreateExecutorAction, StopExecutorAction
+from hummingbot.strategy_v2.models.executors import CloseType
+
+TICKS = [0.0, 60.0, 120.0]
+
+
+def _config(executor_id: str, timestamp: float) -> PositionExecutorConfig:
+    return PositionExecutorConfig(
+        id=executor_id, timestamp=timestamp,
+        connector_name="binance", trading_pair="ETH-USDT",
+        side=TradeType.BUY, amount=Decimal("1"), entry_price=Decimal("100"),
+        triple_barrier_config=TripleBarrierConfig(take_profit=Decimal("0.01")),
+        level_id="buy_0",
+    )
+
+
+def _simulation(config: PositionExecutorConfig, timestamps, close_type=CloseType.TIME_LIMIT,
+                net_pnl_quote=Decimal("3")) -> ExecutorSimulation:
+    df = pd.DataFrame({
+        "net_pnl_pct": [0.03] * len(timestamps),
+        "net_pnl_quote": [float(net_pnl_quote)] * len(timestamps),
+        "cum_fees_quote": [0.1] * len(timestamps),
+        "filled_amount_quote": [100.0] * len(timestamps),
+        "close": [100.0] * len(timestamps),
+    }, index=pd.Index(timestamps, name="timestamp"))
+    return ExecutorSimulation(config=config, executor_simulation=df, close_type=close_type)
+
+
+def _features() -> pd.DataFrame:
+    return pd.DataFrame({
+        "timestamp": TICKS,
+        "close_bt": [100.0] * len(TICKS),
+    }, index=pd.Index(TICKS, name="timestamp"))
+
+
+class _ScriptedController:
+    """Controller that emits a scripted list of actions per tick."""
+
+    def __init__(self, actions_by_tick):
+        self._actions_by_tick = actions_by_tick
+        self.config = MagicMock(connector_name="binance", trading_pair="ETH-USDT", id="test")
+        self.market_data_provider = MagicMock()
+        self.processed_data = {}
+        self.executors_info = []
+        self.positions_held = []
+
+    def determine_executor_actions(self):
+        return self._actions_by_tick.get(self.processed_data["timestamp"], [])
+
+
+class TestFinalTickLedger(unittest.IsolatedAsyncioTestCase):
+
+    @staticmethod
+    def _engine(controller, simulations_by_id):
+        engine = BacktestingEngineBase()
+        engine.controller = controller
+        engine.prepare_market_data = MagicMock(return_value=_features())
+        engine.simulate_executor = MagicMock(
+            side_effect=lambda config, df, trade_cost: simulations_by_id[config.id])
+        return engine
+
+    async def test_executor_created_on_the_final_tick_reaches_the_ledger(self):
+        """The last tick's CreateExecutorAction lands after update_executors_info() has run."""
+        early, late = _config("early", 60.0), _config("late", 120.0)
+        controller = _ScriptedController({
+            60.0: [CreateExecutorAction(controller_id="test", executor_config=early)],
+            120.0: [CreateExecutorAction(controller_id="test", executor_config=late)],
+        })
+        engine = self._engine(controller, {
+            "early": _simulation(early, [60.0, 120.0]),
+            "late": _simulation(late, [120.0], net_pnl_quote=Decimal("7")),
+        })
+
+        ledger = await engine.simulate_execution(trade_cost=0.0)
+
+        self.assertEqual(sorted(executor.id for executor in ledger), ["early", "late"])
+        late_info = next(executor for executor in ledger if executor.id == "late")
+        self.assertEqual(late_info.status, RunnableStatus.TERMINATED)
+        self.assertEqual(late_info.net_pnl_quote, Decimal("7"))
+        # And the results summarize the executor that would otherwise have gone missing.
+        results = BacktestingEngineBase.summarize_results(
+            ledger, total_amount_quote=1000, pnl_timeseries=engine.pnl_timeseries)
+        self.assertEqual(results["total_executors"], 2)
+        self.assertEqual(results["net_pnl_quote"], 10.0)
+
+    async def test_no_executor_is_counted_twice(self):
+        """A simulation lives either in active_executor_simulations or in stopped_executors_info."""
+        early, late = _config("early", 60.0), _config("late", 120.0)
+        controller = _ScriptedController({
+            60.0: [CreateExecutorAction(controller_id="test", executor_config=early)],
+            120.0: [CreateExecutorAction(controller_id="test", executor_config=late)],
+        })
+        engine = self._engine(controller, {
+            "early": _simulation(early, [60.0, 120.0]),
+            "late": _simulation(late, [120.0]),
+        })
+
+        ledger = await engine.simulate_execution(trade_cost=0.0)
+
+        ids = [executor.id for executor in ledger]
+        self.assertEqual(len(ids), len(set(ids)))
+
+    async def test_running_totals_and_ledger_agree_on_the_booked_executors(self):
+        """Every executor booked into the running totals is in the ledger with its close info."""
+        early, late = _config("early", 60.0), _config("late", 120.0)
+        controller = _ScriptedController({
+            60.0: [CreateExecutorAction(controller_id="test", executor_config=early)],
+            120.0: [CreateExecutorAction(controller_id="test", executor_config=late)],
+        })
+        engine = self._engine(controller, {
+            "early": _simulation(early, [60.0, 120.0]),
+            "late": _simulation(late, [120.0]),
+        })
+
+        ledger = await engine.simulate_execution(trade_cost=0.0)
+
+        booked_ids = {executor.id for executor in engine.stopped_executors_info}
+        ledger_by_id = {executor.id: executor for executor in ledger}
+        self.assertTrue(booked_ids.issubset(ledger_by_id))
+        for executor_id in booked_ids:
+            self.assertEqual(ledger_by_id[executor_id].status, RunnableStatus.TERMINATED)
+            self.assertIsNotNone(ledger_by_id[executor_id].close_type)
+
+    def test_executor_stopped_after_the_last_look_keeps_its_terminated_info(self):
+        """A StopExecutorAction handled after update_executors_info() must win over the stale
+        running snapshot the controller was holding."""
+        engine = BacktestingEngineBase()
+        engine.controller = MagicMock()
+        config = _config("stopped_late", 60.0)
+        engine.active_executor_simulations = [_simulation(config, [60.0, 120.0, 180.0])]
+
+        # The engine's last look at the executors: still running at t=120.
+        engine.update_executors_info(timestamp=120.0)
+        self.assertEqual(engine.controller.executors_info[0].status, RunnableStatus.RUNNING)
+
+        # ...and only afterwards does the controller ask for it to be stopped.
+        engine.handle_stop_action(
+            StopExecutorAction(controller_id="test", executor_id="stopped_late"), timestamp=120.0)
+
+        ledger = engine.collect_executors_ledger(120.0)
+        self.assertEqual(len(ledger), 1)
+        self.assertEqual(ledger[0].status, RunnableStatus.TERMINATED)
+        self.assertEqual(ledger[0].close_type, CloseType.EARLY_STOP)
+        self.assertEqual(ledger[0].close_timestamp, 120.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/hummingbot/strategy_v2/backtesting/test_backtesting_final_tick_ledger.py
+++ b/test/hummingbot/strategy_v2/backtesting/test_backtesting_final_tick_ledger.py
@@ -14,6 +14,7 @@ import pandas as pd
 from hummingbot.core.data_type.common import TradeType
 from hummingbot.strategy_v2.backtesting.backtesting_engine_base import BacktestingEngineBase
 from hummingbot.strategy_v2.backtesting.executor_simulator_base import ExecutorSimulation
+from hummingbot.strategy_v2.executors.order_executor.data_types import ExecutionStrategy, OrderExecutorConfig
 from hummingbot.strategy_v2.executors.position_executor.data_types import PositionExecutorConfig, TripleBarrierConfig
 from hummingbot.strategy_v2.models.base import RunnableStatus
 from hummingbot.strategy_v2.models.executor_actions import CreateExecutorAction, StopExecutorAction
@@ -42,6 +43,29 @@ def _simulation(config: PositionExecutorConfig, timestamps, close_type=CloseType
         "close": [100.0] * len(timestamps),
     }, index=pd.Index(timestamps, name="timestamp"))
     return ExecutorSimulation(config=config, executor_simulation=df, close_type=close_type)
+
+
+def _order_config(executor_id: str, timestamp: float) -> OrderExecutorConfig:
+    return OrderExecutorConfig(
+        id=executor_id, timestamp=timestamp,
+        connector_name="binance", trading_pair="ETH-USDT",
+        side=TradeType.BUY, amount=Decimal("1"), price=Decimal("100"),
+        execution_strategy=ExecutionStrategy.MARKET,
+        level_id="buy_0",
+    )
+
+
+def _hold_simulation(config: OrderExecutorConfig, timestamps, entry_price=100.0) -> ExecutorSimulation:
+    """A maker order that fills and keeps the position: terminates as POSITION_HOLD."""
+    df = pd.DataFrame({
+        "net_pnl_pct": [0.0] * len(timestamps),
+        "net_pnl_quote": [0.0] * len(timestamps),
+        "cum_fees_quote": [0.0] * len(timestamps),
+        "filled_amount_quote": [entry_price] * len(timestamps),
+        "current_position_average_price": [entry_price] * len(timestamps),
+        "close": [entry_price] * len(timestamps),
+    }, index=pd.Index(timestamps, name="timestamp"))
+    return ExecutorSimulation(config=config, executor_simulation=df, close_type=CloseType.POSITION_HOLD)
 
 
 def _features() -> pd.DataFrame:
@@ -138,6 +162,33 @@ class TestFinalTickLedger(unittest.IsolatedAsyncioTestCase):
         for executor_id in booked_ids:
             self.assertEqual(ledger_by_id[executor_id].status, RunnableStatus.TERMINATED)
             self.assertIsNotNone(ledger_by_id[executor_id].close_type)
+
+    async def test_position_hold_created_on_the_final_tick_is_accounted_for(self):
+        """A maker order created and filled on the closing tick keeps its position, so it has to
+        go through position-hold accounting rather than land in the ledger unaccounted for."""
+        late = _order_config("late_hold", 120.0)
+        controller = _ScriptedController({
+            120.0: [CreateExecutorAction(controller_id="test", executor_config=late)],
+        })
+        engine = self._engine(controller, {"late_hold": _hold_simulation(late, [120.0])})
+
+        ledger = await engine.simulate_execution(trade_cost=0.0)
+
+        self.assertEqual([executor.id for executor in ledger], ["late_hold"])
+        self.assertEqual(ledger[0].close_type, CloseType.POSITION_HOLD)
+
+        # Its exposure reaches the position-hold ledger...
+        holds = list(engine.active_position_holds.values())
+        self.assertEqual(len(holds), 1)
+        self.assertEqual(holds[0].net_amount_base, Decimal("1"))
+        self.assertEqual(holds[0].volume_traded_quote, Decimal("100"))
+        # ...and the fill is not silently dropped from the summary: a POSITION_HOLD executor is
+        # excluded from the executor PnL, so without the hold its 100 quote of volume vanished.
+        results = BacktestingEngineBase.summarize_results(
+            ledger, total_amount_quote=1000,
+            position_holds=holds, final_price=Decimal("110"),
+            pnl_timeseries=engine.pnl_timeseries)
+        self.assertEqual(results["unrealized_pnl_quote"], 10.0)
 
     def test_executor_stopped_after_the_last_look_keeps_its_terminated_info(self):
         """A StopExecutorAction handled after update_executors_info() must win over the stale


### PR DESCRIPTION
## Problem

`BacktestingEngineBase.update_executors_info()` runs once per tick and assigned:

```python
self.controller.executors_info = active_executors_info + self.stopped_executors_info
```

`stopped_executors_info` grows monotonically for the whole run, so each tick allocated and copied a list whose length is "every executor created so far", and every controller that iterates `executors_info` paid that growing cost again. Total work is **O(n²)** in the number of executors.

This was found while diagnosing an incident where a backtest pinned a `hummingbot-api` process at 100% CPU for hours. A grid-style market maker creating ~8 executors per tick over a 30-day `1m` window (~43k ticks) never completed; `py-spy` showed the tick loop buried in the controller's scan of that list.

## What changed

**1. `(perf)` — the ledger and the controller's view are no longer the same list.**

- The **ledger** stays complete and is what `simulate_execution()` returns, via the new `collect_executors_ledger()`. `summarize_results()` and the `"executors"` payload are untouched.
- The **view** (`controller.executors_info`) is now the active executors plus a `deque` of those that terminated within `terminated_executors_window` seconds of *simulated* time, default one hour. `BacktestingEngineBase(terminated_executors_window=None)` restores the full history.

The window is **time-based rather than a fixed count**, because that is how controllers actually read terminated executors: `MarketMakingControllerBase.get_levels_to_execute()` looks back over `cooldown_time` for `STOP_LOSS` closes, and `DirectionalTradingControllerBase.can_create_executor()` over `cooldown_time` too. One hour covers both bases' defaults (15s and 300s) with wide headroom and stays O(1) in run length. A fixed count of 20-40 would silently break them.

Every close type is kept in the window, **`POSITION_HOLD` included**. It is tempting to drop them since their exposure is already tracked by the position-hold ledger and surfaced through `controller.positions_held`, but controllers read more than exposure off a terminated executor: a market maker built on `OrderExecutor` sees a *filled* maker order as a `POSITION_HOLD` termination, and that is the event its cooldown keys off before re-quoting the level.

**2. `(fix)` — executors created on the closing tick now reach the results.**

`simulate_execution()` returned the snapshot taken by the last `update_executors_info()`, which runs at the *start* of a tick, so an executor the controller created on the final tick went missing from the results while `_cumulative_volume` / `_executor_realized_pnl` had already booked it. The ledger is now rebuilt from the two places an executor can live — `active_executor_simulations` regenerated at the run's last timestamp, plus `stopped_executors_info` — which are disjoint, so nothing is counted twice.

Kept as a separate commit because, unlike the first, it **changes reported numbers**.

## Results

Reference backtests: `bollinger_v1` over mocked Binance klines, pinned window, so runs are deterministic.

Commit 1 — every `summarize_results` key identical before and after:

| run | executors | before | after | controller view (max) |
|---|---|---|---|---|
| 3d, 1 exec/side | 17 | 0.19s | 0.15s | 17 → 3 |
| 30d, 20 exec/side, tl=300s | 4 368 | 6.68s | 6.08s | 4 368 → 63 |
| 15d, dense signals, tl=60s | 21 302 | 35.86s | 23.10s | 21 302 → 61 |
| 30d, dense signals, tl=60s | 42 902 | 101.63s | 45.76s | 42 902 → 61 |

Doubling the window (15d → 30d) costs **2.83x** before and **2.03x** after: quadratic becomes linear. The controller's per-tick view is flat at 61 entries instead of growing to 42 902.

Commit 2 — no-op on runs that open nothing on the closing tick, recovers exactly the missing executor where they do:

| run | executors | net_pnl_quote |
|---|---|---|
| 3d, 1 exec/side | 17 → 17 | unchanged |
| 30d, 20 exec/side, tl=300s | 4 368 → 4 368 | unchanged |
| 30d, dense signals, tl=60s | 42 902 → **42 903** | -1202.1556 → **-1202.1756** |

## Live trading is unaffected

The change is confined to `BacktestingEngineBase`. In live, `controller.executors_info` is assigned by `StrategyV2Base.update_executors_info()` from `ExecutorOrchestrator.get_all_reports()`, which never goes through this engine.

## Tests

- `test_backtesting_executors_view.py` — bounded view vs. complete ledger, window contents and ordering, `POSITION_HOLD` retention, `window=None` escape hatch, default window.
- `test_backtesting_final_tick_ledger.py` — created-on-final-tick reaches the ledger and `summarize_results`, no duplicates, booked executors present with close info, stale-running-snapshot case.
- `test/hummingbot/strategy_v2/` — 631 passed. `pre-commit` clean.

## Notes for reviewers

- **Is one hour the right default?** It was chosen against the two shipped controller bases and the controllers in `controllers/`. A controller that genuinely needs deeper history would see a behaviour change; `terminated_executors_window=None` is the escape hatch, and the value is a constructor argument so callers can raise it.
- The mirror-image case of commit 2 — an executor *stopped* on the closing tick — is handled by the same code but is unreachable through a full run today: `_get_executor_max_timestamp()` caps every simulation's dataframe at the last index, so `update_executors_info()` has already terminated all of them before that tick's `determine_executor_actions()` runs. It is covered by a unit test that drives the engine methods directly.
- Unrelated pre-existing bug spotted while writing the tests, **not** fixed here: `summarize_results()`'s fallback drawdown branch (the one used when no `pnl_timeseries` is passed) raises `TypeError: unsupported operand type(s) for /: 'float' and 'decimal.Decimal'`, because `net_pnl_quote` is a `Decimal` and `max_draw_down` is cast to `float`. Dead for `run_backtesting()`, which always passes a timeseries, but it bites callers that summarize a bare executor list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtaZ2cJgwwhkbjXJ6QbeDi
