### PR TITLE
fix(hyperliquid): omit the builder field when the fee resolves to 0

### DIFF
--- a/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_derivative.py
+++ b/hummingbot/connector/derivative/hyperliquid_perpetual/hyperliquid_perpetual_derivative.py
@@ -681,8 +681,15 @@ class HyperliquidPerpetualDerivative(PerpetualDerivativePyBase):
 
     def _build_builder_field(self) -> Optional[Dict[str, Any]]:
         """The ``{"b": <address>, "f": <tenths_of_bps>}`` order field, or None when omitted. Address
-        is lowercased (the venue rejects mixed-case)."""
+        is lowercased (the venue rejects mixed-case).
+
+        Omitted when the resolved fee is 0, i.e. the user has not approved this builder (or the
+        lookup failed). Hyperliquid rejects an order carrying a builder the user has not approved
+        - "Builder fee has not been approved." - regardless of the fee being 0, so sending the
+        field would fail every order while collecting nothing."""
         if not self._should_inject_builder():
+            return None
+        if self._builder_fee_tenths_bps <= 0:
             return None
         return {"b": self._builder_address.lower(), "f": self._builder_fee_tenths_bps}
 

--- a/test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_derivative.py
+++ b/test/hummingbot/connector/derivative/hyperliquid_perpetual/test_hyperliquid_perpetual_derivative.py
@@ -3876,12 +3876,48 @@ class HyperliquidPerpetualBuilderCodeTests(TestCase):
     def test_default_foundation_address_configured_so_field_injected(self):
         self.assertIsNotNone(CONSTANTS.FOUNDATION_BUILDER_ADDRESS)
         connector = self._build_connector()
+        connector._builder_fee_tenths_bps = 10  # as if the user approved 1 bps
         self.assertEqual(CONSTANTS.FOUNDATION_BUILDER_ADDRESS.lower(), connector._builder_address)
         self.assertTrue(connector._should_inject_builder())
         self.assertEqual(
-            {"b": CONSTANTS.FOUNDATION_BUILDER_ADDRESS.lower(), "f": 0},
+            {"b": CONSTANTS.FOUNDATION_BUILDER_ADDRESS.lower(), "f": 10},
             connector._build_builder_field(),
         )
+
+    def test_builder_field_omitted_when_fee_is_zero(self):
+        """A zero fee means the builder is unapproved (or the lookup failed).
+
+        Hyperliquid rejects an order carrying an unapproved builder outright -
+        "Builder fee has not been approved." - so sending the field at f=0 fails every
+        order while collecting nothing.
+        """
+        connector = self._build_connector()
+        self.assertTrue(connector._should_inject_builder())
+        self.assertEqual(0, connector._builder_fee_tenths_bps)
+        self.assertIsNone(connector._build_builder_field())
+
+    @patch.object(HyperliquidPerpetualDerivative, "_api_post", new_callable=AsyncMock)
+    def test_place_order_omits_builder_key_when_fee_is_zero(self, api_post_mock):
+        """The key must be absent from the signed action, not present with f=0."""
+        api_post_mock.return_value = {"status": "ok", "response": {"data": {"statuses": [{"resting": {"oid": 7}}]}}}
+        connector = self._build_connector()
+        connector._builder_fee_tenths_bps = 0
+        connector.coin_to_asset = {"BTC": 0}
+        with patch.object(connector, "exchange_symbol_associated_to_pair",
+                          new_callable=AsyncMock, return_value="BTC"):
+            self.async_run_with_timeout(
+                connector._place_order(
+                    order_id="test-order",
+                    trading_pair="BTC-USD",
+                    amount=Decimal("1"),
+                    trade_type=TradeType.BUY,
+                    order_type=OrderType.LIMIT,
+                    price=Decimal("10000"),
+                    position_action=PositionAction.OPEN,
+                )
+            )
+        sent = api_post_mock.call_args.kwargs["data"]
+        self.assertNotIn("builder", sent)
 
     def test_builder_field_omitted_when_not_supported(self):
         connector = self._build_connector()
@@ -3936,11 +3972,9 @@ class HyperliquidPerpetualBuilderCodeTests(TestCase):
         connector = self._build_connector()
         self.async_run_with_timeout(connector._initialize_builder_fee())
         self.assertEqual(0, connector._builder_fee_tenths_bps)
-        # Still attributes to the Foundation builder address, just at 0 bps.
-        self.assertEqual(
-            {"b": CONSTANTS.FOUNDATION_BUILDER_ADDRESS.lower(), "f": 0},
-            connector._build_builder_field(),
-        )
+        # And the field is omitted: the venue rejects an order carrying a builder the
+        # user has not approved, so attributing at 0 bps would fail the order outright.
+        self.assertIsNone(connector._build_builder_field())
 
     @patch.object(HyperliquidPerpetualDerivative, "_api_post", new_callable=AsyncMock)
     def test_initialize_builder_fee_clamped_to_configured_fee(self, api_post_mock):


### PR DESCRIPTION
## Problem

Every order fails for any user who has not approved the Hummingbot Foundation builder:

```
Error submitting order 0x4f111ae6...: Builder fee has not been approved.
Failed to submit SELL order to Hyperliquid_perpetual. Check API key and network connection.
```

The connector is unusable on mainnet until the user approves a builder they may not know about and may not want to pay.

## Cause

`_initialize_builder_fee()` resolves the fee correctly — `min(approved, configured)`, which is `0` when `maxBuilderFee` returns `0`:

```python
self._builder_fee_tenths_bps = min(approved_max_tenths_bps, CONSTANTS.FOUNDATION_BUILDER_FEE_TENTHS_BPS)
```

But `_build_builder_field()` attaches the field regardless of the resolved fee:

```python
return {"b": self._builder_address.lower(), "f": self._builder_fee_tenths_bps}   # f == 0
```

Hyperliquid rejects an order carrying a builder the sender has not approved **even when the fee is 0**. The surrounding comments assume otherwise — "The fee only takes effect if the user has approved this builder in Condor; otherwise it is 0 bps" — which holds for the fee but not for the order.

## Fix

Omit the field when the resolved fee is 0. That matches what the existing comments already assume the behaviour to be, and it collects nothing either way.

An approved user is unaffected: the fee is non-zero and the field is attached exactly as before. Vault and testnet handling is untouched.

## Tests

Two existing tests asserted the field was still built at `f=0`, one of them noting *"Still attributes to the Foundation builder address, just at 0 bps"* — that is precisely the assumption the venue rejects. Both now assert the field is omitted.

Added:
- `test_builder_field_omitted_when_fee_is_zero`
- `test_place_order_omits_builder_key_when_fee_is_zero` — asserts the key is **absent** from the signed action rather than present with a zero value, driving the real `_place_order` path

`148 passed` for the full connector suite.

## Verification

Reproduced on mainnet with an account where `maxBuilderFee` returns `0`: every order failed with the message above. With the field omitted, orders submit and fill normally.
