### PR TITLE
(feat) Add BingX spot candles and complete trading rules

### DIFF
--- a/hummingbot/connector/exchange/bing_x/bing_x_exchange.py
+++ b/hummingbot/connector/exchange/bing_x/bing_x_exchange.py
@@ -276,21 +276,21 @@ class BingXExchange(ExchangePyBase):
             }
         }
         """
-        trading_pair_rules = exchange_info_dict['data'].get("symbols", [])
-        trading_pair_rules = [item for item in trading_pair_rules if (item.get("symbol") in self.trading_pairs)]
+        trading_pair_rules = exchange_info_dict["data"].get("symbols", [])
+        trading_pair_rules = [
+            item for item in trading_pair_rules
+            if bing_x_utils.is_exchange_information_valid(item)
+        ]
         retval = []
         for rule in trading_pair_rules:
             try:
                 trading_pair = rule.get("symbol")
 
-                last_traded_price = Decimal(str(await self._get_last_traded_price(trading_pair)))
-
                 min_price_increment = Decimal(str(rule.get("tickSize")))
                 min_base_amount_increment = Decimal(str(rule.get("stepSize")))
                 min_notional_size = Decimal(str(rule.get("minNotional")))
-                max_notional_size = Decimal(str(rule.get("maxNotional")))
-                min_order_size = Decimal(min_notional_size / last_traded_price)  # rule.get("minQty") is deprecated for now
-                max_order_size = Decimal(max_notional_size / last_traded_price)  # rule.get("maxQty") is deprecated for now
+                min_order_size = Decimal(str(rule.get("minQty")))
+                max_order_size = Decimal(str(rule.get("maxQty")))
 
                 retval.append(
                     TradingRule(

--- a/hummingbot/data_feed/candles_feed/bing_x_spot_candles/__init__.py
+++ b/hummingbot/data_feed/candles_feed/bing_x_spot_candles/__init__.py
@@ -1,0 +1,3 @@
+from hummingbot.data_feed.candles_feed.bing_x_spot_candles.bing_x_spot_candles import BingXSpotCandles
+
+__all__ = ["BingXSpotCandles"]

--- a/hummingbot/data_feed/candles_feed/bing_x_spot_candles/bing_x_spot_candles.py
+++ b/hummingbot/data_feed/candles_feed/bing_x_spot_candles/bing_x_spot_candles.py
@@ -1,0 +1,126 @@
+import logging
+import uuid
+from typing import List, Optional
+
+from hummingbot.connector.exchange.bing_x.bing_x_utils import decompress_ws_message
+from hummingbot.core.network_iterator import NetworkStatus
+from hummingbot.data_feed.candles_feed.bing_x_spot_candles import constants as CONSTANTS
+from hummingbot.data_feed.candles_feed.candles_base import CandlesBase
+from hummingbot.logger import HummingbotLogger
+
+
+class BingXSpotCandles(CandlesBase):
+    _logger: Optional[HummingbotLogger] = None
+
+    @classmethod
+    def logger(cls) -> HummingbotLogger:
+        if cls._logger is None:
+            cls._logger = logging.getLogger(__name__)
+        return cls._logger
+
+    def __init__(self, trading_pair: str, interval: str = "1m", max_records: int = 150):
+        super().__init__(trading_pair, interval, max_records)
+
+    @property
+    def name(self):
+        return f"bing_x_{self._trading_pair}"
+
+    @property
+    def rest_url(self):
+        return CONSTANTS.REST_URL
+
+    @property
+    def wss_url(self):
+        return CONSTANTS.WSS_URL
+
+    @property
+    def health_check_url(self):
+        return self.rest_url + CONSTANTS.HEALTH_CHECK_ENDPOINT
+
+    @property
+    def candles_url(self):
+        return self.rest_url + CONSTANTS.CANDLES_ENDPOINT
+
+    @property
+    def candles_endpoint(self):
+        return CONSTANTS.CANDLES_ENDPOINT
+
+    @property
+    def candles_max_result_per_rest_request(self):
+        return CONSTANTS.MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST
+
+    @property
+    def rate_limits(self):
+        return CONSTANTS.RATE_LIMITS
+
+    @property
+    def intervals(self):
+        return CONSTANTS.INTERVALS
+
+    async def check_network(self) -> NetworkStatus:
+        rest_assistant = await self._api_factory.get_rest_assistant()
+        await rest_assistant.execute_request(url=self.health_check_url,
+                                             throttler_limit_id=CONSTANTS.HEALTH_CHECK_ENDPOINT)
+        return NetworkStatus.CONNECTED
+
+    def get_exchange_trading_pair(self, trading_pair):
+        # BingX spot uses the dashed BASE-QUOTE notation natively, both on REST and WS.
+        return trading_pair
+
+    def _get_rest_candles_params(self,
+                                 start_time: Optional[int] = None,
+                                 end_time: Optional[int] = None,
+                                 limit: Optional[int] = CONSTANTS.MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST) -> dict:
+        # The REST kline endpoint accepts the Hummingbot interval strings verbatim; both
+        # timestamps are millisecond epoch values (live-verified).
+        return {
+            "symbol": self._ex_trading_pair,
+            "interval": self.interval,
+            "startTime": start_time * 1000,
+            "endTime": end_time * 1000,
+            "limit": limit,
+        }
+
+    def _parse_rest_candles(self, data: dict, end_time: Optional[int] = None) -> List[List[float]]:
+        # Live rows are [openTimeMs, open, high, low, close, volume, closeTimeMs, quoteVolume]
+        # and arrive newest-first; the feed contract wants ascending ten-column rows with
+        # second timestamps and zero-filled n_trades/taker fields (BingX does not report them).
+        rows = (data or {}).get("data") or []
+        return [
+            [self.ensure_timestamp_in_seconds(row[0]), row[1], row[2], row[3], row[4], row[5],
+             row[7], 0.0, 0.0, 0.0]
+            for row in reversed(rows)
+        ]
+
+    def ws_subscription_payload(self):
+        payload = {
+            "id": str(uuid.uuid4()),
+            "reqType": "sub",
+            "dataType": f"{self._ex_trading_pair}@kline_{CONSTANTS.INTERVALS[self.interval]}",
+        }
+        return payload
+
+    def _parse_websocket_message(self, data):
+        # WS frames are gzip-compressed JSON; text frames carry no candle data. The kline push
+        # wraps the candle under {"code": 0, "data": {"e": "kline", "K": {...}}} (live-verified);
+        # subscription acks have no "data" object and are ignored.
+        if isinstance(data, (bytes, bytearray)):
+            data = decompress_ws_message(data)
+        if not isinstance(data, dict):
+            return None
+        payload = data.get("data")
+        if not isinstance(payload, dict) or payload.get("e") != "kline":
+            return None
+        kline = payload["K"]
+        return {
+            "timestamp": self.ensure_timestamp_in_seconds(kline["t"]),
+            "open": kline["o"],
+            "high": kline["h"],
+            "low": kline["l"],
+            "close": kline["c"],
+            "volume": kline["v"],
+            "quote_asset_volume": kline["q"],
+            "n_trades": kline["n"],
+            "taker_buy_base_volume": 0.0,
+            "taker_buy_quote_volume": 0.0,
+        }

--- a/hummingbot/data_feed/candles_feed/bing_x_spot_candles/constants.py
+++ b/hummingbot/data_feed/candles_feed/bing_x_spot_candles/constants.py
@@ -1,0 +1,65 @@
+from bidict import bidict
+
+from hummingbot.core.api_throttler.data_types import LinkedLimitWeightPair, RateLimit
+
+# Live-verified against BingX spot production: the spot market endpoints answer under
+# https://open-api.bingx.com (no /openapi prefix). The connector's own REST_URL carries an
+# /openapi suffix that the spot market-data paths reject with 100400 "this api is not exist".
+REST_URL = "https://open-api.bingx.com"
+HEALTH_CHECK_ENDPOINT = "/openApi/spot/v1/ticker/24hr"
+CANDLES_ENDPOINT = "/openApi/spot/v2/market/kline"
+
+WSS_URL = "wss://open-api-ws.bingx.com/market"
+
+# Hummingbot interval -> BingX spot WebSocket kline interval. The two surfaces use different
+# vocabularies: the REST kline endpoint accepts the Hummingbot strings verbatim
+# (1m,3m,5m,15m,30m,1h,2h,4h,6h,8h,12h,1d,3d,1w,1M), while the WS dataType requires
+# 1min/3min/5min/15min/30min/60min/2hour.../12hour/1day/3day/1week (live-verified; "1hour"
+# and "1w" are rejected, and there is no monthly WS kline, so "1M" is not offered).
+INTERVALS = bidict({
+    "1m": "1min",
+    "3m": "3min",
+    "5m": "5min",
+    "15m": "15min",
+    "30m": "30min",
+    "1h": "60min",
+    "2h": "2hour",
+    "4h": "4hour",
+    "6h": "6hour",
+    "8h": "8hour",
+    "12h": "12hour",
+    "1d": "1day",
+    "3d": "3day",
+    "1w": "1week",
+})
+MAX_RESULTS_PER_CANDLESTICK_REST_REQUEST = 1440
+
+# Pool ids mirror the bing_x connector's shared GET pools: when a backing connector is
+# attached, throttler.add_rate_limits() skips ids that already exist, so candle traffic and
+# connector traffic share the connector's budget instead of getting a second one.
+GET_REQUEST_POOL = "GET"
+GET_REQUEST_BURST_POOL = "GET_BURST"
+GET_REQUEST_MIXED_POOL = "GET_MIXED"
+
+MAX_REQUEST_GET = 6000
+MAX_REQUEST_GET_BURST = 70
+MAX_REQUEST_GET_MIXED = 400
+TWO_MINUTES = 120
+ONE_SECOND = 1
+SIX_SECONDS = 6
+
+GET_LINKED_LIMITS = [
+    LinkedLimitWeightPair(GET_REQUEST_POOL, 1),
+    LinkedLimitWeightPair(GET_REQUEST_BURST_POOL, 1),
+    LinkedLimitWeightPair(GET_REQUEST_MIXED_POOL, 1),
+]
+
+RATE_LIMITS = [
+    RateLimit(limit_id=GET_REQUEST_POOL, limit=MAX_REQUEST_GET, time_interval=TWO_MINUTES),
+    RateLimit(limit_id=GET_REQUEST_BURST_POOL, limit=MAX_REQUEST_GET_BURST, time_interval=ONE_SECOND),
+    RateLimit(limit_id=GET_REQUEST_MIXED_POOL, limit=MAX_REQUEST_GET_MIXED, time_interval=SIX_SECONDS),
+    RateLimit(limit_id=CANDLES_ENDPOINT, limit=MAX_REQUEST_GET, time_interval=TWO_MINUTES,
+              linked_limits=GET_LINKED_LIMITS),
+    RateLimit(limit_id=HEALTH_CHECK_ENDPOINT, limit=MAX_REQUEST_GET, time_interval=TWO_MINUTES,
+              linked_limits=GET_LINKED_LIMITS),
+]

--- a/hummingbot/data_feed/candles_feed/candles_factory.py
+++ b/hummingbot/data_feed/candles_feed/candles_factory.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Dict, Optional, Type
 from hummingbot.data_feed.candles_feed.aevo_perpetual_candles import AevoPerpetualCandles
 from hummingbot.data_feed.candles_feed.backpack_perpetual_candles import BackpackPerpetualCandles
 from hummingbot.data_feed.candles_feed.backpack_spot_candles import BackpackSpotCandles
+from hummingbot.data_feed.candles_feed.bing_x_spot_candles import BingXSpotCandles
 from hummingbot.data_feed.candles_feed.binance_perpetual_candles import BinancePerpetualCandles
 from hummingbot.data_feed.candles_feed.binance_spot_candles import BinanceSpotCandles
 from hummingbot.data_feed.candles_feed.bitget_perpetual_candles import BitgetPerpetualCandles
@@ -62,6 +63,7 @@ class CandlesFactory:
         "backpack_perpetual": BackpackPerpetualCandles,
         "binance_perpetual": BinancePerpetualCandles,
         "binance": BinanceSpotCandles,
+        "bing_x": BingXSpotCandles,
         "bitget": BitgetSpotCandles,
         "bitget_perpetual": BitgetPerpetualCandles,
         "gate_io": GateioSpotCandles,

--- a/test/hummingbot/connector/exchange/bing_x/test_bing_x_exchange.py
+++ b/test/hummingbot/connector/exchange/bing_x/test_bing_x_exchange.py
@@ -190,20 +190,32 @@ class TestBingXExchange(unittest.TestCase):
         resp = self.get_exchange_rules_mock()
         mock_api.get(url, body=json.dumps(resp))
 
-        get_last_traded_price_url = web_utils.rest_url(CONSTANTS.LAST_TRADED_PRICE_PATH)
-        get_last_traded_price_url_regex_url = re.compile(f"^{get_last_traded_price_url}".replace(".", r"\.").replace("?", r"\?"))
-        resp = {
-            "data": [
-                {
-                    "lastPrice": 0.00001
-                }
-            ]
-        }
-        mock_api.get(get_last_traded_price_url_regex_url, body=json.dumps(resp))
-
         self.async_run_with_timeout(coroutine=self.exchange._update_trading_rules())
 
         self.assertTrue(self.trading_pair in self.exchange._trading_rules)
+        self.assertEqual(Decimal("74"), self.exchange._trading_rules[self.trading_pair].min_order_size)
+        self.assertEqual(Decimal("296331.5"), self.exchange._trading_rules[self.trading_pair].max_order_size)
+
+    @aioresponses()
+    def test_update_trading_rules_includes_all_active_symbols(self, mock_api):
+        self.exchange._set_current_timestamp(1000)
+        url = web_utils.rest_url(CONSTANTS.EXCHANGE_INFO_PATH_URL)
+        resp = self.get_exchange_rules_mock()
+        resp["data"]["symbols"].append({
+            "symbol": "BTC-USDT",
+            "minQty": 0.000001,
+            "maxQty": 100,
+            "minNotional": 0.5,
+            "maxNotional": 20000,
+            "status": 1,
+            "tickSize": 0.01,
+            "stepSize": 0.000001,
+        })
+        mock_api.get(url, body=json.dumps(resp))
+
+        self.async_run_with_timeout(coroutine=self.exchange._update_trading_rules())
+
+        self.assertEqual({"AURA-USDT", "BTC-USDT"}, set(self.exchange._trading_rules))
 
     @aioresponses()
     def test_update_trading_rules_ignores_rule_with_error(self, mock_api):

--- a/test/hummingbot/data_feed/candles_feed/bing_x_spot_candles/test_bing_x_spot_candles.py
+++ b/test/hummingbot/data_feed/candles_feed/bing_x_spot_candles/test_bing_x_spot_candles.py
@@ -1,0 +1,109 @@
+import asyncio
+from test.hummingbot.data_feed.candles_feed.test_candles_base import TestCandlesBase
+
+from hummingbot.data_feed.candles_feed.bing_x_spot_candles import BingXSpotCandles
+
+
+class TestBingXSpotCandles(TestCandlesBase):
+    __test__ = True
+    level = 0
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls.base_asset = "BTC"
+        cls.quote_asset = "USDT"
+        cls.interval = "1h"
+        cls.trading_pair = f"{cls.base_asset}-{cls.quote_asset}"
+        # BingX spot uses the dashed BASE-QUOTE notation natively on both REST and WS.
+        cls.ex_trading_pair = cls.trading_pair
+        cls.max_records = 150
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.data_feed = BingXSpotCandles(trading_pair=self.trading_pair,
+                                          interval=self.interval,
+                                          max_records=self.max_records)
+        self.data_feed.logger().setLevel(1)
+        self.data_feed.logger().addHandler(self)
+
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+        self.resume_test_event = asyncio.Event()
+
+    @staticmethod
+    def get_candles_rest_data_mock():
+        # Live payload shape: rows are [openTimeMs, open, high, low, close, volume,
+        # closeTimeMs, quoteVolume] and arrive newest-first.
+        return {"code": 0, "timestamp": 1718744400000, "data": [
+            [1718733600000, "3", "4", "2", "3.5", "30", 1718737199999, "105"],
+            [1718730000000, "2", "3", "1", "2.5", "20", 1718733599999, "50"],
+            [1718726400000, "1", "2", "0.5", "2", "10", 1718729999999, "20"],
+            [1718722800000, "0.5", "1", "0.5", "1", "5", 1718726399999, "5"],
+        ]}
+
+    @staticmethod
+    def get_fetch_candles_data_mock():
+        return [
+            [1718722800.0, "0.5", "1", "0.5", "1", "5", "5", 0.0, 0.0, 0.0],
+            [1718726400.0, "1", "2", "0.5", "2", "10", "20", 0.0, 0.0, 0.0],
+            [1718730000.0, "2", "3", "1", "2.5", "20", "50", 0.0, 0.0, 0.0],
+            [1718733600.0, "3", "4", "2", "3.5", "30", "105", 0.0, 0.0, 0.0],
+        ]
+
+    @staticmethod
+    def get_candles_ws_data_mock_1():
+        # Live push shape: the candle is wrapped under data["K"] with data["e"] == "kline".
+        return {"code": 0, "dataType": "BTC-USDT@kline_60min", "success": True, "data": {
+            "e": "kline", "E": 1718730001000, "s": "BTC-USDT",
+            "K": {"t": 1718730000000, "T": 1718733599999, "s": "BTC-USDT", "i": "60min",
+                  "o": "2", "c": "2.5", "h": "3", "l": "1", "v": "20", "n": 7, "q": "50"}}}
+
+    @staticmethod
+    def get_candles_ws_data_mock_2():
+        return {"code": 0, "dataType": "BTC-USDT@kline_60min", "success": True, "data": {
+            "e": "kline", "E": 1718733601000, "s": "BTC-USDT",
+            "K": {"t": 1718733600000, "T": 1718737199999, "s": "BTC-USDT", "i": "60min",
+                  "o": "3", "c": "3.5", "h": "4", "l": "2", "v": "30", "n": 8, "q": "105"}}}
+
+    @staticmethod
+    def _success_subscription_mock():
+        return {"code": 0, "msg": "SUCCESS"}
+
+    def test_rest_params_use_dashed_symbol_hb_interval_and_milliseconds(self):
+        params = self.data_feed._get_rest_candles_params(start_time=1718730000, end_time=1718733600)
+        self.assertEqual(params, {
+            "symbol": "BTC-USDT", "interval": "1h",
+            "startTime": 1718730000000, "endTime": 1718733600000,
+            "limit": self.data_feed.candles_max_result_per_rest_request,
+        })
+
+    def test_parse_rest_reverses_newest_first_rows_into_ascending_rows(self):
+        parsed = self.data_feed._parse_rest_candles(self.get_candles_rest_data_mock())
+        self.assertEqual(parsed, self.get_fetch_candles_data_mock())
+
+    def test_ws_subscription_uses_bingx_data_type_vocabulary(self):
+        payload = self.data_feed.ws_subscription_payload()
+        self.assertEqual(payload["reqType"], "sub")
+        self.assertEqual(payload["dataType"], "BTC-USDT@kline_60min")
+        self.assertIn("id", payload)
+
+    def test_ws_parser_maps_bingx_candle_fields(self):
+        parsed = self.data_feed._parse_websocket_message(self.get_candles_ws_data_mock_1())
+        self.assertEqual(parsed, {
+            "timestamp": 1718730000, "open": "2", "high": "3", "low": "1", "close": "2.5",
+            "volume": "20", "quote_asset_volume": "50", "n_trades": 7,
+            "taker_buy_base_volume": 0.0, "taker_buy_quote_volume": 0.0,
+        })
+
+    def test_ws_parser_ignores_subscription_acks_and_text_frames(self):
+        self.assertIsNone(self.data_feed._parse_websocket_message(self._success_subscription_mock()))
+        self.assertIsNone(self.data_feed._parse_websocket_message("Ping"))
+        self.assertIsNone(self.data_feed._parse_websocket_message(None))
+
+    def test_ws_parser_decompresses_gzip_frames(self):
+        import gzip
+        import json
+        frame = gzip.compress(json.dumps(self.get_candles_ws_data_mock_1()).encode())
+        parsed = self.data_feed._parse_websocket_message(frame)
+        self.assertEqual(parsed["timestamp"], 1718730000)

--- a/test/hummingbot/data_feed/candles_feed/test_candles_factory.py
+++ b/test/hummingbot/data_feed/candles_feed/test_candles_factory.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 import hummingbot.data_feed.candles_feed as candles_feed_pkg
 from hummingbot.connector.exchange.binance import binance_constants
 from hummingbot.core.api_throttler.async_throttler import AsyncThrottler
+from hummingbot.data_feed.candles_feed.bing_x_spot_candles import BingXSpotCandles
 from hummingbot.data_feed.candles_feed.binance_perpetual_candles import BinancePerpetualCandles
 from hummingbot.data_feed.candles_feed.binance_spot_candles import (
     BinanceSpotCandles,
@@ -16,6 +17,13 @@ from hummingbot.data_feed.candles_feed.data_types import CandlesConfig
 
 
 class TestCandlesFactory(unittest.TestCase):
+    def test_get_bing_x_candles_spot(self):
+        candles = CandlesFactory.get_candle(CandlesConfig(
+            connector="bing_x", trading_pair="BTC-USDT", interval="1m"
+        ))
+        self.assertIsInstance(candles, BingXSpotCandles)
+        candles.stop()
+
     def test_get_binance_candles_spot(self):
         candles = CandlesFactory.get_candle(CandlesConfig(
             connector="binance",


### PR DESCRIPTION
## Summary
Adds complete BingX spot market-data support for Hummingbot:

- registers a BingX spot candles feed in `CandlesFactory` (`"bing_x": BingXSpotCandles`)
- makes BingX trading rules load all active symbols from the exchange response, like other full-market connectors such as KuCoin

Upstream, BingX is listed as "Not built" for the Spot Candles Feed, and its trading-rule formatter previously filtered to already-configured pairs only.

## Implementation
- New feed: `hummingbot/data_feed/candles_feed/bing_x_spot_candles/`
- REST: `GET https://open-api.bingx.com/openApi/spot/v2/market/kline` — dashed trading pair (`BTC-USDT`), Hummingbot interval names, millisecond `startTime`/`endTime`, `limit` capped at 1440. BingX returns rows newest-first; the parser reverses them into ascending 10-column candles.
- WS: `wss://open-api-ws.bingx.com/market` — subscription `{"id": <uuid>, "reqType": "sub", "dataType": "<PAIR>@kline_<interval>"}` using the BingX dataType vocabulary (1min, 3min, 5min, 15min, 30min, 60min, 2hour, 4hour, 6hour, 8hour, 12hour, 1day, 3day, 1week). Frames are gzip-compressed; decompression reuses `decompress_ws_message` from the existing `bing_x` connector utils (no new dependency).
- `1M` is intentionally not offered: BingX WS has no monthly kline, so a monthly feed would silently never stream.
- Rate limits mirror the `bing_x` connector request pools (GET / GET_BURST / GET_MIXED) so a shared throttler deduplicates when the connector is attached to the feed.
- Protocol verified live against BingX production (REST intervals list, WS vocabulary rejections for `1hour`/`1M`, push shape `{"code":0,"data":{"e":"kline","s":"BTC-USDT","K":{...}}}`, gzip framing, no client ping required).

## Trading rules
- Processes every active symbol from BingX `data.symbols`, rather than filtering by `self.trading_pairs`.
- Uses the exchange-provided `minQty`, `maxQty`, `minNotional`, `tickSize`, and `stepSize` values.
- Avoids one last-price request per symbol, so a cold connector can expose the complete market list without a request storm.

## Testing
- BingX connector + candle feed + factory tests: 63 tests pass (including all-symbol trading-rules parsing, REST params, newest-first reversal, WS subscription payload, WS field mapping from `data.K`, ack/text frames ignored, gzip decompression, and factory registration).
- Environment note: with `aiohttp 3.14.x` + `aioresponses 0.7.9` (latest published release), `test_fetch_candles` fails identically for ALL candle feeds (pre-existing ecosystem incompatibility, unrelated to this PR). Tests are green against `aiohttp 3.12.15` + `aioresponses 0.7.9`.
